### PR TITLE
Example in man page for 'core is-installed' doesn't work

### DIFF
--- a/man-src/core-is-installed.txt
+++ b/man-src/core-is-installed.txt
@@ -1,5 +1,5 @@
 ## EXAMPLES
 
-if [ ! $(wp core is-installed) ]; then
+if ! $(wp core is-installed); then
 	wp core install
 fi

--- a/man/core-is-installed.1
+++ b/man/core-is-installed.1
@@ -10,7 +10,7 @@
 wp core is\-installed
 .
 .SH "EXAMPLES"
-if [ ! $(wp core is\-installed) ]; then
+if ! $(wp core is\-installed); then
 .
 .IP "" 4
 .


### PR DESCRIPTION
The example in the man page always acts like WordPress is not installed.

This works for me (removed the square brakets).

```
if ! $(wp core is-installed); then
    echo 'Not installed'
fi
```

or maybe…

```
$(wp core is-installed)
if [ $? -ne 0 ]; then
    echo 'Not installed'
fi
```
