### PR TITLE
script tags stripped by html source

### DIFF
--- a/features/post.feature
+++ b/features/post.feature
@@ -31,7 +31,9 @@ Feature: Manage WordPress posts
       """
       This is some content.
 
-      It will be inserted in a post.
+      <script>
+      alert('This should not be stripped.');
+      </script>
       """
     And a command.sh file:
       """
@@ -43,20 +45,15 @@ Feature: Manage WordPress posts
     Then STDOUT should be a number
     And save STDOUT as {POST_ID}
 
-    When I run `wp eval '$post_id = {POST_ID}; echo get_post( $post_id )->post_excerpt;'`
+    When I run `wp post get --field=excerpt {POST_ID}`
     Then STDOUT should be:
       """
       A multiline
       excerpt
       """
 
-    When I run `wp post get --field=content {POST_ID}`
-    Then STDOUT should be:
-      """
-      This is some content.
-
-      It will be inserted in a post.
-      """
+    When I run `wp post get --field=content {POST_ID} | diff -Bu content.html -`
+    Then STDOUT should be empty
 
     When I run `wp post get --format=table {POST_ID}`
     Then STDOUT should be a table containing rows:

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -139,13 +139,13 @@ class Runner {
 	}
 
 	private static function set_user( $assoc_args ) {
-		if ( !isset( $assoc_args['user'] ) )
-			return;
-
-		$fetcher = new \WP_CLI\Fetchers\User;
-		$user = $fetcher->get_check( $assoc_args['user'] );
-		wp_set_current_user( $user->ID );
-
+		if ( isset( $assoc_args['user'] ) ) {
+			$fetcher = new \WP_CLI\Fetchers\User;
+			$user = $fetcher->get_check( $assoc_args['user'] );
+			wp_set_current_user( $user->ID );
+		} else {
+			kses_remove_filters();
+		}
 	}
 
 	private static function guess_url( $assoc_args ) {


### PR DESCRIPTION
I have run the followingcommand on a wp 3.8 install on a Centos server:

```
wp post create post_text.html \
                --post_type=post \
                --post_status=publish \
                --post_title='title of the post' \
                --post_date='2014-01-04 17:02:00' \
                --tags_input='tag 1, tag 2''
```

The post is created as expected, with one problem: javascript in post_text.html is stripped as follows:

ORIGINAL TEXT in post_text.html:

```
<p>
<script type="text/javascript"><!--
JAVASCRIPT CODE
</script>

</p>

```

SAME SNIPPET OF TEXT in the "view source" window of the post seen in the browser:

```
<p><!--<br />
SAME JAVASCRIPT CODE
//--></p>
```
