### PR TITLE
Make the taxonomy the first parameter for all term subcommands

### DIFF
--- a/features/site.feature
+++ b/features/site.feature
@@ -59,7 +59,7 @@ Feature: Manage sites in a multisite installation
     When I run `wp post create --post_title='Test post' --post_content='Test content.' --porcelain`
     Then STDOUT should not be empty
 
-    When I run `wp term create 'Test term' post_tag --slug=test --description='This is a test term'`
+    When I run `wp term create post_tag 'Test term' --slug=test --description='This is a test term'`
     Then STDOUT should not be empty
 
     When I run `wp site empty --yes`

--- a/features/term.feature
+++ b/features/term.feature
@@ -4,7 +4,7 @@ Feature: Manage WordPress terms
     Given a WP install
 
   Scenario: Creating/listing a term
-    When I run `wp term create 'Test term' post_tag --slug=test --description='This is a test term' --porcelain`
+    When I run `wp term create post_tag 'Test term' --slug=test --description='This is a test term' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {TERM_ID}
 
@@ -28,18 +28,18 @@ Feature: Manage WordPress terms
       | name      | slug |
       | Test term | test |
 
-    When I run `wp term get {TERM_ID} post_tag`
+    When I run `wp term get post_tag {TERM_ID}`
     Then STDOUT should be a table containing rows:
       | Field     | Value      |
       | term_id   | {TERM_ID}  |
       | name      | Test term  |
 
   Scenario: Creating/deleting a term
-    When I run `wp term create 'Test delete term' post_tag --slug=test-delete --description='This is a test term to be deleted' --porcelain`
+    When I run `wp term create post_tag 'Test delete term' --slug=test-delete --description='This is a test term to be deleted' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {TERM_ID}
 
-    When I run `wp term get {TERM_ID} post_tag --field=slug --format=json`
+    When I run `wp term get post_tag {TERM_ID} --field=slug --format=json`
     Then STDOUT should contain:
       """
       "test-delete"

--- a/php/commands/term.php
+++ b/php/commands/term.php
@@ -64,11 +64,11 @@ class Term_Command extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <term>
-	 * : A name for the new term.
-	 *
 	 * <taxonomy>
 	 * : Taxonomy for the new term.
+	 *
+	 * <term>
+	 * : A name for the new term.
 	 *
 	 * [--slug=<slug>]
 	 * : A unique slug for the new term. Defaults to sanitized version of name.
@@ -84,11 +84,11 @@ class Term_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp term create Apple category --description="A type of fruit"
+	 *     wp term create category Apple --description="A type of fruit"
 	 */
 	public function create( $args, $assoc_args ) {
 
-		list( $term, $taxonomy ) = $args;
+		list( $taxonomy, $term ) = $args;
 
 		$defaults = array(
 			'slug'        => sanitize_title( $term ),
@@ -121,11 +121,11 @@ class Term_Command extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <term-id>
-	 * : ID of the term to get
-	 *
 	 * <taxonomy>
 	 * : Taxonomy of the term to get
+	 *
+	 * <term-id>
+	 * : ID of the term to get
 	 *
 	 * [--field=<field>]
 	 * : Instead of returning the whole term, returns the value of a single field.
@@ -135,12 +135,12 @@ class Term_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp term get 1 category --format=json
+	 *     wp term get category 1 --format=json
 	 */
 	public function get( $args, $assoc_args ) {
 		$formatter = $this->get_formatter( $assoc_args );
 
-		list( $term_id, $taxonomy ) = $args;
+		list( $taxonomy, $term_id ) = $args;
 		$term = get_term_by( 'id', $term_id, $taxonomy );
 		if ( ! $term )
 			WP_CLI::error( "Term doesn't exist." );
@@ -153,11 +153,11 @@ class Term_Command extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <term-id>
-	 * : ID for the term to update.
-	 *
 	 * <taxonomy>
 	 * : Taxonomy of the term to update.
+	 *
+	 * <term-id>
+	 * : ID for the term to update.
 	 *
 	 * [--name=<name>]
 	 * : A new name for the term.
@@ -173,11 +173,11 @@ class Term_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp term update 15 category --name=Apple
+	 *     wp term update category 15 --name=Apple
 	 */
 	public function update( $args, $assoc_args ) {
 
-		list( $term_id, $taxonomy ) = $args;
+		list( $taxonomy, $term_id ) = $args;
 
 		$defaults = array(
 			'name'        => null,


### PR DESCRIPTION
It's just makes more sense: you can pass 0 or more term IDs, but you always need exactly 1 taxonomy.
