### PR TITLE
`wp core is-installed` breaks on multisite

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -84,11 +84,6 @@ Feature: Manage WordPress installation
 
     When I try `wp core is-installed`
     Then the return code should be 1
-    And STDERR should be:
-      """
-      Error: The site you have requested is not installed.
-      Run `wp core install`.
-      """
 
     When I try `wp core install`
     Then the return code should be 1

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -463,10 +463,14 @@ class Runner {
 			exit;
 		}
 
+		if ( $this->cmd_starts_with( array( 'core', 'is-installed' ) ) ) {
+			define( 'WP_INSTALLING', true );
+		}
+
 		if (
 			count( $this->arguments ) >= 2 &&
 			$this->arguments[0] == 'core' &&
-			in_array( $this->arguments[1], array( 'install', 'multisite-install', 'is-installed' ) )
+			in_array( $this->arguments[1], array( 'install', 'multisite-install' ) )
 		) {
 			define( 'WP_INSTALLING', true );
 


### PR DESCRIPTION
Related to #730, `wp-includes/ms-settings.php` uses `$_SERVER['HTTP_HOST']`, and thus causes warnings. In turn, this makes PHP return a `0` status code (sigh).

Looks like we also have to set `WP_INSTALLING` to be able to get past the `die()` calls.
