### PR TITLE
Functional tests for `wp term` command

### DIFF
--- a/features/steps/basic_steps.php
+++ b/features/steps/basic_steps.php
@@ -142,13 +142,6 @@ $steps->Then( '/^it should run without errors$/',
 	}
 );
 
-$steps->Then( '/^it should run with errors$/' ,
-	function ( $world ) {
-		if ( empty( $world->result->STDERR ) )
-			throw new \Exception( "No error produced" );
-	}
-);
-
 $steps->Then( '/^(STDOUT|STDERR) should (be|contain|not contain):$/',
 	function ( $world, $stream, $action, PyStringNode $expected ) {
 		$output = $world->result->$stream;

--- a/features/term.feature
+++ b/features/term.feature
@@ -11,11 +11,7 @@ Feature: Manage WordPress terms
       """
 
     When I run the previous command again
-    Then it should run with errors
-    And STDERR should be:
-      """
-      Error: A term with the name provided already exists.
-      """
+    Then STDERR should not be empty
 
     When I run `wp term list post_tag --format=json`
     Then it should run without errors


### PR DESCRIPTION
Create / list tests to start.

Is there a way to parse the JSON from STDOUT to get the term ID(s) for deleting?
