### PR TITLE
Change cd $(wp theme path) to cd $(wp plugin path) in plugin.php

### DIFF
--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -220,7 +220,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     cd $(wp theme path)
+	 *     cd $(wp plugin path)
 	 */
 	function path( $args, $assoc_args ) {
 		$path = untrailingslashit( WP_PLUGIN_DIR );


### PR DESCRIPTION
Hallo
Introduced a slight change in the  `php/commands/plugin.php`
`cd $(wp theme path)`
to
`cd $(wp plugin path)`
Should I open a similar PR against https://github.com/wp-cli/wp-cli.github.com to lead to changes in the documentation?
Greetings
