### PR TITLE
Update total cache command

### DIFF
--- a/src/php/wp-cli/commands/community/total-cache.php
+++ b/src/php/wp-cli/commands/community/total-cache.php
@@ -97,15 +97,16 @@ class W3TotalCache_Command extends WP_CLI_Command {
 	 */
 	public static function help() {
 		WP_CLI::line( <<<EOB
-usage: wp total-cache flush [post|database|minify|object] [--post_id=<post-id>] [--permalink=<post-permalink>]
+usage: wp total-cache flush [post|database|minify|object|page] [--post_id=<post-id>] [--permalink=<post-permalink>]
 
 Available sub-commands:
-	flush    flushes whole cache
+	flush
 			 --post_id=<id>                  flush specific ID
 			 --permalink=<post-permalink>    flush specific permalink
 			 database                        flushes database cache
 			 object                          flush object cache
 			 minify                          flush minify cache
+			 page                            flush page cache
 EOB
 	);
 	}


### PR DESCRIPTION
This fixes some false error/succes messages when flushing caches, plus adds a separate handler for flushing the page cache.

I've extended the permalink and post flush options to check if it actually exists before flushing, so the error messages are correct.

When flushing all caches after an update or deploy it makes more sens to do a 

```
$ wp total-cache flush object db page
```
