### PR TITLE
Make `wp import` accept multiple files

### DIFF
--- a/php/commands/import.php
+++ b/php/commands/import.php
@@ -34,6 +34,8 @@ class Import_Command extends WP_CLI_Command {
 
 		$this->add_wxr_filters();
 
+		WP_CLI::log( 'Starting the import process...' );
+
 		foreach ( $args as $file ) {
 			if ( ! is_readable( $file ) ) {
 				WP_CLI::warning( "Can't read $file file." );


### PR DESCRIPTION
`wp export` can generate multiple WXR files, but when it comes time to import them, you have to do it one by one.

Instead, you should be able to use the holy wildcard: `wp import some-batch.*.wxr`
