### PR TITLE
Correct the grammar when executing or deleting cron events

### DIFF
--- a/features/cron.feature
+++ b/features/cron.feature
@@ -18,7 +18,7 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event delete wp_cli_test_event_1`
     Then STDOUT should contain:
       """
-      Success: Deleted 1 instances of the cron event 'wp_cli_test_event_1'
+      Success: Deleted the cron event 'wp_cli_test_event_1'
       """
 
     When I run `wp cron event list`
@@ -141,7 +141,7 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event delete wp_cli_test_event_2`
     Then STDOUT should contain:
       """
-      Success: Deleted 1 instances of the cron event 'wp_cli_test_event_2'
+      Success: Deleted the cron event 'wp_cli_test_event_2'
       """
 
     When I run `wp cron event list`

--- a/php/commands/cron.php
+++ b/php/commands/cron.php
@@ -170,7 +170,8 @@ class Cron_Event_Command extends WP_CLI_Command {
 		}
 
 		if ( $executed ) {
-			WP_CLI::success( sprintf( "Executed %d instances of the cron event '%s'", $executed, $hook ) );
+			$message = ( 1 == $executed ) ? "Executed the cron event '%2\$s'" : "Executed %1\$d instances of the cron event '%2\$s'";
+			WP_CLI::success( sprintf( $message, $executed, $hook ) );
 		} else {
 			WP_CLI::error( sprintf( "Invalid cron event '%s'", $hook ) );
 		}
@@ -232,7 +233,8 @@ class Cron_Event_Command extends WP_CLI_Command {
 		}
 
 		if ( $deleted ) {
-			WP_CLI::success( sprintf( "Deleted %d instances of the cron event '%s'", $deleted, $hook ) );
+			$message = ( 1 == $deleted ) ? "Deleted the cron event '%2\$s'" : "Deleted %1\$d instances of the cron event '%2\$s'";
+			WP_CLI::success( sprintf( $message, $deleted, $hook ) );
 		} else {
 			WP_CLI::error( sprintf( "Invalid cron event '%s'", $hook ) );
 		}


### PR DESCRIPTION
Correct the grammar when executing or deleting cron events where there is only one instance.

Previously: #1336
