### PR TITLE
Support Subdomains

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -158,7 +158,7 @@ class Core_Command extends WP_CLI_Command {
 	 * Transform a single-site install into a multi-site install.
 	 *
 	 * @subcommand install-network
-	 * @synopsis --title=<network-title> [--base=<url-path>]
+	 * @synopsis --title=<network-title> [--base=<url-path>] [--subdomains=<TRUE>]
 	 */
 	public function install_network( $args, $assoc_args ) {
 		if ( is_multisite() )


### PR DESCRIPTION
`wp core install-network --title=MiteshShah`

The above command always set false in wp-config.php file
`define('SUBDOMAIN_INSTALL', false);`

After applying this patch and run the following command  fix my problem :)
`wp core install-network --subdomains=TRUE --title=MiteshShah
define('SUBDOMAIN_INSTALL', true);`
