### PR TITLE
walk up directory tree to find config file

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -27,7 +27,16 @@ class Runner {
 			'wp-cli.local.yml',
 			'wp-cli.yml'
 		);
-		$path = Utils\find_file_upward( $config_files, getcwd() );
+		// Stop looking upward when we find we have emerged from a subdirectory install into a parent install
+		$stop_check = function ( $dir ) {
+			static $wp_load_count = 0;
+			$wp_load_path = $dir . DIRECTORY_SEPARATOR . 'wp-load.php';
+			if ( file_exists( $wp_load_path ) ) {
+				$wp_load_count += 1;
+			}
+			return $wp_load_count > 1;
+		};
+		$path = Utils\find_file_upward( $config_files, getcwd(), $stop_check );
 		if ( $path ) {
 			return $path;
 		}

--- a/php/utils.php
+++ b/php/utils.php
@@ -49,17 +49,23 @@ function get_config_spec() {
 }
 
 /**
- * Search for file by walking up the directory tree until the first file is found
+ * Search for file by walking up the directory tree until the first file is found or until $stop_check($dir) returns true
  * @param string|array The files (or file) to search for
  * @param string|null The directory to start searching from; defaults to CWD
+ * @param callable Function which is passed the current dir each time a directory level is traversed
  * @return null|string Null if the file was not found
  */
-function find_file_upward($files, $dir = null) {
+function find_file_upward( $files, $dir = null, $stop_check = null ) {
 	$files = (array) $files;
 	if ( is_null( $dir ) ) {
 		$dir = getcwd();
 	}
 	while ( is_readable( $dir ) ) {
+		// Stop walking up when the supplied callable returns true being passed the $dir
+		if ( is_callable( $stop_check ) && call_user_func( $stop_check, $dir ) ) {
+			return null;
+		}
+
 		foreach ( $files as $file ) {
 			$path = $dir . DIRECTORY_SEPARATOR . $file;
 			if ( file_exists( $path ) ) {


### PR DESCRIPTION
Allows WP-CLI to be invoked from anywhere within a project, so you are not limited to being in the directory where the `wp-cli*.yml` file is.
The `DOCUMENT_ROOT` is then set to the supplied path relative to the config file.
