### PR TITLE
Add optional 'before_invoke' parameter to WP_CLI::add_command()

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -72,9 +72,15 @@ class WP_CLI {
 	 *
 	 * @param string $name The name of the command that will be used in the cli
 	 * @param string $class The command implementation
+	 * @param array $args An associative array with additional parameters:
+	 *   'before_invoke' => callback to execute before invoking the command
 	 */
-	static function add_command( $name, $class ) {
+	static function add_command( $name, $class, $args = array() ) {
 		$command = Dispatcher\CommandFactory::create( $name, $class, self::$root );
+
+		if ( isset( $args['before_invoke'] ) ) {
+			self::add_action( "before_invoke:$name", $args['before_invoke'] );
+		}
 
 		self::$root->add_subcommand( $name, $command );
 	}

--- a/php/commands/network-meta.php
+++ b/php/commands/network-meta.php
@@ -9,11 +9,11 @@ class Network_Meta_Command extends \WP_CLI\CommandWithMeta {
 	protected $meta_type = 'site';
 }
 
-WP_CLI::add_command( 'network-meta', 'Network_Meta_Command' );
-
-WP_CLI::add_action( 'before_invoke:network-meta', function () {
-	if ( !is_multisite() ) {
-		WP_CLI::error( 'This is not a multisite install.' );
+WP_CLI::add_command( 'network-meta', 'Network_Meta_Command', array(
+	'before_invoke' => function () {
+		if ( !is_multisite() ) {
+			WP_CLI::error( 'This is not a multisite install.' );
+		}
 	}
-} );
+) );
 


### PR DESCRIPTION
This avoids repeating the command name and makes it clearer when the
callback is fired.

The question is: do we still need hooks?
