### PR TITLE
Use consistent capitalization for "Add New" in post type scaffold to mat...

### DIFF
--- a/templates/post_type.mustache
+++ b/templates/post_type.mustache
@@ -10,9 +10,9 @@
 		'labels'            => array(
 			'name'                => __( '{{label_plural_ucfirst}}', '{{textdomain}}' ),
 			'singular_name'       => __( '{{label_ucfirst}}', '{{textdomain}}' ),
-			'add_new'             => __( 'Add new {{label}}', '{{textdomain}}' ),
+			'add_new'             => __( 'Add New {{label}}', '{{textdomain}}' ),
 			'all_items'           => __( '{{label_plural_ucfirst}}', '{{textdomain}}' ),
-			'add_new_item'        => __( 'Add new {{label}}', '{{textdomain}}' ),
+			'add_new_item'        => __( 'Add New {{label}}', '{{textdomain}}' ),
 			'edit_item'           => __( 'Edit {{label}}', '{{textdomain}}' ),
 			'new_item'            => __( 'New {{label}}', '{{textdomain}}' ),
 			'view_item'           => __( 'View {{label}}', '{{textdomain}}' ),


### PR DESCRIPTION
A very small update to the `wp scaffold post-type` mustache template that capitalizes "Add new" to "Add New", keeping the UI consistent with built-in post type labels.

![add-new-capitalization](https://f.cloud.github.com/assets/1149744/1525460/3a011284-4bd5-11e3-8c48-6bc5cf6fcf8f.png)
