### PR TITLE
Allow wp-db-export to write to STDOUT if <file> is -

### DIFF
--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -11,7 +11,7 @@ use \WP_CLI\Utils;
  * : Answer yes to the confirmation message.
  *
  * <file>
- * : The name of the export file. If '-', then outputs to STDOUT. If omitted, it will be '{dbname}.sql'.
+ * : The name of the SQL file for import/export. If '-', then inputs from STDIN and outputs to STDOUT. If omitted, it will be '{dbname}.sql'.
  *
  * <SQL>
  * : A SQL query.
@@ -133,21 +133,30 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Import database from a file.
+	 * Import database from a file or from STDIN.
 	 *
 	 * @synopsis [<file>]
 	 */
 	function import( $args, $assoc_args ) {
 		$result_file = $this->get_file_name( $args );
-		if ( !file_exists( $result_file ) ) {
-			WP_CLI::error( sprintf( 'Import file missing: %s', $result_file ) );
-		}
 
-		$descriptors = array(
-			array( 'file', $result_file, 'r' ),
-			STDOUT,
-			STDERR,
-		);
+		if ( '-' === $result_file ) {
+			$descriptors = array(
+				STDIN,
+				STDOUT,
+				STDERR,
+			);
+		} else {
+			if ( ! file_exists( $result_file ) ) {
+				WP_CLI::error( sprintf( 'Import file missing: %s', $result_file ) );
+			}
+
+			$descriptors = array(
+				array( 'file', $result_file, 'r' ),
+				STDOUT,
+				STDERR,
+			);
+		}
 
 		self::run( 'mysql --no-defaults', array(
 			'database' => DB_NAME


### PR DESCRIPTION
I often want to grab the SQL dump form a remote server, just outputting the SQL right over the SSH connection without ever writing it to a file. But with `wp db export` right now, it always generates a file for writing to. So this patch allows writing to `STDOUT` if the `result-file` is `-`.
