### PR TITLE
Fix `update --all`

### DIFF
--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -31,6 +31,9 @@ Feature: Manage WordPress themes and plugins
     When I run `wp <type> update <item>`
     Then STDOUT should not be empty
 
+    When I run `wp <type> update --all`
+    Then STDOUT should not be empty
+
     When I run `wp <type> status <item>`
     Then STDOUT should not contain:
       """

--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -311,7 +311,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *
 	 *     wp plugin update --all
 	 *
-	 * @synopsis <plugin>... [--version=<version>] [--all] [--dry-run]
+	 * @synopsis [<plugin>...] [--version=<version>] [--all] [--dry-run]
 	 */
 	function update( $args, $assoc_args ) {
 		if ( isset( $assoc_args['version'] ) && 'dev' == $assoc_args['version'] ) {

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -335,7 +335,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 	 *
 	 *     wp theme update --all
 	 *
-	 * @synopsis <theme>... [--version=<version>] [--all] [--dry-run]
+	 * @synopsis [<theme>...] [--version=<version>] [--all] [--dry-run]
 	 */
 	function update( $args, $assoc_args ) {
 		parent::update_many( $args, $assoc_args );


### PR DESCRIPTION
After 6dec5cb7aea69dc4aa0e7586f2c16732aefab6b0, `wp plugin update --all` doesn't work anymore, because `<plugin>...` is not optional in its synopsis.

Originally reported by @danielbachhuber in https://github.com/wp-cli/wp-cli/pull/720#issuecomment-24178700

The bigger concern is that we don't have any tests for `update --all`.
