### PR TITLE
WXR Export: errors in GUID

### DIFF
--- a/php/export/class-wp-export-wxr-formatter.php
+++ b/php/export/class-wp-export-wxr-formatter.php
@@ -166,7 +166,7 @@ COMMENT;
 			->link( esc_url( apply_filters('the_permalink_rss', get_permalink() ) ) )
 			->pubDate( mysql2date( 'D, d M Y H:i:s +0000', get_post_time( 'Y-m-d H:i:s', true ), false ) )
 			->tag( 'dc:creator', get_the_author_meta( 'login' ) )
-			->guid( get_the_guid(), array( 'isPermaLink' => 'false' ) )
+			->guid( esc_url( get_the_guid() ), array( 'isPermaLink' => 'false' ) )
 			->description( '' )
 			->tag( 'content:encoded' )->contains->cdata( $post->post_content )->end
 			->tag( 'excerpt:encoded' )->contains->cdata( $post->post_excerpt )->end


### PR DESCRIPTION
I was getting the following error and only partial output of the guid element's value if a guid contained an `&`:

<pre>
Warning: DOMDocument::createElement(): unterminated entity reference        p=123... in phar:///usr/bin/wp/vendor/nb/oxymel/Oxymel.php on line 166
</pre>


In the database I'm working with right now, all the GUIDs are either URLs or blank, so this patch seems to work just fine for me, but I'm not sure if it's really universal enough to merge. I figured it'd make sense to offer it up for feedback either way though. Thanks!
