### PR TITLE
No error reporting if XDebug is not installed

### DIFF
--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -22,8 +22,8 @@ function wp_debug_mode() {
 		\wp_debug_mode();
 	}
 
-	// Never show errors on STDOUT; only on STDERR
-	ini_set( 'display_errors', false );
+	// XDebug already sends errors to STDERR
+	ini_set( 'display_errors', function_exists( 'xdebug_debug_zval' ) ? false : 'STDERR' );
 }
 
 function replace_wp_die_handler() {


### PR DESCRIPTION
The following table describes where errors are sent in various situations: 

|  | XDebug enabled | XDebug disabled |
| --- | :-- | :-- |
| display_errors => true | STDOUT, STDERR | STDOUT |
| display_errors => false | STDERR | - |

WP-CLI currently always sets display_errors => false, so users that don't have XDebug installed will see no errors.
