### PR TITLE
Allow additional fields to be added to the user when importing a CSV of users

### DIFF
--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -638,6 +638,8 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 				delete_user_option( $user_id, 'user_level' );
 			}
 
+			do_action( 'wp_cli_import_csv_user', $user_id, $new_user );
+
 			if ( !empty( $existing_user ) ) {
 				WP_CLI::success( $new_user['user_login'] . " updated" );
 			} else {


### PR DESCRIPTION
Our CSV includes Google Profile and Twitter columns. We'd like to make sure this data is added to user meta when the user is created.

An alternative approach is to use core's `user_contactmethods` filter:
http://core.trac.wordpress.org/browser/trunk/src/wp-includes/user.php#L1551

However, the alternative approach seems like a hack and I'm not sure what negative consequences it has.

@scribu How do you feel about this?
