### PR TITLE
Don't create temporary wordpress directory during "wp core download"

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -35,9 +35,11 @@ class Core_Command extends WP_CLI_Command {
 		}
 
 		$silent = WP_CLI::get_config('quiet') ? ' --silent ' : ' ';
-
-		WP_CLI::launch( 'curl -f' . $silent . escapeshellarg( $download_url ) . ' | tar xz' );
-		WP_CLI::launch( sprintf( 'cp -r wordpress/* %s && rm -rf wordpress', escapeshellarg( ABSPATH ) ) );
+		
+		WP_CLI::launch( sprintf( 'mkdir -p %s', escapeshellarg( ABSPATH ) ) );
+		$curl_command = 'curl -f' . $silent . escapeshellarg( $download_url );
+		$tar_command = sprintf( 'tar xz --directory=%s --strip-components=1', escapeshellarg( ABSPATH ) );
+		WP_CLI::launch( $curl_command . ' | ' . $tar_command );
 
 		WP_CLI::success( 'WordPress downloaded.' );
 	}


### PR DESCRIPTION
At the moment, `wp core download` untars WordPress to a temporary directory, then copies the files to the correct location. This patch changes the invocation of tar so that files are untarred directly to the correct location, avoiding an unnecessary temporary directory.
