### PR TITLE
Allow defining --extra-php in wp-cli.yml

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -107,24 +107,31 @@ Feature: Have a config file
       command has been disabled
       """
 
-  Scenario: Command-specific configs
-    Given a WP install
+  Scenario: 'core config' parameters
+    Given an empty directory
+    And WP files
     And a wp-cli.yml file:
       """
       core config:
         dbname: wordpress
         dbuser: root
+        extra-php: |
+          define( 'WP_DEBUG', true );
+          define( 'WP_POST_REVISIONS', 50 );
+      """
+
+    When I run `wp core config --skip-check`
+    And I run `grep WP_POST_REVISIONS wp-config.php`
+    Then STDOUT should not be empty
+
+  Scenario: Command-specific configs
+    Given a WP install
+    And a wp-cli.yml file:
+      """
       eval:
         foo: bar
       post list:
         format: count
-      """
-
-    # Required parameters should be recognized
-    When I try `wp core config`
-    Then STDERR should not contain:
-      """
-      Parameter errors
       """
 
     # Arbitrary values should be passed, without warnings

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -265,7 +265,7 @@ class Core_Command extends WP_CLI_Command {
 			) );
 		}
 
-		if ( isset( $assoc_args['extra-php'] ) ) {
+		if ( isset( $assoc_args['extra-php'] ) && $assoc_args['extra-php'] === true ) {
 			$assoc_args['extra-php'] = file_get_contents( 'php://stdin' );
 		}
 


### PR DESCRIPTION
fixes #1061
