### PR TITLE
Support for whitespace in file path

### DIFF
--- a/bin/wp
+++ b/bin/wp
@@ -7,8 +7,8 @@
 # https://github.com/88mph/wpadmin/blob/master/wpadmin.php
 
 # Get the absolute path of this executable
-ORIGDIR=$(pwd)
-SELF_PATH=$(cd -P -- "$(dirname -- "$0")" && pwd -P) && SELF_PATH=$SELF_PATH/$(basename -- "$0")
+ORIGDIR="$(pwd)"
+SELF_PATH="$(cd -P -- "$(dirname -- "$0")" && pwd -P)" && SELF_PATH="$SELF_PATH/$(basename -- "$0")"
 
 # Resolve symlinks - this is the equivalent of "readlink -f", but also works with non-standard OS X readlink.
 while [ -h "$SELF_PATH" ]; do
@@ -16,18 +16,18 @@ while [ -h "$SELF_PATH" ]; do
 	# 2) cd to the directory of where the symlink points
 	# 3) Get the pwd
 	# 4) Append the basename
-	DIR=$(dirname -- "$SELF_PATH")
-	SYM=$(readlink $SELF_PATH)
-	SELF_PATH=$(cd $DIR && cd $(dirname -- "$SYM") && pwd)/$(basename -- "$SYM")
+	DIR="$(dirname -- "$SELF_PATH")"
+	SYM="$(readlink "$SELF_PATH")"
+	SELF_PATH="$(cd "$DIR" && cd "$(dirname -- "$SYM")" && pwd)/$(basename -- "$SYM")"
 done
 cd "$ORIGDIR"
 
 # Build the path to the root PHP file
-SCRIPT_PATH=$(dirname "$SELF_PATH")/../php/boot-fs.php
+SCRIPT_PATH="$(dirname "$SELF_PATH")/../php/boot-fs.php"
 
 case $(uname -a) in
 	CYGWIN*)
-		SCRIPT_PATH=$(cygpath -w -a -- "$SCRIPT_PATH") ;;
+		SCRIPT_PATH="$(cygpath -w -a -- "$SCRIPT_PATH")" ;;
 esac
 
 if [ ! -z "$WP_CLI_PHP" ] ; then
@@ -36,11 +36,11 @@ if [ ! -z "$WP_CLI_PHP" ] ; then
 else
 	# Default to using the php that we find on the PATH.
 	# Note that we need the full path to php here for Dreamhost, which behaves oddly.  See http://drupal.org/node/662926
-	php=`which php`
+	php="`which php`"
 fi
 
 # Pass in the path to php so that wp-cli knows which one
 # to use if it re-launches itself to run subcommands
-export WP_CLI_PHP_USED=$php
+export WP_CLI_PHP_USED="$php"
 
 exec "$php" $WP_CLI_PHP_ARGS "$SCRIPT_PATH" "$@"


### PR DESCRIPTION
If wp-cli is installed in a directory containing whitespace, it is unable to find required php files. This can be alleviated by quoting file paths in shell script. Note that this has not been thoroughly tested, however it it seems to work fine on OS X.
