### PR TITLE
Trimmed whitespace on extracted synopsis lines

### DIFF
--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -25,8 +25,8 @@ class Subcommand extends CompositeCommand {
 	}
 
 	private static function extract_synopsis( $longdesc ) {
-		preg_match_all( '/(.+)\n:/', $longdesc, $matches );
-		return implode( ' ', array_map( 'trim', $matches[1] ) );
+		preg_match_all( '/(.+?)[\r\n]+:/', $longdesc, $matches );
+		return implode( ' ', $matches[1] );
 	}
 
 	function get_synopsis() {


### PR DESCRIPTION
Fixes #770 on Windows

Regex just above doesn't match end of line completely and it gets into strings, completely messing up implode.
