### PR TITLE
make wp-cli path agnosic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 nbproject
 review
 vendor
+.*.swp

--- a/src/bin/wp
+++ b/src/bin/wp
@@ -95,8 +95,14 @@ if [ "x$wp_cli_php_override" != "x" ] ; then
   php="$php $wp_cli_override_vars"
 fi
 
+if [ -z "$php" ]; then
+	echo "Error: Unable to find php!"
+	echo "Set the environment variable WP_CLI_PHP to the location of the php executable and try agin"
+	exit 1
+fi
+
 # Get the php version
-PHP_VERSION=$(php -v | awk '/^PHP / {print $2}' | cut -d '-' -f 1)
+PHP_VERSION=$($php -v | awk '/^PHP / {print $2}' | cut -d '-' -f 1)
 
 # Format version numbers
 CURRENT_NUMBER=$(echo "$PHP_VERSION" | tr -d '.')

--- a/src/php/wp-cli/wp-cli.php
+++ b/src/php/wp-cli/wp-cli.php
@@ -34,22 +34,26 @@ if ( isset( $assoc_args['version'] ) ) {
 // Define the WordPress location
 if ( is_readable( $_SERVER['PWD'] . '/../wp-load.php' ) ) {
 	define('WP_ROOT', $_SERVER['PWD'] . '/../');
-}
-else {
+} elseif (isset($assoc_args['wproot'])) {
+	$root = (preg_match('@/$@', $assoc_args['wproot'])) ? $assoc_args['wproot'] : $assoc_args['wproot'] . "/";
+	define('WP_ROOT', $root);
+} else {
 	define('WP_ROOT', $_SERVER['PWD'] . '/');
 }
 
 if ( !is_readable( WP_ROOT . 'wp-load.php' ) ) {
 	if ( array( 'core', 'download' ) == $arguments ) {
+		if (isset($assoc_args['path'])) $docroot = $assoc_args['path'];
+		else $docroot = './'
 		WP_CLI::line('Downloading WordPress...');
 		exec("curl http://wordpress.org/latest.zip > /tmp/wordpress.zip");
 		exec("unzip /tmp/wordpress.zip");
-		exec("mv wordpress/* ./");
+		exec("mv wordpress/* $docroot");
 		exec("rm -r wordpress");
 		WP_CLI::success('WordPress downloaded.');
 		exit;
 	} else {
-		WP_CLI::error('This does not seem to be a WordPress install. Try running `wp core download`.');
+		WP_CLI::error('This does not seem to be a WordPress install. Pass --wproot=`path/to/wordpress` or run `wp core download`.');
 		exit;
 	}
 }
@@ -59,7 +63,7 @@ if ( array( 'core', 'config' ) == $arguments ) {
 	$_POST['uname'] = $assoc_args['user'];
 	$_POST['pwd'] = $assoc_args['pass'];
 	$_POST['dbhost'] = isset( $assoc_args['host'] ) ? $assoc_args['host'] : 'localhost';
-	$_POST['prefix'] = isset( $assoc_args['prefix'] ) ? $assoc_args['prefix'] : '';
+	$_POST['prefix'] = isset( $assoc_args['prefix'] ) ? $assoc_args['prefix'] : 'wp_';
 
 	$_GET['step'] = 2;
 	require WP_ROOT . '/wp-admin/setup-config.php';

--- a/utils/build-local
+++ b/utils/build-local
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "$BASH_SOURCE" = "$0" ]; then
+	echo "This file should not be executed. It should be sourced into your current shell like this:"
+	echo
+	echo "source $BASH_SOURCE"
+	echo
+	echo "Add the above line to your .bashrc or .bash_profile to have this environment set up"
+	echo "automatically when you log in."
+	exit 1
+fi
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+alias wp='$DIR/../src/bin/wp'
+
+. $DIR/wp-completion.bash


### PR DESCRIPTION
I added some code to make wp-cli path-agnostic:

utils/build-local -- to allow for non-root "installation" and set up of the environment
src/wp-cli/wp-cli.php -- I added two flags:
  --wproot :: which can be used anywhere to set WP_ROOT to something other than $(pwd)
  wp core download --path :: which can be used to set a target installation directory for wordpress.

I also fixed a bug in src/bin/wp where you were calling 'php -v' rather than '$php -v'
