### PR TITLE
Updating MAMP php 5.3 executable directory

### DIFF
--- a/src/bin/wp
+++ b/src/bin/wp
@@ -67,7 +67,7 @@ else
 	fi
 
 	# Special case for *AMP installers, since they normally don't set themselves as the default cli php out of the box.
-	for amp_php in /Applications/MAMP/bin/php5*/bin/php /Applications/MAMP/bin/php/php.[34]*/bin/php /opt/lampp/bin/php /Applications/xampp/xamppfiles/bin/php; do
+	for amp_php in /Applications/MAMP/bin/php/php5.3*/bin/php /Applications/MAMP/bin/php5*/bin/php /Applications/MAMP/bin/php/php.[34]*/bin/php /opt/lampp/bin/php /Applications/xampp/xamppfiles/bin/php; do
 		if [ -x $amp_php ]; then
 			php=$amp_php
 			break


### PR DESCRIPTION
In response to Issue #133:

Updating the 'Special case for *AMP installers' to reflect that the
current version of MAMP stores the PHP 5.3 executable at

/Applications/MAMP/bin/php/php5.3*/bin/php

Instead of /Applications/MAMP/bin/php5_/bin/php or /Applications/MAMP/bin/php/php.[34]_/bin/php.

This change allows people running MAMP with PHP 5.3.\* to use wp-cli
