### PR TITLE
support for port and socket configurations with wp core config

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -371,8 +371,6 @@ function run_mysql_query( $query, $args ) {
     }
   }
 
-  echo $arg_str . "\n";
-
 	run_mysql_command( 'mysql', $arg_str, $args['pass'] );
 }
 


### PR DESCRIPTION
Currently there is no way to use the `wp core config` command with a mysql server with a custom socket or TCP port. This is because the `run_mysql_query` doesn't process `dbhost` values with port or custom socket parameters.

This PR parses out an optional port or socket parameter when testing the connection.

For example

```
$ wp core config --dbname=testwordpress --dbuser=root --dbhost=localhost:/tmp/mysql.wordpress.sock
$ wp core config --dbname=testwordpress --dbuser=root --dbhost=localhost:4000
```
