### PR TITLE
Add bulk delete functionality

### DIFF
--- a/php/WP_CLI/CommandWithDBObject.php
+++ b/php/WP_CLI/CommandWithDBObject.php
@@ -78,5 +78,14 @@ abstract class CommandWithDBObject extends \WP_CLI_Command {
 
 		exit( $status );
 	}
+
+	public function bulk_delete( $assoc_args ) {
+		$status = 0;
+
+		$r = $this->_bulk_delete( $assoc_args );
+		$status = $this->success_or_failure( $r );
+
+		exit( $status );
+	}
 }
 

--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -157,6 +157,53 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	}
 
 	/**
+	 * Bulk delete posts
+	 *
+	 * @synopsis [--force] [--confirm] [--limit]
+	 */
+	public function bulk_delete( $args, $assoc_args ) {
+		$assoc_args = wp_parse_args( $assoc_args, array(
+			'force' => false,
+			'confirm' => false,
+			'limit' => 0,
+		) );
+
+		parent::bulk_delete( $assoc_args );
+	}
+
+	protected function _bulk_delete( $assoc_args ) {
+		if ( ! $assoc_args['confirm'] )
+			return array( 'error', "You must provide the confirm argument to bulk delete posts" );
+
+		$args = array(
+			'posts_per_page' => $assoc_args['limit'],
+			'post_status' => 'any',
+			'cache_results' => false
+		);
+		$delete_query = new WP_Query( $args );
+		$total_deleted = 0;
+
+		if ( $delete_query->have_posts() ) {
+			while ( $delete_query->have_posts() ) {
+				$delete_query->the_post();
+
+				$r = wp_delete_post( get_the_ID(), $assoc_args['force'] );
+
+				if ( true != $r ) {
+					return array( 'error', 'Failed deleting post ' . get_the_ID() );
+				}
+
+				$total_deleted++;
+			}
+		}
+		wp_reset_postdata();
+
+		$action = $assoc_args['force'] ? 'Deleted' : 'Trashed';
+
+		return array( 'success', "$action $total_deleted posts" );
+	}
+
+	/**
 	 * Get a list of posts.
 	 *
 	 * @subcommand list


### PR DESCRIPTION
This adds bulk delete functionality. I know this is unsafe, but it is really useful for dev environments. A lot of times when I am doing imports, I need a way to clear out all the posts; this makes it easy. In order to make this safer, you have to provide a --confirm=1 arg and a --limit arg.
