### PR TITLE
throw error when wp-config.php looks invalid

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -262,13 +262,21 @@ class Runner {
 
 		$wp_config_code = explode( "\n", file_get_contents( $wp_config_path ) );
 
+		$found_wp_settings = false;
+
 		$lines_to_run = array();
 
 		foreach ( $wp_config_code as $line ) {
-			if ( preg_match( '/^\s*require.+wp-settings\.php/', $line ) )
+			if ( preg_match( '/^\s*require.+wp-settings\.php/', $line ) ) {
+				$found_wp_settings = true;
 				continue;
+			}
 
 			$lines_to_run[] = $line;
+		}
+
+		if ( !$found_wp_settings ) {
+			WP_CLI::error( 'Strange wp-config.php file: wp-settings.php is not loaded directly.' );
 		}
 
 		$source = implode( "\n", $lines_to_run );


### PR DESCRIPTION
Fixes #992 

@rarst Could you confirm that this error is triggered for you?
