### PR TITLE
Allow capital letters in <value> tokens in @synopsis

### DIFF
--- a/php/WP_CLI/SynopsisParser.php
+++ b/php/WP_CLI/SynopsisParser.php
@@ -108,7 +108,7 @@ class SynopsisParser {
 
 	private static function init_patterns() {
 		$p_name = '(?P<name>[a-z-_]+)';
-		$p_value = '(?P<value>[a-z-|]+)';
+		$p_value = '(?P<value>[a-zA-Z-|]+)';
 
 		self::gen_patterns( 'positional', "<$p_value>",           array( 'mandatory', 'optional', 'repeating' ) );
 		self::gen_patterns( 'generic',    "--<field>=<value>",    array( 'mandatory', 'optional', 'repeating' ) );

--- a/tests/test-synopsis.php
+++ b/tests/test-synopsis.php
@@ -85,5 +85,23 @@ class SynopsisParserTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'generic', $r[2]['type'] );
 		$this->assertEquals( 'flag', $r[3]['type'] );
 	}
+
+    function testAllowedValueCharacters() {
+        $r = SynopsisParser::parse( '--capitals=<VALUE> --hyphen=<val-ue> --combined=<VAL-ue> --disallowed=<wrong:char>' );
+
+        $this->assertCount( 4, $r );
+
+        $this->assertEquals( 'assoc', $r[0]['type'] );
+        $this->assertEquals( 'mandatory', $r[0]['flavour'] );
+
+        $this->assertEquals( 'assoc', $r[1]['type'] );
+        $this->assertEquals( 'mandatory', $r[1]['flavour'] );
+
+        $this->assertEquals( 'assoc', $r[2]['type'] );
+        $this->assertEquals( 'mandatory', $r[2]['flavour'] );
+
+        $this->assertEquals( 'unknown', $r[3]['type'] );
+    }
+
 }
 


### PR DESCRIPTION
Values in @synopsis tags are not matched if they contain capital letters.
This allows for capital letters i.e. `--name=<myPropertyValue>`
fixes #493
