### PR TITLE
Fix version check

### DIFF
--- a/wp
+++ b/wp
@@ -92,7 +92,9 @@ if [ "x$wp_cli_php_override" != "x" ] ; then
 fi
 
 # Get the php version
-PHP_VERSION=$($php -r echo\ phpversion\(\)\;)
+PHP_VERSION=$($php -r 'echo phpversion();')
+# Keep only major version number
+PHP_VERSION=${PHP_VERSION%%-*}
 
 # Format version numbers
 CURRENT_NUMBER=$(echo "$PHP_VERSION" | tr -d '.')


### PR DESCRIPTION
In Ubuntu, the version number looks like this: `5.3.6-13ubuntu3.1`

With the current handling, it produces an error: `[: 105: Illegal number: 536-13ubuntu31`
