### PR TITLE
search-replace: query tables instead of relying on what's in wpdb

### DIFF
--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -67,13 +67,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 		if ( !empty( $args ) )
 			return $args;
 
-		if ( !$network ) {
-			$tables = $wpdb->tables( 'blog' );
-		} else {
-			$tables = $wpdb->get_col( "SHOW TABLES LIKE '{$wpdb->base_prefix}%'" );
-		}
+		$prefix = $network ? $wpdb->base_prefix : $wpdb->prefix;
 
-		return $tables;
+		return $wpdb->get_col( $wpdb->prepare( "SHOW TABLES LIKE %s", like_escape( $prefix ) . '%' ) );
 	}
 
 	private static function handle_col( $col, $primary_key, $table, $old, $new, $dry_run ) {


### PR DESCRIPTION
It's very likely that some plugins might create custom tables without properly registering them in the `$wpdb` global.

So, we should use the same mechanism we use when `--network` is passed.
