### PR TITLE
move --format=ids handling to individual commands

### DIFF
--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -240,12 +240,14 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 			}
 		}
 
-		if ( 'ids' == $formatter->format )
+		if ( 'ids' == $formatter->format ) {
 			$query_args['fields'] = 'ids';
-
-		$query = new WP_Query( $query_args );
-
-		$formatter->display_items( $query->posts );
+			$query = new WP_Query( $query_args );
+			echo implode( ' ', $query->posts );
+		} else {
+			$query = new WP_Query( $query_args );
+			$formatter->display_items( $query->posts );
+		}
 	}
 
 	/**

--- a/php/commands/term.php
+++ b/php/commands/term.php
@@ -53,10 +53,13 @@ class Term_Command extends WP_CLI_Command {
 		$assoc_args = array_merge( $defaults, $assoc_args );
 
 		$terms = get_terms( $args, $assoc_args );
-		if ( 'ids' == $formatter->format )
-			$terms = wp_list_pluck( $terms, 'term_id' );
 
-		$formatter->display_items( $terms );
+		if ( 'ids' == $formatter->format ) {
+			$terms = wp_list_pluck( $terms, 'term_id' );
+			echo implode( ' ', $terms );
+		} else {
+			$formatter->display_items( $terms );
+		}
 	}
 
 	/**

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -62,16 +62,20 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 
 		$users = get_users( $assoc_args );
 
-		$it = WP_CLI\Utils\iterator_map( $users, function ( $user ) {
-			if ( !is_object( $user ) )
+		if ( 'ids' == $formatter->format ) {
+			echo implode( ' ', $users );
+		} else {
+			$it = WP_CLI\Utils\iterator_map( $users, function ( $user ) {
+				if ( !is_object( $user ) )
+					return $user;
+
+				$user->roles = implode( ',', $user->roles );
+
 				return $user;
+			} );
 
-			$user->roles = implode( ',', $user->roles );
-
-			return $user;
-		} );
-
-		$formatter->display_items( $it );
+			$formatter->display_items( $it );
+		}
 	}
 
 	/**


### PR DESCRIPTION
I think `--format=ids` was a bad idea (not scalable), so instead of making it work for `wp plugin list` and `wp theme list`, I'm going to limit it to the commands that already supported it.

Fixes #1057
