### PR TITLE
Fix WP_CLI_ROOT

### DIFF
--- a/php/boot-fs.php
+++ b/php/boot-fs.php
@@ -12,7 +12,7 @@ if ( version_compare( PHP_VERSION, '5.3.0', '<' ) ) {
 	die(-1);
 }
 
-define( 'WP_CLI_ROOT', __DIR__ . '/' );
+define( 'WP_CLI_ROOT', dirname( __DIR__ ) );
 
-include dirname(__FILE__) . '/wp-cli.php';
+include WP_CLI_ROOT . '/php/wp-cli.php';
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -23,11 +23,11 @@ class WP_CLI {
 	 */
 	static function init() {
 		self::add_man_dir(
-			WP_CLI_ROOT . "../man",
-			WP_CLI_ROOT . "../man-src"
+			WP_CLI_ROOT . "/man",
+			WP_CLI_ROOT . "/man-src"
 		);
 
-		self::$configurator = new WP_CLI\Configurator( WP_CLI_ROOT . '/config-spec.php' );
+		self::$configurator = new WP_CLI\Configurator( WP_CLI_ROOT . '/php/config-spec.php' );
 		self::$root = new Dispatcher\RootCommand;
 		self::$runner = new WP_CLI\Runner;
 	}

--- a/php/commands/_sys.php
+++ b/php/commands/_sys.php
@@ -35,7 +35,7 @@ class Sys_Command extends WP_CLI_Command {
 		WP_CLI::line( "PHP binary:\t" . $php_bin );
 		WP_CLI::line( "PHP version:\t" . PHP_VERSION );
 		WP_CLI::line( "php.ini used:\t" . get_cfg_var( 'cfg_file_path' ) );
-		WP_CLI::line( "WP-CLI root:\t" . dirname( WP_CLI_ROOT ) );
+		WP_CLI::line( "WP-CLI root:\t" . WP_CLI_ROOT );
 		WP_CLI::line( "WP-CLI config:\t" . WP_CLI::get_config_path() );
 		WP_CLI::line( "WP-CLI version:\t" . WP_CLI_VERSION );
 	}

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -260,7 +260,7 @@ class Scaffold_Command extends WP_CLI_Command {
 		);
 
 		foreach ( $to_copy as $file => $dir ) {
-			$wp_filesystem->copy( WP_CLI_ROOT . "../templates/$file", "$dir/$file", true );
+			$wp_filesystem->copy( WP_CLI_ROOT . "/templates/$file", "$dir/$file", true );
 		}
 
 		WP_CLI::success( "Created test files." );

--- a/php/utils.php
+++ b/php/utils.php
@@ -8,8 +8,8 @@ use \WP_CLI\Dispatcher;
 
 function load_dependencies() {
 	$vendor_paths = array(
-		WP_CLI_ROOT . '../vendor',           // top-level project
-		WP_CLI_ROOT . '../../../../vendor',  // part of a larger project
+		WP_CLI_ROOT . '/vendor',           // top-level project
+		WP_CLI_ROOT . '/../../../vendor',  // part of a larger project
 	);
 
 	$has_autoload = false;
@@ -27,11 +27,11 @@ function load_dependencies() {
 		exit(3);
 	}
 
-	include WP_CLI_ROOT . 'Spyc.php';
+	include WP_CLI_ROOT . '/php/Spyc.php';
 }
 
 function load_command( $name ) {
-	$path = WP_CLI_ROOT . "/commands/$name.php";
+	$path = WP_CLI_ROOT . "/php/commands/$name.php";
 
 	if ( is_readable( $path ) ) {
 		include_once $path;
@@ -39,7 +39,7 @@ function load_command( $name ) {
 }
 
 function load_all_commands() {
-	$cmd_dir = WP_CLI_ROOT . "commands";
+	$cmd_dir = WP_CLI_ROOT . "/php/commands";
 
 	$iterator = new \DirectoryIterator( $cmd_dir );
 
@@ -372,7 +372,7 @@ function run_mysql_command( $cmd, $arg_str, $pass ) {
 }
 
 function mustache_render( $template_name, $data ) {
-	$template = file_get_contents( WP_CLI_ROOT . "../templates/$template_name" );
+	$template = file_get_contents( WP_CLI_ROOT . "/templates/$template_name" );
 
 	$m = new \Mustache_Engine;
 

--- a/php/wp-cli.php
+++ b/php/wp-cli.php
@@ -5,10 +5,10 @@ define( 'WP_CLI', true );
 
 define( 'WP_CLI_VERSION', '0.11.0-alpha' );
 
-include WP_CLI_ROOT . 'utils.php';
-include WP_CLI_ROOT . 'dispatcher.php';
-include WP_CLI_ROOT . 'class-wp-cli.php';
-include WP_CLI_ROOT . 'class-wp-cli-command.php';
+include WP_CLI_ROOT . '/php/utils.php';
+include WP_CLI_ROOT . '/php/dispatcher.php';
+include WP_CLI_ROOT . '/php/class-wp-cli.php';
+include WP_CLI_ROOT . '/php/class-wp-cli-command.php';
 
 \WP_CLI\Utils\load_dependencies();
 
@@ -26,7 +26,7 @@ define( 'WP_NETWORK_ADMIN', false );
 define( 'WP_USER_ADMIN', false );
 
 // Load Core, mu-plugins, plugins, themes etc.
-require WP_CLI_ROOT . 'wp-settings-cli.php';
+require WP_CLI_ROOT . '/php/wp-settings-cli.php';
 
 // Fix memory limit. See http://core.trac.wordpress.org/ticket/14889
 @ini_set( 'memory_limit', -1 );

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -40,7 +40,7 @@ wp_fix_server_vars();
 timer_start();
 
 // Load WP-CLI utilities
-require WP_CLI_ROOT . 'utils-wp.php';
+require WP_CLI_ROOT . '/php/utils-wp.php';
 
 // Check if we're in WP_DEBUG mode.
 Utils\wp_debug_mode();


### PR DESCRIPTION
In 3ca6c14ab22042ce3a1be78a5ac057ec0c735358 I fixed the output from `wp --info`, but maybe we should fix WP_CLI_ROOT instead.

We use it to access files from `man-src` and `man`, not just stuff in the `php/` dir.

While we're at it, we could also remove the trailing slash.

Related: #439
