### PR TITLE
Skip PHP 5.5 builds on Travis for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: php
 
 php:
   - 5.3
-  - 5.5
+  # WP-CLI currently fails on PHP 5.5.11, which Travis is using
+  - 5.4
 
 env:
   global:
@@ -32,12 +33,12 @@ env:
     - secure: "TVMYSuxuZojZUHn3R9me8FCA1V6RaOTNE6A5gta7LSTtqZFLAQOer6tfLVof5fB3SHh2ANcOYPpjO729Mcrg195p1I/0nS18WZ0BVYvsN0Dob1I79rqYvsaW8syxCd/6TZvr7XZYdd1fDtt7kxsv74SljkliYwI2mTniQDxMONE="
     - secure: "OqbgLy6Rn+NvhjpYygNZDWf6rj8sVejRZJBmssNi5fHRXopEtfIHids2FjSXZUVPs3ShqNuczo1jzgt7N3JHbcSaiedHlc7ONqDK0SyyOcsv1oKOR81bvYcL/KIoGiMRvkQI5IW01YWfSZlS0wgL2NYdJvYanCnSUUv6nNZAF7E="
   matrix:
-    - WP_VERSION=3.9-RC1
+    - WP_VERSION=3.9
     - WP_VERSION=3.5.2 DEPLOY_BRANCH=master
 
 matrix:
   exclude:
-    - php: 5.5
+    - php: 5.4
       env: WP_VERSION=3.5.2 DEPLOY_BRANCH=master
 
 before_script: ./ci/prepare.sh


### PR DESCRIPTION
Travis recently upgraded to 5.5.11, and our tests fail because of segmentation faults:

![image](https://cloud.githubusercontent.com/assets/36432/2863897/7c64d712-d20a-11e3-8d6a-95787c290ccc.png)
