### PR TITLE
Make `wp help` use a pager

### DIFF
--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -82,15 +82,6 @@ class Help_Command extends WP_CLI_Command {
 		return proc_close( proc_open( 'less -r', $descriptorspec, $pipes ) );
 	}
 
-	private static function find( $candidates, $callback ) {
-		foreach ( $candidates as $candidate ) {
-			if ( call_user_func( $callback, $candidate ) )
-				return $candidate;
-		}
-
-		return false;
-	}
-
 	private static function get_initial_markdown( $command ) {
 		$name = implode( ' ', Dispatcher\get_path( $command ) );
 


### PR DESCRIPTION
Follow-up to #548.

When using `man`, the output was paged. You could achieve the same effect, without this patch, by running this:

```
wp help core config --color | less -r
```
### less bug

When I run the above command, the output skips the "NAME" header.

Omitting the `--color` flag has no effect.
Changing from iTerm2 to Terminal has no effect.
Piping explicitly instead of from PHP has no effect.

Removing `config` from the command does have an effect. Maybe it's because the synopsis for `core config` is longer than $COLUMNS.
