### PR TITLE
Use Checksum API to verify core integrity

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -270,6 +270,9 @@ Feature: Manage WordPress installation
   Scenario: Verify core checksums
     Given a WP install
 
+    When I run `wp core update`
+    Then STDOUT should not be empty
+
     When I run `wp core verify-checksums`
     Then STDOUT should be:
       """

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -666,7 +666,12 @@ define('BLOG_ID_CURRENT_SITE', 1);
 	public function verify_checksums( $args, $assoc_args ) {
 		global $wp_version, $wp_local_package;
 
-		$checksums = get_core_checksums( $wp_version, isset( $wp_local_package ) ? $wp_local_package : 'en_US' );
+		// Introduced in 3.7
+		if ( function_exists( 'get_core_checksums' ) ) {
+			$checksums = get_core_checksums( $wp_version, isset( $wp_local_package ) ? $wp_local_package : 'en_US' );
+		} else {
+			$checksums = false;
+		}
 
 		if ( ! is_array( $checksums ) ) {
 			WP_CLI::error( "Couldn't get checksums from WordPress.org." );


### PR DESCRIPTION
This is a feature request.
Using the [Checksum API](http://api.wordpress.org/core/checksums/1.0/?version=3.7.1&locale=en_US) it would be nice to have a new core command to check WP integrity.
`check`
Usecase: detect compromised sites
