### PR TITLE
`wp search-replace` fails on objects with non-public constructors

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -223,13 +223,24 @@ function recursive_unserialize_replace( $from = '', $to = '', $data = '', $seria
 		// Submitted by Tina Matter
 		elseif ( is_object( $data ) ) {
 			$dataClass = get_class( $data );
-			$_tmp = new $dataClass( );
-			foreach ( $data as $key => $value ) {
-				$_tmp->$key = recursive_unserialize_replace( $from, $to, $value, false );
+
+			$canReplace = true;
+			if ( method_exists( $dataClass, '__construct' ) ) {
+				$classConstructor = new \ReflectionMethod( $dataClass, '__construct' );
+
+				if ( ! $classConstructor->isPublic() )
+					$canReplace = false;
 			}
 
-			$data = $_tmp;
-			unset( $_tmp );
+			if ( $canReplace ) {
+				$_tmp = new $dataClass();
+				foreach ( $data as $key => $value ) {
+					$_tmp->$key = recursive_unserialize_replace( $from, $to, $value, false );
+				}
+
+				$data = $_tmp;
+				unset( $_tmp );
+			}
 		}
 
 		else {


### PR DESCRIPTION
When doing a recursive serialized search-replace on objects, our search-replace code will attempt to instantiate a serialized object.

This does not fail in the upstream (interconnectit) code because it doesn't load any plugin code, and skips instantiation due to the try{} block eating the failure.  However, it does fail with a fatal error in wp-cli when the object is of a class that has a private constructor.  As an example, I ran into this problem with a database that had objects from Gantry.

Here are a few potential workarounds:
- Do not search-replace when __construct method exists and is not public (pull request for this to be attached to the issue shortly)
- Launch search-replace before any plugin code gets launched (although we may want  make it so that plugins can "play nice" with search-replace in the future).
- Whitelist only PHP base objects, and skip the rest

Thoughts?  Concerns?  Better ideas?
