### PR TITLE
Add utility method for getting the path to the top-level directory

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -65,6 +65,19 @@ class Runner {
 		return false;
 	}
 
+	public function get_toplevel_dir() {
+		if ( null === $this->config_path ) {
+			trigger_error( __METHOD__ . ' called too early.', E_USER_WARNING );
+			return false;
+		}
+
+		if ( false === $this->config_path ) {
+			return rtrim( ABSPATH, '/' );
+		}
+
+		return dirname( $this->config_path );
+	}
+
 	private static function set_wp_root( $config ) {
 		$path = getcwd();
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -54,6 +54,13 @@ class WP_CLI {
 		return $runner;
 	}
 
+	/**
+	 * Returns the directory that contains the project's wp-cli.yml file and/or the wp-load.php file.
+	 */
+	static function get_toplevel_dir() {
+		return self::get_runner()->get_toplevel_dir();
+	}
+
 	static function colorize( $string ) {
 		return \cli\Colors::colorize( $string, self::get_runner()->in_color() );
 	}


### PR DESCRIPTION
To fix wp-cli/server-command#3, we'd need the equivalent of `git rev-parse --show-toplevel` from WP-CLI.
