### PR TITLE
`wp core download` picks up outer installs

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -8,8 +8,12 @@ Feature: Manage WordPress installation
     Then the return code should be 1
     And STDERR should not be empty
 
-    When I run `wp core download --quiet`
+    When I run `wp core download`
     Then the wp-settings.php file should exist
+
+    When I run `mkdir inner`
+    And I run `cd inner && wp core download`
+    Then the inner/wp-settings.php file should exist
 
   @download
   Scenario: Localized install

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -394,10 +394,6 @@ class Runner {
 		}
 
 		list( $this->config, $this->extra_config ) = $configurator->to_array();
-
-		if ( !isset( $this->config['path'] ) ) {
-			$this->config['path'] = dirname( Utils\find_file_upward( 'wp-load.php' ) );
-		}
 	}
 
 	public function before_wp_load() {
@@ -430,6 +426,13 @@ class Runner {
 		}
 
 		// Handle --path parameter
+		if ( !isset( $this->config['path'] ) ) {
+			if ( $this->cmd_starts_with( array( 'core', 'download' ) ) ) {
+				$this->config['path'] = getcwd();
+			} else {
+				$this->config['path'] = dirname( Utils\find_file_upward( 'wp-load.php' ) );
+			}
+		}
 		self::set_wp_root( $this->config );
 
 		// First try at showing man page


### PR DESCRIPTION
Steps to reproduce:

```
$ mkdir /tmp/test-wp-download && cd /tmp/test-wp-download
$ wp core download
Downloading latest WordPress (en_US)...
Success: WordPress downloaded.
$ mkdir inner && cd inner
$ wp core download
Error: WordPress files seem to already be present here.
```

Original report: https://twitter.com/aaroneaton/status/421469536647266305
