### PR TITLE
Add is-multisite command

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -291,6 +291,25 @@ class Core_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Determine if the WordPress tables are installed.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     if ! $(wp core is-multisite); then
+	 *         wp core multisite-convert
+	 *     fi
+	 *
+	 * @subcommand is-multisite
+	 */
+	public function is_multisite() {
+		if ( is_blog_installed() && is_multisite() ) {
+			exit( 0 );
+		} else {
+			exit( 1 );
+		}
+	}
+
+	/**
 	 * Create the WordPress tables in the database.
 	 *
 	 * ## OPTIONS


### PR DESCRIPTION
This adds `wp core is-multisite`, which goes hand-in-hand with `wp core is-installed`. See #503
