### PR TITLE
Add support for exporting specific tables

### DIFF
--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -125,6 +125,7 @@ class DB_Command extends WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     wp db dump --add-drop-table
+	 *     wp db dump --tables=wp_options,wp_users
 	 *
 	 * @alias dump
 	 */


### PR DESCRIPTION
There's no way to export only specific tables with `wp db export` (or if there is, I've missed it).

This PR adds a new `--tables` parameter to `wp db export` that allows a comma separated list of table names to be set.
