### PR TITLE
Don't use now-deprecated get_themes in favor of wp_get_themes to avoid deprecation notices

### DIFF
--- a/src/php/wp-cli/commands/internals/theme.php
+++ b/src/php/wp-cli/commands/internals/theme.php
@@ -137,7 +137,12 @@ class Theme_Command extends WP_CLI_Command_With_Upgrade {
 	protected function get_item_list() {
 		$items = array();
 
-		foreach ( get_themes() as $title => $details ) {
+		if( function_exists( 'wp_get_themes' ) )
+			$themes = wp_get_themes();
+		else
+			$themes = get_themes();
+
+		foreach ( $themes as $title => $details ) {
 			$file = $this->get_stylesheet_path( $details['Stylesheet'] );
 
 			$items[ $file ] = array(


### PR DESCRIPTION
Checks for existence of wp_get_themes to use instead of deprecated (as of 3.4) get_themes function
