### PR TITLE
Split `wp post delete` assoc args into `wp post delete-many`

### DIFF
--- a/src/php/wp-cli/commands/internals/post.php
+++ b/src/php/wp-cli/commands/internals/post.php
@@ -54,12 +54,10 @@ class Post_Command extends WP_CLI_Command {
 	/**
 	 * Delete a post by ID.
 	 *
-	 * @synopsis <id>
+	 * @synopsis <id>... [--force]
 	 */
 	public function delete( $args, $assoc_args ) {
-		$post_id = WP_CLI::get_numeric_arg( $args, 0, "Post ID" );
-
-		$this->_delete_posts( array( $post_id ), isset( $assoc_args['force'] ) );
+		$this->_delete_posts( $args, isset( $assoc_args['force'] ) );
 	}
 
 	/**


### PR DESCRIPTION
Adding associative parameters to `wp post delete` was a mistake. It should have been a separate subcommand all along.

It will make both documentation and implementation clearer.
