### PR TITLE
`wp plugin` fails when plugin bundles another plugin

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -17,7 +17,9 @@ Feature: Manage WordPress plugins
     And the {PLUGIN_DIR}/zombieland/zombieland.php file should exist
     And the {PLUGIN_DIR}/zombieland/phpunit.xml file should exist
 
-    When I run `wp plugin status zombieland`
+    # Check that the inner-plugin is not picked up
+    When I run `mv {PLUGIN_DIR}/plugin1 {PLUGIN_DIR}/zombieland/`
+    And I run `wp plugin status zombieland`
     Then STDOUT should contain:
       """
       Plugin zombieland details:

--- a/php/WP_CLI/Fetchers/Plugin.php
+++ b/php/WP_CLI/Fetchers/Plugin.php
@@ -9,22 +9,30 @@ class Plugin extends Base {
 	public function get( $name ) {
 		$plugins = get_plugins( '/' . $name );
 
-		if ( !empty( $plugins ) ) {
-			$file = $name . '/' . key( $plugins );
-		} else {
-			$file = $name . '.php';
+		// some-plugin/the-plugin.php
+		while ( !empty( $plugins ) ) {
+			$file = key( $plugins );
+			array_shift( $plugins );
 
-			$plugins = get_plugins();
-
-			if ( !isset( $plugins[$file] ) ) {
-				return false;
+			// ignore files inside a plugin's subdirectory (like WP does)
+			if ( dirname( $file ) == '.' ) {
+				return (object) array(
+					'name' => $name,
+					'file' => $name . '/' . $file
+				);
 			}
 		}
 
-		return (object) array(
-			'name' => $name,
-			'file' => $file
-		);
+		// some-plugin.php
+		$file = $name . '.php';
+
+		$plugins = get_plugins();
+
+		if ( isset( $plugins[ $file ] ) ) {
+			return (object) compact( 'name', 'file' );
+		}
+
+		return false;
 	}
 }
 


### PR DESCRIPTION
Create a plugin inside another plugin:

```
$ wp plugin scaffold --skip-tests plugin1
$ wp plugin status plugin1
$ wp plugin scaffold --skip-tests plugin1/demo
$ wp plugin scaffold --skip-tests demo
$ cd $(wp plugin path)
$ mv demo/ plugin1/
```

Now try to activate the parent:

```
$ wp plugin activate plugin1
Warning: Could not activate the 'plugin1' plugin.
```

The root cause is that WP-CLI picks up `plugin1/demo/demo.php`, whereas Core doesn't check a plugin's subdirectories.
