### PR TITLE
Show warning if HTTPS request fails

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -83,6 +83,7 @@ class Core_Command extends WP_CLI_Command {
 			return Requests::get( $url, $headers, $options );
 		} catch( Requests_Exception $ex ) {
 			// Handle SSL certificate issues gracefully
+			WP_CLI::warning( $ex->getMessage() );
 			$options['verify'] = false;
 			try {
 				return Requests::get( $url, $headers, $options );


### PR DESCRIPTION
In `Core_Command`, `download` first [tries](https://github.com/wp-cli/wp-cli/blob/master/php/commands/core.php#L71) to access the URL via HTTPS with verification, then falls back to ignoring the certificate. By doing this without a warning, it's basically equivalent to always ignoring verification. (Ditto in `_read`)

As of 1.6, Requests has browser-level SSL verification, so any issues will be with the certificate, not with the library. Hence, any errors here should either kill the request immediately or at least show a warning to the user.
