### PR TITLE
Updating a plugin deactivates it

### DIFF
--- a/src/php/wp-cli/commands/internals/plugin.php
+++ b/src/php/wp-cli/commands/internals/plugin.php
@@ -193,7 +193,20 @@ class Plugin_Command extends WP_CLI_Command_With_Upgrade {
 		} else {
 			list( $basename ) = $this->parse_name( $args );
 
+			$was_active = is_plugin_active( $basename );
+			$was_network_active = is_plugin_active_for_network( $basename );
+
 			parent::_update( $basename );
+
+			if ( $was_active ) {
+				$new_args = array( $args[0] );
+
+				$new_assoc_args = array();
+				if ( $was_network_active )
+					$new_assoc_args['network'] = true;
+
+				$this->activate( $new_args, $new_assoc_args );
+			}
 		}
 	}
 


### PR DESCRIPTION
Tested on the latest and greatest version (I JUST pulled 2 min ago).
1. Have an out of date plugin that is active. 
2. Run 'wp plugin update pluginname'
3. Now you have an updated plugin that is IN active

That doesn't seem right. Shouldn't the plugin check if it's active and retain that state?
