### PR TITLE
Allow cached packages in Behat runs

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -3,6 +3,7 @@ Feature: Manage WordPress installation
   @download
   Scenario: Empty dir
     Given an empty directory
+    And an empty cache
 
     When I try `wp core is-installed`
     Then the return code should be 1
@@ -28,6 +29,7 @@ Feature: Manage WordPress installation
   @download
   Scenario: Localized install
     Given an empty directory
+    And an empty cache
     When I run `wp core download --locale=de_DE`
     And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION}
     Then the wp-settings.php file should exist

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -9,6 +9,12 @@ $steps->Given( '/^an empty directory$/',
 	}
 );
 
+$steps->Given( '/^an empty cache/',
+	function ( $world ) {
+		$world->variables['SUITE_CACHE_DIR'] = FeatureContext::create_cache_dir();
+	}
+);
+
 $steps->Given( '/^an? ([^\s]+) file:$/',
 	function ( $world, $path, PyStringNode $content ) {
 		$content = (string) $content . "\n";

--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -1,5 +1,8 @@
 Feature: Manage WordPress themes and plugins
 
+  Background:
+    Given an empty cache
+
   Scenario Outline: Installing, upgrading and deleting a theme or plugin
     Given a WP install
     And I run `wp <type> path`


### PR DESCRIPTION
We run `wp theme install p2` over and over again, which leads to slower and flakier builds.

We should share the cache dir for normal tests and use a clean one just for the cache tests themselves (in `upgradables.feature`; see #619).
