### PR TITLE
Error notices when using `wp widget add`

### DIFF
--- a/php/commands/widget.php
+++ b/php/commands/widget.php
@@ -480,7 +480,9 @@ class Widget_Command extends WP_CLI_Command {
 			return array();
 		}
 
-		return $widget->update( $dirty_options, $old_options );
+		// No easy way to determine expected array keys for $dirty_options
+		// because Widget API dependent on the form fields
+		return @$widget->update( $dirty_options, $old_options );
 
 	}
 


### PR DESCRIPTION
```
salty-wordpress ➜  wordpress-trunk.dev  wp widget add recent-posts sidebar-1 --number="5"
PHP Notice:  Undefined index: title in /srv/www/wordpress-trunk.dev/wp-includes/default-widgets.php on line 597
```

Unfortunately, I don't think there's any way for us to know which settings a widget expects. We'll just need to suppress errors when we call `$widget->update( $dirty_options, $old_options )`
