### PR TITLE
Remove unused `check_verbose()` method

### DIFF
--- a/php/commands/export.php
+++ b/php/commands/export.php
@@ -130,12 +130,6 @@ class Export_Command extends WP_CLI_Command {
 		}
 	}
 
-	private function check_verbose( $verbose ) {
-		$this->verbose = $verbose;
-
-		return true;
-	}
-
 	private function check_dir( $path ) {
 		if ( empty( $path ) ) {
 			$path = getcwd();


### PR DESCRIPTION
Added in 32402827d8e738c7c4e6025b7b3bbc6d7a1a45d2 but doesn't appear to be
used. aa542585aeeef589b1ce1e18edf3d4aa30a06786 removed the verbosity argument
