### PR TITLE
Bug: `wp core install` allows --url to be empty

### DIFF
--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -57,7 +57,12 @@ class Subcommand extends CompositeCommand {
 			exit(1);
 		}
 
-		$errors = $parser->validate_assoc( $assoc_args, array_keys( \WP_CLI::get_config() ) );
+		$ignored_args = array_keys( \WP_CLI::get_config() );
+		// --url= can be a required key in `core install` and similar
+		if ( false !== ( $key = array_search( 'url', $ignored_args ) ) )
+			unset( $ignored_args[$key] );
+
+		$errors = $parser->validate_assoc( $assoc_args, $ignored_args );
 
 		if ( !empty( $errors['fatal'] ) ) {
 			$out = '';

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -365,6 +365,10 @@ class Runner {
 		list( $args, $assoc_args, $runtime_config ) = \WP_CLI::get_configurator()->parse_args(
 			array_slice( $GLOBALS['argv'], 1 ) );
 
+		// Allow --url= to be used in subcommands
+		if ( isset( $runtime_config['url'] ) )
+			$assoc_args['url'] = $runtime_config['url'];
+
 		list( $this->arguments, $this->assoc_args ) = self::back_compat_conversions(
 			$args, $assoc_args );
 


### PR DESCRIPTION
I can get away with:

`wp core install --title=WP --admin_name=daniel --admin_email=d@danielbachhuber.com --admin_password=daniel`

This means `--url` is set to `example.com`.

Instead, `--url` should actually be required, which is what it's supposed to be according to the synopsis.
