### PR TITLE
Help no longer requires proc_open if that function isn't available

### DIFF
--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -86,8 +86,9 @@ class Help_Command extends WP_CLI_Command {
 	}
 
 	private static function pass_through_pager( $out ) {
-		if ( Utils\is_windows() ) {
-			// no paging for Windows cmd.exe; sorry
+		// no paging for Windows cmd.exe; sorry
+		// proc_open disable by system
+		if ( Utils\is_windows() || ! function_exists( 'proc_open' ) ) {
 			echo $out;
 			return 0;
 		}


### PR DESCRIPTION
This adds a graceful fallback for help on systems that have proc_open disabled. We're already doing it for Windows anyway.
