### PR TITLE
`wp plugin update` runs with missing argument, 

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -108,6 +108,15 @@ Feature: Manage WordPress plugins
       | name       | status   | update    | version   |
       | akismet    | active   | available | 2.5.6     |
 
+    When I try `wp plugin update`
+    Then STDERR should be:
+      """
+      Error: Please specify one or more plugins, or use --all.
+      """
+
+    When I run `wp plugin update --all`
+    Then STDOUT should not be empty
+
   Scenario: Activate a network-only plugin
     Given a WP multisite install
     And a wp-content/plugins/network-only.php file:

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -72,6 +72,15 @@ Feature: Manage WordPress themes
       | name  | status   | update    | version   |
       | p2    | active   | available | 1.4.1     |
 
+    When I try `wp theme update`
+    Then STDERR should be:
+      """
+      Error: Please specify one or more themes, or use --all.
+      """
+
+    When I run `wp theme update --all`
+    Then STDOUT should not be empty
+
   Scenario: Get the path of an installed theme
     Given a WP install
 

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -199,6 +199,10 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	protected function update_many( $args, $assoc_args ) {
 		call_user_func( $this->upgrade_refresh );
 
+		if ( ! isset( $assoc_args['all'] ) && empty( $args ) ) {
+			\WP_CLI::error( "Please specify one or more {$this->item_type}s, or use --all." );
+		}
+
 		$items = $this->get_item_list();
 
 		if ( !isset( $assoc_args['all'] ) ) {


### PR DESCRIPTION
`wp plugin update` accepts calls without `<plugin>` or `--all`, makes no updates, and succeeds. ;)

Can we print a warning message instead?

```
wp plugin update
Success: Updated 0/0 plugins.
# oops, I meant --all
wp plugin update --all
Enabling Maintenance mode...
# …
Success: Updated 3/3 plugins.
```
