### PR TITLE
scaffold plugin-tests: use develop.svn.wordpress.org

### DIFF
--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -26,6 +26,8 @@ install_wp() {
 
 	wget -nv -O /tmp/wordpress.tar.gz http://wordpress.org/${ARCHIVE_NAME}.tar.gz
 	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+
+	wget -nv -O $WP_CORE_DIR/wp-content/db.php https://raw.github.com/markoheijnen/wp-mysqli/master/db.php
 }
 
 install_test_suite() {


### PR DESCRIPTION
See http://make.wordpress.org/core/2013/08/06/a-new-frontier-for-core-development/
