### PR TITLE
Add `wp plugin scaffold` alias

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -16,7 +16,7 @@ Feature: Wordpress code scaffolding
     And I run `wp plugin path`
     And save STDOUT as {PLUGIN_DIR}
 
-    When I run `wp scaffold plugin zombieland --plugin_name="Welcome to Zombieland" --activate`
+    When I run `wp plugin scaffold zombieland --plugin_name="Welcome to Zombieland" --activate`
     Then STDOUT should not be empty
     And the {PLUGIN_DIR}/zombieland/zombieland.php file should exist
 

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -214,6 +214,11 @@ class Runner {
 			unset( $assoc_args['all'] );
 		}
 
+		// plugin scaffold  ->  scaffold plugin
+		if ( array( 'plugin', 'scaffold' ) == array_slice( $args, 0, 2 ) ) {
+			list( $args[0], $args[1] ) = array( $args[1], $args[0] );
+		}
+
 		// {post|user} list --ids  ->  {post|user} list --format=ids
 		if ( count( $args ) > 1 && in_array( $args[0], array( 'post', 'user' ) )
 			&& $args[1] == 'list'


### PR DESCRIPTION
I just caught myself mindlessly typing `wp plugin scaffold` and being surprised that it didn't work. That's a textbook example of the [principle of least astonishment](http://en.wikipedia.org/wiki/Principle_of_least_astonishment) being broken.

We should alias it to `wp scaffold plugin`.

If we ever add a `wp child-theme` top-level command, we should also alias `wp child-theme scaffold` to `wp scaffold child-theme`.
