### PR TITLE
--role inconsistency

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -160,7 +160,7 @@ Feature: Manage WordPress users
       admin,admin@domain.com,Existing User,administrator
       """
 
-    When I run `wp user create bobjones bobjones@domain.com --display_name="Robert Jones" --role=administrator`
+    When I run `wp user create bobjones bobjones@domain.com --display_name="Robert Jones" --user_role=administrator`
     Then STDOUT should not be empty
 
     When I run `wp user import-csv users.csv --skip-update`

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -439,6 +439,14 @@ class Runner {
 			}
 		}
 
+		// user create --user_role=role -> user create --role=role
+		if ( count( $args ) > 1 && $args[0] == 'user'
+			&& $args[1] == 'create' && isset( $assoc_args['user_role'] )
+		) {
+			$assoc_args['role'] = $assoc_args['user_role'];
+			unset( $assoc_args['user_role'] );
+		}
+
 		return array( $args, $assoc_args );
 	}
 


### PR DESCRIPTION
`wp user create` has `--role`, whereas `wp user update` accepts `--user_role`.

Let's pick one and stick with it.
