### PR TITLE
Support for `--porcelain` with `wp media import`

### DIFF
--- a/features/media.feature
+++ b/features/media.feature
@@ -39,3 +39,17 @@ Feature: Manage WordPress attachments
       and attached to post 1 as featured image
       """
     And the {CACHE_DIR}/large-image.jpg file should exist
+
+  Scenario: Import a file as an attachment but porcelain style
+    Given download:
+      | path                        | url                                              |
+      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
+
+    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported attachment" --porcelain`
+    Then save STDOUT as {ATTACHMENT_ID}
+
+    When I run `wp post get {ATTACHMENT_ID} --field=title`
+    Then STDOUT should be:
+      """
+      My imported attachment
+      """

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -90,6 +90,9 @@ class Media_Command extends WP_CLI_Command {
 	 * [--featured_image]
 	 * : If set, set the imported image as the Featured Image of the post its attached to.
 	 *
+	 * [--porcelain]
+	 * : Output just the new attachment id.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Import all jpgs in the current user's "Pictures" directory, not attached to any post
@@ -170,10 +173,14 @@ class Media_Command extends WP_CLI_Command {
 					$attachment_success_text .= ' as featured image';
 			}
 
-			WP_CLI::success( sprintf(
-				'Imported file %s as attachment ID %d%s.',
-				$orig_filename, $success, $attachment_success_text
-			) );
+			if ( isset( $assoc_args['porcelain'] ) ) {
+				WP_CLI::line( $success );
+			} else {
+				WP_CLI::success( sprintf(
+					'Imported file %s as attachment ID %d%s.',
+					$orig_filename, $success, $attachment_success_text
+				) );
+			}
 		}
 	}
 


### PR DESCRIPTION
`--porcelain` makes it much easier to use a new entity in subsequent commands
