### PR TITLE
Use wp locale instead of 'en_US' if locale argument is not used in wp core update

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -685,6 +685,7 @@ define('BLOG_ID_CURRENT_SITE', 1);
 		if ( empty( $assoc_args['version'] ) ) {
 			wp_version_check();
 			$from_api = get_site_transient( 'update_core' );
+
 			if ( empty( $from_api->updates ) )
 				$update = false;
 			else


### PR DESCRIPTION
Use the locale setting from wp-config.php instead of hardcoded 'en_US' when `wp core update` is called without locale parameter.
