### PR TITLE
Add subcommand for listing database tables

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -526,7 +526,7 @@ class Runner {
 				"Either create one manually or use `wp core config`." );
 		}
 
-		if ( $this->cmd_starts_with( array( 'db' ) ) ) {
+		if ( $this->cmd_starts_with( array( 'db' ) ) && !$this->cmd_starts_with( array( 'db', 'tables' ) ) ) {
 			eval( $this->get_wp_config_code() );
 			$this->_run_command();
 			exit;

--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -195,6 +195,31 @@ class DB_Command extends WP_CLI_Command {
 		WP_CLI::success( sprintf( 'Imported from %s', $result_file ) );
 	}
 
+	/**
+	 * List the database tables.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--scope=<scope>]
+	 * : Can be all, global, ms_global, blog, or old tables. Defaults to all.
+	 *
+	 * ## EXAMPLES
+	 *
+	 * # Export only tables for a single site
+	 * wp db export --tables=$(wp db tables --url=sub.example.com | tr '\n' ',')
+	 */
+	function tables( $args, $assoc_args ) {
+		global $wpdb;
+
+		$scope = isset( $assoc_args['scope'] ) ? $assoc_args['scope'] : 'all';
+
+		$tables = $wpdb->tables( $scope );
+
+		foreach ( $tables as $table ) {
+			WP_CLI::line( $table );
+		}
+	}
+
 	private function get_file_name( $args ) {
 		if ( empty( $args ) )
 			return sprintf( '%s.sql', DB_NAME );


### PR DESCRIPTION
Went with `wp db tables`, since it's shorter than `wp db list-tables`.

Closes #708.
