### PR TITLE
`wp user` command

### DIFF
--- a/src/php/wp-cli/commands/internals/user.php
+++ b/src/php/wp-cli/commands/internals/user.php
@@ -15,7 +15,7 @@ class UserCommand extends WP_CLI_Command {
    * @param array $args
 	 * @param array $assoc_args
    **/
-  public function all( $args, $assoc_args ) {
+  public function _list( $args, $assoc_args ) {
     global $blog_id;
 
     $params = array(
@@ -162,7 +162,7 @@ class UserCommand extends WP_CLI_Command {
 	 */
 	public static function help() {
 		WP_CLI::line( <<<EOB
-usage: wp user all [--role=<role>]
+usage: wp user list [--role=<role>]
    or: wp user create <user_login> <user_email> [--role=<default_role>]
    or: wp user update <ID> [--field_name=<field_value>]
    or: wp user delete <ID> [--reassign=<reassign_id>]


### PR DESCRIPTION
User command with list (all), create, update and delete subcommands.

I noticed there's an idea to drop php-cli-tools (#60). The `wp user all` command I've added uses the table formatter in php-cli. Happy to change that if there's a better/different way.
