### PR TITLE
Stop breaking at first cron event when looping over events to run/delete

### DIFF
--- a/features/cron.feature
+++ b/features/cron.feature
@@ -18,7 +18,7 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event delete wp_cli_test_event_1`
     Then STDOUT should contain:
       """
-      Success: Successfully deleted the cron event 'wp_cli_test_event_1'
+      Success: Deleted 1 instances of the cron event 'wp_cli_test_event_1'
       """
 
     When I run `wp cron event list`
@@ -46,6 +46,63 @@ Feature: Manage WP-Cron events and schedules
     Then STDOUT should not contain:
       """
       wp_cli_test_event_3
+      """
+
+  Scenario: Scheduling, running, and deleting duplicate events
+    When I run `wp cron event schedule wp_cli_test_event_5 '+20 minutes' --apple=banana`
+    When I run `wp cron event schedule wp_cli_test_event_5 '+20 minutes' --foo=bar`
+    Then STDOUT should not be empty
+
+    When I run `wp cron event list --format=csv --fields=hook,recurrence,args`
+    Then STDOUT should be CSV containing:
+      | hook                | recurrence    | args                |
+      | wp_cli_test_event_5 | Non-repeating | {"apple":"banana"}  |
+      | wp_cli_test_event_5 | Non-repeating | {"foo":"bar"}       |
+
+    When I run `wp cron event run wp_cli_test_event_5`
+    Then STDOUT should be:
+      """
+      Success: Executed 2 instances of the cron event 'wp_cli_test_event_5'
+      """
+
+    When I run `wp cron event list`
+    Then STDOUT should not contain:
+      """
+      wp_cli_test_event_5
+      """
+
+    When I try `wp cron event run wp_cli_test_event_5`
+    Then STDERR should be:
+      """
+      Error: Invalid cron event 'wp_cli_test_event_5'
+      """
+
+    When I run `wp cron event schedule wp_cli_test_event_5 '+20 minutes' --apple=banana`
+    When I run `wp cron event schedule wp_cli_test_event_5 '+20 minutes' --foo=bar`
+    Then STDOUT should not be empty
+
+    When I run `wp cron event list`
+    Then STDOUT should contain:
+      """
+      wp_cli_test_event_5
+      """
+
+    When I run `wp cron event delete wp_cli_test_event_5`
+    Then STDOUT should be:
+      """
+      Success: Deleted 2 instances of the cron event 'wp_cli_test_event_5'
+      """
+
+    When I run `wp cron event list`
+    Then STDOUT should not contain:
+      """
+      wp_cli_test_event_5
+      """
+
+    When I try `wp cron event delete wp_cli_test_event_5`
+    Then STDERR should be:
+      """
+      Error: Invalid cron event 'wp_cli_test_event_5'
       """
 
   Scenario: Scheduling and then running a re-occurring event
@@ -84,7 +141,7 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event delete wp_cli_test_event_2`
     Then STDOUT should contain:
       """
-      Success: Successfully deleted the cron event 'wp_cli_test_event_2'
+      Success: Deleted 1 instances of the cron event 'wp_cli_test_event_2'
       """
 
     When I run `wp cron event list`

