### PR TITLE
`post_type` should also support multiple arguments

### DIFF
--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -235,7 +235,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 
 		foreach ( $query_args as $key => $query_arg ) {
 			if ( false !== strpos( $key, '__' )
-				|| 'post_type' == $key ) {
+				|| ( 'post_type' == $key && 'any' != $query_arg ) ) {
 				$query_args[$key] = explode( ',', $query_arg );
 			}
 		}


### PR DESCRIPTION
Use case: generate a list of two or more post types, but not all post types
