### PR TITLE
Use the SSL CA bundle that Requests includes, rather than relying upon t...

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -126,7 +126,6 @@ class Core_Command extends WP_CLI_Command {
 
 	private static function _request( $method, $url, $headers = array(), $options = array() ) {
 		try {
-			$options['verify'] = true;
 			return Requests::get( $url, $headers, $options );
 		} catch( Requests_Exception $ex ) {
 			// Handle SSL certificate issues gracefully


### PR DESCRIPTION
Use the SSL CA bundle that Requests includes, rather than relying upon the systems CA bundle which is often unavailable, or out of date.
Fixes #859
