### PR TITLE
Interactive shell

### DIFF
--- a/src/php/wp-cli/commands/internals/shell.php
+++ b/src/php/wp-cli/commands/internals/shell.php
@@ -21,7 +21,7 @@ class Shell_Command extends WP_CLI_Command {
 		);
 		$non_expressions = implode( '|', $non_expressions );
 
-		$pattern = "/^\s*($non_expressions)\s+/";
+		$pattern = "/^\s*($non_expressions)[\(\s]+/";
 
 		while ( true ) {
 			$line = call_user_func( array( __CLASS__, $repl ), 'wp> ' );


### PR DESCRIPTION
It would be interesting to have a command that would open an interactive read-eval-print-loop console, similar to [wpshell](http://code.trac.wordpress.org/browser/wpshell). 

Example usage:

```
$ wp shell
wp> get_option('home')
'http://wp.dev/core'
wp> strtoupper($_)
'HTTP://WP.DEV/CORE'
```
