### PR TITLE
`WP_CLI::confirm()` doesn't flush output

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -152,7 +152,7 @@ class WP_CLI {
 	 */
 	static function confirm( $question, $assoc_args = array() ) {
 		if ( !isset( $assoc_args['yes'] ) ) {
-			echo $question . " [y/n] ";
+			fwrite( STDOUT, $question . " [y/n] " );
 
 			$answer = trim( fgets( STDIN ) );
 


### PR DESCRIPTION
It uses `echo`, instead of `fwrite()`.
