### PR TITLE
--reasign parameter is ignored on multisite

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -1,9 +1,8 @@
 Feature: Manage WordPress users
 
-  Background:
+  Scenario: User CRUD operations
     Given a WP install
 
-  Scenario: User CRUD operations
     When I try `wp user get bogus-user`
     Then the return code should be 1
     And STDOUT should be empty
@@ -11,7 +10,8 @@ Feature: Manage WordPress users
     When I run `wp user create testuser2 testuser2@example.com --role=author --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {USER_ID}
-    And I run `wp user get {USER_ID}`
+
+    When I run `wp user get {USER_ID}`
     Then STDOUT should be a table containing rows:
       | Field        | Value      |
       | ID           | {USER_ID}  |
@@ -48,6 +48,8 @@ Feature: Manage WordPress users
     Then STDOUT should not be empty
 
   Scenario: Reassigning user posts
+    Given a WP multisite install
+
     When I run `wp user create bob bob@example.com --role=author --porcelain`
     And save STDOUT as {BOB_ID}
 
@@ -69,6 +71,8 @@ Feature: Manage WordPress users
       """
 
   Scenario: Generating and deleting users
+    Given a WP install
+
     When I run `wp user list --role=editor --format=count`
     Then STDOUT should be:
       """
@@ -90,7 +94,8 @@ Feature: Manage WordPress users
       """
 
   Scenario: Importing users from a CSV file
-    Given a users.csv file:
+    Given a WP install
+    And a users.csv file:
       """
       user_login,user_email,display_name,role
       bobjones,bobjones@domain.com,Bob Jones,contributor
@@ -119,6 +124,8 @@ Feature: Manage WordPress users
       """
 
   Scenario: Managing user roles
+    Given a WP install
+
     When I run `wp user add-role 1 editor`
     Then STDOUT should not be empty
     And I run `wp user get 1 --field=roles`
@@ -167,6 +174,8 @@ Feature: Manage WordPress users
       | roles |       |
       
   Scenario: Managing user capabilities
+    Given a WP install
+
     When I run `wp user add-cap 1 edit_vip_product`
     Then STDOUT should be:
       """

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -132,13 +132,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 		parent::_delete( $users, $assoc_args, function ( $user, $assoc_args ) {
 			$user_id = $user->ID;
 
-			if ( is_multisite() ) {
-				$r = wpmu_delete_user( $user_id );
-			} else {
-				$r = wp_delete_user( $user_id, $assoc_args['reassign'] );
-			}
-
-			if ( $r ) {
+			if ( wp_delete_user( $user_id, $assoc_args['reassign'] ) ) {
 				return array( 'success', "Deleted user $user_id." );
 			} else {
 				return array( 'error', "Failed deleting user $user_id." );


### PR DESCRIPTION
i.e. `wp user delete bob --reasign=sally` simply deletes all of Bob's posts, instead of reassigning them to Sally.

The `wpmu_delete_user()` call was introduced in ce99707c049945f10f26bc513b2ac82fefae3721, without a clear reason.

Noticed while working on #1064.
