### PR TITLE
Don't ignore non-optional keys even if in ignored keys

### DIFF
--- a/php/WP_CLI/SynopsisValidator.php
+++ b/php/WP_CLI/SynopsisValidator.php
@@ -42,7 +42,7 @@ class SynopsisValidator {
 		foreach ( $assoc as $param ) {
 			$key = $param['name'];
 
-			if ( in_array( $key, $ignored_keys ) )
+			if ( in_array( $key, $ignored_keys ) && $param['optional'] )
 				continue;
 
 			if ( !isset( $assoc_args[ $key ] ) ) {


### PR DESCRIPTION
Allow for external required attributes to override default ignored keys
