### PR TITLE
Better error message for update()

### DIFF
--- a/php/commands/option.php
+++ b/php/commands/option.php
@@ -107,8 +107,10 @@ class Option_Command extends WP_CLI_Command {
 		$result = update_option( $key, $value );
 
 		// update_option() returns false if the value is the same
-		if ( !$result && $value != get_option( $key ) ) {
-			WP_CLI::error( "Option '$key' value is already set to '$value'." );
+		if ( ! $result ) {
+			WP_CLI::error( "Could not update option '$key'." );
+		} else if ( $value == get_option( $key ) ) {
+			WP_CLI::error( "Value passed for '$key' option is unchanged." );
 		} else {
 			WP_CLI::success( "Updated '$key' option." );
 		}


### PR DESCRIPTION
Improves the error message for update() when the existing value is the same as the new one, as suggested in #1254
