### PR TITLE
Cygwin shell doesn't support inline environment variables

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -323,10 +323,11 @@ function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
 		$assoc_args = array_merge( $assoc_args, mysql_host_to_cli_args( $assoc_args['host'] ) );
 	}
 
-	if ( isset( $assoc_args['pass'] ) ) {
-		$cmd = esc_cmd( 'MYSQL_PWD=%s ', $assoc_args['pass'] ) . $cmd;
-		unset( $assoc_args['pass'] );
-	}
+	$pass = $assoc_args['pass'];
+	unset( $assoc_args['pass'] );
+
+	$old_pass = getenv( 'MYSQL_PWD' );
+	putenv( 'MYSQL_PWD=' . $pass );
 
 	$final_cmd = $cmd . assoc_args_to_str( $assoc_args );
 
@@ -335,6 +336,8 @@ function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
 		exit(1);
 
 	$r = proc_close( $proc );
+
+	putenv( 'MYSQL_PWD=' . $old_pass );
 
 	if ( $r ) exit( $r );
 }


### PR DESCRIPTION
i.e. `MYSQL_PWD=123 mysql` causes a "MYSQL_PWD is not recognized as an internal or external command." error

More info: http://wordpress.stackexchange.com/questions/136348/wp-cli-0-14-1-mysql-error

So, it looks like it's back to `putenv()`: https://github.com/wp-cli/wp-cli/issues/950#issuecomment-35818536
