### PR TITLE
Scaffold tax queryvar fix

### DIFF
--- a/templates/taxonomy.mustache
+++ b/templates/taxonomy.mustache
@@ -3,7 +3,7 @@
 		'public'                  => true,
 		'show_in_nav_menus'       => true,
 		'show_ui'                 => true,
-		'query_var'               => {{slug}},
+		'query_var'               => true,
 		'rewrite'                 => true,
 		'capabilities'            => array(
 			'manage_terms'  => 'edit_posts',


### PR DESCRIPTION
It used the $slug which could contain a dash in it which would trigger an error because it wasn't surrounded by quote to be a string.
So instead of making it a string, true would trigger the same behaviour and which is default.
