### PR TITLE
WP_CLI::add_action() and WP_CLI::do_action() are confusing

### DIFF
--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -203,7 +203,7 @@ class Subcommand extends CompositeCommand {
 
 		$this->validate_args( $args, $assoc_args );
 
-		\WP_CLI::do_action( 'before_invoke:' . $this->get_parent()->get_name() );
+		\WP_CLI::do_hook( 'before_invoke:' . $this->get_parent()->get_name() );
 
 		call_user_func( $this->when_invoked, $args, array_merge( $extra_args, $assoc_args ) );
 	}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -133,7 +133,7 @@ class WP_CLI {
 	/**
 	 * Schedule a callback to be executed at a certain point (before WP is loaded).
 	 */
-	static function add_action( $when, $callback ) {
+	static function add_hook( $when, $callback ) {
 		if ( in_array( $when, self::$hooks_passed ) )
 			call_user_func( $callback );
 
@@ -143,7 +143,7 @@ class WP_CLI {
 	/**
 	 * Execute registered callbacks.
 	 */
-	static function do_action( $when ) {
+	static function do_hook( $when ) {
 		self::$hooks_passed[] = $when;
 
 		if ( !isset( self::$hooks[ $when ] ) )
@@ -164,7 +164,7 @@ class WP_CLI {
 		$command = Dispatcher\CommandFactory::create( $name, $class, self::get_root_command() );
 
 		if ( isset( $args['before_invoke'] ) ) {
-			self::add_action( "before_invoke:$name", $args['before_invoke'] );
+			self::add_hook( "before_invoke:$name", $args['before_invoke'] );
 		}
 
 		self::get_root_command()->add_subcommand( $name, $command );


### PR DESCRIPTION
Exhibit A: https://github.com/wp-cli/wp-cli/issues/844#issuecomment-27117617

They have the same names as the WordPress API (`add_action()` and `do_action()`), yet they don't inter-operate and don't even accept all of the same parameters.

One solution would be to give them different names, like `WP_CLI::add_hook()`.

Another solution would be to copy all the code from their WP counterparts. This would mean that both WP-CLI events and WP events would reside in the same namespace. Need to study the implications of this further.
