### PR TITLE
Fix search replace reserved column name issue

### DIFF
--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -101,10 +101,12 @@ class Search_Replace_Command extends WP_CLI_Command {
 		// We don't want to have to generate thousands of rows when running the test suite
 		$chunk_size = getenv( 'BEHAT_RUN' ) ? 10 : 1000;
 
+		$fields = array( $primary_key, $col );
+		$fields = array_map( function ($v) { return "`$v`"; }, $fields );
 		$args = array(
 			'table' => $table,
-			'fields' => array( $primary_key, $col ),
-			'where' => $col . ' LIKE "%' . like_escape( esc_sql( $old ) ) . '%"',
+			'fields' => $fields,
+			'where' => "`$col`" . ' LIKE "%' . like_escape( esc_sql( $old ) ) . '%"',
 			'chunk_size' => $chunk_size
 		);
 


### PR DESCRIPTION
The 'search-replace' command resulted in an error if one of the table columns was using a reserved word like 'default' for a name.

This fixes that issue.
