### PR TITLE
wp user import-csv users.csv with ID column

### DIFF
--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -561,6 +561,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 
 			// Create the user
 			} else {
+				unset( $new_user['ID'] ); // Unset else it will just return the ID 
 				$user_id = wp_insert_user( $new_user );
 			}
 


### PR DESCRIPTION
**Doesn't work**
First export 
`wp user list --format=csv > users.csv`

Go to clean install and import
`wp user import-csv users.csv` with ID column returns a success message while the users aren't created. 

**Does work**
`wp user list --fields='user_login,display_name,user_email,user_registered,roles' --format=csv > users.csv`
