### PR TITLE
core update: add intermediate message to break the long silence

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -246,11 +246,10 @@ Feature: Manage WordPress installation
       """
 
     When I run `wget http://wordpress.org/wordpress-3.9.zip --quiet`
-    Then STDOUT should be empty
-
-    When I run `wp core update wordpress-3.9.zip`
+    And I run `wp core update wordpress-3.9.zip`
     Then STDOUT should be:
       """
+      Starting update...
       Unpacking the update...
       Success: WordPress updated successfully.
       """

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -793,6 +793,7 @@ define('BLOG_ID_CURRENT_SITE', 1);
 									'full' => $args[0],
 								),
 				'version' => $version,
+				'locale' => null
 			);
 
 		} else if ( empty( $assoc_args['version'] ) ) {
@@ -827,6 +828,7 @@ define('BLOG_ID_CURRENT_SITE', 1);
 					'full' => $new_package,
 				),
 				'version' => $version,
+				'locale' => $locale
 			);
 
 		} else {
@@ -836,7 +838,11 @@ define('BLOG_ID_CURRENT_SITE', 1);
 
 		require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
 
-		WP_CLI::log( "Updating to version {$update->version} ({$update->locale})..." );
+		if ( $update->version ) {
+			WP_CLI::log( "Updating to version {$update->version} ({$update->locale})..." );
+		} else {
+			WP_CLI::log( "Starting update..." );
+		}
 
 		$result = Utils\get_upgrader( $upgrader )->upgrade( $update );
 


### PR DESCRIPTION
When running `wp core update` on my machine, there's a relatively long period when there is no output. This leaves the impression that something might be wrong.
