### PR TITLE
Move command instance creation logic out of the WP_CLI class

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -59,3 +59,16 @@ Feature: Have a config file
       wp-cli.yml
       """
 
+  Scenario: Disabled subcommands
+    Given a WP install
+    And a wp-cli.yml file:
+      """
+      disabled_commands:
+        - db drop
+      """
+
+    When I try `wp db drop --yes`
+    Then STDERR should contain:
+      """
+      command has been disabled
+      """

--- a/php/WP_CLI/Dispatcher/CommandFactory.php
+++ b/php/WP_CLI/Dispatcher/CommandFactory.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace WP_CLI\Dispatcher;
+
+/**
+ * Creates CompositeCommand or Subcommand instances.
+ */
+class CommandFactory {
+
+	public static function create( $name, $class, $parent ) {
+		$reflection = new \ReflectionClass( $class );
+
+		if ( $reflection->hasMethod( '__invoke' ) ) {
+			$command = self::create_subcommand( $parent, $name, $reflection->name,
+				$reflection->getMethod( '__invoke' ) );
+		} else {
+			$command = self::create_composite_command( $parent, $name, $reflection );
+		}
+
+		return $command;
+	}
+
+	private static function create_subcommand( $parent, $name, $class_name, $method ) {
+		$docparser = new \WP_CLI\DocParser( $method );
+
+		if ( !$name )
+			$name = $docparser->get_tag( 'subcommand' );
+
+		if ( !$name )
+			$name = $method->name;
+
+		$method_name = $method->name;
+
+		$when_invoked = function ( $args, $assoc_args ) use ( $class_name, $method_name ) {
+			call_user_func( array( new $class_name, $method_name ), $args, $assoc_args );
+		};
+
+		return new Subcommand( $parent, $name, $docparser, $when_invoked );
+	}
+
+	private static function create_composite_command( $parent, $name, $reflection ) {
+		$docparser = new \WP_CLI\DocParser( $reflection );
+
+		$container = new CompositeCommand( $parent, $name, $docparser );
+
+		foreach ( $reflection->getMethods() as $method ) {
+			if ( !self::is_good_method( $method ) )
+				continue;
+
+			$subcommand = self::create_subcommand( $container, false, $reflection->name, $method );
+
+			$subcommand_name = $subcommand->get_name();
+
+			$container->add_subcommand( $subcommand_name, $subcommand );
+		}
+
+		return $container;
+	}
+
+	private static function is_good_method( $method ) {
+		return $method->isPublic() && !$method->isConstructor() && !$method->isStatic();
+	}
+}
+


### PR DESCRIPTION
The WP_CLI class isn't the best place for putting the code that creates CompositeCommand and Subcommand instances.

It belongs in the WP_CLI\Dispatcher namespace, but not in the RootCommand class, which should remain just a container.

Hence, a new class, in preparation for #453.
