### PR TITLE
Clear `is_blog_installed` cache before checking

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -288,6 +288,9 @@ class Core_Command extends WP_CLI_Command {
 	 * @subcommand is-installed
 	 */
 	public function is_installed() {
+
+		wp_cache_delete( 'is_blog_installed' );
+
 		if ( is_blog_installed() ) {
 			exit( 0 );
 		} else {
@@ -443,6 +446,9 @@ class Core_Command extends WP_CLI_Command {
 	}
 
 	private function _install( $assoc_args ) {
+
+		wp_cache_delete( 'is_blog_installed' );
+
 		if ( is_blog_installed() ) {
 			return false;
 		}

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -5,6 +5,9 @@
 namespace WP_CLI\Utils;
 
 function wp_not_installed() {
+
+	wp_cache_delete( 'is_blog_installed' );
+
 	if ( !is_blog_installed() && !defined( 'WP_INSTALLING' ) ) {
 		\WP_CLI::error(
 			"The site you have requested is not installed.\n" .


### PR DESCRIPTION
Core utilizes the object cache when checking `is_blog_installed()`. However,
when a persistent object cache is hooked up to the site, `is_blog_installed()`
can return the ghost of a previous WordPress install.
