### PR TITLE
`wp post generate --post_author=` only accepts logins

### DIFF
--- a/features/post.feature
+++ b/features/post.feature
@@ -133,6 +133,18 @@ Feature: Manage WordPress posts
       """
     And STDERR should be empty
 
+  Scenario: Generating posts by a specific author
+
+    When I run `wp user create dummyuser dummy@example.com --porcelain`
+    Then save STDOUT as {AUTHOR_ID}
+
+    When I run `wp post generate --post_author={AUTHOR_ID} --post_type=post --count=16`
+    And I run `wp post list --post_type=post --author={AUTHOR_ID} --format=count`
+    Then STDOUT should contain:
+      """
+      16
+      """
+
   Scenario: Generating pages
     When I run `wp post generate --post_type=page --max_depth=10`
     And I run `wp post list --post_type=page --field=post_parent`

--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -305,10 +305,8 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 		}
 
 		if ( $post_author ) {
-			$post_author = get_user_by( 'login', $post_author );
-
-			if ( $post_author )
-				$post_author = $post_author->ID;
+			$user_fetcher = new \WP_CLI\Fetchers\User;
+			$post_author = $user_fetcher->get_check( $post_author )->ID;
 		}
 
 		if ( isset( $assoc_args['post_content'] ) ) {


### PR DESCRIPTION
It should accept all the things that the `wp user` subcommands accept.
