### PR TITLE
Fixed regex for better matching EOL when cleaning doc block

### DIFF
--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -11,7 +11,7 @@ class DocParser {
 	}
 
 	private static function remove_decorations( $comment ) {
-		$comment = preg_replace( '|^/\*\*\n|', '', $comment );
+		$comment = preg_replace( '|^/\*\*[\r\n]+|', '', $comment );
 		$comment = preg_replace( '|\n[\t ]*\*/$|', '', $comment );
 		$comment = preg_replace( '|^[\t ]*\* ?|m', '', $comment );
 


### PR DESCRIPTION
`\n` doesn't match end of line in all cases and ends up with all help descriptions equal to `/**` instead of content.
