### PR TITLE
make slug required, and add safe fn name regex.

### DIFF
--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -116,7 +116,12 @@ class Scaffold_Command extends WP_CLI_Command {
 	 */
 	function _s( $args, $assoc_args ) {
 
-		$theme_slug = $args[0];
+		// Used for function prefixes, clean for safety.
+		$theme_slug = preg_replace('/[^a-zA-Z0-9\-]/', '', $args[0]);
+
+		if( empty( $theme_slug ) )
+			return false;
+
 		$theme_path = WP_CONTENT_DIR . "/themes";
 		$url = "http://underscores.me";
 		$timeout = 30;


### PR DESCRIPTION
Making slug required to encourage concise and clean function prefixes.
#285 and #583
