### PR TITLE
Cast $category to an int if it's numeric, to pass the term_exists() check

### DIFF
--- a/php/commands/export.php
+++ b/php/commands/export.php
@@ -198,6 +198,10 @@ class Export_Command extends WP_CLI_Command {
 		if ( is_null( $category ) )
 			return true;
 
+		// term_exists() expects an int, not an int as a string, so force it if it's numeric
+		if ( is_numeric( $category ) )
+			$category = (int) $category;
+
 		$term = category_exists( $category );
 		if ( empty( $term ) || is_wp_error( $term ) ) {
 			WP_CLI::warning( sprintf( 'Could not find a category matching %s', $category ) );


### PR DESCRIPTION
`term_exists()` does an `is_int()` check (and not `is_numeric()`), so
if `$category` is an integer as a string, the export will fail.

This casts it to an int (if it's numeric) to ensure `term_exists()`
works correctly under all inputs.

Fixes #894