### PR TITLE
Switch php-cli-tools to dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	],
 	"require": {
 		"php": ">=5.3.2",
-		"wp-cli/php-cli-tools": "0.9.5",
+		"wp-cli/php-cli-tools": "dev-master",
 		"mustache/mustache": "~2.4",
 		"rhumsaa/array_column": "~1.1",
 		"rmccue/requests": "~1.6",


### PR DESCRIPTION
Now that we maintain php-cli-tools, we'll let WP-CLI users dogfood `dev-master` during the release cycle and use a tagged release in our release.
