### PR TITLE
Display password when wp cli creates it

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -253,3 +253,18 @@ Feature: Manage WordPress users
       """
       Success: Removed 'edit_vip_product' cap for admin (1).
       """
+
+  Scenario: Show password when creating a user
+    Given a WP install
+
+    When I run `wp user create testrandompass testrandompass@example.com`
+    Then STDOUT should contain:
+       """
+       Password:
+       """
+
+    When I run `wp user create testsuppliedpass testsuppliedpass@example.com --user_pass=suppliedpass`
+    Then STDOUT should not contain:
+       """
+       Password:
+       """

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -229,8 +229,12 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 		$user->last_name = isset( $assoc_args['last_name'] )
 			? $assoc_args['last_name'] : false;
 
-		$user->user_pass = isset( $assoc_args['user_pass'] )
-			? $assoc_args['user_pass'] : wp_generate_password();
+		if ( isset( $assoc_args['user_pass'] ) ) {
+			$user->user_pass = $assoc_args['user_pass'];
+		} else {
+			$user->user_pass = wp_generate_password();
+			$generated_pass = true;
+		}
 
 		if ( isset( $assoc_args['role'] ) ) {
 			$role = $assoc_args['role'];
@@ -259,7 +263,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 		} else {
 			WP_CLI::success( "Created user $user_id." );
 			if ( isset( $generated_pass ) )
-				WP_CLI::line( "Password: $user_pass" );
+				WP_CLI::line( "Password: $user->user_pass" );
 		}
 	}
 


### PR DESCRIPTION
In an earlier version of wp cli, typing `wp user create bill bill.erickson@gmail.com` would generate a random password and then display it. Now it generates a password, but doesn't display it.

I understand why this was removed by default, but it would be nice if there was a way get it back, maybe passing --show_password=true or something. 

When I build a site for a client, I send them a review email that includes instructions on using every aspect of their site. At the top I include their username and password. 

Now that this feature has been removed, I either have to go to strongpasswordgenerator.com to copy a password, then `wp user create clientname client@email.com --user_pass=[paste password]`. Or, I just set the password to changeme, which isn't strong but less work.
