### PR TITLE
Allow users to specify a custom path to the wp-config file.

### DIFF
--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -6,6 +6,12 @@ return array(
 		'file' => '<path>',
 		'desc' => 'Path to the WordPress files',
 	),
+	'wp-config-path' => array(
+        'runtime' => '=<path>',
+        'file' => '<path>',
+        'desc' => 'Path to the WordPress config file',
+        'default' => false,
+    ),
 
 	'url' => array(
 		'runtime' => '=<url>',

--- a/php/utils.php
+++ b/php/utils.php
@@ -187,7 +187,11 @@ function locate_wp_config() {
 	static $path;
 
 	if ( null === $path ) {
-		if ( file_exists( ABSPATH . 'wp-config.php' ) )
+		$custom_path = \WP_CLI::get_config('wp-config-path');
+
+        if ( ! empty( $custom_path ) && file_exists( $custom_path . '/wp-config.php' ) )
+            $path = $custom_path . '/wp-config.php';
+        elseif ( file_exists( ABSPATH . 'wp-config.php' ) )
 			$path = ABSPATH . 'wp-config.php';
 		elseif ( file_exists( ABSPATH . '../wp-config.php' ) && ! file_exists( ABSPATH . '/../wp-settings.php' ) )
 			$path = ABSPATH . '../wp-config.php';


### PR DESCRIPTION
Similar to @markjaquith skeleton project at http://github.com/markjaquith/WordPress-Skeleton I use a setup with WordPress in a subfolder. One difference in my setup though is, that I create a symlink to the actual WordPress installation. 

Now, the problem with the current version of locate_wp_config() is, that it tries to find the wp-config.php in the root of the WordPress installation or one folder up in the hierarchy. As a consequence it will only find a custom written wp-config.php which determines the path of the projects actual wp-config.php file, resulting in wp-cli complaining about a "Strange wp-config.php file", where the "wp-settings.php is not loaded directly".

A quick solution to this problem would be to allow users to specify a custom path to the WordPress configuration file as implemented by this pull request.

Example configuration for a project called 'projectname':

``` yaml
path: 'wp'
wp-config-path: '/Users/username/Sites/projectname'
```
