### PR TITLE
Correct config spec for `--user=<user>`

### DIFF
--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -23,8 +23,8 @@ return array(
 	),
 
 	'user' => array(
-		'runtime' => '=<id|login>',
-		'file' => '<id|login>',
+		'runtime' => '=<id|login|email>',
+		'file' => '<id|login|email>',
 		'desc' => 'Set the WordPress user',
 	),
 


### PR DESCRIPTION
Works with email addresses since 1b04e06fca552b7f400cec7a361da79f0805e2dc
