### PR TITLE
`wp scaffold` commands should ask before overwriting files

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -72,3 +72,29 @@ Feature: Wordpress code scaffolding
       """
       __( 'Brain eaters'
       """
+
+  # Test for --yes flags
+  @tax @cpt @test
+  Scenario: Scaffold commands should ask for confirmation to overwrite if file already exists which can be overruled by passing --yes flag 
+    When I run `wp scaffold cpt zombie-speed --theme`
+    And I run `wp scaffold taxonomy zombie-speed --theme --yes`
+    Then STDOUT should contain:
+      """
+      Created
+      """
+    When I run `wp scaffold post-type zombie --theme`
+    When I run `wp scaffold post-type zombie --theme --yes`
+    Then STDOUT should contain:
+      """
+      Created
+      """
+
+# Not working....
+#    When I run `wp scaffold taxonomy zombie-speed --theme`
+#    And I run `wp scaffold taxonomy zombie-speed --theme`
+#    And STDERR should be:
+#      """
+#      Error: File already exists
+#      """
+#    Then the return code should be 1
+ 

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -3,7 +3,6 @@ Feature: Wordpress code scaffolding
   Background:
     Given a WP install
 
-  @theme
   Scenario: Scaffold a child theme
     Given I run `wp theme path`
     And save STDOUT as {THEME_DIR}
@@ -12,7 +11,6 @@ Feature: Wordpress code scaffolding
     Then STDOUT should not be empty
     And the {THEME_DIR}/zombieland/style.css file should exist
 
-  @tax @cpt
   Scenario: Scaffold a Custom Taxonomy and Custom Post Type and write it to active theme
     Given I run `wp eval 'echo STYLESHEETPATH;'`
     And save STDOUT as {STYLESHEETPATH}
@@ -24,7 +22,6 @@ Feature: Wordpress code scaffolding
     Then the {STYLESHEETPATH}/post-types/zombie.php file should exist
 
   # Test for all flags but --label, --theme, --plugin and --raw
-  @tax
   Scenario: Scaffold a Custom Taxonomy and attach it to CPTs including one that is prefixed and has a text domain
     When I run `wp scaffold taxonomy zombie-speed --post_types="prefix-zombie,wraith" --textdomain=zombieland`
     Then STDOUT should contain:
