### PR TITLE
db str command to output credentials for mysql

### DIFF
--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -137,10 +137,11 @@ class DB_Command extends WP_CLI_Command {
 	 * Output WordPress credentials as MySQL command arguments.
 	 *
 	 * The output will include the hostname, username and password needed to
-	 * connect to the MySQL database for WordPress.
+	 * connect to the MySQL database for WordPress. Useful with MySQL CLI commands.
 	 *
-	 * Useful with MySQL CLI commands, for example with mysqldump:
-	 * $ mysqldump $(wp db args) --lock-tables false
+	 * ## EXAMPLES
+	 *
+	 *     mysqldump $(wp db args) --lock-tables false
 	 */
 	function args() {
 		WP_CLI::out( WP_CLI\Utils\assoc_args_to_str( self::get_mysql_credentials() ) );


### PR DESCRIPTION
As discussed in #817 - a new subcommand for getting just the MySQL credentials formatted as command line arguments.
