### PR TITLE
Doesn't work with WP Super Cache enabled

### DIFF
--- a/src/php/wp-cli/class-wp-cli.php
+++ b/src/php/wp-cli/class-wp-cli.php
@@ -268,6 +268,10 @@ class WP_CLI {
 		if ( array( 'core', 'install' ) == self::$arguments ) {
 			define( 'WP_INSTALLING', true );
 		}
+
+		// Pretend we're in WP_ADMIN, to side-step full-page caching plugins
+		define( 'WP_ADMIN', true );
+		$_SERVER['PHP_SELF'] = '/wp-admin/index.php';
 	}
 
 	static function after_wp_load() {


### PR DESCRIPTION
I just set up wp-cli version a45bfd0240.  If I run it from outside my wordpress installation, it correctly prompts me to prove the `--path` argument.  If I run `wp --version`, I see `wp-cli 0.7.0-alpha`, so that looks good.  However, if I run any other command, either from the WP install folder, or by providing `--path` pointing to it, all I see is the HTML of my homepage.

Have I just misconfigured something?
