### PR TITLE
Specify DB_CHARSET as default-character-set for wp-db-import

### DIFF
--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -167,6 +167,7 @@ class DB_Command extends WP_CLI_Command {
 			'host' => DB_HOST,
 			'user' => DB_USER,
 			'pass' => DB_PASSWORD,
+			'default-character-set' => DB_CHARSET,
 		) );
 
 		Utils\run_mysql_command( $cmd, $final_args, $descriptors );


### PR DESCRIPTION
A DB export followed by a DB import of the same file was resulting in corrupted UTF-8 characters. The script was being run in the varying-vagrant-vagrants environment which has `latin1` as the default charset, which was not the same as the `DB_CHARSET` of `utf-8`:

```
mysql> show variables like "character_set_%";
+--------------------------+----------------------------+
| Variable_name            | Value                      |
+--------------------------+----------------------------+
| character_set_client     | latin1                     |
| character_set_connection | latin1                     |
| character_set_database   | latin1                     |
| character_set_filesystem | binary                     |
| character_set_results    | latin1                     |
| character_set_server     | latin1                     |
| character_set_system     | utf8                       |
| character_sets_dir       | /usr/share/mysql/charsets/ |
+--------------------------+----------------------------+
```
