### PR TITLE
unit tests WP_TESTS_DIR env var necessary

### DIFF
--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -11,7 +11,6 @@ env:
     - WP_VERSION=3.6.1 WP_MULTISITE=1
 
 before_script:
-    - export WP_TESTS_DIR=/tmp/wordpress-tests/
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION 
 
 script: phpunit

--- a/templates/bootstrap.mustache
+++ b/templates/bootstrap.mustache
@@ -1,11 +1,14 @@
 <?php
 
-require_once getenv( 'WP_TESTS_DIR' ) . '/includes/functions.php';
+$_tests_dir = getenv('WP_TESTS_DIR');
+if ( !$_tests_dir ) $_tests_dir = '/tmp/wordpress-tests-lib';
+
+require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
 	require dirname( __FILE__ ) . '/../{{plugin_slug}}.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
-require getenv( 'WP_TESTS_DIR' ) . '/includes/bootstrap.php';
+require $_tests_dir . '/includes/bootstrap.php';
 

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -11,6 +11,7 @@ DB_PASS=$3
 DB_HOST=${4-localhost}
 WP_VERSION=${5-master}
 
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
 WP_CORE_DIR=/tmp/wordpress/
 
 set -ex


### PR DESCRIPTION
Am running the unit tests and wondering if there was need for the `WP_TESTS_DIR` env var. Currently the env var is specified to be declared on the command line with every call to `phpunit` according to the [docs](http://wp-cli.org/blog/plugin-unit-tests.html)

running `phpunit` from a plugin that was scaffolded with the `wp scaffold plugin-tests` will return the following error:

``` log
PHP Fatal error:  require_once(): Failed opening required '/includes/functions.php'
```

This may confuse most non-technical wordpress users. 

Suggestion:
Seeing as how the `unit-tests` are, by default, in the `blog_root/unit-tests` dir, think we should check if the env var `WP_TESTS_DIR` exists, if not then look for `ABSPATH/unit-tests` folder, if not default to throw exception.

 in [bootstrap.php](https://github.com/wp-cli/wp-cli/blob/master/templates/bootstrap.mustache)

``` php
<?php
if( isset( getenv( 'WP_TESTS_DIR' ) )
    define( 'WP_TESTS_DIR', getenv( 'WP_TESTS_DIR' ) );
elseif( file_exists( ABSPATH . '/unit-tests' ) )
    define( 'WP_TESTS_DIR', ABSPATH . '/unit-tests' ) );
else
    throw new Exception( 'Please set the WP_TESTS_DIR' );

require_once WP_TESTS_DIR . '/includes/functions.php';

function _manually_load_plugin() {
    require dirname( __FILE__ ) . '/../$pluginName.php';
}
tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

require WP_TESTS_DIR . '/includes/bootstrap.php';

```
