### PR TITLE
Exit on end-of-file

### DIFF
--- a/php/commands/shell.php
+++ b/php/commands/shell.php
@@ -52,6 +52,10 @@ class Shell_Command extends \WP_CLI_Command {
 
 		$line = fgets( $fp );
 
+		if ( !$line ) {
+			$line = 'exit';
+		}
+
 		return trim( $line );
 	}
 
@@ -61,6 +65,7 @@ class Shell_Command extends \WP_CLI_Command {
 			sprintf( 'history -r %s', escapeshellarg( $history_path ) ),
 			'LINE=""',
 			sprintf( 'read -re -p %s LINE', escapeshellarg( $prompt ) ),
+			'[ $? -eq 0 ] || exit',
 			'history -s "$LINE"',
 			sprintf( 'history -w %s', escapeshellarg( $history_path ) ),
 			'echo $LINE'


### PR DESCRIPTION
It's a common practice shells to exit on end-of-file. WP-CLI doesn't do
this.

I traced the reason to the fact we're not checking the exit code from
the `read` builtin. If it timeouts or receives end-of-file, it's
non-zero. In both these cases it makes sense to exit.
