### PR TITLE
Core download command failing in VVV

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -87,36 +87,38 @@ class Core_Command extends WP_CLI_Command {
 
 		$phar->extractTo( dirname( $tempdir ), null, true );
 
-		self::_move_overwrite_files( $tempdir, $dest );
+		self::_copy_overwrite_files( $tempdir, $dest );
 
-		rmdir( dirname( $tempdir ) );
+		self::_rmdir( dirname( $tempdir ) );
 	}
 
-	private static function _move_overwrite_files( $source, $dest ) {
-		$flags = FilesystemIterator::SKIP_DOTS
-			| FilesystemIterator::KEY_AS_PATHNAME
-			| FilesystemIterator::CURRENT_AS_FILEINFO;
+	private static function _copy_overwrite_files( $source, $dest ) {
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $source, RecursiveDirectoryIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::SELF_FIRST);
 
-		$dstOffset = strlen( $source );
-
-		foreach( new RecursiveIteratorIterator (
-			new RecursiveDirectoryIterator( $source, $flags ),
-			RecursiveIteratorIterator::CHILD_FIRST
-		) as $src ) {
-			$dst = $dest . substr( $src, $dstOffset );
-			$dstdir = dirname( $dst );
-			if ( ! is_dir( $dstdir ) ) continue;
-
-			if ( $src->isDir() && is_dir( $dst ) ) {
-				rmdir( $src );
-				continue;
+		foreach ( $iterator as $item ) {
+			if ( $item->isDir() ) {
+				$dest_path = $dest . DIRECTORY_SEPARATOR . $iterator->getSubPathName();
+				if ( !is_dir( $dest_path ) ) {
+					mkdir( $dest_path );
+				}
+			} else {
+				copy( $item, $dest . DIRECTORY_SEPARATOR . $iterator->getSubPathName() );
 			}
-
-			// rename() is not reliable inside VMs: https://github.com/wp-cli/wp-cli/issues/853
-			copy( $src, $dst );
-			unlink( $src );
 		}
-		rmdir( $source );
+	}
+
+	private static function _rmdir( $dir ) {
+		$files = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $dir, RecursiveDirectoryIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+
+		foreach ( $files as $fileinfo ) {
+			$todo = $fileinfo->isDir() ? 'rmdir' : 'unlink';
+			$todo( $fileinfo->getRealPath() );
+		}
 	}
 
 	private static function _request( $method, $url, $headers = array(), $options = array() ) {


### PR DESCRIPTION
/cc @jeremyfelt

I'm trying to get `wp core download` working in a directory in a [VVV](https://github.com/10up/varying-vagrant-vagrants) virtual machine. When I run the command I get:

```
root@vvv:/srv/www/vvv-demo-1/htdocs# wp core download
Downloading latest WordPress (en_US)...

Warning: rename(): The first argument to copy() function cannot be a directory in /srv/www/wp-cli/php/commands/core.php on line 114

Warning: rename(/tmp/wp_52703b5c866dc/wordpress/wp-content,/srv/www/vvv-demo-1/htdocs//wp-content): Invalid cross-device link in /srv/www/wp-cli/php/commands/core.php on line 114

Warning: rename(): The first argument to copy() function cannot be a directory in /srv/www/wp-cli/php/commands/core.php on line 114

Warning: rename(/tmp/wp_52703b5c866dc/wordpress/wp-includes,/srv/www/vvv-demo-1/htdocs//wp-includes): Invalid cross-device link in /srv/www/wp-cli/php/commands/core.php on line 114

Warning: rename(): The first argument to copy() function cannot be a directory in /srv/www/wp-cli/php/commands/core.php on line 114

Warning: rename(/tmp/wp_52703b5c866dc/wordpress/wp-admin,/srv/www/vvv-demo-1/htdocs//wp-admin): Invalid cross-device link in /srv/www/wp-cli/php/commands/core.php on line 114

Warning: rmdir(/tmp/wp_52703b5c866dc/wordpress): Directory not empty in /srv/www/wp-cli/php/commands/core.php on line 116

Warning: rmdir(/tmp/wp_52703b5c866dc): Directory not empty in /srv/www/wp-cli/php/commands/core.php on line 92
```

This looks a bit like [PHP bug 54097](https://bugs.php.net/bug.php?id=54097).
