### PR TITLE
wp scaffold post-type should fail with an error if post-slug

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -65,6 +65,13 @@ Feature: WordPress code scaffolding
       __( 'Zombies', 'zombieland'
       """
 
+  Scenario: CPT slug is too long
+    When I try `wp scaffold post-type slugiswaytoolonginfact`
+    Then STDERR should be:
+      """
+      Error: Post type slugs cannot exceed 20 characters in length.
+      """
+
   @cpt
   Scenario: Scaffold a Custom Post Type with label
     When I run `wp scaffold post-type zombie --label="Brain eater"`

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -42,6 +42,11 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * @alias cpt
 	 */
 	function post_type( $args, $assoc_args ) {
+
+		if ( strlen( $args[0] ) > 20 ) {
+			WP_CLI::error( "Post type slugs cannot exceed 20 characters in length." );
+		}
+
 		$defaults = array(
 			'textdomain' => '',
 		);


### PR DESCRIPTION
There's a max character length of 20 for `register_post_type()`'s `$post_type` parameter. It would be helpful if `$ wp scaffold post-type` checked and alerted you to this. 

Based on my own experience with this pain point, this along with #1255 should save a lot of folks a few hours. 
