### PR TITLE
Introduce --skip-plugins flag

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -92,6 +92,55 @@ Feature: Global flags
       log: called 'error' method
       """
 
+  Scenario: Skipping plugins
+    Given a WP install
+    And I run `wp plugin activate hello akismet`
+
+    When I run `wp eval 'var_export( defined("AKISMET_VERSION") );'`
+    Then STDOUT should be:
+      """
+      true
+      """
+
+    When I run `wp eval 'var_export( function_exists( "hello_dolly" ) );'`
+    Then STDOUT should be:
+      """
+      true
+      """
+
+    # The specified plugin should be skipped
+    When I run `wp --skip-plugins=akismet eval 'var_export( defined("AKISMET_VERSION") );'`
+    Then STDOUT should be:
+      """
+      false
+      """
+
+    # The specified plugin should still show up as an active plugin
+    When I run `wp --skip-plugins=akismet plugin status`
+    Then STDOUT should contain:
+      """
+      akismet
+      """
+
+    # The un-specified plugin should continue to be loaded
+    When I run `wp --skip-plugins=akismet eval 'var_export( function_exists( "hello_dolly" ) );'`
+    Then STDOUT should be:
+      """
+      true
+      """
+
+    # No plugins should be loaded when --skip-plugins doesn't have a value
+    When I run `wp --skip-plugins eval 'var_export( defined("AKISMET_VERSION") );'`
+    Then STDOUT should be:
+      """
+      false
+      """
+    When I run `wp --skip-plugins eval 'var_export( function_exists( "hello_dolly" ) );'`
+    Then STDOUT should be:
+      """
+      false
+      """
+
   Scenario: Using --require
     Given an empty directory
     And a custom-cmd.php file:

--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -1,5 +1,7 @@
 <?php
 
+use \WP_CLI\Utils;
+
 /**
  * Manage plugins.
  *
@@ -102,7 +104,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			$version .= ' (%gUpdate available%n)';
 
 		echo WP_CLI::colorize( \WP_CLI\Utils\mustache_render( 'plugin-status.mustache', array(
-			'slug' => $this->get_name( $file ),
+			'slug' => Utils\get_plugin_name( $file ),
 			'status' => $status,
 			'version' => $version,
 			'name' => $details['Name'],
@@ -116,7 +118,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 		foreach ( get_mu_plugins() as $file => $mu_plugin ) {
 			$items[ $file ] = array(
-				'name' => $this->get_name( $file ),
+				'name' => Utils\get_plugin_name( $file ),
 				'status' => 'must-use',
 				'update' => false
 			);
@@ -169,7 +171,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 				if ( $this->get_status( $file ) == "inactive" )
 					continue;
 
-				$name = $this->get_name( $file );
+				$name = Utils\get_plugin_name( $file );
 
 				deactivate_plugins( $file, false, $network_wide );
 
@@ -307,7 +309,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			$update_info = $this->get_update_info( $file );
 
 			$items[ $file ] = array(
-				'name' => $this->get_name( $file ),
+				'name' => Utils\get_plugin_name( $file ),
 				'status' => $this->get_status( $file ),
 				'update' => (bool) $update_info,
 				'update_version' => $update_info['new_version'],
@@ -387,7 +389,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $file, false, false );
 
 		$plugin_obj = (object)array(
-			'name'        => $this->get_name( $file ),
+			'name'        => Utils\get_plugin_name( $file ),
 			'title'       => $plugin_data['Name'],
 			'author'      => $plugin_data['Author'],
 			'version'     => $plugin_data['Version'],
@@ -543,18 +545,6 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		$plugin_file = basename( $file );
 
 		return $plugin_folder[$plugin_file];
-	}
-
-	/**
-	 * Converts a plugin basename back into a friendly slug.
-	 */
-	private function get_name( $file ) {
-		if ( false === strpos( $file, '/' ) )
-			$name = basename( $file, '.php' );
-		else
-			$name = dirname( $file );
-
-		return $name;
 	}
 
 	private function _delete( $plugin ) {

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -28,6 +28,14 @@ return array(
 		'desc' => 'Set the WordPress user',
 	),
 
+	'skip-plugins' => array(
+		'runtime' => '[=<plugin>]',
+		'file' => false,
+		'desc' => 'Skip loading all or some plugins',
+		'multiple' => false,
+		'default' => '',
+	),
+
 	'require' => array(
 		'runtime' => '=<path>',
 		'file' => '<path>',

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -69,3 +69,25 @@ function get_upgrader( $class ) {
 	return new $class( new \WP_CLI\UpgraderSkin );
 }
 
+/**
+ * Converts a plugin basename back into a friendly slug.
+ */
+function get_plugin_name( $basename ) {
+	if ( false === strpos( $basename, '/' ) )
+		$name = basename( $basename, '.php' );
+	else
+		$name = dirname( $basename );
+
+	return $name;
+}
+
+function is_plugin_skipped( $file ) {
+	$name = get_plugin_name( str_replace( WP_PLUGIN_DIR . '/', '', $file ) );
+
+	$skipped_plugins = \WP_CLI::get_runner()->config['skip-plugins'];
+	if ( true === $skipped_plugins )
+		return true;
+
+	return in_array( $name, array_filter( explode( ',', $skipped_plugins ) ) );
+}
+

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -181,7 +181,8 @@ unset( $mu_plugin );
 // Load network activated plugins.
 if ( is_multisite() ) {
 	foreach( wp_get_active_network_plugins() as $network_plugin ) {
-		include_once( $network_plugin );
+		if ( !Utils\is_plugin_skipped( $network_plugin ) )
+			include_once( $network_plugin );
 	}
 	unset( $network_plugin );
 }
@@ -210,7 +211,8 @@ register_theme_directory( get_theme_root() );
 
 // Load active plugins.
 foreach ( wp_get_active_and_valid_plugins() as $plugin )
-	include_once( $plugin );
+	if ( !Utils\is_plugin_skipped( $plugin ) )
+		include_once( $plugin );
 unset( $plugin );
 
 // Load pluggable functions.


### PR DESCRIPTION
Scenario: one particular plugin is preventing WP-CLI from functioning.

You can't run `wp plugin deactivate` because the faulty plugin is loaded before that command is executed.

You might not be able to delete or rename the plugin folder, because it can be a critical component of a production site.

Previous discussion: #940, #966 
