### PR TITLE
`wp user *-role` should accept a list of users

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -65,21 +65,21 @@ Feature: Manage WordPress users
   Scenario: Managing user roles
     Given a WP install
 
-    When I run `wp user add-role 1 editor`
+    When I run `wp user add-role --role=editor 1`
     Then STDOUT should not be empty
     And I run `wp user get 1`
     Then STDOUT should be a table containing rows:
       | Field | Value                 |
       | roles | administrator, editor |
 
-    When I run `wp user set-role 1 author`
+    When I run `wp user set-role --role=author 1`
     Then STDOUT should not be empty
     And I run `wp user get 1`
     Then STDOUT should be a table containing rows:
       | Field | Value  |
       | roles | author |
 
-    When I run `wp user remove-role 1 editor`
+    When I run `wp user remove-role --role=editor 1`
     Then STDOUT should not be empty
     And I run `wp user get 1`
     Then STDOUT should be a table containing rows:

--- a/man-src/user-add-role.txt
+++ b/man-src/user-add-role.txt
@@ -4,11 +4,11 @@
 
 	User ID or user login.
 
-* `<role>`:
+* `--role=<role>`:
 
 	Add the specified role to the user.
 
 ## EXAMPLES
 
-	wp user set-role bob author
-	wp user set-role 12 author
+	# Add the 'author' role to the user with ID '12' and to the user with login 'bob'
+	wp user add-role 12 bob --role=author

--- a/man-src/user-remove-role.txt
+++ b/man-src/user-remove-role.txt
@@ -4,7 +4,11 @@
 
 	User ID or user login.
 
+* `[--role=<role>]`:
+
+	Remove only the specified role. If not passed, all roles will be deleted.
+
 ## EXAMPLES
 
-	wp user remove-role bob
-	wp user remove-role 12
+	# Remove roles for the user with ID '12' and for the user with login 'bob'
+	wp user remove-role 12 bob

--- a/man-src/user-set-role.txt
+++ b/man-src/user-set-role.txt
@@ -4,12 +4,12 @@
 
 	User ID or user login.
 
-* `[<role>]`:
+* `[--role=<role>]`:
 
 	Make the user have the specified role. If not passed, the default role is
 used.
 
 ## EXAMPLES
 
-	wp user set-role bob author
-	wp user set-role 12 author
+	# Set the 'author' role for the user with ID '12' and for the user with login 'bob'
+	wp user set-role 12 bob --role=author


### PR DESCRIPTION
The issue is that they accept the role as the second positional parameter.

All the other subcommands use `--role=<role>` and accept multiple user IDs or logins.

Related: #555 #229