### PR TITLE
Fix WP_CLI::colorize warnings

### DIFF
--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -104,7 +104,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 		if ( in_array( true, wp_list_pluck( $items, 'update' ) ) )
 			$legend_line[] = '%yU = Update Available%n';
 
-		\WP_CLI::line( 'Legend: ' . implode( ', ', \WP_CLI::colorize( $legend_line ) ) );
+		\WP_CLI::line( 'Legend: ' . \WP_CLI::colorize( implode( ', ', $legend_line ) ) );
 	}
 
 	function install( $args, $assoc_args ) {


### PR DESCRIPTION
Passing an array to colorize causes warnings since the passed in value ends up being passed
into md5

Warning was
PHP Warning:  md5() expects parameter 1 to be string, array given in git/wp-cli/vendor/wp-cli/php-cli-tools/lib/cli/Colors.php on line 118
