### PR TITLE
Check if WP_CLI_SILENT is defined before using it

### DIFF
--- a/src/php/wp-cli/class-wp-cli.php
+++ b/src/php/wp-cli/class-wp-cli.php
@@ -25,7 +25,7 @@ class WP_CLI {
 	 * @param string $message
 	 */
 	static function out( $message ) {
-	    if ( WP_CLI_SILENT ) return;
+	    if ( defined( 'WP_CLI_SILENT' ) && WP_CLI_SILENT ) return;
 		\cli\out($message);
 	}
 
@@ -35,7 +35,7 @@ class WP_CLI {
 	 * @param string $message
 	 */
 	static function line( $message = '' ) {
-	    if ( WP_CLI_SILENT ) return;
+	    if ( defined( 'WP_CLI_SILENT' ) && WP_CLI_SILENT ) return;
 		\cli\line($message);
 	}
 
@@ -57,7 +57,7 @@ class WP_CLI {
 	 * @param string $label
 	 */
 	static function success( $message, $label = 'Success' ) {
-	    if ( WP_CLI_SILENT ) return;
+	    if ( defined( 'WP_CLI_SILENT' ) && WP_CLI_SILENT ) return;
 		\cli\line( '%G' . $label . ': %n' . $message );
 	}
 
@@ -68,7 +68,7 @@ class WP_CLI {
 	 * @param string $label
 	 */
 	static function warning( $message, $label = 'Warning' ) {
-	    if ( WP_CLI_SILENT ) return;
+	    if ( defined( 'WP_CLI_SILENT' ) && WP_CLI_SILENT ) return;
 		\cli\line( '%C' . $label . ': %n' . $message );
 	}
 


### PR DESCRIPTION
Otherwise you can get PHP warnings about using undefined constants.
