### PR TITLE
Support PsySH instead of Boris

### DIFF
--- a/bin/ci/install_dependencies.sh
+++ b/bin/ci/install_dependencies.sh
@@ -9,7 +9,6 @@ curl http://behat.org/downloads/behat.phar > behat.phar
 
 # install dependencies
 composer install --no-interaction --prefer-source
-composer require d11wtq/boris=dev-master --no-interaction --prefer-source
 
 # set up WP install
 ./bin/wp core download --version=$WP_VERSION --path=/tmp/wp-cli-test-core-download-cache/

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"rmccue/requests": "dev-master"
 	},
 	"suggest": {
-		"d11wtq/boris": "Enhanced `wp shell` functionality"
+		"psy/psysh": "Enhanced `wp shell` functionality"
 	},
 	"autoload": {
 		"psr-0": { "WP_CLI": "php" }

--- a/php/commands/shell.php
+++ b/php/commands/shell.php
@@ -18,20 +18,27 @@ class Shell_Command extends \WP_CLI_Command {
 	 */
 	public function __invoke( $_, $assoc_args ) {
 		$implementations = array(
+			'\\Psy\\Shell',
 			'\\Boris\\Boris',
 			'\\WP_CLI\\REPL',
 		);
 
 		if ( isset( $assoc_args['basic'] ) ) {
-			unset( $implementations[0] );
+			$class = '\\WP_CLI\\REPL';
+		} else {
+			foreach ( $implementations as $candidate ) {
+				if ( class_exists( $candidate ) ) {
+					$class = $candidate;
+					break;
+				}
+			}
 		}
 
-		foreach ( $implementations as $class ) {
-			if ( class_exists( $class ) ) {
-				$repl = new $class( 'wp> ' );
-				$repl->start();
-				break;
-			}
+		if ( '\\Psy\\Shell' == $class ) {
+			\Psy\Shell::debug();
+		} else {
+			$repl = new $class( 'wp> ' );
+			$repl->start();
 		}
 	}
 }


### PR DESCRIPTION
[PsySH](https://github.com/bobthecow/psysh) vs. [Boris](https://github.com/d11wtq/boris):
- dependency on ext-pcntl is optional
- doesn't need trailing semicolon to finish commands
- supports the `$_` variable

Disadvantages:
- has dependency on symfony-console
- doesn't support the `$in_a_long_running_operation` trick

Overall, I think it's a better fit as an enhanced `wp shell`. Just need to see how easy it is to integrate.
