### PR TITLE
Create a valid local file location vs a URL

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -70,7 +70,7 @@ class WP_CLI {
 			$home = getenv( 'HOME' );
 			if ( !$home ) {
 				// sometime in windows $HOME is not defined
-				$home = getenv( 'HOMEDRIVE' ) . '/' . getenv( 'HOMEPATH' );
+				$home = getenv( 'HOMEDRIVE' ) . getenv( 'HOMEPATH' );
 			}
 			$dir = getenv( 'WP_CLI_CACHE_DIR' ) ? : "$home/.wp-cli/cache";
 


### PR DESCRIPTION
I got this fatal error when trying to utilize a cached "wp core download":

PHP Fatal error:  Uncaught exception 'UnexpectedValueException' with message 'Cannot create a phar archive from a URL like "C://Users/xxx/.wp-cli/cache/core/en_US-3.9.1.tar.gz". Phar objects can only be created from local files' in C:\Users\xxx\wp-cli\php\commands\core.php:93

I'm not sure if my pull is the best solution, but the comments seem to suggest that $home is only manually constructed on Windows, so removing the middle slash may work for everyone. It did for me. After making this change and running the command again, all was well.

I'm using PHP 5.5.9.0 on Windows 8.1.
