### PR TITLE
Scaffold command for post type and taxonomy

### DIFF
--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -20,7 +20,7 @@ class Scaffold_Command extends WP_CLI_Command {
    *
    * @alias pt
    *
-   * @synopsis [--description=<description>] [--public=<public>] [--exclude_from_search=<exclude_from_search>] [--show_ui=<show_ui>] [--show_in_nav_menus=<show_in_nav_menus>] [--show_in_menu=<show_in_menu>] [--show_in_admin_bar=<show_in_admin_bar>] [--menu_position=<menu_position>] [--menu_icon=<menu_icon>] [--capability_type=<capability_type>] [--hierarchical=<hierarchical>] [--supports=<supports>] [--has_archive=<has_archive>] [--slug=<slug>] [--feed=<feed>] [--pages=<pages>] [--query_var=<query_var>] [--can_export=<can_export>] [--textdomain=<textdomain>] [--theme] [--plugin_name=<plugin_name>]
+   * @synopsis [--description=<description>] [--public=<public>] [--exclude_from_search=<exclude_from_search>] [--show_ui=<show_ui>] [--show_in_nav_menus=<show_in_nav_menus>] [--show_in_menu=<show_in_menu>] [--show_in_admin_bar=<show_in_admin_bar>] [--menu_position=<menu_position>] [--menu_icon=<menu_icon>] [--capability_type=<capability_type>] [--hierarchical=<hierarchical>] [--supports=<supports>] [--has_archive=<has_archive>] [--slug=<slug>] [--feed=<feed>] [--pages=<pages>] [--query_var=<query_var>] [--can_export=<can_export>] [--textdomain=<textdomain>] [--theme] [--plugin_name=<plugin_name>] [--raw]
    */
   function post_type( $args, $assoc_args ) {
     global $wp_filesystem;
@@ -33,7 +33,7 @@ class Scaffold_Command extends WP_CLI_Command {
     $machine_name_plural      = $this->pluralize( $post_type );
 
     // If no label is given use the slug and prettify it as good as possible
-    if( !isset( $assoc_args['label'] ) ) {
+    if( ! isset( $assoc_args['label'] ) ) {
       $label                  = preg_replace( '/_|-/', ' ', strtolower( $post_type ) );
       $label_ucfirst          = ucfirst( $label );
       $label_plural           = $this->pluralize( $label );
@@ -62,7 +62,8 @@ class Scaffold_Command extends WP_CLI_Command {
       'can_export'          => 'true',
       'textdomain'          => '',
       'theme'               => false,
-      'plugin_name'         => false
+      'plugin_name'         => false,
+      'raw'                 => false,
     );
 
     // Generate the variables from the defaults and associated arguments if they are set
@@ -70,7 +71,13 @@ class Scaffold_Command extends WP_CLI_Command {
 
     $textdomain = $this->get_textdomain( $textdomain, $theme, $plugin_name );
     
-    include 'skeletons/post_type_skeleton.php';
+    if( ! $raw ) {
+      include 'skeletons/post_type_skeleton.php';
+      $output = str_replace( "<?php", "", $output);
+      include 'skeletons/post_type_skeleton_extended.php';
+    } else {
+      include 'skeletons/post_type_skeleton.php';
+    }
 
     if ( $theme || ! empty( $plugin_name ) ) {
       // Write file to theme or given plugin_name
@@ -94,7 +101,7 @@ class Scaffold_Command extends WP_CLI_Command {
    *
    * @alias tax
    *
-   * @synopsis [--public=<public>] [--show_in_nav_menus=<show_in_nav_menus>] [--show_ui=<show_ui>] [--show_tagcloud=<show_tagcloud>] [--hierarchical=<hierarchical>]  [--rewrite=<rewrite>] [--query_var=<query_var>] [--slug=<slug>] [--textdomain=<textdomain>] [--post_types=<post_types>] [--theme] [--plugin_name=<plugin_name>]
+   * @synopsis [--public=<public>] [--show_in_nav_menus=<show_in_nav_menus>] [--show_ui=<show_ui>] [--show_tagcloud=<show_tagcloud>] [--hierarchical=<hierarchical>]  [--rewrite=<rewrite>] [--query_var=<query_var>] [--slug=<slug>] [--textdomain=<textdomain>] [--post_types=<post_types>] [--theme] [--plugin_name=<plugin_name>] [--raw]
    */
   function taxonomy( $args, $assoc_args ) {
     global $wp_filesystem;
@@ -107,7 +114,7 @@ class Scaffold_Command extends WP_CLI_Command {
     $machine_name_plural      = $this->pluralize( $taxonomy );
 
     // If no label is given use the slug and prettify it as good as possible
-    if( !isset( $assoc_args['label'] ) ) {
+    if( ! isset( $assoc_args['label'] ) ) {
       $label                  = preg_replace( '/_|-/', ' ', strtolower( $taxonomy ) );
       $label_ucfirst          = ucfirst( $label );
       $label_plural           = $this->pluralize( $label );
@@ -127,7 +134,8 @@ class Scaffold_Command extends WP_CLI_Command {
       'post_types'          => 'post',
       'textdomain'          => '',
       'theme'               => false,
-      'plugin_name'         => false
+      'plugin_name'         => false,
+      'raw'                 => false,
     );
     
     // Generate the variables from the defaults and associated arguments if they are set
@@ -135,9 +143,15 @@ class Scaffold_Command extends WP_CLI_Command {
 
     $textdomain = $this->get_textdomain( $textdomain, $theme, $plugin_name );
 
-    include 'skeletons/taxonomy_skeleton.php';
+    if( ! $raw ) {
+      include 'skeletons/taxonomy_skeleton.php';
+      $output = str_replace( "<?php", "", $output);
+      include 'skeletons/taxonomy_skeleton_extended.php';
+    } else {
+      include 'skeletons/taxonomy_skeleton.php';
+    }
 
-    if ( $theme || !empty( $plugin_name ) ) {
+    if ( $theme || ! empty( $plugin_name ) ) {
       // Write file to theme or given plugin_name
       $assoc_args = array(
         'type' => 'taxonomy',

--- a/php/commands/skeletons/post_type_skeleton.php
+++ b/php/commands/skeletons/post_type_skeleton.php
@@ -1,7 +1,5 @@
 <?php
 $output = "<?php
-
-function {$machine_name}_init() {
   register_post_type( '{$post_type}', 
     array(
       'label'               => __( '{$label_plural_ucfirst}', '{$textdomain}' ),
@@ -37,30 +35,4 @@ function {$machine_name}_init() {
         'menu_name'           => __( '{$label_plural_ucfirst}', '{$textdomain}' ),
       ),
     ) 
-  );
-}
-add_action( 'init', '{$machine_name}_init' );
-
-function {$machine_name}_updated_messages( \$messages ) {
-  global \$post, \$post_ID;
-
-  \$messages['{$post_type}'] = array(
-    0 => '', // Unused. Messages start at index 1.
-    1 => sprintf( __('{$label_ucfirst} updated. <a target=\"_blank\" href=\"%s\">View {$label}</a>', '{$textdomain}'), esc_url( get_permalink(\$post_ID) ) ),
-    2 => __('Custom field updated.', '{$textdomain}'),
-    3 => __('Custom field deleted.', '{$textdomain}'),
-    4 => __('{$label_ucfirst} updated.', '{$textdomain}'),
-    /* translators: %s: date and time of the revision */
-    5 => isset(\$_GET['revision']) ? sprintf( __('{$label_ucfirst} restored to revision from %s', '{$textdomain}'), wp_post_revision_title( (int) \$_GET['revision'], false ) ) : false,
-    6 => sprintf( __('{$label_ucfirst} published. <a href=\"%s\">View {$label}</a>', '{$textdomain}'), esc_url( get_permalink(\$post_ID) ) ),
-    7 => __('{$label_ucfirst} saved.', '{$textdomain}'),
-    8 => sprintf( __('{$label_ucfirst} submitted. <a target=\"_blank\" href=\"%s\">Preview {$post_type}</a>', '{$textdomain}'), esc_url( add_query_arg( 'preview', 'true', get_permalink(\$post_ID) ) ) ),
-    9 => sprintf( __('{$label_ucfirst} scheduled for: <strong>%1\$s</strong>. <a target=\"_blank\" href=\"%2\$s\">Preview {$label}</a>', '{$textdomain}'),
-      // translators: Publish box date format, see http://php.net/date
-      date_i18n( __( 'M j, Y @ G:i' ), strtotime( \$post->post_date ) ), esc_url( get_permalink( \$post_ID ) ) ),
-    10 => sprintf( __('{$label_ucfirst} draft updated. <a target=\"_blank\" href=\"%s\">Preview {$post_type}</a>', '{$textdomain}'), esc_url( add_query_arg( 'preview', 'true', get_permalink( \$post_ID ) ) ) ),
-  );
-
-  return \$messages;
-}
-add_filter( 'post_updated_messages', '{$machine_name}_updated_messages' );";
+  );";

--- a/php/commands/skeletons/post_type_skeleton_extended.php
+++ b/php/commands/skeletons/post_type_skeleton_extended.php
@@ -1,0 +1,32 @@
+<?php
+$output = "<?php
+
+function {$machine_name}_init() {
+  {$output}
+}
+add_action( 'init', '{$machine_name}_init' );
+
+function {$machine_name}_updated_messages( \$messages ) {
+  global \$post, \$post_ID;
+
+  \$messages['{$post_type}'] = array(
+    0 => '', // Unused. Messages start at index 1.
+    1 => sprintf( __('{$label_ucfirst} updated. <a target=\"_blank\" href=\"%s\">View {$label}</a>', '{$textdomain}'), esc_url( get_permalink(\$post_ID) ) ),
+    2 => __('Custom field updated.', '{$textdomain}'),
+    3 => __('Custom field deleted.', '{$textdomain}'),
+    4 => __('{$label_ucfirst} updated.', '{$textdomain}'),
+    /* translators: %s: date and time of the revision */
+    5 => isset(\$_GET['revision']) ? sprintf( __('{$label_ucfirst} restored to revision from %s', '{$textdomain}'), wp_post_revision_title( (int) \$_GET['revision'], false ) ) : false,
+    6 => sprintf( __('{$label_ucfirst} published. <a href=\"%s\">View {$label}</a>', '{$textdomain}'), esc_url( get_permalink(\$post_ID) ) ),
+    7 => __('{$label_ucfirst} saved.', '{$textdomain}'),
+    8 => sprintf( __('{$label_ucfirst} submitted. <a target=\"_blank\" href=\"%s\">Preview {$post_type}</a>', '{$textdomain}'), esc_url( add_query_arg( 'preview', 'true', get_permalink(\$post_ID) ) ) ),
+    9 => sprintf( __('{$label_ucfirst} scheduled for: <strong>%1\$s</strong>. <a target=\"_blank\" href=\"%2\$s\">Preview {$label}</a>', '{$textdomain}'),
+      // translators: Publish box date format, see http://php.net/date
+      date_i18n( __( 'M j, Y @ G:i' ), strtotime( \$post->post_date ) ), esc_url( get_permalink( \$post_ID ) ) ),
+    10 => sprintf( __('{$label_ucfirst} draft updated. <a target=\"_blank\" href=\"%s\">Preview {$post_type}</a>', '{$textdomain}'), esc_url( add_query_arg( 'preview', 'true', get_permalink( \$post_ID ) ) ) ),
+  );
+
+  return \$messages;
+}
+add_filter( 'post_updated_messages', '{$machine_name}_updated_messages' );";
+?>

--- a/php/commands/skeletons/taxonomy_skeleton.php
+++ b/php/commands/skeletons/taxonomy_skeleton.php
@@ -1,7 +1,5 @@
 <?php
 $output = "<?php
-
-function {$machine_name}_init() {
   \$labels = array( 
     'name'                        =>  __( '{$label_plural_ucfirst}', '{$textdomain}' ),
     'singular_name'               =>  __( '{$label_ucfirst}', '{$textdomain}' ),
@@ -20,8 +18,8 @@ function {$machine_name}_init() {
     'menu_name'                   =>  __( '{$label_plural_ucfirst}', '{$textdomain}' ),
   );
 
-  \$args = array( 
-    'labels'                  => \$labels,
+  \$args = array(
+  	'labels'                  => \$labels,
     'public'                  => {$public},
     'show_in_nav_menus'       => {$show_in_nav_menus},
     'show_ui'                 => {$show_ui},
@@ -42,7 +40,4 @@ function {$machine_name}_init() {
     ),
   );
     
-  register_taxonomy( '{$taxonomy}', array( '{$post_types}' ), \$args );
-
-}
-add_action( 'init', '{$machine_name}_init' );";
+  register_taxonomy( '{$taxonomy}', array( '{$post_types}' ), \$args );";

--- a/php/commands/skeletons/taxonomy_skeleton_extended.php
+++ b/php/commands/skeletons/taxonomy_skeleton_extended.php
@@ -1,0 +1,8 @@
+<?php
+$output = "<?php
+
+function {$machine_name}_init() {
+  {$output}
+
+}
+add_action( 'init', '{$machine_name}_init' );";


### PR DESCRIPTION
A scaffold command for post types and taxonomies
## Scaffold a custom post type

`wp scaffold post-type`

`wp scaffold post-type zombie`
## Scaffold a taxonomy

`wp scaffold taxonomy zombie_speed`
`wp scaffold taxonomy zombie_speed --post_type="zombie"`
