### PR TITLE
Add comma as valid character in synopsis parser

### DIFF
--- a/php/WP_CLI/SynopsisParser.php
+++ b/php/WP_CLI/SynopsisParser.php
@@ -36,7 +36,7 @@ class SynopsisParser {
 		list( $param['repeating'], $token ) = self::is_repeating( $token );
 
 		$p_name = '([a-z-_]+)';
-		$p_value = '([a-zA-Z-|]+)';
+		$p_value = '([a-zA-Z-|,]+)';
 
 		if ( '--<field>=<value>' === $token ) {
 			$param['type'] = 'generic';


### PR DESCRIPTION
Add a comma as a valid character in the value field of the synopsis parser.
Example:

```
[--allowed_themes=<themeA,themeB>]
```
