### PR TITLE
WP in subdir only works from the root dir

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -76,6 +76,7 @@ Feature: Have a config file
     Then STDOUT should be empty
 
     When I run `mkdir -p other/subdir`
+    And I run `echo '<?php // Silence is golden' > other/subdir/index.php`
     And I run `wp core is-installed` from 'other/subdir'
     Then STDOUT should be empty
 


### PR DESCRIPTION
In #878 we introduced the ability to detect WP being installed in a subdirectory.

However, this only works if you run WP-CLI from the root dir.

Example:

```
$ ls
index.php wp wp-content wp-config.php
$ wp core version
3.9-alpha
$ cd wp-content
$ wp core version
Error: This does not seem to be a WordPress install.
```

This differs from the usual behavior, where `wp-cli.yml` and `wp-load.php` files are searched up the directory tree.
