### PR TITLE
Allow themes and plugins to be listed with `update_version`

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -92,10 +92,14 @@ Feature: Manage WordPress plugins
     When I run `wp plugin install akismet --version=2.5.7 --force`
     Then STDOUT should not be empty
 
-    When I run `wp plugin list`
+    When I run `wp plugin list --name=akismet --field=update_version`
+    Then STDOUT should not be empty
+    And save STDOUT as {UPDATE_VERSION}
+
+    When I run `wp plugin list --fields=name,status,update,version,update_version`
     Then STDOUT should be a table containing rows:
-      | name       | status   | update    | version   |
-      | akismet    | inactive | available | 2.5.7     |
+      | name       | status   | update    | version   | update_version   |
+      | akismet    | inactive | available | 2.5.7     | {UPDATE_VERSION} |
 
     When I run `wp plugin activate akismet`
     Then STDOUT should not be empty

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -175,7 +175,7 @@ class Formatter {
 	 */
 	private function find_item_key( $item, $field ) {
 		foreach ( array( $field, $this->prefix . '_' . $field ) as $maybe_key ) {
-			if ( ( is_object( $item ) && isset( $item->$maybe_key ) ) || ( is_array( $item ) && isset( $item[$maybe_key] ) ) ) {
+			if ( ( is_object( $item ) && property_exists( $item, $maybe_key ) ) || ( is_array( $item ) && array_key_exists( $maybe_key, $item ) ) ) {
 				$key = $maybe_key;
 				break;
 			}


### PR DESCRIPTION
When there's no `update_version` available, the attribute is `null` on the
plugin info array.
`isset()` returns false for null values, but `array_key_exists()` and
`property_exists()` do the job

See https://github.com/wp-cli/wp-cli/issues/1166#issuecomment-52911998
