### PR TITLE
Multisite loading is broken

### DIFF
--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -103,6 +103,9 @@ require( ABSPATH . WPINC . '/default-filters.php' );
 
 // Initialize multisite if enabled.
 if ( is_multisite() ) {
+	// require_once because introduced in 4.0-ish https://core.trac.wordpress.org/changeset/28910/trunk/src
+	require_once( ABSPATH . WPINC . '/ms-load.php' );
+	require_once( ABSPATH . WPINC . '/ms-default-constants.php' );
 	require( ABSPATH . WPINC . '/ms-blogs.php' );
 	require( ABSPATH . WPINC . '/ms-settings.php' );
 } elseif ( ! defined( 'MULTISITE' ) ) {


### PR DESCRIPTION
```
salty-wordpress ➜  vip.dev  wp
PHP Fatal error:  Call to undefined function ms_subdomain_constants() in /srv/www/vip.dev/wp/wp-includes/ms-settings.php on line 18
```

Probably from https://core.trac.wordpress.org/changeset/28910/trunk/src
