### PR TITLE
Passwords incorrectly are getting HTML-escaped

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -340,13 +340,20 @@ function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
 	if ( $r ) exit( $r );
 }
 
+/**
+ * Render PHP or other types of files using Mustache templates.
+ *
+ * IMPORTANT: Automatic HTML escaping is disabled!
+ */
 function mustache_render( $template_name, $data ) {
 	if ( ! file_exists( $template_name ) )
 		$template_name = WP_CLI_ROOT . "/templates/$template_name";
 
 	$template = file_get_contents( $template_name );
 
-	$m = new \Mustache_Engine;
+	$m = new \Mustache_Engine( array(
+		'escape' => function ( $val ) { return $val; }
+	) );
 
 	return $m->render( $template, $data );
 }

--- a/templates/man-params.mustache
+++ b/templates/man-params.mustache
@@ -1,7 +1,7 @@
 ## GLOBAL PARAMETERS
 
 {{#parameters}}
-  {{{synopsis}}}
+  {{synopsis}}
       {{desc}}
 
 {{/parameters}}

--- a/templates/man.mustache
+++ b/templates/man.mustache
@@ -1,20 +1,20 @@
 ## NAME
 
-	{{{name}}}
+	{{name}}
 
 ## DESCRIPTION
 
-	{{{shortdesc}}}
+	{{shortdesc}}
 
 ## SYNOPSIS
 
-	{{{synopsis}}}
+	{{synopsis}}
 
 {{#has-subcommands}}
 ## SUBCOMMANDS
 
 {{#subcommands}}
-	{{{.}}}
+	{{.}}
 {{/subcommands}}
 
 {{/has-subcommands}}

--- a/templates/post_type_extended.mustache
+++ b/templates/post_type_extended.mustache
@@ -1,7 +1,7 @@
 <?php
 
 function {{machine_name}}_init() {
-{{{output}}}
+{{output}}
 }
 add_action( 'init', '{{machine_name}}_init' );
 

--- a/templates/taxonomy_extended.mustache
+++ b/templates/taxonomy_extended.mustache
@@ -1,6 +1,6 @@
 <?php
 
 function {{machine_name}}_init() {
-{{{output}}}
+{{output}}
 }
 add_action( 'init', '{{machine_name}}_init' );

--- a/templates/wp-config.mustache
+++ b/templates/wp-config.mustache
@@ -36,7 +36,7 @@ define('DB_COLLATE', '{{dbcollate}}');
  * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
  * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
  */
-{{{keys-and-salts}}}
+{{keys-and-salts}}
 /**#@-*/
 {{/keys-and-salts}}
 
@@ -58,7 +58,7 @@ $table_prefix = '{{dbprefix}}';
  */
 define('WPLANG', '{{locale}}');
 
-{{{extra-php}}}
+{{extra-php}}
 
 /* That's all, stop editing! Happy blogging. */
 


### PR DESCRIPTION
If you pass `&` (or, I will speculate, `<` and `>` as well) as characters of the DB password to `wp core config`, those HTML-sensitive characters get escaped to `&amp;`   (and other HTML entities respectively) incorrectly.
