### PR TITLE
Throw warning on `wp rewrite flush` and no permalink structure

### DIFF
--- a/features/rewrite.feature
+++ b/features/rewrite.feature
@@ -34,6 +34,24 @@ Feature: Manage WordPress rewrites
       | match            | query                               | source   |
       | topic/([^/]+)/?$ | index.php?tag=$matches[1]           | post_tag |
 
+  Scenario: Missing permalink_structure
+    Given a WP install
+
+    When I run `wp option delete permalink_structure`
+    And I try `wp option get permalink_structure`
+    Then STDOUT should be empty
+
+    When I try `wp rewrite flush`
+    Then STDERR should contain:
+      """
+      Warning: Rewrite rules are empty, possibly because of a missing permalink_structure option.
+      """
+    And STDOUT should be empty
+
+    When I run `wp rewrite structure /%year%/%monthnum%/%day%/%postname%/`
+    Then I run `wp rewrite flush`
+    Then STDOUT should be empty
+
   Scenario: Generate .htaccess on hard flush
     Given a WP install
     And a wp-cli.yml file:

--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -32,6 +32,9 @@ class Rewrite_Command extends WP_CLI_Command {
 			WP_CLI::warning( "Regenerating a .htaccess file requires special configuration. See usage docs." );
 		}
 		flush_rewrite_rules( isset( $assoc_args['hard'] ) );
+		if ( ! get_option( 'rewrite_rules' ) ) {
+			WP_CLI::warning( "Rewrite rules are empty, possibly because of a missing permalink_structure option. Use 'wp rewrite list' to verify, or 'wp rewrite structure' to update permalink_structure." );
+		}
 	}
 
 	/**


### PR DESCRIPTION
`wp rewrite flush` is successful, even when you don't have a permalink structure, and results in an empty rewrite rules option. To make this more user-friendly, let's throw a warning.
