### PR TITLE
scaffold plugin-tests: create install-wp-tests.sh script

### DIFF
--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -240,17 +240,19 @@ class Scaffold_Command extends WP_CLI_Command {
 		$plugin_slug = $args[0];
 
 		$plugin_dir = WP_PLUGIN_DIR . "/$plugin_slug";
-
 		$tests_dir = "$plugin_dir/tests";
+		$bin_dir = "$plugin_dir/bin";
 
 		$wp_filesystem->mkdir( $tests_dir );
+		$wp_filesystem->mkdir( $bin_dir );
 
 		$this->create_file( "$tests_dir/bootstrap.php",
 			Utils\mustache_render( 'bootstrap.mustache', compact( 'plugin_slug' ) ) );
 
 		$to_copy = array(
-			'phpunit.xml' => $plugin_dir,
+			'install-wp-tests.sh' => $bin_dir,
 			'.travis.yml' => $plugin_dir,
+			'phpunit.xml' => $plugin_dir,
 			'test-sample.php' => $tests_dir,
 		);
 
@@ -258,7 +260,7 @@ class Scaffold_Command extends WP_CLI_Command {
 			$wp_filesystem->copy( WP_CLI_ROOT . "../templates/$file", "$dir/$file", true );
 		}
 
-		WP_CLI::success( "Created test files in $plugin_dir" );
+		WP_CLI::success( "Created test files." );
 	}
 
 	private function create_file( $filename, $contents ) {

--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -10,26 +10,8 @@ env:
     - WP_VERSION=3.5.1 WP_MULTISITE=0
     - WP_VERSION=3.5.1 WP_MULTISITE=1
 
-before_install:
-    - git submodule update --init --recursive
-
 before_script:
-    # set up WP install
-    - WP_CORE_DIR=/tmp/wordpress/
-    - mkdir -p $WP_CORE_DIR
-    - wget -nv -O /tmp/wordpress.tar.gz https://github.com/WordPress/WordPress/tarball/$WP_VERSION
-    - tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
-    # set up testing suite
     - export WP_TESTS_DIR=/tmp/wordpress-tests/
-    - svn co --ignore-externals --quiet http://unit-tests.svn.wordpress.org/trunk/ $WP_TESTS_DIR
-    - cd $WP_TESTS_DIR
-    - cp wp-tests-config-sample.php wp-tests-config.php
-    - sed -i "s:dirname( __FILE__ ) . '/wordpress/':'$WP_CORE_DIR':" wp-tests-config.php
-    - sed -i "s/yourdbnamehere/wordpress_test/" wp-tests-config.php
-    - sed -i "s/yourusernamehere/root/" wp-tests-config.php
-    - sed -i "s/yourpasswordhere//" wp-tests-config.php
-    - cd -
-    # set up database
-    - mysql -e 'CREATE DATABASE wordpress_test;' -uroot
+    - bash bin/install-wp-tests.sh wordpress_test root '' $WP_VERSION 
 
 script: phpunit

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [wp-version]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+WP_VERSION=${4-master}
+
+set -ex
+
+# set up a WP install
+WP_CORE_DIR=/tmp/wordpress/
+mkdir -p $WP_CORE_DIR
+wget -nv -O /tmp/wordpress.tar.gz https://github.com/WordPress/WordPress/tarball/$WP_VERSION
+tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+
+# set up testing suite
+svn co --ignore-externals --quiet http://unit-tests.svn.wordpress.org/trunk/ $WP_TESTS_DIR
+
+cd $WP_TESTS_DIR
+cp wp-tests-config-sample.php wp-tests-config.php
+sed -i "s:dirname( __FILE__ ) . '/wordpress/':'$WP_CORE_DIR':" wp-tests-config.php
+sed -i "s/yourdbnamehere/$DB_NAME/" wp-tests-config.php
+sed -i "s/yourusernamehere/$DB_USER/" wp-tests-config.php
+sed -i "s/yourpasswordhere/$DB_PASS/" wp-tests-config.php
+
+# create database
+mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"


### PR DESCRIPTION
Writing all that bash code in `.travis.yml` always felt awkward. But the most annoying part is that you couldn't test the script that sets up the test environment locally.

So, let's just move the bulk of the code to a separate file.

We've adopted this strategy for WP-CLI itself: f121dfac28e9268f55a03f911e8c2f366441ec46
