### PR TITLE
framework: Allow third-party Mustache templates

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -442,7 +442,10 @@ function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
 }
 
 function mustache_render( $template_name, $data ) {
-	$template = file_get_contents( WP_CLI_ROOT . "/templates/$template_name" );
+	if ( ! file_exists( $template_name ) )
+		$template_name = WP_CLI_ROOT . "/templates/$template_name";
+
+	$template = file_get_contents( $template_name );
 
 	$m = new \Mustache_Engine;
 


### PR DESCRIPTION
Allow arbitrary mustache template to be supplied in mustache_render, to allow for --template in other commands.

Perhaps this isn't the way it's preferred to be done (is an argument better?), but consider this a starting point in the conversation.
