### PR TITLE
Always return the list of subcommands as alphabetically sorted.

### DIFF
--- a/php/WP_CLI/Dispatcher/RootCommand.php
+++ b/php/WP_CLI/Dispatcher/RootCommand.php
@@ -85,6 +85,8 @@ EOB
 	function get_subcommands() {
 		$this->load_all_commands();
 
+		ksort( $this->subcommands );
+
 		return $this->subcommands;
 	}
 


### PR DESCRIPTION
This ensures commands added by plugins are added in their proper place.
