### PR TITLE
allow (but ignore) a leading "[no-]" before flag name in @synopsis

### DIFF
--- a/php/WP_CLI/SynopsisParser.php
+++ b/php/WP_CLI/SynopsisParser.php
@@ -44,7 +44,7 @@ class SynopsisParser {
 			$param['type'] = 'generic';
 		} elseif ( preg_match( "/^<$p_value>$/", $token, $matches ) ) {
 			$param['type'] = 'positional';
-		} elseif ( preg_match( "/^--$p_name/", $token, $matches ) ) {
+		} elseif ( preg_match( "/^--(?:\\[no-\\])?$p_name/", $token, $matches ) ) {
 			$param['name'] = $matches[1];
 
 			$value = substr( $token, strlen( $matches[0] ) );


### PR DESCRIPTION
`no-` prefix on flag name sets it to `false`, but there was no valid way to show this in usage synopsis. Showing this is relevant for flags with a dynamic default value (like `--color` config flag).  This change makes `@synopsis [--[no-]flag]` valid.
