### PR TITLE
Add -d variables_order=ES to shell scripts.

### DIFF
--- a/bin/wp
+++ b/bin/wp
@@ -43,4 +43,4 @@ fi
 # to use if it re-launches itself to run other commands.
 export WP_CLI_PHP_USED="$php"
 
-exec "$php" $WP_CLI_PHP_ARGS "$SCRIPT_PATH" "$@"
+exec "$php" -d variables_order=ES $WP_CLI_PHP_ARGS "$SCRIPT_PATH" "$@"

--- a/bin/wp.bat
+++ b/bin/wp.bat
@@ -1,2 +1,2 @@
 @ECHO OFF
-php "%~dp0../php/boot-fs.php" %*
+php -d variables_order=ES "%~dp0../php/boot-fs.php" %*


### PR DESCRIPTION
Fixes #950

This needs windows test and how can we fix this for IDEs like netbeans?
