### PR TITLE
Disabled commands shouldn't appear in usage docs

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -132,6 +132,12 @@ Feature: Have a config file
       command has been disabled
       """
 
+    When I try `WP_CLI_CONFIG_PATH=config.yml wp help core multisite-convert`
+    Then STDERR should contain:
+      """
+      Error: The 'core multisite-convert' command has been disabled from the config file.
+      """
+
   Scenario: 'core config' parameters
     Given an empty directory
     And WP files

--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -139,12 +139,10 @@ class CompositeCommand {
 
 		$i = 0;
 
-		$disabled_commands = \WP_CLI::get_runner()->config['disabled_commands'];
 		foreach ( $methods as $name => $subcommand ) {
 			$prefix = ( 0 == $i++ ) ? 'usage: ' : '   or: ';
 
-			$path = implode( ' ', array_slice( get_path( $subcommand ), 1 ) );
-			if ( in_array( $path, $disabled_commands ) ) {
+			if ( \WP_CLI::get_runner()->is_command_disabled( $subcommand ) ) {
 				continue;
 			}
 

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -251,8 +251,6 @@ class Runner {
 
 		$cmd_path = array();
 
-		$disabled_commands = $this->config['disabled_commands'];
-
 		while ( !empty( $args ) && $command->can_have_subcommands() ) {
 			$cmd_path[] = $args[0];
 			$full_name = implode( ' ', $cmd_path );
@@ -266,7 +264,7 @@ class Runner {
 				);
 			}
 
-			if ( in_array( $full_name, $disabled_commands ) ) {
+			if ( $this->is_command_disabled( $subcommand ) ) {
 				return sprintf(
 					"The '%s' command has been disabled from the config file.",
 					$full_name
@@ -311,6 +309,16 @@ class Runner {
 
 	private function _run_command() {
 		$this->run_command( $this->arguments, $this->assoc_args );
+	}
+
+	/**
+	 * Check whether a given command is disabled by the config
+	 *
+	 * @return bool
+	 */
+	public function is_command_disabled( $command ) {
+		$path = implode( ' ', array_slice( \WP_CLI\Dispatcher\get_path( $command ), 1 ) );
+		return in_array( $path, $this->config['disabled_commands'] );
 	}
 
 	/**

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -23,11 +23,11 @@ class Help_Command extends WP_CLI_Command {
 
 		if ( $command ) {
 
-			$full_name = implode( ' ', array_slice( WP_CLI\Dispatcher\get_path( $command ), 1 ) );
-			if ( in_array( $full_name , self::get_disabled_commands() ) ) {
+			if ( WP_CLI::get_runner()->is_command_disabled( $command ) ) {
+				$path = implode( ' ', array_slice( \WP_CLI\Dispatcher\get_path( $command ), 1 ) );
 				WP_CLI::error( sprintf(
 					"The '%s' command has been disabled from the config file.",
-					$full_name
+					$path
 				) );
 			}
 
@@ -127,8 +127,7 @@ class Help_Command extends WP_CLI_Command {
 		$subcommands = array();
 		foreach ( $command->get_subcommands() as $subcommand ) {
 
-			$path = implode( ' ', array_slice( WP_CLI\Dispatcher\get_path( $subcommand ), 1 ) );
-			if ( in_array( $path , self::get_disabled_commands() ) ) {
+			if ( WP_CLI::get_runner()->is_command_disabled( $subcommand ) ) {
 				continue;
 			}
 
@@ -156,9 +155,6 @@ class Help_Command extends WP_CLI_Command {
 		return $max_len;
 	}
 
-	private static function get_disabled_commands() {
-		return WP_CLI::get_runner()->config['disabled_commands'];
-	}
 }
 
 WP_CLI::add_command( 'help', 'Help_Command' );


### PR DESCRIPTION
When a command is disabled via `wp-cli.yml`, it shouldn't appear in the usage docs.
