### PR TITLE
Delete all and expired transient commands

### DIFF
--- a/php/commands/transient.php
+++ b/php/commands/transient.php
@@ -96,7 +96,7 @@ class Transient_Command extends WP_CLI_Command {
 		if ( $count > 0 ) {
 			WP_CLI::success( "$count expired transients deleted from the database." );
 		} else {
-			WP_CLI::success( "No transients found" );
+			WP_CLI::success( "No expired transients found" );
 		}
 
 		if ( $_wp_using_ext_object_cache ) {


### PR DESCRIPTION
There are a couple of open tickets relating to resetting/flushing transients.
#908 and #704 although it doesn't look like there has been any work done here - so I thought I'd kick things off...

This PR adds the commands `wp transient delete-expired` and `wp transient delete-all`. It handles deleting them from the database, and displays a warning if the the an external object cache is in use.
