### PR TITLE
Abstract behat testing framework for use in community packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
     - secure: "TVMYSuxuZojZUHn3R9me8FCA1V6RaOTNE6A5gta7LSTtqZFLAQOer6tfLVof5fB3SHh2ANcOYPpjO729Mcrg195p1I/0nS18WZ0BVYvsN0Dob1I79rqYvsaW8syxCd/6TZvr7XZYdd1fDtt7kxsv74SljkliYwI2mTniQDxMONE="
     - secure: "OqbgLy6Rn+NvhjpYygNZDWf6rj8sVejRZJBmssNi5fHRXopEtfIHids2FjSXZUVPs3ShqNuczo1jzgt7N3JHbcSaiedHlc7ONqDK0SyyOcsv1oKOR81bvYcL/KIoGiMRvkQI5IW01YWfSZlS0wgL2NYdJvYanCnSUUv6nNZAF7E="
   matrix:
-    - WP_VERSION=3.9-beta1
+    - WP_VERSION=3.9-RC1
     - WP_VERSION=3.5.2 DEPLOY_BRANCH=master
 
 matrix:

--- a/features/core.feature
+++ b/features/core.feature
@@ -101,6 +101,9 @@ Feature: Manage WordPress installation
     When I try `wp core is-installed`
     Then the return code should be 1
 
+    When I try `wp core is-installed --network`
+    Then the return code should be 1
+
     When I try `wp core install`
     Then the return code should be 1
     And STDERR should contain:
@@ -116,6 +119,9 @@ Feature: Manage WordPress installation
       """
       http://localhost:8001
       """
+
+    When I try `wp core is-installed --network`
+    Then the return code should be 1
 
   Scenario: Install WordPress by prompting
     Given an empty directory
@@ -169,7 +175,10 @@ Feature: Manage WordPress installation
     Then STDOUT should be:
       """
       false
-      """ 
+      """
+
+    When I try `wp core is-installed --network`
+    Then the return code should be 1
 
     When I run `wp core install-network --title='test network'`
     Then STDOUT should not be empty
@@ -178,7 +187,10 @@ Feature: Manage WordPress installation
     Then STDOUT should be:
       """
       true
-      """ 
+      """
+
+    When I run `wp core is-installed --network`
+    Then the return code should be 0
 
     When I try `wp core install-network --title='test network'`
     Then the return code should be 1

--- a/features/sidebar.feature
+++ b/features/sidebar.feature
@@ -1,0 +1,12 @@
+Feature: Manage WordPress sidebars
+
+  Scenario: List available sidebars
+    Given a WP install
+
+    When I run `wp theme install p2 --activate`
+    Then STDOUT should not be empty
+
+    When I run `wp sidebar list --fields=name,id`
+    Then STDOUT should be a table containing rows:
+      | name       | id        |
+      | Sidebar    | sidebar-1 |

