### PR TITLE
First pass at `wp rewrite server-rules` command for initial feedback

### DIFF
--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -115,6 +115,14 @@ class Rewrite_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Retrieve mod_rewrite formatted rewrite rules to write to .htaccess.
+	 */
+	public function rules() {
+		global $wp_rewrite;
+		echo $wp_rewrite->mod_rewrite_rules();
+	}
+
+	/**
 	 * Expose apache modules if present in config
 	 *
 	 * Implementation Notes: This function exposes a global function


### PR DESCRIPTION
Adding this PR in order to get some feedback.

When you're running a Multisite install, doing a rewrite flush will not update your .htaccess file, even with the `$hard` parameter set to `true`. `flush_rewrite_rules()` calls `save_mod_rewrite_rules()` or `iis7_save_url_rewrite_rules()` depending on your server environment, and both these functions bail out if `is_multisite()` is true (see [wp-admin/includes/misc.php lines 123 and 152](http://core.trac.wordpress.org/browser/tags/3.6/wp-admin/includes/misc.php#L114)).

This means that in order to add the Multisite rewrite rules to your .htaccess file, it has to be done manually. Therefore it would be nice if WP-CLI had a command for echoing the server rewrite rules so you could pipe them (or copy and paste them) into your .htaccess file.

My first patch here doesn't attack Multisite yet because there's actually no function or method in WordPress for getting the server rewrite rules (they're all contained within `wp-admin/network.php`), but it does output the single site rewrite rules so you can see what I mean.

If you think this would be a handy command I'll work on outputting the Multisite rewrite rules. Also there might be a better subcommand name than `wp rewrite rules`.

Feedback welcome.
