### PR TITLE
Scaffold filename using slug and not machinename

### DIFF
--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -121,7 +121,7 @@ class Scaffold_Command extends WP_CLI_Command {
 		}
 
 		if ( $path = $this->get_output_path( $control_args, $subdir ) ) {
-			$filename = $path . $machine_name .'.php';
+			$filename = $path . $slug .'.php';
 
 			$this->create_file( $filename, $final_output );
 


### PR DESCRIPTION
Because `wp scaffold post-type jm-foo` scaffolds a file name jm_foo.php bacause the machinename hyphens get replaced by underscores.
Same behaviour as the plugin scaffold.

Hyphens should separate words.
