### PR TITLE
Add warning when a URL redirection is attempted

### DIFF
--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -45,6 +45,16 @@ function wp_die_handler( $message ) {
 	\WP_CLI::error( $message );
 }
 
+function wp_redirect_handler( $url ) {
+	\WP_CLI::warning( 'Some code is trying to do a URL redirect. Backtrace:' );
+
+	ob_start();
+	debug_print_backtrace();
+	fwrite( STDERR, ob_get_clean() );
+
+	return $url;
+}
+
 function maybe_require( $since, $path ) {
 	global $wp_version;
 

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -56,7 +56,9 @@ require( ABSPATH . WPINC . '/class-wp-error.php' );
 require( ABSPATH . WPINC . '/plugin.php' );
 require( ABSPATH . WPINC . '/pomo/mo.php' );
 
+// WP_CLI: Early hooks
 Utils\replace_wp_die_handler();
+add_filter( 'wp_redirect', 'WP_CLI\\Utils\\wp_redirect_handler' );
 
 // Include the wpdb class and, if present, a db.php database drop-in.
 require_wp_db();


### PR DESCRIPTION
If a plugin or theme (or even Core) calls `wp_redirect()` during WP-CLI's bootstrap process, something is definitely wrong.

Therefore, it would be nice if a warning was showed to the user.
