### PR TITLE
Implement --porcelain option for wp plugin status

### DIFF
--- a/src/php/wp-cli/class-wp-cli-command-with-upgrade.php
+++ b/src/php/wp-cli/class-wp-cli-command-with-upgrade.php
@@ -23,16 +23,19 @@ abstract class WP_CLI_Command_With_Upgrade extends WP_CLI_Command {
 	 *
 	 * @param array $args
 	 */
-	function status( $args = array() ) {
+	function status( $args = array(), $assoc_args ) {
+
+		$porcelain = ( isset( $assoc_args['porcelain'] ) );
+
 		// Force WordPress to check for updates
 		call_user_func( $this->upgrade_refresh );
 
 		if ( empty( $args ) ) {
-			$this->status_all();
+			$this->status_all( $porcelain );
 		} else {
 			list( $file, $name ) = $this->parse_name( $args, __FUNCTION__ );
 
-			$this->status_single( $file, $name );
+			$this->status_single( $file, $name, $porcelain );
 		}
 	}
 

--- a/src/php/wp-cli/commands/internals/plugin.php
+++ b/src/php/wp-cli/commands/internals/plugin.php
@@ -44,7 +44,7 @@ class Plugin_Command extends WP_CLI_Command_With_Upgrade {
 	}
 
 	// Show details about all plugins
-	protected function status_all() {
+	protected function status_all( $porcelain = false ) {
 		$this->mu_plugins = get_mu_plugins();
 
 		$plugins = get_plugins();
@@ -61,15 +61,18 @@ class Plugin_Command extends WP_CLI_Command_With_Upgrade {
 				$name = dirname($file);
 
 			if ( $this->get_update_status( $file ) ) {
-				$line = ' %yU%n';
+				$line = $porcelain ? 'U' : ' %yU%n';
 			} else {
-				$line = '  ';
+				$line = $porcelain ? '' : '  ';
 			}
 
-			$line .= $this->get_status( $file ) . " $name%n";
+			$line .= $this->get_status( $file, null, $porcelain ) . ( $porcelain ? "\t" : ' ' ) . "$name" . ( $porcelain ? '' : "%n");
 
 			WP_CLI::line( $line );
 		}
+
+		if ( $porcelain )
+			return;
 
 		// Print the footer
 		WP_CLI::line();
@@ -86,15 +89,15 @@ class Plugin_Command extends WP_CLI_Command_With_Upgrade {
 		WP_CLI::legend( $legend );
 	}
 
-	private function get_status( $file, $long = false ) {
+	private function get_status( $file, $long = false, $porcelain = false ) {
 		if ( isset( $this->mu_plugins[ $file ] ) ) {
-			$line  = '%c';
+			$line  = $porcelain ? '' : '%c';
 			$line .= $long ? 'Must Use' : 'M';
 		} elseif ( is_plugin_active_for_network( $file ) ) {
-			$line  = '%b';
+			$line  = $porcelain ? '' : '%b';
 			$line .= $long ? 'Network Active' : 'N';
 		} elseif ( is_plugin_active( $file ) ) {
-			$line  = '%g';
+			$line  = $porcelain ? '' : '%g';
 			$line .= $long ? 'Active' : 'A';
 		} else {
 			$line  = $long ? 'Inactive' : 'I';


### PR DESCRIPTION
I needed this one for a script I was writing; I have a script which deploys
changes from a staging site to a production site using mysqldump and import.
Since I keep different plugins active on the production site, I was trying
to compare the output of `wp plugin status` before and after importing the
database, then activating or deactivating plugins as necessary. Trying to
parse out the escape codes was way too complex, so I tried hacking WP CLI
instead, which was much easier.

This is admittedly a fairly hacky approach, and it would be good to refactor
this so that the same option can be used for all the commands which extend
WP_CLI_Command_With_Upgrade (the `status` subcommand, where I see this being
most helpful, is common to all of them). I wasn't sure where the best place
to define it would be though.

Any thoughts?
