### PR TITLE
Network-only plugin check should only happen on multisite

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -117,15 +117,41 @@ Feature: Manage WordPress plugins
     When I run `wp plugin update --all`
     Then STDOUT should not be empty
 
-  Scenario: Activate a network-only plugin
+  Scenario: Activate a network-only plugin on single site
+    Given a WP install
+    And a wp-content/plugins/network-only.php file:
+      """
+      // Plugin Name: Example Plugin
+      // Network: true
+      """
+
+    When I run `wp plugin activate network-only`
+    Then STDOUT should be:
+      """
+      Success: Plugin 'network-only' activated.
+      """
+
+    When I run `wp plugin status network-only`
+    Then STDOUT should contain:
+      """
+          Status: Active
+      """
+
+  Scenario: Activate a network-only plugin on multisite
     Given a WP multisite install
     And a wp-content/plugins/network-only.php file:
       """
       // Plugin Name: Example Plugin
       // Network: true
       """
+
     When I run `wp plugin activate network-only`
-    And I run `wp plugin status network-only`
+    Then STDOUT should be:
+      """
+      Success: Plugin 'network-only' network activated.
+      """
+
+    When I run `wp plugin status network-only`
     Then STDOUT should contain:
       """
           Status: Network Active

--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -530,7 +530,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	}
 
 	private function active_output( $name, $file, $network_wide, $action ) {
-		$network_wide = $network_wide || is_network_only_plugin( $file );
+		$network_wide = $network_wide || ( is_multisite() && is_network_only_plugin( $file ) );
 
 		$check = $this->check_active( $file, $network_wide );
 


### PR DESCRIPTION
According to `is_network_only_plugin()`:

```
Checks for "Network: true" in the plugin header to see if this should
be activated only as a network wide plugin. The plugin would also work
when Multisite is not enabled.
```

Fixes #1244
