### PR TITLE
Fixes issue with transient get command improperly handling "%"

### DIFF
--- a/src/bin/wp
+++ b/src/bin/wp
@@ -68,7 +68,7 @@ else
   fi
 
   # Special case for *AMP installers, since they normally don't set themselves as the default cli php out of the box.
-  for amp_php in /Applications/MAMP/bin/php5/bin/php /Applications/MAMP/bin/php5.2/bin/php /Applications/MAMP/bin/php5.3/bin/php /Applications/MAMP/bin/php/php5.3.6/bin/php /opt/lampp/bin/php /Applications/xampp/xamppfiles/bin/php; do
+  for amp_php in /Applications/MAMP/bin/php5/bin/php /Applications/MAMP/bin/php5.2/bin/php /Applications/MAMP/bin/php5.3/bin/php /opt/lampp/bin/php /Applications/xampp/xamppfiles/bin/php; do
     if [ -x $amp_php ]; then
       php=$amp_php
     fi


### PR DESCRIPTION
As indicated in issue #71, `WP_CLI::line` does not handle "%" well. This same error is present in the transient get command. This request fixes that issue by using `echo` as an alternative to output the content.

Note that this pull request also contains 2 other commits that address the php path. I initially committed this, but reverted the change as there likely needs to be a better way of addressing this in the future.
