### PR TITLE
trim commas on tables list in wp db export

### DIFF
--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -141,7 +141,7 @@ class DB_Command extends WP_CLI_Command {
 		$command_esc_args = array( DB_NAME );
 
 		if ( isset( $assoc_args['tables'] ) ) {
-			$tables = explode( ',', $assoc_args['tables'] );
+			$tables = explode( ',', trim( $assoc_args['tables'], ',' ) );
 			unset( $assoc_args['tables'] );
 			$command .= ' --tables';
 			foreach ( $tables as $table ) {


### PR DESCRIPTION
In running `wp db export --tables=$(wp db tables --url=local.dev/msstable/feta --scope=blog | tr '\n' ',')` the list of tables passed looks like `wp_4_posts,wp_4_comments,wp_4_links,wp_4_options,wp_4_postmeta,wp_4_terms,wp_4_term_taxonomy,wp_4_term_relationships,wp_4_commentmeta,` 

When the list is later explode()d, the trailing comma causes there to be an empty element in the array, and on export an extra table gets included (whatever is first alphabetically).