@@ -40,7 +37,6 @@ Feature: Wordpress code scaffolding
       __( 'Zombie speeds', 'zombieland'
       """
   
-  @tax
   Scenario: Scaffold a Custom Taxonomy with label "Speed"
     When I run `wp scaffold taxonomy zombie-speed --label="Speed"`
     Then STDOUT should contain:
@@ -53,7 +49,6 @@ Feature: Wordpress code scaffolding
         """
 
   # Test for all flags but --label, --theme, --plugin and --raw
-  @cpt
   Scenario: Scaffold a Custom Post Type
     When I run `wp scaffold post-type zombie --textdomain=zombieland`
     Then STDOUT should contain:
@@ -65,7 +60,6 @@ Feature: Wordpress code scaffolding
       __( 'Zombies', 'zombieland'
       """
 
-  @cpt
   Scenario: Scaffold a Custom Post Type with label
     When I run `wp scaffold post-type zombie --label="Brain eater"`
     Then STDOUT should contain:
@@ -73,8 +67,6 @@ Feature: Wordpress code scaffolding
       __( 'Brain eaters'
       """
 
-  # Test for --yes flags
-  @tax @cpt @test
   Scenario: Scaffold commands should ask for confirmation to overwrite if file already exists which can be overruled by passing --yes flag 
     When I run `wp scaffold cpt zombie-speed --theme`
     And I run `wp scaffold taxonomy zombie-speed --theme --yes`

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -68,7 +68,7 @@ Feature: Wordpress code scaffolding
       """
 
   Scenario: Scaffold commands should ask for confirmation to overwrite if file already exists which can be overruled by passing --yes flag 
-    When I run `wp scaffold cpt zombie-speed --theme`
+    When I run `wp scaffold taxonomy zombie-speed --theme`
     And I run `wp scaffold taxonomy zombie-speed --theme --yes`
     Then STDOUT should contain:
       """

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -67,6 +67,7 @@ Feature: Wordpress code scaffolding
       __( 'Brain eaters'
       """
 
+  # Test for the overwrite --yes flags
   Scenario: Scaffold commands should ask for confirmation to overwrite if file already exists which can be overruled by passing --yes flag 
     When I run `wp scaffold taxonomy zombie-speed --theme`
     And I run `wp scaffold taxonomy zombie-speed --theme --yes`
@@ -76,6 +77,12 @@ Feature: Wordpress code scaffolding
       """
     When I run `wp scaffold post-type zombie --theme`
     When I run `wp scaffold post-type zombie --theme --yes`
+    Then STDOUT should contain:
+      """
+      Created
+      """
+    When I run `wp scaffold plugin zombieland`
+    When I run `wp scaffold plugin zombieland --yes`
     Then STDOUT should contain:
       """
       Created

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -244,26 +244,25 @@ class WP_CLI {
 
 	/**
 	 * Ask for confirmation before running a destructive operation.
-	 * 
+	 *
 	 * @param string $question
 	 * @param array $assoc_args
+	 * @return bool Wether the user accepted the action or not
 	 */
-	static function confirm( $question, $assoc_args = array() ) {
-		if ( ! isset( $assoc_args['yes'] ) ) {
-			fwrite( STDOUT, $question . " [y/n] " );
-
-			$answer = trim( fgets( STDIN ) );
-
-			if ( 'y' != $answer ){
-				if( isset( $assoc_args['return'] ) && true !== $assoc_args['return'] ){
-					return false;
-				} else {
-					exit;
-				}
-			}
+	public static function confirm( $question, $assoc_args = array() ) {
+		if ( isset( $assoc_args['yes'] ) ) {
+			return true;
 		}
 
-		return true;
+		fwrite( STDOUT, $question . " [y/n] " );
+
+		$answer = trim( fgets( STDIN ) );
+
+		if ( 'y' === $answer ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -244,16 +244,26 @@ class WP_CLI {
 
 	/**
 	 * Ask for confirmation before running a destructive operation.
+	 * 
+	 * @param string $question
+	 * @param array $assoc_args
 	 */
 	static function confirm( $question, $assoc_args = array() ) {
-		if ( !isset( $assoc_args['yes'] ) ) {
+		if ( ! isset( $assoc_args['yes'] ) ) {
 			fwrite( STDOUT, $question . " [y/n] " );
 
 			$answer = trim( fgets( STDIN ) );
 
-			if ( 'y' != $answer )
-				exit;
+			if ( 'y' != $answer ){
+				if( isset( $assoc_args['return'] ) && true !== $assoc_args['return'] ){
+					return false;
+				} else {
+					exit;
+				}
+			}
 		}
+
+		return true;
 	}
 
 	/**

--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -25,7 +25,9 @@ class DB_Command extends WP_CLI_Command {
 	 * : Answer yes to the confirmation message.
 	 */
 	function drop( $_, $assoc_args ) {
-		WP_CLI::confirm( "Are you sure you want to drop the database?", $assoc_args );
+		if ( !WP_CLI::confirm( "Are you sure you want to drop the database?", $assoc_args ) ) {
+			return;
+		}
 
 		self::run_query( sprintf( 'DROP DATABASE `%s`', DB_NAME ) );
 
@@ -41,7 +43,9 @@ class DB_Command extends WP_CLI_Command {
 	 * : Answer yes to the confirmation message.
 	 */
 	function reset( $_, $assoc_args ) {
-		WP_CLI::confirm( "Are you sure you want to reset the database?", $assoc_args );
+		if ( !WP_CLI::confirm( "Are you sure you want to reset the database?", $assoc_args ) ) {
+			return;
+		}
 
 		self::run_query( sprintf( 'DROP DATABASE IF EXISTS `%s`', DB_NAME ) );
 		self::run_query( sprintf( 'CREATE DATABASE `%s`', DB_NAME ) );

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -28,7 +28,9 @@ class Media_Command extends WP_CLI_Command {
 	 */
 	function regenerate( $args, $assoc_args = array() ) {
 		if ( empty( $args ) ) {
-			WP_CLI::confirm( 'Do you realy want to regenerate all images?', $assoc_args );
+			if ( !WP_CLI::confirm( 'Do you realy want to regenerate all images?', $assoc_args ) ) {
+				return;
+			}
 		}
 
 		$query_args = array(

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -116,7 +116,6 @@ class Scaffold_Command extends WP_CLI_Command {
 			'label'  => preg_replace( '/_|-/', ' ', strtolower( $slug ) ),
 			'theme'  => false,
 			'plugin' => false,
-			'yes'    => false,
 			'raw'    => false,
 		) );
 
@@ -154,9 +153,7 @@ class Scaffold_Command extends WP_CLI_Command {
 		if ( $path = $this->get_output_path( $control_args, $subdir ) ) {
 			$filename = $path . $slug .'.php';
 			
-			$this->create_file( $filename, $final_output, $control_args['yes'] );
-
-			WP_CLI::success( "Created $filename" );
+			$this->create_file( $filename, $final_output, $assoc_args );
 
 		} else {
 			// STDOUT
@@ -403,18 +400,26 @@ class Scaffold_Command extends WP_CLI_Command {
 		WP_CLI::success( "Created test files." );
 	}
 
-	private function create_file( $filename, $contents, $overwrite ) {
+	private function create_file( $filename, $contents, $assoc_args = array() ) {
 		global $wp_filesystem;
 
-		if ( file_exists( $filename ) && empty( $overwrite ) ) {
-			WP_CLI::confirm( "Overwrite existsing file? $filename", $overwrite );
+		if ( file_exists( $filename ) ) {
+			$overwrite = WP_CLI::confirm( "Overwrite existsing file? $filename", $assoc_args );
+		} else {
+			$overwrite = true; //because it doesn't exists so proceed
 		}
 
-		//if( file_exists( $filename ) && !$overwrite ){
-		//	WP_CLI::error( "File already exists: $filename." );
-		//}
+		if( $overwrite ){ 
+			$wp_filesystem->mkdir( dirname( $filename ) );
 
-		$wp_filesystem->mkdir( dirname( $filename ) );
+			if ( !$wp_filesystem->put_contents( $filename, $contents ) ) {
+				WP_CLI::error( "Error creating file: $filename" );
+			} else {
+				WP_CLI::success( "Created $filename" );
+			}
+		}
+
+	}
 
 		if ( !$wp_filesystem->put_contents( $filename, $contents ) ) {
 			WP_CLI::error( "Error creating file: $filename" );

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -152,7 +152,7 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		if ( $path = $this->get_output_path( $control_args, $subdir ) ) {
 			$filename = $path . $slug .'.php';
-			
+
 			$this->create_file( $filename, $final_output, $assoc_args );
 
 		} else {
@@ -333,12 +333,8 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		$plugin_dir = WP_PLUGIN_DIR . "/$plugin_slug";
 		$plugin_path = "$plugin_dir/$plugin_slug.php";
-		
-		$assoc_args['return'] = true;
-		
-		$this->create_file( $plugin_path, Utils\mustache_render( 'plugin.mustache', $data ), $assoc_args );
 
-		unset( $assoc_args['return'] );
+		$this->create_file( $plugin_path, Utils\mustache_render( 'plugin.mustache', $data ), $assoc_args );
 
 		if ( !isset( $assoc_args['skip-tests'] ) ) {
 			WP_CLI::run_command( array( 'scaffold', 'plugin-tests', $plugin_slug ), $assoc_args );
@@ -392,8 +388,6 @@ class Scaffold_Command extends WP_CLI_Command {
 		$wp_filesystem->mkdir( $tests_dir );
 		$wp_filesystem->mkdir( $bin_dir );
 
-		$assoc_args['return'] = true;
-
 		$this->create_file( "$tests_dir/bootstrap.php",
 			Utils\mustache_render( 'bootstrap.mustache', compact( 'plugin_slug' ) ), $assoc_args );
 
@@ -414,13 +408,7 @@ class Scaffold_Command extends WP_CLI_Command {
 	private function create_file( $filename, $contents, $assoc_args = array() ) {
 		global $wp_filesystem;
 
-		if ( file_exists( $filename ) ) {
-			$overwrite = WP_CLI::confirm( "Overwrite existsing file? $filename", $assoc_args );
-		} else {
-			$overwrite = true; //because it doesn't exists so proceed
-		}
-
-		if( $overwrite ){ 
+		if ( self::check_overwrite( $filename, $assoc_args ) ) {
 			$wp_filesystem->mkdir( dirname( $filename ) );
 
 			if ( !$wp_filesystem->put_contents( $filename, $contents ) ) {
@@ -429,25 +417,25 @@ class Scaffold_Command extends WP_CLI_Command {
 				WP_CLI::success( "Created $filename" );
 			}
 		}
-
 	}
 
 	private function copy( $source, $destination, $assoc_args ) {
 		global $wp_filesystem;
 
-		if ( file_exists( $destination ) ) {
-			$overwrite = WP_CLI::confirm( "Overwrite existsing file? $destination", $assoc_args );
-		} else {
-			$overwrite = true; //because it doesn't exists so proceed
-		}
-
-		if( $overwrite ){ 
+		if ( self::check_overwrite( $filename, $assoc_args ) ) {
 			if ( $wp_filesystem->copy( $source, $destination, $overwrite ) ){
 				WP_CLI::success( "Copied file: $destination" );
 			} else {
 				WP_CLI::error( "Error copying file: $destination" );
 			}
 		}
+	}
+
+	private static function check_overwrite( $file, $assoc_args ) {
+		if ( !file_exists( $file ) )
+			return true;
+
+		return WP_CLI::confirm( "Overwrite existing file? $filename", $assoc_args );
 	}
 
 	/**

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -34,6 +34,9 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * [--plugin=<plugin>]
 	 * : Create a file in the given plugin's directory, instead of sending to STDOUT.
 	 *
+	 * [--yes]
+	 * : Answer yes to the confirmation message.
+	 *
 	 * [--raw]
 	 * : Just generate the `register_post_type()` call and nothing else.
 	 *
@@ -76,6 +79,9 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * [--plugin=<plugin>]
 	 * : Create a file in the given plugin's directory, instead of sending to STDOUT.
 	 *
+	 * [--yes]
+	 * : Answer yes to the confirmation message.
+	 *
 	 * [--raw]
 	 * : Just generate the `register_taxonomy()` call and nothing else.
 	 *
@@ -110,6 +116,7 @@ class Scaffold_Command extends WP_CLI_Command {
 			'label'  => preg_replace( '/_|-/', ' ', strtolower( $slug ) ),
 			'theme'  => false,
 			'plugin' => false,
+			'yes'    => false,
 			'raw'    => false,
 		) );
 
@@ -146,10 +153,11 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		if ( $path = $this->get_output_path( $control_args, $subdir ) ) {
 			$filename = $path . $slug .'.php';
-
-			$this->create_file( $filename, $final_output );
+			
+			$this->create_file( $filename, $final_output, $control_args['yes'] );
 
 			WP_CLI::success( "Created $filename" );
+
 		} else {
 			// STDOUT
 			echo $final_output;
@@ -175,6 +183,7 @@ class Scaffold_Command extends WP_CLI_Command {
 	 *
 	 * [--author_uri=<uri>]
 	 * : What to put in the 'Author URI:' header in style.css
+	 *
 	 */
 	function _s( $args, $assoc_args ) {
 
@@ -394,8 +403,16 @@ class Scaffold_Command extends WP_CLI_Command {
 		WP_CLI::success( "Created test files." );
 	}
 
-	private function create_file( $filename, $contents ) {
+	private function create_file( $filename, $contents, $overwrite ) {
 		global $wp_filesystem;
+
+		if ( file_exists( $filename ) && empty( $overwrite ) ) {
+			WP_CLI::confirm( "Overwrite existsing file? $filename", $overwrite );
+		}
+
+		//if( file_exists( $filename ) && !$overwrite ){
+		//	WP_CLI::error( "File already exists: $filename." );
+		//}
 
 		$wp_filesystem->mkdir( dirname( $filename ) );
 

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -128,7 +128,10 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 	 */
 	public function _empty( $args, $assoc_args ) {
 
-		WP_CLI::confirm( 'Are you sure you want to empty the site at ' . site_url() . ' of all posts, comments, and terms?', $assoc_args );
+		if ( !WP_CLI::confirm(
+			'Are you sure you want to empty ' . site_url() . ' of all posts, comments, and terms?', $assoc_args ) ) {
+			return;
+		}
 
 		$this->_empty_posts();
 		$this->_empty_comments();
@@ -176,7 +179,10 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 			WP_CLI::error( "Site not found." );
 		}
 
-		WP_CLI::confirm( "Are you sure you want to delete the $blog->siteurl site?", $assoc_args );
+		if ( !WP_CLI::confirm(
+			"Are you sure you want to delete the $blog->siteurl site?", $assoc_args ) ) {
+			return;
+		}
 
 		wpmu_delete_blog( $blog->blog_id, !isset( $assoc_args['keep-tables'] ) );
 


### PR DESCRIPTION
For each file it would overwrite, it should ask for confirmation.

Also, there should be a `--force` flag that skips the confirmation.