### PR TITLE
Fix the `--format` flag for the `wp rewrite dump` command

### DIFF
--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -105,12 +105,22 @@ class Rewrite_Command extends WP_CLI_Command {
 			$rules = array();
 			WP_CLI::warning( 'No rewrite rules.' );
 		}
+		$defaults = array(
+			'format' => ''
+		);
+		$assoc_args = array_merge( $defaults, $assoc_args );
 
-		if ( isset( $assoc_args['json'] ) ) {
-			echo json_encode( $rules );
-		} else {
-			foreach ( $rules as $route => $rule )
-				WP_CLI::line( $route . "\t" . $rule );
+		switch ( $assoc_args['format'] ) {
+
+			case 'json':
+				echo json_encode( $rules );
+				break;
+
+			default:
+				foreach ( $rules as $route => $rule )
+					WP_CLI::line( $route . "\t" . $rule );
+				break;
+
 		}
 	}
 


### PR DESCRIPTION
The `--format` flag for `wp rewrite dump` doesn't work because the code in the `Rewrite_Command::dump()` method still expects the old format `--json` flag instead. This fixes that.
