### PR TITLE
add user prompts request_input and request_options

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -177,6 +177,38 @@ class WP_CLI {
 	}
 
 	/**
+	 * Ask question return asnwer.
+	 */
+	static function request_input( $question ) {
+	  WP_CLI::line( WP_CLI::colorize( "%Y$question" ) );
+
+	  $answer = trim( fgets( STDIN ) );
+
+	  return $answer;
+	}
+
+	/**
+	 * Ask question with controlled options.
+	 */
+	static function request_options( $question, $assoc_args = array() ) {
+		WP_CLI::line( WP_CLI::colorize( "%Y$question" ) );
+
+		$x=1;
+		foreach($assoc_args as $arg){
+			WP_CLI::line( WP_CLI::colorize( "%Y$x:%n $arg") );
+			$x++;
+		}
+
+		$answer = trim( fgets( STDIN ) );
+
+		if ( ( 0 < $answer ) && ( $x > $answer ) ){
+			return $answer;
+		}else{
+			return WP_CLI::error( sprintf( 'Invalid Option Selected: %s', $answer ) );
+		}
+	}
+
+	/**
 	 * Read a value, from various formats
 	 *
 	 * @param mixed $value


### PR DESCRIPTION
I've wanted an interactive console for wp-cli for awhile and I've seen a few comments that mention it'd be desirable, so here's my approach.

This would make it easier to prompt users when they've left out required elements or provide the user with a list of options to choose from.

Here's how it could be used in wp scaffold_s:

```
  if( empty( $data['theme_name'] ) ){
    $result = WP_CLI::request_input( 'Theme Name is required.' );
    $data['theme_name'] = sanitize_text_field($result);
  }
```

And use case for a series of controlled options.

```
  $result = WP_CLI::request_options( 'Favorite forgotten Disney character?', array('fox','hound','tramp') );
  WP_CLI::success("Valid Response: ".$result);
```
