### PR TITLE
Simplify STDERR text check in flags.feature

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -40,7 +40,7 @@ Feature: Global flags
       """
     And STDERR should contain:
       """
-      PHP Notice:  Use of undefined constant CONST_WITHOUT_QUOTES
+      Use of undefined constant CONST_WITHOUT_QUOTES
       """
 
   Scenario: Setting the WP user


### PR DESCRIPTION
I ran into a failing flags.feature behat test:

https://github.com/wp-cli/wp-cli/blob/master/features/flags.feature#L43 my Behat tests fail.

Because my error says `Notice` and not `PHP Notice`.
Also there is an extra space less after `Notice:` while mine has only one.

I've got php 5.4.17 built-in with OSX currently. Will be switching to a different custom install because, but still. Weird that the Notice notices are different.
