### PR TITLE
Invalid behavior when trying to install a non-existing plugin

### DIFF
--- a/commands/internals/plugin.php
+++ b/commands/internals/plugin.php
@@ -179,6 +179,11 @@ class PluginCommand extends WP_CLI_Command {
 
 		WP_CLI::line( 'Installing '.$api->name.' ('.$api->version.')' );
 
+		if ( stripslashes( $name ) != $api->slug ) {
+			WP_CLI::error( 'Can\'t find the plugin in the WordPress.org plugins repository.' );
+			exit();
+		}
+
 		// Check what to do
 		switch ( $status['status'] ) {
 		case 'update_available':


### PR DESCRIPTION
Workaround for an invalid plugin status returned from the 'install_plugin_install_status' when trying to install a non-existing plugin.
