### PR TITLE
Backport #674 to 0.11 branch

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -95,7 +95,7 @@ Feature: Manage WordPress installation
     When I run `wp eval 'var_export( is_admin() );'`
     Then STDOUT should be:
       """
-      true
+      false
       """ 
 
     When I run `wp eval 'var_export( function_exists( 'media_handle_upload' ) );'`

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -220,6 +220,9 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	}
 
 	protected function _list( $_, $format ) {
+		// Force WordPress to check for updates
+		call_user_func( $this->upgrade_refresh );
+
 		$values = array(
 			'format' => 'table',
 			'fields' => $this->fields

--- a/php/wp-cli.php
+++ b/php/wp-cli.php
@@ -19,20 +19,14 @@ WP_CLI::get_runner()->before_wp_load();
 // Load wp-config.php code, in the global scope
 eval( WP_CLI::get_runner()->get_wp_config_code() );
 
-// Simulate a /wp-admin/ page load
-$_SERVER['PHP_SELF'] = '/wp-admin/index.php';
-define( 'WP_ADMIN', true );
-define( 'WP_NETWORK_ADMIN', false );
-define( 'WP_USER_ADMIN', false );
-
 // Load Core, mu-plugins, plugins, themes etc.
 require WP_CLI_ROOT . '/php/wp-settings-cli.php';
 
 // Fix memory limit. See http://core.trac.wordpress.org/ticket/14889
 @ini_set( 'memory_limit', -1 );
 
+// Load all the admin APIs, for convenience
 require ABSPATH . 'wp-admin/includes/admin.php';
-do_action( 'admin_init' );
 
 WP_CLI::get_runner()->after_wp_load();
 


### PR DESCRIPTION
10845a747904cf2a6ddefbf9b6c07e1d769238c2 fixes a lot of bugs and shouldn't be too hard to apply to the 0.11.1 tag.

Context: https://twitter.com/grhmc/status/368080768649547777

Ref #674 
