### PR TITLE
Fixes the 'db export' when DB_CHARSET value is empty

### DIFF
--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -236,8 +236,11 @@ class DB_Command extends WP_CLI_Command {
 			'host' => DB_HOST,
 			'user' => DB_USER,
 			'pass' => DB_PASSWORD,
-			'default-character-set' => DB_CHARSET,
 		) );
+
+		if ( defined( "DB_CHARSET" ) )
+			if ( DB_CHARSET )
+				$final_args = array_merge( $final_args, array( 'default-character-set' => DB_CHARSET ) );
 
 		Utils\run_mysql_command( $cmd, $final_args, $descriptors );
 	}


### PR DESCRIPTION
If DB_CHARSET value is empty on wp-config.php, the below error is displayed:

mysqldump: Character set '' is not a compiled character set and is not specified in the '/usr/share/mysql/charsets/Index.xml' file
