### PR TITLE
Update `wp term list` to support multiple taxonomies

### DIFF
--- a/features/term.feature
+++ b/features/term.feature
@@ -28,6 +28,15 @@ Feature: Manage WordPress terms
       | name      | slug |
       | Test term | test |
 
+    When I run `wp term create category 'Test category' --slug=test-category --description='This is a test category'`
+    Then STDOUT should not be empty
+
+    When I run `wp term list post_tag category --fields=name,slug --format=csv`
+    Then STDOUT should be CSV containing:
+      | name           | slug           |
+      | Test term      | test           |
+      | Test category  | test-category  |
+
     When I run `wp term get post_tag {TERM_ID}`
     Then STDOUT should be a table containing rows:
       | Field     | Value      |

--- a/php/commands/term.php
+++ b/php/commands/term.php
@@ -21,8 +21,8 @@ class Term_Command extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <taxonomy>
-	 * : List terms of a given taxonomy.
+	 * <taxonomy>...
+	 * : List terms of one or more taxonomies
 	 *
 	 * [--<field>=<value>]
 	 * : Filter by one or more fields. For accepted fields, see get_terms().


### PR DESCRIPTION
Fortunately, `get_terms()` does the heavy lifting behind the scenes.
