### PR TITLE
make all mysql command run with --no-defaults; fix #377 regression

### DIFF
--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -53,7 +53,7 @@ class DB_Command extends WP_CLI_Command {
 	 * Optimize the database.
 	 */
 	function optimize() {
-		self::run( Utils\esc_cmd( 'mysqlcheck %s', DB_NAME ), array(
+		self::run( Utils\esc_cmd( 'mysqlcheck --no-defaults %s', DB_NAME ), array(
 			'optimize' => true,
 		) );
 
@@ -64,7 +64,7 @@ class DB_Command extends WP_CLI_Command {
 	 * Repair the database.
 	 */
 	function repair() {
-		self::run( Utils\esc_cmd( 'mysqlcheck %s', DB_NAME ), array(
+		self::run( Utils\esc_cmd( 'mysqlcheck --no-defaults %s', DB_NAME ), array(
 			'repair' => true,
 		) );
 
@@ -133,7 +133,7 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args['result-file'] = $result_file;
 		}
 
-		self::run( Utils\esc_cmd( 'mysqldump %s', DB_NAME ), $assoc_args );
+		self::run( Utils\esc_cmd( 'mysqldump --no-defaults %s', DB_NAME ), $assoc_args );
 
 		if ( ! $stdout ) {
 			WP_CLI::success( sprintf( 'Exported to %s', $result_file ) );


### PR DESCRIPTION
in #377 the .my.cnf interference was fixed by always adding `--defaults-file=/dev/null`, later changed to `--no-defaults`.
a9f7b7c76d6e22f38ae922efa86de13f03324c63 refactored it moving `--no-defaults` from a unique location to the single mysql commands but forgot mysqldump and mysqlcheck
