### PR TITLE
Allow (sub)commands to be filtered.

### DIFF
--- a/php/WP_CLI/Dispatcher/RootCommand.php
+++ b/php/WP_CLI/Dispatcher/RootCommand.php
@@ -85,7 +85,7 @@ EOB
 	function get_subcommands() {
 		$this->load_all_commands();
 
-		return $this->subcommands;
+		return apply_filters( 'wp_cli_commands', $this->subcommands );
 	}
 
 	protected function load_all_commands() {
@@ -112,7 +112,7 @@ EOB
 			return false;
 		}
 
-		return $this->subcommands[$command];
+		return apply_filters( 'wp_cli_commands', $this->subcommands );
 	}
 }
 


### PR DESCRIPTION
Some (sub)commands we don't want to accidentally run in certain environments. We should allow them to be permanently disabled.

@scribu I'd be interested to hear what you think of this approach, and whether you had a different approach in mind.
