### PR TITLE
Used getenv to grab the path for mysql.

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -329,6 +329,7 @@ function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
 		unset( $assoc_args['pass'] );
 	}
 
+	$env['PATH'] = getenv('PATH');
 	$final_cmd = $cmd . assoc_args_to_str( $assoc_args );
 
 	$proc = proc_open( $final_cmd, $descriptors, $pipes, null, $env );


### PR DESCRIPTION
This fixes #950 and does not change `bin/wp` tried in #1029

`$ wp db cli`

As mentioned in #950 we should not rely on $_ENV altogether but that's not in scope for bug #950
