### PR TITLE
Tiny correction: colorize is misspelled in php/config-spec.php

### DIFF
--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -45,7 +45,7 @@ return array(
 		'runtime' => true,
 		'file' => '<bool>',
 		'default' => 'auto',
-		'desc' => 'Whether to colozire the output',
+		'desc' => 'Whether to colorize the output',
 	),
 
 	'debug' => array(


### PR DESCRIPTION
Fixed the spelling of "colorize."