--- a/php/commands/cron.php
+++ b/php/commands/cron.php
@@ -151,24 +151,28 @@ class Cron_Event_Command extends WP_CLI_Command {
 	public function run( $args, $assoc_args ) {
 
 		$hook   = $args[0];
-		$result = false;
 		$events = self::get_cron_events();
 
 		if ( is_wp_error( $events ) ) {
 			WP_CLI::error( $events );
 		}
 
+		$executed = 0;
 		foreach ( $events as $id => $event ) {
 			if ( $event->hook == $hook ) {
 				$result = self::run_event( $event );
-				break;
+				if ( $result ) {
+					$executed++;
+				} else {
+					WP_CLI::warning( sprintf( "Failed to the execute the cron event '%s'", $hook ) );
+				}
 			}
 		}
 
-		if ( $result ) {
-			WP_CLI::success( sprintf( "Successfully executed the cron event '%s'", $hook ) );
+		if ( $executed ) {
+			WP_CLI::success( sprintf( "Executed %d instances of the cron event '%s'", $executed, $hook ) );
 		} else {
-			WP_CLI::error( sprintf( "Failed to the execute the cron event '%s'", $hook ) );
+			WP_CLI::error( sprintf( "Invalid cron event '%s'", $hook ) );
 		}
 
 	}
@@ -209,24 +213,28 @@ class Cron_Event_Command extends WP_CLI_Command {
 	public function delete( $args, $assoc_args ) {
 
 		$hook   = $args[0];
-		$result = false;
 		$events = self::get_cron_events();
 
 		if ( is_wp_error( $events ) ) {
 			WP_CLI::error( $events );
 		}
 
+		$deleted = 0;
 		foreach ( $events as $id => $event ) {
 			if ( $event->hook == $hook ) {
 				$result = self::delete_event( $event );
-				break;
+				if ( $result ) {
+					$deleted++;
+				} else {
+					WP_CLI::warning( sprintf( "Failed to the delete the cron event '%s'", $hook ) );
+				}
 			}
 		}
 
-		if ( $result ) {
-			WP_CLI::success( sprintf( "Successfully deleted the cron event '%s'", $hook ) );
+		if ( $deleted ) {
+			WP_CLI::success( sprintf( "Deleted %d instances of the cron event '%s'", $deleted, $hook ) );
 		} else {
-			WP_CLI::error( sprintf( "Failed to the delete the cron event '%s'", $hook ) );
+			WP_CLI::error( sprintf( "Invalid cron event '%s'", $hook ) );
 		}
 
 	}


### PR DESCRIPTION
The `wp cron event run` and `wp cron event delete` commands are almost identical, and they both have the problem of doing a `break` after the first matching hook is found. However, you may have scheduled multiple events for the same hook but with different cron arguments associated with it, for example:

``` php
wp_schedule_single_event( time(), 'computer_numbers', array( 1, 1 ) );
wp_schedule_single_event( time(), 'computer_numbers', array( 2, 2 ) );
```

Only one of these will get run via WP-CLI currently. So we should instead looping over them all.

So for `wp cron event run`, something like this change:

``` diff
diff --git a/php/commands/cron.php b/php/commands/cron.php
index db4e07d..bc67221 100644
--- a/php/commands/cron.php
+++ b/php/commands/cron.php@@ -116,7 +117,7 @@ class Cron_Event_Command extends WP_CLI_Command {
        }

        /**
-    * Run the next scheduled cron event for the given hook.
+  * Run the next scheduled cron event(s) for the given hook.
         *
         * ## OPTIONS
         *
@@ -126,24 +127,27 @@ class Cron_Event_Command extends WP_CLI_Command {
        public function run( $args, $assoc_args ) {

                $hook   = $args[0];
-           $result = false;
                $events = self::get_cron_events();

                if ( is_wp_error( $events ) ) {
                        WP_CLI::error( $events );
                }

+         $found = 0;
                foreach ( $events as $id => $event ) {
-                   if ( $event->hook == $hook ) {
+                 if ( $event->hook === $hook ) {
                                $result = self::run_event( $event );
-                           break;
+                         if ( $result ) {
+                                 WP_CLI::success( sprintf( "Successfully executed the cron event '%s'", $hook ) );
+                         } else {
+                                 WP_CLI::error( sprintf( "Failed to the execute the cron event '%s'", $hook ) );
+                         }
+                         $found += 1;
                        }
                }

-           if ( $result ) {
-                   WP_CLI::success( sprintf( "Successfully executed the cron event '%s'", $hook ) );
-           } else {
-                   WP_CLI::error( sprintf( "Failed to the execute the cron event '%s'", $hook ) );
+         if ( 0 === $found ) {
+                 WP_CLI::warning( sprintf( "Cron event '%s' not found", $hook ) );
                }

        }
```
