### PR TITLE
Widget Add - Warning: array_slice() expects parameter 1 to be array

### DIFF
--- a/php/commands/widget.php
+++ b/php/commands/widget.php
@@ -437,7 +437,7 @@ class Widget_Command extends WP_CLI_Command {
 		}
 
 		if ( $needs_placement ) {
-			$widgets = $all_widgets[ $new_sidebar_id ];
+			$widgets = ! empty( $all_widgets[ $new_sidebar_id ] ) ? $all_widgets[ $new_sidebar_id ] : array();
 			$before = array_slice( $widgets, 0, $new_index, true );
 			$after = array_slice( $widgets, $new_index, count( $widgets ), true );
 			$widgets = array_merge( $before, array( $widget_id ), $after );


### PR DESCRIPTION
Hello,

I am using wp-cli in a bash script. At the end of the script, I am attempting to add a few widgets to sidebars. I am receiving these warnings:

Warning: array_slice() expects parameter 1 to be array, null given in /root/.wp-cli/vendor/wp-cli/wp
-cli/php/commands/widget.php on line 441
Warning: array_slice() expects parameter 1 to be array, null given in /root/.wp-cli/vendor/wp-cli/wp
-cli/php/commands/widget.php on line 442
Warning: array_merge(): Argument #1 is not an array in /root/.wp-cli/vendor/wp-cli/wp-cli/php/comman
ds/widget.php on line 443
Warning: array_values() expects parameter 1 to be array, null given in /root/.wp-cli/vendor/wp-cli/w
p-cli/php/commands/widget.php on line 444

Even though I am getting the message "Success: Added widget to sidebar", the sidebars are in fact not being added.

After kicking it around some, I found that if I manually add a widget to the sidebar, and then run the wp widget add commands again, that the widgets are then added successfully.

A sample of the commands:

wp widget add recent-posts sidebar --number="5"
wp widget add nav_menu header-right --nav_menu="26"

Through out my script I have no other errors. The database looks fine, as doe the site itself.

I am using wp-cli 0.15 on Apache 2.2.27, PHP 5.4.27, mySQL 5.5.36, and WordPress 3.9.

Any idea what the issue might be?
Thank you for a great tool!
