### PR TITLE
Add some sorting to the output of `wp role list` and `wp cap list`

### DIFF
--- a/php/commands/cap.php
+++ b/php/commands/cap.php
@@ -25,7 +25,10 @@ class Capabilities_Command extends WP_CLI_Command {
 	public function _list( $args ) {
 		$role_obj = self::get_role( $args[0] );
 
-		foreach ( array_keys( $role_obj->capabilities ) as $cap )
+		$caps = array_keys( $role_obj->capabilities );
+		sort( $caps );
+
+		foreach ( $caps as $cap )
 			WP_CLI::line( $cap );
 	}
 

--- a/php/commands/role.php
+++ b/php/commands/role.php
@@ -49,8 +49,10 @@ class Role_Command extends WP_CLI_Command {
 			$output_role->name = $role['name'];
 			$output_role->role = $key;
 
-			$output_roles[] = $output_role;
+			$output_roles[$key] = $output_role;
 		}
+
+		ksort( $output_roles );
 
 		WP_CLI\Utils\format_items( $params['format'], $output_roles, $fields );
 	}


### PR DESCRIPTION
As per the title. Let's sort the roles and caps lists when they're output so they show up alphabetically.
