### PR TITLE
Apply default filters in content in `wp post edit`

### DIFF
--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -123,7 +123,9 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	}
 
 	protected function _edit( $content, $title ) {
-		return \WP_CLI\Utils\launch_editor_for_input( $content, $title );
+		$content = apply_filters( 'the_editor_content', $content );
+		$output = \WP_CLI\Utils\launch_editor_for_input( $content, $title );
+		return apply_filters( 'content_save_pre', $output );
 	}
 
 	/**


### PR DESCRIPTION
I noticed that without applying the `the_editor_content` and
`content_save_pre` filters to the post content being edited, unexpected
things could happen when editing posts with the system editor. For
example, the Syntaxhighlighter Extended plugin uses these filters cto
decode entities when retrieving a post from that database to edit, and
then re-encode them on save.

There may be some extra thought required as to what the expected behavior
should be, but this apporach seems to make the most sense to me.
