### PR TITLE
Add support for --prompt option for wp core config

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -168,12 +168,14 @@ class WP_CLI {
 	 * Function for reading a value from user.
 	 * 
 	 * @see sprintf()
-	 * 
+	 *
+	 * @param string $question the quesiton to be asked
 	 * @param string $format the format for the input - %s, %d, %f etc.
 	 * 
 	 * @return string input from user.
 	 */
-	static function ask( $format = '%s' ) {
+	static function ask( $question, $format = '%s' ) {
+		WP_CLI::line( $question );
 		try {
 			$input = cli\input( $format );
 			

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -189,12 +189,9 @@ class Core_Command extends WP_CLI_Command {
 		);
 		
 		if( isset( $assoc_args['prompt'] ) ) {
-			WP_CLI::line( '(1/3) --dbname=' );
-			$dbname = WP_CLI::ask();
-			WP_CLI::line( '(2/3) --dbuser=' );
-			$dbuser = WP_CLI::ask();
-			WP_CLI::line( '(3/3) --dbpass=' );
-			$dbpass = WP_CLI::ask();
+			$dbname = WP_CLI::ask( '(1/3) --dbname=' );
+			$dbuser = WP_CLI::ask( '(2/3) --dbuser=' );
+			$dbpass = WP_CLI::ask( '(3/3) --dbpass=' );
 			
 			$assoc_args['dbname'] = $dbname;
 			$assoc_args['dbuser'] = $dbuser;


### PR DESCRIPTION
As per @danielbachhuber's #673, adding a proposal for `--prompt` support for `wp core config`.

It's reusing `cli\input` as one of the cli-tools functions as @scribu mentioned [here](https://github.com/wp-cli/wp-cli/pull/600). Not sure about the right fallback as the Synopsis validation had to be updated to support the --prompt in the first place.
