### PR TITLE
Add `wp comment update` subcommand

### DIFF
--- a/features/comment.feature
+++ b/features/comment.feature
@@ -3,7 +3,7 @@ Feature: Manage WordPress comments
   Scenario: Creating/updating/deleting comments
     Given a WP install
 
-    When I run `wp comment create --comment_post_ID=1 --comment_content='Hello' --porcelain`
+    When I run `wp comment create --comment_post_ID=1 --comment_content='Hello' --comment_author='Billy' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {COMMENT_ID}
 
@@ -12,6 +12,14 @@ Feature: Manage WordPress comments
       """
 	  Success: Comment with ID {COMMENT_ID} exists.
       """
+
+    When I run `wp comment update {COMMENT_ID} --comment_author='Johnny'`
+    Then STDOUT should not be empty
+
+    When I run `wp comment get {COMMENT_ID}`
+    Then STDOUT should be a table containing rows:
+      | Field           | Value  |
+      | comment_author  | Johnny |
 
     When I run `wp comment delete {COMMENT_ID}`
     Then STDOUT should be:

--- a/php/WP_CLI/CommandWithDBObject.php
+++ b/php/WP_CLI/CommandWithDBObject.php
@@ -9,12 +9,15 @@ namespace WP_CLI;
  */
 abstract class CommandWithDBObject extends \WP_CLI_Command {
 
+	protected $obj_type;
+	protected $obj_id_key = 'ID';
+
 	abstract protected function _create( $params );
 	abstract protected function _update( $params );
 	abstract protected function _delete( $obj_id, $assoc_args );
 
 	public function create( $args, $assoc_args ) {
-		unset( $assoc_args['ID'] );
+		unset( $assoc_args[ $this->obj_id_key ] );
 
 		$obj_id = $this->_create( $assoc_args );
 
@@ -36,7 +39,7 @@ abstract class CommandWithDBObject extends \WP_CLI_Command {
 		}
 
 		foreach ( $args as $obj_id ) {
-			$params = array_merge( $assoc_args, array( 'ID' => $obj_id ) );
+			$params = array_merge( $assoc_args, array( $this->obj_id_key => $obj_id ) );
 
 			$status = $this->success_or_failure( $this->wp_error_to_resp(
 				$this->_update( $params ),


### PR DESCRIPTION
This is needed in order to make `Comment_Command` extend `CommandWithDbObject`.
