### PR TITLE
Update importer to handle one or more directories

### DIFF
--- a/features/import.feature
+++ b/features/import.feature
@@ -36,3 +36,46 @@ Feature: Import content.
 
     When I run `wp import {EXPORT_FILE} --authors=skip --skip=image_resize`
     Then STDOUT should not be empty
+
+  Scenario: Export and import a directory of files
+    Given a WP install
+    And I run `mkdir export-posts`
+    And I run `mkdir export-pages`
+
+    When I run `wp post generate --count=49`
+    When I run `wp post generate --post_type=page --count=49`
+    And I run `wp post list --post_type=post,page --format=count`
+    Then STDOUT should be:
+      """
+      100
+      """
+
+    When I run `wp export --dir=export-posts --post_type=post`
+    When I run `wp export --dir=export-pages --post_type=page`
+    Then STDOUT should not be empty
+
+    When I run `wp site empty --yes`
+    Then STDOUT should not be empty
+
+    When I run `wp post list --post_type=post,page --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `find export-* -type f | wc -l`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp plugin install wordpress-importer --activate`
+    And I run `wp import export-posts --authors=skip --skip=image_resize`
+    And I run `wp import export-pages --authors=skip --skip=image_resize`
+    Then STDOUT should not be empty
+
+    When I run `wp post list --post_type=post,page --format=count`
+    Then STDOUT should be:
+      """
+      100
+      """

--- a/php/commands/import.php
+++ b/php/commands/import.php
@@ -8,7 +8,7 @@ class Import_Command extends WP_CLI_Command {
 	 * ## OPTIONS
 	 *
 	 * <file>...
-	 * : Path to one or more valid WXR files for importing.
+	 * : Path to one or more valid WXR files for importing. Directories are also accepted.
 	 *
 	 * --authors=<authors>
 	 * : How the author mapping should be handled. Options are 'create', 'mapping.csv', or 'skip'. The first will create any non-existent users from the WXR file. The second will read author mapping associations from a CSV, or create a CSV for editing if the file path doesn't exist. The CSV requires two columns, and a header row like "old_user_login,new_user_login". The last option will skip any author mapping.
@@ -35,6 +35,17 @@ class Import_Command extends WP_CLI_Command {
 		$this->add_wxr_filters();
 
 		WP_CLI::log( 'Starting the import process...' );
+
+		$new_args = array();
+		foreach( $args as $arg ) {
+			if ( is_dir( $arg ) ) {
+				$files = glob( rtrim( $arg, '/' ) . '/*.{wxr,xml}', GLOB_BRACE );
+				$new_args = array_merge( $new_args, $files );
+			} else {
+				$new_args[] = $arg;
+			}
+		}
+		$args = $new_args;
 
 		foreach ( $args as $file ) {
 			if ( ! is_readable( $file ) ) {


### PR DESCRIPTION
Specify one or more directories when using `wp import`, and it will find and
import `.xml` and `.wxr` files.
