### PR TITLE
Fix notices undefined index post_types when scaffolding CPT

### DIFF
--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -90,8 +90,12 @@ class Scaffold_Command extends WP_CLI_Command {
 	function taxonomy( $args, $assoc_args ) {
 		$defaults = array(
 			'textdomain' => '',
-			'post_types' => 'post'
+			'post_types' => "'post'"
 		);
+
+		if( isset($assoc_args['post_types']) ) {
+			$assoc_args['post_types'] = $this->quote_comma_list_elements( $assoc_args['post_types'] );
+		}
 
 		$this->_scaffold( $args[0], $assoc_args, $defaults, '/taxonomies/', array(
 			'taxonomy.mustache',
@@ -107,14 +111,11 @@ class Scaffold_Command extends WP_CLI_Command {
 			'theme'  => false,
 			'plugin' => false,
 			'raw'    => false,
-			'post_types' => false,
 		) );
 
 		$vars = $this->extract_args( $assoc_args, $defaults );
 
 		$vars['slug'] = $slug;
-
-		$vars['post_types'] = $this->quote_comma_list_elements( $control_args['post_types'] );
 
 		$vars['textdomain'] = $this->get_textdomain( $vars['textdomain'], $control_args );
 


### PR DESCRIPTION
Added `post_type` default value and use `$control_args` because it it won't be available in `$vars`
