### PR TITLE
Replace get_aliases() with '@alias' tag

### DIFF
--- a/src/php/wp-cli/class-wp-cli-command-with-meta.php
+++ b/src/php/wp-cli/class-wp-cli-command-with-meta.php
@@ -7,12 +7,6 @@
  */
 abstract class WP_CLI_Command_With_Meta extends WP_CLI_Command {
 
-	public static function get_aliases() {
-		return array(
-			'set' => 'update'
-		);
-	}
-
 	protected $meta_type;
 
 	/**
@@ -68,6 +62,7 @@ abstract class WP_CLI_Command_With_Meta extends WP_CLI_Command {
 	/**
 	 * Update a meta field.
 	 *
+	 * @alias set
 	 * @synopsis <id> <key> <value>
 	 */
 	public function update( $args, $assoc_args ) {

--- a/src/php/wp-cli/class-wp-cli-command.php
+++ b/src/php/wp-cli/class-wp-cli-command.php
@@ -11,10 +11,6 @@ abstract class WP_CLI_Command {
 		return false;
 	}
 
-	public static function get_aliases() {
-		return array();
-	}
-
 	public function __construct() {}
 }
 

--- a/src/php/wp-cli/commands/internals/db.php
+++ b/src/php/wp-cli/commands/internals/db.php
@@ -14,12 +14,6 @@ class DB_Command extends WP_CLI_Command {
 		return 'cli';
 	}
 
-	public static function get_aliases() {
-		return array(
-			'dump' => 'export'
-		);
-	}
-
 	/**
 	 * Creates the database specified in the wp-config.php file.
 	 */
@@ -137,6 +131,7 @@ class DB_Command extends WP_CLI_Command {
 	/**
 	 * Exports the WordPress DB as SQL using mysqldump.
 	 *
+	 * @alias dump
 	 * @synopsis [<file>]
 	 */
 	function export( $args, $assoc_args ) {

--- a/src/php/wp-cli/commands/internals/option.php
+++ b/src/php/wp-cli/commands/internals/option.php
@@ -10,12 +10,6 @@ WP_CLI::add_command('option', 'Option_Command');
  */
 class Option_Command extends WP_CLI_Command {
 
-	public static function get_aliases() {
-		return array(
-			'set' => 'update'
-		);
-	}
-
 	/**
 	 * Get an option
 	 *
@@ -50,6 +44,7 @@ class Option_Command extends WP_CLI_Command {
 	/**
 	 * Update an option
 	 *
+	 * @alias set
 	 * @synopsis <key> <value> [--json]
 	 */
 	public function update( $args, $assoc_args ) {


### PR DESCRIPTION
The `WP_CLI_Command::get_aliases()` method is kind of clunky, because it's a method that just returns a literal array and it's disconnected from the subcommands in question.

Having an `@alias set` tag in the method's doc would make more sense, since the alias would automatically have a target.
