### PR TITLE
Support `--quiet` config arg for `wp search-replace`

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -24,6 +24,12 @@ Feature: Do global search/replace
       | wp_2_posts | guid   | 2            | SQL  |
       | wp_blogs   | path   | 1            | SQL  |
 
+  Scenario: Quiet search/replace
+    Given a WP install
+
+    When I run `wp search-replace foo bar --quiet`
+    Then STDOUT should be empty
+
   Scenario Outline: Large guid search/replace where replacement contains search (or not)
     Given a WP install
     And I run `wp option get siteurl`

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -102,13 +102,17 @@ class Search_Replace_Command extends WP_CLI_Command {
 			}
 		}
 
-		$table = new \cli\Table();
-		$table->setHeaders( array( 'Table', 'Column', 'Replacements', 'Type' ) );
-		$table->setRows( $report );
-		$table->display();
+		if ( ! WP_CLI::get_config( 'quiet' ) ) {
 
-		if ( !$dry_run )
-			WP_CLI::success( "Made $total replacements." );
+			$table = new \cli\Table();
+			$table->setHeaders( array( 'Table', 'Column', 'Replacements', 'Type' ) );
+			$table->setRows( $report );
+			$table->display();
+
+			if ( !$dry_run )
+				WP_CLI::success( "Made $total replacements." );
+
+		}
 	}
 
 	private static function get_table_list( $args, $network ) {


### PR DESCRIPTION
Previously #1230
