### PR TITLE
`widget list` with format=ids not working

### DIFF
--- a/features/widget.feature
+++ b/features/widget.feature
@@ -68,6 +68,12 @@ Feature: Manage widgets in WordPress sidebar
       | calendar        | calendar-1        | 2        |
       | categories      | categories-2      | 3        |
 
+    When I run `wp widget list sidebar-1 --format=ids`
+    Then STDOUT should be:
+      """
+      search-2 calendar-1 categories-2
+      """
+
     When I run `wp widget update calendar-1 --title="Calendar"`
     Then STDOUT should not be empty
 

--- a/php/commands/widget.php
+++ b/php/commands/widget.php
@@ -37,7 +37,7 @@ class Widget_Command extends WP_CLI_Command {
 	 * : Limit the output to specific object fields. Defaults to name, id, description
 	 *
 	 * [--format=<format>]
-	 * : Accepted values: table, csv, json, count. Default: table
+	 * : Accepted values: table, csv, json, count, ids. Default: table
 	 *
 	 * ## EXAMPLES
 	 *
@@ -57,6 +57,10 @@ class Widget_Command extends WP_CLI_Command {
 			foreach( $output_widgets as &$output_widget ) {
 				$output_widget->options = json_encode( $output_widget->options );
 			}
+		}
+
+		if ( ! empty( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
+			$output_widgets = wp_list_pluck( $output_widgets, 'id' );
 		}
 
 		$formatter = new \WP_CLI\Formatter( $assoc_args, $this->fields );


### PR DESCRIPTION
Running with the phar build version 0.15.0.

Listing the widgets works fine formatted as table, json, csv, but it does not work with the format `ids`. Would be nice if the `widgets list` command would follow the same convention like `post list`, `term list`, etc. so we can execute a similar removal command:

```
php /opt/wp-cli.phar widget delete sidebar-id $(php /opt/wp-cli.phar widget list sidebar-id --format=ids)

php /opt/wp-cli.phar post delete $(php /opt/wp-cli.phar post list --format=ids)
```

Trying the format `ids` with version 0.15.0 gives an error:

```
$ php /opt/wp-cli.phar widget list sidebar-blog --format=ids
Catchable fatal error: Object of class stdClass could not be converted to string in phar:///opt/wp-cli.phar/php/WP_CLI/Formatter.php on line 69
```

```
$ php /opt/wp-cli.phar widget list sidebar-blog
+-----------------+-------------------+----------+----------------------------------------------------------------+
| name            | id                | position | options                                                        |
+-----------------+-------------------+----------+----------------------------------------------------------------+
| categories      | categories-2      | 1        | {"title":"Categories","count":0,"hierarchical":0,"dropdown":0} |
| tag_cloud       | tag_cloud-2       | 2        | {"title":"Tags","taxonomy":"post_tag"}                         |
| recent-posts    | recent-posts-2    | 3        | {"title":"Recents","number":5,"show_date":false}               |
| recent-comments | recent-comments-2 | 4        | {"title":"Comments","number":5}                                |
+-----------------+-------------------+----------+----------------------------------------------------------------+
```
