### PR TITLE
Use the WP _n instead of ngettext function

### DIFF
--- a/features/media.feature
+++ b/features/media.feature
@@ -11,10 +11,10 @@ Feature: Manage WordPress attachments
       """
 
   Scenario: Import image from remote URL
-    When I run `wp media import 'http://s.wordpress.org/style/images/codeispoetry.png' --post_id=1`
+    When I run `wp media import 'http://wp-cli.org/behat-data/codeispoetry.png' --post_id=1`
     Then STDOUT should contain:
       """
-      Success: Imported file http://s.wordpress.org/style/images/codeispoetry.png
+      Success: Imported file http://wp-cli.org/behat-data/codeispoetry.png
       """
 
   Scenario: Fail to import missing image
@@ -26,8 +26,8 @@ Feature: Manage WordPress attachments
 
   Scenario: Import a file as attachment from a local image
     Given download:
-      | path                        | url                                                                             |
-      | {CACHE_DIR}/large-image.jpg | http://wordpresswallpaper.com/wp-content/gallery/photo-based-wallpaper/1058.jpg |
+      | path                        | url                                              |
+      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
 
     When I run `wp media import {CACHE_DIR}/large-image.jpg --post_id=1 --featured_image`
     Then STDOUT should contain:


### PR DESCRIPTION
Currently fails because http://wordpresswallpaper.com/wp-content/gallery/photo-based-wallpaper/1058.jpg is down, so every build will fail
