### PR TITLE
Add --autoload option to 'wp option add' command

### DIFF
--- a/php/commands/option.php
+++ b/php/commands/option.php
@@ -50,6 +50,9 @@ class Option_Command extends WP_CLI_Command {
 	 * [--format=<format>]
 	 * : The serialization format for the value. Default is plaintext.
 	 *
+	 * [--autoload=<autoload>]
+	 * : Should this option be automatically loaded. Accepted values: yes, no. Default: yes
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Create an option by reading a JSON file
@@ -61,7 +64,13 @@ class Option_Command extends WP_CLI_Command {
 		$value = WP_CLI::get_value_from_arg_or_stdin( $args, 1 );
 		$value = WP_CLI::read_value( $value, $assoc_args );
 
-		if ( !add_option( $key, $value ) ) {
+		if ( isset( $assoc_args['autoload'] ) && $assoc_args['autoload'] == 'no' ) {
+			$autoload = 'no';
+		} else {
+			$autoload = 'yes';
+		}
+
+		if ( !add_option( $key, $value, '', $autoload ) ) {
 			WP_CLI::error( "Could not add option '$key'. Does it already exist?" );
 		} else {
 			WP_CLI::success( "Added '$key' option." );


### PR DESCRIPTION
Closes #1113

I don't know what is the best way to create a test for this new option. There is no straightforward way to get the value of the autoload field using wp-cli.

One hackish possibility is to use `wp db query` to query wp_options directly and check if the autoload field was populated correctly. Should I create a test using this approach or should I leave this part untested? Do you see another option to test this?
