### PR TITLE
WP_CLI::error() - don't call exit(1); directly

### DIFF
--- a/php/WP_CLI/Exceptions/GeneralError.php
+++ b/php/WP_CLI/Exceptions/GeneralError.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace WP_CLI\Exceptions;
+
+class GeneralError extends \RuntimeException {
+}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -34,6 +34,15 @@ class WP_CLI {
 		self::$logger = $logger;
 	}
 
+	/**
+	 * Get the logger instance.
+	 *
+	 * @return object
+	 */
+	static function get_logger() {
+		return self::$logger;
+	}
+
 	static function get_configurator() {
 		return self::$configurator;
 	}
@@ -152,14 +161,9 @@ class WP_CLI {
 	 * Display an error in the CLI and end with a newline
 	 *
 	 * @param string $message
-	 * @param string $label
 	 */
-	static function error( $message, $label = 'Error' ) {
-		if ( ! isset( self::get_runner()->assoc_args[ 'completions' ] ) ) {
-			self::$logger->error( self::error_to_string( $message ), $label );
-		}
-
-		exit(1);
+	static function error( $message, $deprecated = null ) {
+		throw new \WP_CLI\Exceptions\GeneralError( $message );
 	}
 
 	/**

--- a/php/wp-cli.php
+++ b/php/wp-cli.php
@@ -14,25 +14,32 @@ include WP_CLI_ROOT . '/php/class-wp-cli-command.php';
 
 WP_CLI::init();
 
-WP_CLI::get_runner()->before_wp_load();
+try {
+	WP_CLI::get_runner()->before_wp_load();
 
-// Load wp-config.php code, in the global scope
-eval( WP_CLI::get_runner()->get_wp_config_code() );
+	// Load wp-config.php code, in the global scope
+	eval( WP_CLI::get_runner()->get_wp_config_code() );
 
-// Simulate a /wp-admin/ page load
-$_SERVER['PHP_SELF'] = '/wp-admin/index.php';
-define( 'WP_ADMIN', true );
-define( 'WP_NETWORK_ADMIN', false );
-define( 'WP_USER_ADMIN', false );
+	// Simulate a /wp-admin/ page load
+	$_SERVER['PHP_SELF'] = '/wp-admin/index.php';
+	define( 'WP_ADMIN', true );
+	define( 'WP_NETWORK_ADMIN', false );
+	define( 'WP_USER_ADMIN', false );
 
-// Load Core, mu-plugins, plugins, themes etc.
-require WP_CLI_ROOT . '/php/wp-settings-cli.php';
+	// Load Core, mu-plugins, plugins, themes etc.
+	require WP_CLI_ROOT . '/php/wp-settings-cli.php';
 
-// Fix memory limit. See http://core.trac.wordpress.org/ticket/14889
-@ini_set( 'memory_limit', -1 );
+	// Fix memory limit. See http://core.trac.wordpress.org/ticket/14889
+	@ini_set( 'memory_limit', -1 );
 
-require ABSPATH . 'wp-admin/includes/admin.php';
-do_action( 'admin_init' );
+	require ABSPATH . 'wp-admin/includes/admin.php';
+	do_action( 'admin_init' );
 
-WP_CLI::get_runner()->after_wp_load();
+	WP_CLI::get_runner()->after_wp_load();
+} catch ( \WP_CLI\Exceptions\GeneralError $e ) {
+	if ( !isset( WP_CLI::get_runner()->assoc_args[ 'completions' ] ) ) {
+		WP_CLI::get_logger()->error( WP_CLI::error_to_string( $e->getMessage() ), 'Error' );
+	}
+	exit(1);
+}
 


### PR DESCRIPTION
This is a problem when calling `WP_CLI::run_command()`. See #627.

One solution would be to throw an exception. This would still abort the existing command, but would allow something like this:

```
try {
  WP_CLI::run_command( ... );
} catch ( \WP_CLI\Exceptions\CommandError $e ) {
  // pass
}
```

Or we could catch the exception inside `WP_CLI::run_command()` and then just `return 1;`.

If the exception is not caught here, it will get caught by the main runner.