--- a/features/widget.feature
+++ b/features/widget.feature
@@ -1,0 +1,77 @@
+Feature: Manage widgets in WordPress sidebar
+
+  Scenario: Widget CRUD
+    Given a WP install
+
+    When I run `wp theme install p2 --activate`
+    Then STDOUT should not be empty
+
+    When I run `wp widget list sidebar-1 --fields=name,id,position`
+    Then STDOUT should be a table containing rows:
+      | name            | id                | position |
+      | search          | search-2          | 1        |
+      | recent-posts    | recent-posts-2    | 2        |
+      | recent-comments | recent-comments-2 | 3        |
+      | archives        | archives-2        | 4        |
+      | categories      | categories-2      | 5        |
+      | meta            | meta-2            | 6        |
+
+    When I run `wp widget move recent-comments-2 --position=2`
+    Then STDOUT should not be empty
+
+    When I run `wp widget list sidebar-1 --fields=name,id,position`
+    Then STDOUT should be a table containing rows:
+      | name            | id                | position |
+      | search          | search-2          | 1        |
+      | recent-comments | recent-comments-2 | 2        |
+      | recent-posts    | recent-posts-2    | 3        |
+      | archives        | archives-2        | 4        |
+      | categories      | categories-2      | 5        |
+      | meta            | meta-2            | 6        |
+
+    When I run `wp widget move recent-comments-2 --sidebar-id=wp_inactive_widgets`
+    Then STDOUT should not be empty
+
+    When I run `wp widget deactivate meta-2`
+    Then STDOUT should not be empty
+
+    When I run `wp widget list sidebar-1 --fields=name,id,position`
+    Then STDOUT should be a table containing rows:
+      | name            | id                | position |
+      | search          | search-2          | 1        |
+      | recent-posts    | recent-posts-2    | 2        |
+      | archives        | archives-2        | 3        |
+      | categories      | categories-2      | 4        |
+
+    When I run `wp widget list wp_inactive_widgets --fields=name,id,position`
+    Then STDOUT should be a table containing rows:
+      | name            | id                | position |
+      | meta            | meta-2            | 1        |
+      | recent-comments | recent-comments-2 | 2        |
+
+    When I run `wp widget delete archives-2 recent-posts-2`
+    Then STDOUT should not be empty
+
+    When I run `wp widget list sidebar-1 --fields=name,id,position`
+    Then STDOUT should be a table containing rows:
+      | name            | id                | position |
+      | search          | search-2          | 1        |
+      | categories      | categories-2      | 2        |
+
+    When I run `wp widget add calendar sidebar-1 2`
+    Then STDOUT should not be empty
+
+    When I run `wp widget list sidebar-1 --fields=name,id,position`
+    Then STDOUT should be a table containing rows:
+      | name            | id                | position |
+      | search          | search-2          | 1        |
+      | calendar        | calendar-1        | 2        |
+      | categories      | categories-2      | 3        |
+
+    When I run `wp widget update calendar-1 --title="Calendar"`
+    Then STDOUT should not be empty
+
+    When I run `wp widget list sidebar-1 --fields=name,position,options`
+    Then STDOUT should be a table containing rows:
+      | name            | position | options               |
+      | calendar        | 2        | {"title":"Calendar"}  |

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -279,6 +279,9 @@ class Core_Command extends WP_CLI_Command {
 	/**
 	 * Determine if the WordPress tables are installed.
 	 *
+	 * [--network]
+	 * : Check if this is a multisite install
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     if ! $(wp core is-installed); then
@@ -287,8 +290,15 @@ class Core_Command extends WP_CLI_Command {
 	 *
 	 * @subcommand is-installed
 	 */
-	public function is_installed() {
-		if ( is_blog_installed() ) {
+	public function is_installed( $_, $assoc_args ) {
+
+		if ( isset( $assoc_args['network'] ) ) {
+			if ( is_blog_installed() && is_multisite() ) {
+				exit( 0 );
+			} else {
+				exit( 1 );
+			}
+		} else if ( is_blog_installed() ) {
 			exit( 0 );
 		} else {
 			exit( 1 );

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -236,7 +236,8 @@ class Media_Command extends WP_CLI_Command {
 			if ( $intermediate_path == $original_path )
 				continue;
 
-			unlink( $intermediate_path );
+			if ( file_exists( $intermediate_path ) )
+				unlink( $intermediate_path );
 		}
 	}
 }

--- a/php/commands/sidebar.php
+++ b/php/commands/sidebar.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Manage sidebars.
+ */
+class Sidebar_Command extends WP_CLI_Command {
+
+	private $fields = array(
+		'name',
+		'id',
+		'description'
+	);
+
+	/**
+	 * List registered sidebars.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--fields=<fields>]
+	 * : Limit the output to specific object fields. Defaults to name, id, description
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, csv, json, count. Default: table
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp sidebar list --fields=name,id --format=csv
+	 *
+	 * @subcommand list
+	 */
+	public function list_( $args, $assoc_args ) {
+		global $wp_registered_sidebars;
+
+		\WP_CLI\Utils\wp_register_unused_sidebar();
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, $this->fields );
+		$formatter->display_items( $wp_registered_sidebars );
+	}
+
+}
+
+WP_CLI::add_command( 'sidebar', 'Sidebar_Command' );

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -163,6 +163,9 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	 * [--display_name=<name>]
 	 * : The display name.
 	 *
+	 * [--send-email]
+	 * : Send an email to the user with their new account details.
+	 *
 	 * [--porcelain]
 	 * : Output just the new user id.
 	 *
@@ -201,6 +204,9 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 		$user->role = $role;
 
 		$user_id = wp_insert_user( $user );
+		if ( isset( $assoc_args['send-email'] ) ) {
+			wp_new_user_notification( $user_id, $user->user_pass );
+		}
 
 		if ( is_wp_error( $user_id ) ) {
 			WP_CLI::error( $user_id );
@@ -505,6 +511,9 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	 * <file>
 	 * : The CSV file of users to import.
 	 *
+	 * [--send-email]
+	 * : Send an email to new users with their account details.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp user import-csv /path/to/users.csv
@@ -564,6 +573,9 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 			} else {
 				unset( $new_user['ID'] ); // Unset else it will just return the ID
 				$user_id = wp_insert_user( $new_user );
+				if ( isset( $assoc_args['send-email'] ) ) {
+					wp_new_user_notification( $user_id, $new_user['user_pass'] );
+				}
 			}
 
 			if ( is_wp_error( $user_id ) ) {

--- a/php/commands/widget.php
+++ b/php/commands/widget.php
@@ -1,0 +1,489 @@
+<?php
+
+/**
+ * Manage sidebar widgets.
+ *
+ * ## EXAMPLES
+ *
+ *     # List widgets on a given sidebar
+ *     wp widget list sidebar-1
+ *
+ *     # Add a calendar widget to the second position on the sidebar
+ *     wp widget add calendar sidebar-1 2
+ *
+ *     # Update option(s) associated with a given widget
+ *     wp widget update calendar-1 --title="Calendar"
+ *
+ *     # Delete one or more widgets entirely
+ *     wp widget delete calendar-2 archive-1
+ */
+
+class Widget_Command extends WP_CLI_Command {
+
+	private $fields = array(
+		'name',
+		'id',
+		'position',
+		'options',
+		);
+
+	/**
+	 * List widgets associated with a sidebar.
+	 *
+	 * <sidebar-id>
+	 * : ID for the corresponding sidebar.
+	 *
+	 * [--fields=<fields>]
+	 * : Limit the output to specific object fields. Defaults to name, id, description
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, csv, json, count. Default: table
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp sidebar widget list <sidebar-id> --fields=name --format=csv
+	 *
+	 * @subcommand list
+	 */
+	public function list_( $args, $assoc_args ) {
+
+		list( $sidebar_id ) = $args;
+
+		$this->validate_sidebar( $sidebar_id );
+
+		$output_widgets = $this->get_sidebar_widgets( $sidebar_id );
+
+		if ( empty( $assoc_args['format'] ) || in_array( $assoc_args['format'], array( 'table', 'csv') ) ) {
+			foreach( $output_widgets as &$output_widget ) {
+				$output_widget->options = json_encode( $output_widget->options );
+			}
+		}
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, $this->fields );
+		$formatter->display_items( $output_widgets );
+
+	}
+
+	/**
+	 * Add a widget to a sidebar.
+	 *
+	 * <name>
+	 * : Widget name.
+	 *
+	 * <sidebar-id>
+	 * : ID for the corresponding sidebar.
+	 *
+	 * [<position>]
+	 * : Widget's current position within the sidebar. Defaults to last
+	 *
+	 * [--<field>=<value>]
+	 * : Widget option to add, with its new value
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp widget add calendar sidebar-1 2 --title="Calendar"
+	 *
+	 * @subcommand add
+	 */
+	public function add( $args, $assoc_args ) {
+
+		list( $name, $sidebar_id ) = $args;
+		$position = ( isset( $args[2] ) ) ? (int) $args[2] - 1 : 0;
+		$this->validate_sidebar( $sidebar_id );
+
+		if ( false == ( $widget = $this->get_widget_obj( $name ) ) ) {
+			WP_CLI::error( "Invalid widget type." );
+		}
+
+		/**
+		 * Adding a widget is as easy as:
+		 * 1. Creating a new widget option
+		 * 2. Adding the widget to the sidebar
+		 * 3. Positioning appropriately
+		 */
+		$widget_options = $option_keys = $this->get_widget_options( $name );
+		if ( ! isset( $widget_options['_multiwidget'] ) ) {
+			$widget_options['_multiwidget'] = 1;
+		}
+		unset( $option_keys['_multiwidget'] );
+		$option_keys = array_keys( $option_keys );
+		$last_key = array_pop( $option_keys );
+		$option_index = $last_key + 1;
+		$widget_options[ $option_index ] = $this->sanitize_widget_options( $name, $assoc_args, array() );
+		$this->update_widget_options( $name, $widget_options );
+
+		$widget_id = $name . '-' . $option_index;
+		$this->move_sidebar_widget( $widget_id, null, $sidebar_id, null, $position );
+
+		WP_CLI::success( "Added widget to sidebar." );
+
+
+	}
+
+	/**
+	 * Update a given widget's options.
+	 *
+	 * <widget-id>
+	 * : Unique ID for the widget
+	 *
+	 * [--<field>=<value>]
+	 * : Field to update, with its new value
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp widget update calendar-1 --title="Calendar"
+	 *
+	 * @subcommand update
+	 */
+	public function update( $args, $assoc_args ) {
+
+		list( $widget_id ) = $args;
+		$this->validate_sidebar_widget( $widget_id );
+
+		if ( empty( $assoc_args ) ) {
+			WP_CLI::error( "No options specified to update." );
+		}
+
+		list( $name, $option_index ) = $this->get_widget_data( $widget_id );
+
+		$widget_options = $this->get_widget_options( $name );
+		$clean_options = $this->sanitize_widget_options( $name, $assoc_args, $widget_options[ $option_index ] );
+		$widget_options[ $option_index ] = array_merge( (array)$widget_options[ $option_index ], $clean_options );
+		$this->update_widget_options( $name, $widget_options );
+
+		WP_CLI::success( "Widget updated." );
+
+	}
+
+	/**
+	 * Move a widget from one position on a sidebar to another.
+	 *
+	 * <widget-id>
+	 * : Unique ID for the widget
+	 *
+	 * [--position=<position>]
+	 * : Assign the widget to a new position.
+	 *
+	 * [--sidebar-id=<sidebar-id>]
+	 * : Assign the widget to a new sidebar
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp widget move recent-comments-2 --position=2
+	 *
+	 *     wp widget move recent-comments-2 --sidebar-id=wp_inactive_widgets
+	 *
+	 * @subcommand move
+	 */
+	public function move( $args, $assoc_args ) {
+
+		list( $widget_id ) = $args;
+		$this->validate_sidebar_widget( $widget_id );
+
+		if ( empty( $assoc_args['position'] ) && empty( $assoc_args['sidebar-id'] ) ) {
+			WP_CLI::error( "A new position or new sidebar must be specified." );
+		}
+
+		list( $name, $option_index, $current_sidebar_id, $current_sidebar_index ) = $this->get_widget_data( $widget_id );
+
+		$new_sidebar_id = ! empty( $assoc_args['sidebar-id'] ) ? $assoc_args['sidebar-id'] : $current_sidebar_id;
+		$this->validate_sidebar( $new_sidebar_id );
+
+		$new_sidebar_index = ! empty( $assoc_args['position'] ) ? $assoc_args['position'] - 1 : $current_sidebar_index;
+		// Moving between sidebars adds to the top
+		if ( $new_sidebar_id != $current_sidebar_id && $new_sidebar_index == $current_sidebar_index ) {
+			// Human-readable positions are different than numerically indexed array
+			$new_sidebar_index = 0;
+		}
+
+		$this->move_sidebar_widget( $widget_id, $current_sidebar_id, $new_sidebar_id, $current_sidebar_index, $new_sidebar_index );
+
+		WP_CLI::success( "Widget moved." );
+
+	}
+
+	/**
+	 * Deactivate one or more widgets from an active sidebar.
+	 *
+	 * <widget-id>...
+	 * : Unique ID for the widget(s)
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp widget deactivate recent-comments-2
+	 *
+	 * @subcommand deactivate
+	 */
+	public function deactivate( $args, $assoc_args ) {
+
+		foreach( $args as $widget_id ) {
+			$this->validate_sidebar_widget( $widget_id );
+
+			list( $name, $option_index, $sidebar_id, $sidebar_index ) = $this->get_widget_data( $widget_id );
+			if ( 'wp_inactive_widgets' == $sidebar_id ) {
+				WP_CLI::warning( sprintf( "'%s' is already deactivated.", $widget_id ) );
+				continue;
+			}
+
+			$this->move_sidebar_widget( $widget_id, $sidebar_id, 'wp_inactive_widgets', $sidebar_index, 0 );
+
+		}
+
+		WP_CLI::success( "Widget(s) deactivated" );
+	}
+
+	/**
+	 * Delete one or more widgets from a sidebar.
+	 *
+	 * <widget-id>...
+	 * : Unique ID for the widget(s)
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp widget delete recent-comments-2
+	 *
+	 * @subcommand delete
+	 */
+	public function delete( $args, $assoc_args ) {
+
+		foreach( $args as $widget_id ) {
+			$this->validate_sidebar_widget( $widget_id );
+
+			// Remove the widget's settings
+			list( $name, $option_index, $sidebar_id, $sidebar_index ) = $this->get_widget_data( $widget_id );
+			$widget_options = $this->get_widget_options( $name );
+			unset( $widget_options[ $option_index ] );
+			$this->update_widget_options( $name, $widget_options );
+
+			// Remove the widget from the sidebar
+			$all_widgets = $this->wp_get_sidebars_widgets();
+			unset( $all_widgets[ $sidebar_id ][ $sidebar_index ] );
+			$all_widgets[ $sidebar_id ] = array_values( $all_widgets[ $sidebar_id ] );
+			update_option( 'sidebars_widgets', $all_widgets );
+		}
+
+		WP_CLI::success( "Widget(s) removed from sidebar." );
+	}
+
+	/**
+	 * Check whether a sidebar is a valid sidebar
+	 *
+	 * @param string $sidebar_id
+	 */
+	private function validate_sidebar( $sidebar_id ) {
+		global $wp_registered_sidebars;
+
+		\WP_CLI\Utils\wp_register_unused_sidebar();
+
+		if ( ! array_key_exists( $sidebar_id, $wp_registered_sidebars ) ) {
+			WP_CLI::error( "Invalid sidebar." );
+		}
+	}
+
+	/**
+	 * Check whether the specified widget is on the sidebar
+	 *
+	 * @param string $widget_id
+	 */
+	private function validate_sidebar_widget( $widget_id ) {
+
+		$sidebars_widgets = $this->wp_get_sidebars_widgets();
+
+		$widget_exists = false;
+		foreach( $sidebars_widgets as $sidebar_id => $widgets ) {
+
+			if ( in_array( $widget_id, $widgets ) ) {
+				$widget_exists = true;
+				break;
+			}
+
+		}
+
+		if ( false === $widget_exists ) {
+			WP_CLI::error( "Specified widget isn't present on sidebar." );
+		}
+
+	}
+
+	/**
+	 * Get the widgets (and their associated data) for a given sidebar
+	 *
+	 * @param string $sidebar_id
+	 * @return array
+	 */
+	private function get_sidebar_widgets( $sidebar_id ) {
+
+		$all_widgets = $this->wp_get_sidebars_widgets();
+
+		if ( empty( $all_widgets[ $sidebar_id ] ) ) {
+			return array();
+		}
+
+		$prepared_widgets = array();
+		foreach( $all_widgets[ $sidebar_id ] as $key => $widget_id ) {
+
+			$prepared_widget = new stdClass;
+
+			$parts = explode( '-', $widget_id );
+			$option_index = array_pop( $parts );
+			$widget_name = implode( '-', $parts );
+
+			$prepared_widget->name = $widget_name;
+			$prepared_widget->id = $widget_id;
+			$prepared_widget->position = $key + 1;
+			$widget_options = get_option( 'widget_' . $widget_name );
+			$prepared_widget->options = $widget_options[ $option_index ];
+
+			$prepared_widgets[] = $prepared_widget;
+		}
+
+		return $prepared_widgets;
+	}
+
+	/**
+	 * Re-implementation of wp_get_sidebars_widgets()
+	 * because the original has a nasty global component
+	 */
+	private function wp_get_sidebars_widgets() {
+		$sidebars_widgets = get_option( 'sidebars_widgets', array() );
+
+		if ( is_array( $sidebars_widgets ) && isset( $sidebars_widgets['array_version'] ) ) {
+			unset( $sidebars_widgets['array_version'] );
+		}
+
+		return $sidebars_widgets;
+	}
+
+	/**
+	 * Get the widget's name, option index, sidebar, and sidebar index from its ID
+	 *
+	 * @param string $widget_id
+	 * @return array
+	 */
+	private function get_widget_data( $widget_id ) {
+
+		$parts = explode( '-', $widget_id );
+		$option_index = array_pop( $parts );
+		$name = implode( '-', $parts );
+
+		$sidebar_id = false;
+		$sidebar_index = false;
+		$all_widgets = $this->wp_get_sidebars_widgets();
+		foreach( $all_widgets as $s_id => &$widgets ) {
+
+			if ( false !== ( $key = array_search( $widget_id, $widgets ) ) ) {
+				$sidebar_id = $s_id;
+				$sidebar_index = $key;
+				break;
+			}
+
+		}
+
+		return array( $name, $option_index, $sidebar_id, $sidebar_index );
+	}
+
+	/**
+	 * Get the options for a given widget
+	 *
+	 * @param string $name
+	 * @return array
+	 */
+	private function get_widget_options( $name ) {
+		return get_option( 'widget_' . $name, array() );
+	}
+
+	/**
+	 * Update the options for a given widget
+	 *
+	 * @param string $name
+	 * @param mixed
+	 */
+	private function update_widget_options( $name, $value ) {
+		update_option( 'widget_' . $name, $value );
+	}
+
+	/**
+	 * Reposition a widget within a sidebar
+	 *
+	 * @param string $widget_id
+	 * @param string $current_sidebar_id
+	 * @param string $new_sidebar_id
+	 * @param int $current_index
+	 * @param int $new_index
+	 */
+	private function move_sidebar_widget( $widget_id, $current_sidebar_id, $new_sidebar_id, $current_index, $new_index ) {
+
+		$all_widgets = $this->wp_get_sidebars_widgets();
+		$needs_placement = true;
+		// Existing widget
+		if ( $current_sidebar_id && $current_index ) {
+
+			$widgets = $all_widgets[ $current_sidebar_id ];
+			if ( $current_sidebar_id != $new_sidebar_id ) {
+
+				unset( $widgets[ $current_index ] );
+
+			} else {
+
+				$part = array_splice( $widgets, $current_index, 1 );
+				array_splice( $widgets, $new_index, 0, $part );
+
+				$needs_placement = false;
+
+			}
+
+			$all_widgets[ $current_sidebar_id ] = array_values( $widgets );
+
+		}
+
+		if ( $needs_placement ) {
+			$widgets = $all_widgets[ $new_sidebar_id ];
+			$before = array_slice( $widgets, 0, $new_index, true );
+			$after = array_slice( $widgets, $new_index, count( $widgets ), true );
+			$widgets = array_merge( $before, array( $widget_id ), $after );
+			$all_widgets[ $new_sidebar_id ] = array_values( $widgets );
+		}
+
+		update_option( 'sidebars_widgets', $all_widgets );
+
+	}
+
+	/**
+	 * Get a widget's instantiated object based on its name
+	 *
+	 * @param string $id_base Name of the widget
+	 * @return WP_Widget|false
+	 */
+	private function get_widget_obj( $id_base ) {
+		global $wp_widget_factory;
+
+		$widget = wp_filter_object_list( $wp_widget_factory->widgets, array( 'id_base' => $id_base ) );
+		if ( empty( $widget ) ) {
+			false;
+		}
+
+		return array_pop( $widget );
+	}
+
+	/**
+	 * Clean up a widget's options based on its update callback
+	 *
+	 * @param string $id_base Name of the widget
+	 * @param mixed $dirty_options
+	 * @param mixed $old_options
+	 * @return mixed
+	 */
+	private function sanitize_widget_options( $id_base, $dirty_options, $old_options ) {
+
+		$widget = $this->get_widget_obj( $id_base );
+		if ( empty( $widget ) ) {
+			return array();
+		}
+
+		return $widget->update( $dirty_options, $old_options );
+
+	}
+
+}
+
+WP_CLI::add_command( 'widget', 'Widget_Command' );

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -95,3 +95,21 @@ function is_plugin_skipped( $file ) {
 	return in_array( $name, array_filter( $skipped_plugins ) );
 }
 
+/**
+ * Register the sidebar for unused widgets
+ * Core does this in /wp-admin/widgets.php, which isn't helpful
+ */
+function wp_register_unused_sidebar() {
+
+	register_sidebar(array(
+		'name' => __('Inactive Widgets'),
+		'id' => 'wp_inactive_widgets',
+		'class' => 'inactive-sidebar',
+		'description' => __( 'Drag widgets here to remove them from the sidebar but keep their settings.' ),
+		'before_widget' => '',
+		'after_widget' => '',
+		'before_title' => '',
+		'after_title' => '',
+	));
+
+}

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -184,8 +184,6 @@ if ( $symlinked_plugins_supported ) {
 
 // Load must-use plugins.
 foreach ( wp_get_mu_plugins() as $mu_plugin ) {
-	if ( $symlinked_plugins_supported )
-		wp_register_plugin_realpath( $mu_plugin );
 	include_once( $mu_plugin );
 }
 unset( $mu_plugin );


### PR DESCRIPTION
I've found the behat testing framework to be quite nice to use.

Because my community package is dependent on WP-CLI to use, it would be really neat if I could leverage the testing framework in my community package.

Couple of components I can think of:
- Sample `travis.yml` I can copy and paste into my community package.
- Run any tests I include in `features/`
