### PR TITLE
Guess WordPress root if we're in a plugins directory

### DIFF
--- a/src/php/wp-cli/wp-cli.php
+++ b/src/php/wp-cli/wp-cli.php
@@ -50,6 +50,8 @@ $_SERVER['DOCUMENT_ROOT'] = getcwd();
 if ( !empty( $assoc_args['path'] ) ) {
 	// trailingslashit() isn't available yet
 	define( 'WP_ROOT', rtrim( $assoc_args['path'], '/' ) . '/' );
+} elseif ( preg_match( '|/wp-content/plugins/|', $_SERVER['PWD'] ) ) {
+	define( 'WP_ROOT', preg_replace( '|/wp-content/plugins/.*|', '', $_SERVER['PWD'] ) . '/' );
 } else {
 	define( 'WP_ROOT', $_SERVER['PWD'] . '/' );
 }


### PR DESCRIPTION
This will allow to run wp-cli from a directory of
a plugin.

If wp-content isn't inside the WordPress this
won't work, but since it's not in a WordPress root
it won't work anyway, so I'd risk it.
