### PR TITLE
Allow db export to accept all mysqldump args

### DIFF
--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -115,7 +115,7 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 * @alias dump
 	 *
-	 * @synopsis [<file>] [--extended-insert=FALSE] [--comments] [--replace] ...
+	 * @synopsis [<file>] [--extended-insert] [--skip-comments] [--<field>=<value>]
 	 */
 	function export( $args, $assoc_args ) {
 		$assoc_args['result-file'] = $this->get_file_name( $args );


### PR DESCRIPTION
There are a [plethora of options](http://dev.mysql.com/doc/refman/5.1/en/mysqldump.html#idm47027588843088) that `mysqldump` accepts, but WP-CLI does not pass along of the `$assoc_args` into the command. This patch changes that.

Example use case: during development of a site, we commit a test DB dump into the site repo to facilitate collaboration between developers. Developers on the team commit updates to the DB dump so that everyone is working with the same data. We have invoke `mysqldump` with `--extended-insert=FALSE` so that each `INSERT` appears on a separate line, to make the diffs in DB dump updates more manageable; we have to [resort to using `mysqldump`](https://github.com/x-team/config-driven-wp/blob/d8298ed4b54e3fd81d26d7105bf96a578eb9a4fe/bin/dump-db-vvv#L22-L38) because `wp db export` does not accept any of `mysqldump`'s additional arguments.
