### PR TITLE
Add --skip-update flag for wp user import-csv

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -150,6 +150,39 @@ Feature: Manage WordPress users
       }]
       """
 
+  Scenario: Import new users but don't update existing
+    Given a WP install
+    And a users.csv file:
+      """
+      user_login,user_email,display_name,role
+      bobjones,bobjones@domain.com,Bob Jones,contributor
+      newuser1,newuser1@domain.com,New User,author
+      admin,admin@domain.com,Existing User,administrator
+      """
+
+    When I run `wp user create bobjones bobjones@domain.com --display_name="Robert Jones" --role=administrator`
+    Then STDOUT should not be empty
+
+    When I run `wp user import-csv users.csv --skip-update`
+    Then STDOUT should not be empty
+
+    When I run `wp user list --format=count`
+    Then STDOUT should be:
+      """
+      3
+      """
+
+    When I run `wp user get bobjones --fields=user_login,display_name,user_email,roles --format=json`
+    Then STDOUT should be JSON containing:
+      """
+      {
+        "user_login":"bobjones",
+        "display_name":"Robert Jones",
+        "user_email":"bobjones@domain.com",
+        "roles":"administrator"
+      }
+      """
+
   Scenario: Managing user roles
     Given a WP install
 

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -551,6 +551,9 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	 * [--send-email]
 	 * : Send an email to new users with their account details.
 	 *
+	 * [--skip-update]
+	 * : Don't update users that already exist.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp user import-csv /path/to/users.csv
@@ -597,7 +600,13 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 				$existing_user = get_user_by( 'login', $new_user['user_login'] );
 			}
 
-			if ( $existing_user ) {
+			if ( $existing_user && isset( $assoc_args['skip-update'] ) ) {
+
+				WP_CLI::log( "{$existing_user->user_login} exists and has been skipped" );
+				continue;
+
+			} else if ( $existing_user ) {
+
 				$new_user['ID'] = $existing_user->ID;
 				$user_id = wp_update_user( $new_user );
 


### PR DESCRIPTION
Sometimes you might not want to update existing users if they already exist.
