### PR TITLE
Allow reading values from STDIN

### DIFF
--- a/features/option.feature
+++ b/features/option.feature
@@ -46,3 +46,22 @@ Feature: Manage WordPress options
       """
       [1,2]
       """
+
+
+    # Reading from files
+    Given a value.json file:
+      """
+      {
+        "foo": "bar",
+        "list": [1, 2, 3]
+      }
+      """
+    When I run `wp option set foo --format=json < value.json`
+    And I run `wp option get foo --format=json`
+    Then STDOUT should be JSON containing:
+      """
+      {
+        "foo": "bar",
+        "list": [1, 2, 3]
+      }
+      """

--- a/features/post-meta.feature
+++ b/features/post-meta.feature
@@ -21,6 +21,13 @@ Feature: Manage post custom fields
       ["1","2"]
       """
 
+    When I run `echo 'via STDIN' | wp post-meta set 1 foo`
+    And I run `wp post-meta get 1 foo`
+    Then STDOUT should be:
+      """
+      via STDIN
+      """
+
     When I run `wp post-meta delete 1 foo`
     Then STDOUT should not be empty
 

--- a/php/WP_CLI/CommandWithMeta.php
+++ b/php/WP_CLI/CommandWithMeta.php
@@ -47,12 +47,25 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 	/**
 	 * Add a meta field.
 	 *
-	 * @synopsis <id> <key> <value> [--format=<format>]
+	 * ## OPTIONS
+	 *
+	 * <id>
+	 * : The ID of the object.
+	 *
+	 * <key>
+	 * : The name of the meta field to create.
+	 *
+	 * [<value>]
+	 * : The value of the meta field. If ommited, the value is read from STDIN.
+	 *
+	 * [--format=<format>]
+	 * : The serialization format for the value. Default is plaintext.
 	 */
 	public function add( $args, $assoc_args ) {
 		list( $object_id, $meta_key ) = $args;
 
-		$meta_value = \WP_CLI::read_value( $args[2], $assoc_args );
+		$meta_value = \WP_CLI::get_value_from_arg_or_stdin( $args, 2 );
+		$meta_value = \WP_CLI::read_value( $meta_value, $assoc_args );
 
 		$success = \add_metadata( $this->meta_type, $object_id, $meta_key, $meta_value );
 
@@ -66,13 +79,27 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 	/**
 	 * Update a meta field.
 	 *
+	 * ## OPTIONS
+	 *
+	 * <id>
+	 * : The ID of the object.
+	 *
+	 * <key>
+	 * : The name of the meta field to update.
+	 *
+	 * [<value>]
+	 * : The new value. If ommited, the value is read from STDIN.
+	 *
+	 * [--format=<format>]
+	 * : The serialization format for the value. Default is plaintext.
+	 *
 	 * @alias set
-	 * @synopsis <id> <key> <value> [--format=<format>]
 	 */
 	public function update( $args, $assoc_args ) {
 		list( $object_id, $meta_key ) = $args;
 
-		$meta_value = \WP_CLI::read_value( $args[2], $assoc_args );
+		$meta_value = \WP_CLI::get_value_from_arg_or_stdin( $args, 2 );
+		$meta_value = \WP_CLI::read_value( $meta_value, $assoc_args );
 
 		$success = \update_metadata( $this->meta_type, $object_id, $meta_key, $meta_value );
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -234,7 +234,30 @@ class WP_CLI {
 	}
 
 	/**
-	 * Read a value, from various formats
+	 * Read value from a positional argument or from STDIN.
+	 *
+	 * @param array $args The list of positional arguments.
+	 * @param int $index At which position to check for the value.
+	 *
+	 * @return string
+	 */
+	public static function get_value_from_arg_or_stdin( $args, $index ) {
+		if ( isset( $args[ $index ] ) ) {
+			$raw_value = $args[ $index ];
+		} else {
+			// We don't use file_get_contents() here because it doesn't handle
+			// Ctrl-D properly, when typing in the value interactively.
+			$raw_value = '';
+			while ( ( $line = fgets( STDIN ) ) !== false ) {
+				$raw_value .= $line;
+			}
+		}
+
+		return $raw_value;
+	}
+
+	/**
+	 * Read a value, from various formats.
 	 *
 	 * @param mixed $value
 	 * @param array $assoc_args

--- a/php/commands/option.php
+++ b/php/commands/option.php
@@ -39,12 +39,27 @@ class Option_Command extends WP_CLI_Command {
 	/**
 	 * Add an option.
 	 *
-	 * @synopsis <key> <value> [--format=<format>]
+	 * ## OPTIONS
+	 *
+	 * <key>
+	 * : The name of the option to add.
+	 *
+	 * [<value>]
+	 * : The value of the option to add. If ommited, the value is read from STDIN.
+	 *
+	 * [--format=<format>]
+	 * : The serialization format for the value. Default is plaintext.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Create an option by reading a JSON file
+	 *     wp option add my_option --format=json < config.json
 	 */
 	public function add( $args, $assoc_args ) {
 		$key = $args[0];
 
-		$value = WP_CLI::read_value( $args[1], $assoc_args );
+		$value = WP_CLI::get_value_from_arg_or_stdin( $args, 1 );
+		$value = WP_CLI::read_value( $value, $assoc_args );
 
 		if ( !add_option( $key, $value ) ) {
 			WP_CLI::error( "Could not add option '$key'. Does it already exist?" );
@@ -56,13 +71,29 @@ class Option_Command extends WP_CLI_Command {
 	/**
 	 * Update an option.
 	 *
+	 * ## OPTIONS
+	 *
+	 * <key>
+	 * : The name of the option to add.
+	 *
+	 * [<value>]
+	 * : The new value. If ommited, the value is read from STDIN.
+	 *
+	 * [--format=<format>]
+	 * : The serialization format for the value. Default is plaintext.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Update an option by reading from a file
+	 *     wp option update my_option < value.txt
+	 *
 	 * @alias set
-	 * @synopsis <key> <value> [--format=<format>]
 	 */
 	public function update( $args, $assoc_args ) {
 		$key = $args[0];
 
-		$value = WP_CLI::read_value( $args[1], $assoc_args );
+		$value = WP_CLI::get_value_from_arg_or_stdin( $args, 1 );
+		$value = WP_CLI::read_value( $value, $assoc_args );
 
 		$result = update_option( $key, $value );
 


### PR DESCRIPTION
Pass value inline (current):

```
$ wp option set key value
```

Pass value from a file:

```
$ wp option set key --format=json < value.json
```

Pass a multiline value interactively:

```
$ wp option set haiku<CR>
From time to time<CR>
The clouds give rest<CR>
To the moon-beholders.<Ctrl-D>
```

I'm thinking this would also work for `wp option add` and all the `-meta` commands.

Tasks:
- [x] implement for `option add` and `option update`
- [x] implement for `*-meta add` and `*-meta update`
