### PR TITLE
Correct the inline docs for the `--hard` flag on `wp rewrite flush`

### DIFF
--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -13,7 +13,7 @@ class Rewrite_Command extends WP_CLI_Command {
 	 * ## OPTIONS
 	 *
 	 * --hard
-	 * : Perform a hard flush - do not overwrite `.htaccess`. The default is to update `.htaccess` rules as well as rewrite rules in database.
+	 * : Perform a hard flush - update `.htaccess` rules as well as rewrite rules in database.
 	 *
 	 * @synopsis [--hard]
 	 */


### PR DESCRIPTION
The inline docs for `wp rewrite flush --hard` are incorrect. Presumably a remnant of the older behaviour which defaulted to a hard flush.
