### PR TITLE
Fix wp plugin delete on Windows fixes #934

### DIFF
--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -568,9 +568,16 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		if ( '.' == $plugin_dir )
 			$plugin_dir = $plugin->file;
 
-		$command = 'rm -rf ' . path_join( WP_PLUGIN_DIR, $plugin_dir );
+		$path = path_join( WP_PLUGIN_DIR, $plugin_dir );
 
-		return ! WP_CLI::launch( $command );
+		if ( \WP_CLI\Utils\is_windows() ) {
+			$command = 'rd /s /q ';
+			$path = str_replace( "/", "\\", $path );
+		} else {
+			$command = 'rm -rf ';
+		}
+
+		return ! WP_CLI::launch( $command . $path );
 	}
 }
 


### PR DESCRIPTION
Sending pull request to fix plugin delete command (also used by uninstall) in Windows machines as requested by @scribu
https://github.com/wp-cli/wp-cli/issues/934#issuecomment-31202322
