### PR TITLE
Conflict with lespoilus/spyc when installed with composer

### DIFF
--- a/php/Spyc.php
+++ b/php/Spyc.php
@@ -10,7 +10,7 @@
    * @package Spyc
    */
 
-if (!function_exists('spyc_load')) {
+if (!function_exists('spyc_load')) :
   /**
    * Parses YAML to array.
    * @param string $string YAML string.
@@ -19,9 +19,9 @@ if (!function_exists('spyc_load')) {
   function spyc_load ($string) {
     return Spyc::YAMLLoadString($string);
   }
-}
+endif;
 
-if (!function_exists('spyc_load_file')) {
+if (!function_exists('spyc_load_file')) :
   /**
    * Parses YAML to array.
    * @param string $file Path to YAML file.
@@ -30,7 +30,7 @@ if (!function_exists('spyc_load_file')) {
   function spyc_load_file ($file) {
     return Spyc::YAMLLoad($file);
   }
-}
+endif;
 
 if ( ! class_exists( 'Spyc' ) ) :
 /**


### PR DESCRIPTION
When I install wp-cli with composer, and I have already installed "lespoilus/spyc" librairy in composer, the following error is triggered when I try to execute the "vendor/bin/wp" command : 

``` sh
$ ./vendor/bin/wp

PHP Fatal error:  Cannot redeclare class Spyc in vendor/wp-cli/wp-cli/php/Spyc.php on line 57 
```

The vendor/composer/autoload_files.php  file contains twice "spyc.php"

``` php
return array(
    $vendorDir . '/lespoilus/spyc/spyc.php',
    $vendorDir . '/wp-cli/php-cli-tools/lib/cli/cli.php',
    $vendorDir . '/wp-cli/wp-cli/php/Spyc.php',
);
```

Would not it be better to add a dependency on "lespoilus/spyc"  in your composer.json ?

Thanks.
