### PR TITLE
Update WordPress stable in Travis CI template

### DIFF
--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -7,8 +7,8 @@ php:
 env:
     - WP_VERSION=latest WP_MULTISITE=0
     - WP_VERSION=latest WP_MULTISITE=1
-    - WP_VERSION=3.6.1 WP_MULTISITE=0
-    - WP_VERSION=3.6.1 WP_MULTISITE=1
+    - WP_VERSION=3.8 WP_MULTISITE=0
+    - WP_VERSION=3.8 WP_MULTISITE=1
 
 before_script:
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION 


### PR DESCRIPTION
Current `.travis.yml` tests against 3.6.1, but the 3.6 times are gone.
