### PR TITLE
Adding initial framework for a 'doc' command

### DIFF
--- a/php/commands/doc.php
+++ b/php/commands/doc.php
@@ -57,14 +57,16 @@ class Doc_Command extends WP_CLI_Command {
 				$doc = self::get_class_doc( $args[0] );
 			}
 		} else {
-			$args[1] = ltrim( $args[1], '$' );
 			$command = "{$args[0]}::{$args[1]}";
 			if ( method_exists( $args[0], $args[1] ) ) {
 				$type = 'class method';
 				$doc = self::get_method_doc( $args[0], $args[1] );
-			} elseif ( property_exists( $args[0], $args[1] ) ) {
-				$type = 'class property';
-				$doc = self::get_property_doc( $args[0], $args[1] );
+			} else {
+				$args[1] = ltrim( $args[1], '$' );
+				if ( property_exists( $args[0], $args[1] ) ) {
+					$type = 'class property';
+					$doc = self::get_property_doc( $args[0], $args[1] );
+				}
 			}
 		}
 


### PR DESCRIPTION
This is a proposed new command, `doc`. `doc` pulls the PHPDoc for a given function, class, method, or property. I didn't see anything else quite like this, but if I missed something, please let me know.
### Overview

This command uses the [Reflection Library](http://www.php.net/manual/en/book.reflection.php) to pull PHPDoc comments. I'm hoping to get a ball rolling with this PR; as I see it, there's a lot we can add to this, like parsing the docs to display them in a more elegant way.
### Examples

```
$ wp doc get_permalink
Success: 
Documentation for function 'get_permalink()'
============================================
/**
 * Retrieve full permalink for current post or post ID.
 *
 * @since 1.0.0
 *
 * @param int|WP_Post $id Optional. Post ID or post object, defaults to the current post.
 * @param bool $leavename Optional. Whether to keep post name or page name, defaults to false.
 * @return string|bool The permalink URL or false if post does not exist.
 */
```

```
$ wp doc WP_Query parse_query
Success: 
Documentation for class method 'WP_Query::parse_query()'
========================================================
/**
 * Parse a query string and set query type booleans.
 *
 * @since 1.5.0
 * @access public
 *
 * @param string|array $query Optional query.
 */
```
### Notes
- As far as I know, this should work in all PHP 5 environments. I don't believe any additional extensions need to be installed.
- With the recent push to document actions & filters, it would be amazing if we could figure out a way to pull the docs for those too.
