### PR TITLE
specify versions for plugins and core

### DIFF
--- a/src/php/wp-cli/commands/internals/core.php
+++ b/src/php/wp-cli/commands/internals/core.php
@@ -21,9 +21,20 @@ class CoreCommand extends WP_CLI_Command {
 			$docroot = $assoc_args['path'];
 		else
 			$docroot = './';
+	
+		if (isset($assoc_args['version'])) {
+			$download_url = 'http://wordpress.org/wordpress-' . $assoc_args['version'] . '.zip';
+		} else {
+			$download_url = 'http://wordpress.org/latest.zip';
+		}
+		$version_check_response = wp_remote_head($download_url);
+		if (!$version_check_response || $version_check_response['headers']['content-type'] != 'application/octet-stream') {
+			WP_CLI::error( 'Unable to download remote file ' . $download_url);
+			exit();
+		}
 
 		WP_CLI::line('Downloading WordPress...');
-		exec("curl http://wordpress.org/latest.zip > /tmp/wordpress.zip");
+		exec("curl {$download_url} > /tmp/wordpress.zip");
 		exec("unzip /tmp/wordpress.zip");
 		exec("mv wordpress/* $docroot");
 		exec("rm -r wordpress");

--- a/src/php/wp-cli/commands/internals/plugin.php
+++ b/src/php/wp-cli/commands/internals/plugin.php
@@ -213,6 +213,18 @@ class PluginCommand extends WP_CLI_Command_With_Upgrade {
 
 			$api->download_link = $link . $slug . '.zip';
 			$api->version = 'Development Version';
+		} else if ( isset( $assoc_args['version'] ) ) {
+			list( $link ) = explode( $slug, $api->download_link );
+
+			$api->download_link = $link . $slug . '.' . $assoc_args['version'] .'.zip';
+			$api->version = $assoc_args['version'];
+			
+			//check if the requested version exists
+			$version_check_response = wp_remote_head($api->download_link);
+			if (!$version_check_response || $version_check_response['headers']['content-type'] != 'application/octet-stream') {
+				WP_CLI::error( 'Can\'t find the requested plugin\'s version ' . $assoc_args['version'] . ' in the WordPress.org plugins repository.');
+				exit();
+			}
 		}
 
 		$status = install_plugin_install_status( $api );


### PR DESCRIPTION
Hello, since i want to use wp-cli for a batch installation script i've added a --version parameter to both the plugin install and core download commands in order to download specific versions.
