### PR TITLE
Fail early when search-replace terms are the same

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -44,8 +44,14 @@ Feature: Do global search/replace
   Scenario: Identical search and replace terms
     Given a WP install
 
-    When I run `wp search-replace wp wp`
-    Then STDOUT should be:
+    When I try `wp search-replace wp wp`
+    Then STDERR should be:
       """
       Warning: Use --dry-run for test replacements. Identical <old> and <new> values will not give proper replacement counts.
+      """
+
+    When I try `wp search-replace wp wp --dry-run`
+    Then STDERR should be:
+      """
+      Warning: Identical <old> and <new> values will not give proper replacement counts.
       """

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -40,3 +40,12 @@ Feature: Do global search/replace
       | {SITEURL}/subdir     |           |
       | http://newdomain.com |           |
       | http://newdomain.com | --dry-run |
+
+  Scenario: Identical search and replace terms
+    Given a WP install
+
+    When I run `wp search-replace wp wp`
+    Then STDOUT should be:
+      """
+      Warning: Use --dry-run for test replacements. Identical <old> and <new> values will not give proper replacement counts.
+      """

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -44,13 +44,13 @@ Feature: Do global search/replace
   Scenario: Identical search and replace terms
     Given a WP install
 
-    When I try `wp search-replace wp wp`
+    When I try `wp search-replace foo foo`
     Then STDERR should be:
       """
       Warning: Use --dry-run for test replacements. Identical <old> and <new> values will not give proper replacement counts.
       """
 
-    When I try `wp search-replace wp wp --dry-run`
+    When I try `wp search-replace foo foo --dry-run`
     Then STDERR should be:
       """
       Warning: Identical <old> and <new> values will not give proper replacement counts.

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -49,6 +49,14 @@ class Search_Replace_Command extends WP_CLI_Command {
 	public function __invoke( $args, $assoc_args ) {
 		$old = array_shift( $args );
 		$new = array_shift( $args );
+		if ( $old == $new ) {
+			$msg = 'Identical <old> and <new> values will not give proper replacment counts.';
+			if ( ! isset( $assoc_args['dry-run'] ) ) {
+				$msg = 'Use --dry-run for test replacements. ' . $msg;
+			}
+			WP_CLI::warning( $msg );
+			return;
+		}
 		$total = 0;
 		$report = array();
 		$dry_run = isset( $assoc_args['dry-run'] );

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -55,7 +55,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 				$msg = 'Use --dry-run for test replacements. ' . $msg;
 			}
 			WP_CLI::warning( $msg );
-			return;
+			exit;
 		}
 		$total = 0;
 		$report = array();

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -50,7 +50,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$old = array_shift( $args );
 		$new = array_shift( $args );
 		if ( $old == $new ) {
-			$msg = 'Identical <old> and <new> values will not give proper replacment counts.';
+			$msg = 'Identical <old> and <new> values will not give proper replacement counts.';
 			if ( ! isset( $assoc_args['dry-run'] ) ) {
 				$msg = 'Use --dry-run for test replacements. ' . $msg;
 			}


### PR DESCRIPTION
When doing a search-replace with identical <old> and <new> values, the script will do all the work even though there will be no change. It would be nice to fail early with a warning, and recommend use of the `--dry-run` flag, since the search-replace could take a while on a large database.

I'm sure there are others like me who have the habit of doing test-replacements this way from using tools that don't have a have test/dry-run mode.