### PR TITLE
fix wp rewrite flush --hard doesn't generate .htaccess

### DIFF
--- a/features/rewrite.feature
+++ b/features/rewrite.feature
@@ -33,3 +33,14 @@ Feature: Manage WordPress rewrites
     Then STDOUT should be CSV containing:
       | match            | query                               | source   |
       | topic/([^/]+)/?$ | index.php?tag=$matches[1]           | post_tag |
+
+  Scenario: Generate .htaccess on hard flush
+    Given a WP install
+    And a wp-cli.yml file:
+      """
+      apache_modules: [mod_rewrite]
+      """
+
+    When I run `wp rewrite structure /%year%/%monthnum%/%day%/%postname%/`
+    And I run `wp rewrite flush --hard`
+    Then the .htaccess file should exist

--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -208,6 +208,9 @@ class Rewrite_Command extends WP_CLI_Command {
 			global $is_apache;
 			$is_apache = true;
 
+			// needed for get_home_path() and .htaccess location
+			$_SERVER['SCRIPT_FILENAME'] = ABSPATH;
+
 			function apache_get_modules() {
 				return WP_CLI::get_config( 'apache_modules' );
 			}


### PR DESCRIPTION
I stumbled in a server using apache and experienced #790 bug, this should fix it.

The problem is that `get_home_path()` uses `$_SERVER['SCRIPT_FILENAME']` that is not available and so the resulting location would be `/.htaccess`

This PR only fills the global variable when its actually needed for the .htaccess, however the same fix could be needed in other functionalities that use `get_home_path()` and it might be appropriate to apply it in wp-cli bootstrap (faking an actual file), but I'll leave this consideration to wp-cli maintainers.

It also looks like that  `get_home_path()` doesn't need `$_SERVER['SCRIPT_FILENAME']` at all and it could just use `ABSPATH` to be more cli friendly, I'll make a note to report it upstream on the trac.
