### PR TITLE
Allow directory with extra commands to be specified

### DIFF
--- a/src/php/wp-cli/class-wp-cli.php
+++ b/src/php/wp-cli/class-wp-cli.php
@@ -20,6 +20,11 @@ class WP_CLI {
 		self::$commands[$name] = $class;
 	}
     
+    /**
+     * Add a directory containing commands
+     * 
+     * @param string $dir
+     */
     static function addCommandDirectory( $dir ) {
         array_push( WP_CLI::$extra_command_directories, $dir );
     }

--- a/src/php/wp-cli/wp-cli.php
+++ b/src/php/wp-cli/wp-cli.php
@@ -105,6 +105,7 @@ if ( isset( $assoc_args['completions'] ) ) {
 	exit;
 }
 
+// Allow an extra directory to find commands to be specified
 if ( isset( $assoc_args['extra_command_dir'] ) ) {
     $extra_command_dir = $assoc_args['extra_command_dir'];
     WP_CLI::addCommandDirectory( $extra_command_dir );


### PR DESCRIPTION
So far as I can tell, there's currently no mechanism to specify an additional directory that wp-cli can read commands out of. So, if you write your own command, you have to maintain a branch of wp-cli with the extra command in `src/php/wp-cli/commands/{community|internals}`.

This patch adds an extra command line argument, `--extra_command_dir`, which specifies an additional directory storing commands. The name of the argument isn't particularly succinct, but I couldn't think of anything better.
