### PR TITLE
Unable to install new plugins

### DIFF
--- a/commands/internals/plugin.php
+++ b/commands/internals/plugin.php
@@ -302,7 +302,7 @@ class PluginCommand extends WP_CLI_Command {
 		else {
 			$file = $name . '.php';
 			$plugins = get_plugins();
-			if ( !isset( $plugins[$file] ) ) {
+			if ( !isset( $plugins[$file] && $sub_command != 'install' ) ) {
 				if ( $exit ) {
 					WP_CLI::error( "The plugin '$name' could not be found." );
 					exit();


### PR DESCRIPTION
When trying to install a new plugin the 'parse_name' function always returns 'false', because a plugin file doesn't exits (which is normal, because this plugin in not yet installed). So I'm proposing this small workaround, which doesn't return 'false' when installing a new plugin.
