### PR TITLE
Prefer outer `autoload.php` file

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -8,8 +8,8 @@ use \WP_CLI\Dispatcher;
 
 function load_dependencies() {
 	$vendor_paths = array(
-		WP_CLI_ROOT . '/vendor',           // top-level project
-		WP_CLI_ROOT . '/../../../vendor',  // part of a larger project
+		WP_CLI_ROOT . '/../../../vendor',  // part of a larger project / installed via Composer (preferred)
+		WP_CLI_ROOT . '/vendor',           // top-level project / installed as Git clone
 	);
 
 	$has_autoload = false;


### PR DESCRIPTION
When WP-CLI is installed as part of a larger project, it should ignore the local `./vendor/autoload.php` file.

The only reason that was not the case was because executing `vendor/bin/behat` was the recommended way of running the test suite, but that has changed since #665 landed.

The `./vendor/autoload.php` file is still useful when cloning directly from Github and we rely on it in the Travis CI script.
