### PR TITLE
When a cron event runs, clear it from cron entries

### DIFF
--- a/features/cron.feature
+++ b/features/cron.feature
@@ -27,6 +27,48 @@ Feature: Manage WP-Cron events and schedules
       wp_cli_test_event_1
       """
 
+  Scenario: Scheduling and then running an event
+    When I run `wp cron event schedule wp_cli_test_event_3 '-1 minutes'`
+    Then STDOUT should contain:
+      """
+      Success: Scheduled event with hook 'wp_cli_test_event_3'
+      """
+
+    When I run `wp cron event list --format=csv --fields=hook,recurrence`
+    Then STDOUT should be CSV containing:
+      | hook                | recurrence    |
+      | wp_cli_test_event_3 | Non-repeating |
+
+    When I run `wp cron event run wp_cli_test_event_3`
+    Then STDOUT should not be empty
+
+    When I run `wp cron event list`
+    Then STDOUT should not contain:
+      """
+      wp_cli_test_event_3
+      """
+
+  Scenario: Scheduling and then running a re-occurring event
+    When I run `wp cron event schedule wp_cli_test_event_4 now hourly`
+    Then STDOUT should contain:
+      """
+      Success: Scheduled event with hook 'wp_cli_test_event_4'
+      """
+
+    When I run `wp cron event list --format=csv --fields=hook,recurrence`
+    Then STDOUT should be CSV containing:
+      | hook                | recurrence    |
+      | wp_cli_test_event_4 | 1 hour        |
+
+    When I run `wp cron event run wp_cli_test_event_4`
+    Then STDOUT should not be empty
+
+    When I run `wp cron event list`
+    Then STDOUT should contain:
+      """
+      wp_cli_test_event_4
+      """
+
   Scenario: Scheduling and then deleting a recurring event
     When I run `wp cron event schedule wp_cli_test_event_2 now daily`
     Then STDOUT should contain:

--- a/php/commands/cron.php
+++ b/php/commands/cron.php
@@ -160,6 +160,13 @@ class Cron_Event_Command extends WP_CLI_Command {
 			define( 'DOING_CRON', true );
 		}
 
+		if ( $event->schedule != false ) {
+			$new_args = array( $event->time, $event->schedule, $event->hook, $event->args );
+			call_user_func_array( 'wp_reschedule_event', $new_args );
+		}
+
+		wp_unschedule_event( $event->time, $event->hook, $event->args );
+
 		do_action_ref_array( $event->hook, $event->args );
 
 		return true;


### PR DESCRIPTION
However, if it's scheduled to reoccur, reschedule the cron event. Adds functional tests.

See #1142
