### PR TITLE
Error activating JetPack

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -498,6 +498,10 @@ class Runner {
 			define( 'WP_LOAD_IMPORTERS', true );
 			define( 'WP_IMPORTING', true );
 		}
+
+		if ( $this->cmd_starts_with( array( 'plugin' ) ) ) {
+			$GLOBALS['pagenow'] = 'plugins.php';
+		}
 	}
 
 	private static function fake_current_site_blog( $url_parts ) {

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -198,7 +198,7 @@ wp_cookie_constants( );
 wp_ssl_constants( );
 
 // Create common globals.
-require( ABSPATH . WPINC . '/vars.php' );
+// require( ABSPATH . WPINC . '/vars.php' );
 
 // Make taxonomies and posts available to plugins and themes.
 // @plugin authors: warning: these get registered again on the init hook.


### PR DESCRIPTION
Fresh install of WordPress 3.8 and JetPack 2.7

When I try to 

> wp plugin activate jetpack

I get the following response:

Fatal error: Cannot redeclare class Featured_Content in /public_html/wp-content/plugins/jetpack/modules/theme-tools/featured-content.php on line 24

Activating the plugin from the interface works just fine.
