### PR TITLE
behat: separate tests that require the `ronn` gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ php:
     - 5.4
 
 env:
-    - WP_VERSION=latest
-    - WP_VERSION=3.4.2
+    - WP_VERSION=latest 
+    - WP_VERSION=3.4.2 WITH_RONN=1
 
 matrix:
   exclude:
     - php: 5.4
-      env: WP_VERSION=3.4.2
+      env: WP_VERSION=3.4.2 WITH_RONN=1
 
 before_script: ./bin/ci/install_dependencies.sh
 

--- a/bin/ci/install_dependencies.sh
+++ b/bin/ci/install_dependencies.sh
@@ -7,7 +7,10 @@ set -ex
 # install dependencies
 composer install --dev --no-interaction --prefer-source
 composer require d11wtq/boris=dev-master --no-interaction --prefer-source
-gem install ronn
+
+if [ -n "$WITH_RONN" ]; then
+	gem install ronn
+fi
 
 # set up WP install
 ./bin/wp core download --version=$WP_VERSION --path=/tmp/wp-cli-test-core-download-cache/

--- a/bin/ci/run_build.sh
+++ b/bin/ci/run_build.sh
@@ -4,4 +4,8 @@ set -ex
 
 vendor/bin/phpunit
 
-vendor/bin/behat --format progress
+if [ -z "$WITH_RONN" ]; then
+	BEHAT_OPTS="--tags ~@ronn"
+fi
+
+vendor/bin/behat --format progress $BEHAT_OPTS

--- a/features/help.feature
+++ b/features/help.feature
@@ -31,6 +31,7 @@ Feature: Get help about WP-CLI commands
     Then the return code should be 1
     And STDERR should not be empty
 
+  @ronn
   Scenario: Generating help for subcommands
     Given an empty directory
     When I run `wp help --gen option`
@@ -39,6 +40,7 @@ Feature: Get help about WP-CLI commands
       generated option.1
       """
 
+  @ronn
   Scenario: Generating help for multisite-only subcommands
     Given an empty directory
     When I run `wp help --gen blog create`
@@ -47,6 +49,7 @@ Feature: Get help about WP-CLI commands
       generated blog-create.1
       """
 
+  @ronn
   Scenario: Help for third-party commands
     Given a WP install
     And a wp-content/plugins/test-cli/test-help.txt file:


### PR DESCRIPTION
Currently, we call `gem install ronn` on each test run, which takes over 30 seconds and is only used in a handful of tests.

So, I think we should use the following technique: http://about.travis-ci.org/blog/2012-11-28-speeding-up-your-tests-by-parallelizing-them/

and using Behat filters: http://docs.behat.org/guides/6.cli.html#gherkin-filters
