### PR TITLE
Spelling Mistake

### DIFF
--- a/commands/community/example.php
+++ b/commands/community/example.php
@@ -7,7 +7,7 @@ WP_CLI::addCommand('example', 'ExampleCommand');
  * Implement example command
  *
  * @package wp-cli
- * @subpackage commands/cummunity
+ * @subpackage commands/community
  * @author Andreas Creten
  */
 class ExampleCommand extends WP_CLI_Command {


### PR DESCRIPTION
Just a minor documentation mistake.
