### PR TITLE
Remove temporary files after succesfully running tests

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -69,6 +69,18 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	}
 
 	/**
+	 * @AfterScenario
+	 */
+	public function afterScenario( $event ) {
+		if ( !$this->install_dir )
+			return;
+
+		if ( $event->getResult() < 4 ) {
+			Process::create( Utils\esc_cmd( 'rm -r %s', $this->install_dir ) )->run();
+		}
+	}
+
+	/**
 	 * Initializes context.
 	 * Every scenario gets it's own context object.
 	 *


### PR DESCRIPTION
When a test fails, it's useful to be able to dive into the test dir and look at the files directly. But with more and more test scenarios and each test dir taking up north of 14MB, space usage becomes a problem.

An easy win would be to keep around only files for tests that have failed and delete the rest.
