### PR TITLE
Make sure widget at index=0 is removed from sidebar when deactivated

### DIFF
--- a/php/commands/widget.php
+++ b/php/commands/widget.php
@@ -403,7 +403,7 @@ class Widget_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Reposition a widget within a sidebar
+	 * Reposition a widget within a sidebar or move to another sidebar.
 	 *
 	 * @param string $widget_id
 	 * @param string|null $current_sidebar_id


### PR DESCRIPTION
Without this change, deactivating a widget at the beginning of a widget area will appear twice, once in the original sidebar and again in the Inactive Widgets sidebar.
