### PR TITLE
`wp rewrite structure` fails to properly set tag / category rewrite rules

### DIFF
--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -72,6 +72,7 @@ class Rewrite_Command extends WP_CLI_Command {
 			$category_base = $assoc_args['category-base'];
 			if ( ! empty( $category_base ) )
 				$category_base = $blog_prefix . preg_replace('#/+#', '/', '/' . str_replace( '#', '', $category_base ) );
+			$this->register_taxonomy_rewrite( 'category', $category_base );
 			$wp_rewrite->set_category_base( $category_base );
 		}
 
@@ -80,6 +81,7 @@ class Rewrite_Command extends WP_CLI_Command {
 			$tag_base = $assoc_args['tag-base'];
 			if ( ! empty( $tag_base ) )
 				$tag_base = $blog_prefix . preg_replace('#/+#', '/', '/' . str_replace( '#', '', $tag_base ) );
+			$this->register_taxonomy_rewrite( 'post_tag', $tag_base );
 			$wp_rewrite->set_tag_base( $tag_base );
 		}
 
@@ -164,6 +166,38 @@ class Rewrite_Command extends WP_CLI_Command {
 				return WP_CLI::get_config( 'apache_modules' );
 			}
 		}
+	}
+
+	/**
+	 * Register either category or post_tag rewrite args
+	 */
+	private function register_taxonomy_rewrite( $taxonomy, $slug ) {
+		global $wp_rewrite;
+
+		switch ( $taxonomy ) {
+			case 'category':
+				$args = array(
+					'hierarchical' => true,
+					'slug' => $slug ? $slug : 'category',
+					'with_front' => ! $slug || $wp_rewrite->using_index_permalinks(),
+					'ep_mask' => EP_CATEGORIES,
+				);
+			case 'post_tag':
+				$args =  array(
+					'hierarchical' => false,
+					'slug' => $slug ? $slug : 'tag',
+					'with_front' => ! $slug || $wp_rewrite->using_index_permalinks(),
+					'ep_mask' => EP_TAGS,
+				);
+		}
+
+		if ( $args['hierarchical'] )
+			$tag = '(.+?)';
+		else
+			$tag = '([^/]+)';
+
+		add_rewrite_tag( "%$taxonomy%", $tag, "{$taxonomy}=" );
+		add_permastruct( $taxonomy, "{$args['slug']}/%$taxonomy%", $args );
 	}
 }
 


### PR DESCRIPTION
Steps to reproduce:

```
wp rewrite structure /blog/%year%/%monthnum%/%day%/%postname%/ --category-base=section --tag-base=topic
wp rewrite flush
wp rewrite structure /blog/%year%/%monthnum%/%day%/%postname%/ --category-base=sections --tag-base=topics
wp rewrite list
```

Expected: the rewrite rules include plural versions of regex for category / tag base.

Actual: the rewrite rules still use the singular versions of the regex.

Had to include an extra `wp rewrite flush` in the functional tests to get them to pass: https://github.com/wp-cli/wp-cli/commit/610e0e20ac62fc28bf4c1bad5be1788078d247f0#diff-39480501507816ca5cf3aee44a64518fR8
