### PR TITLE
Add a summary table to the output of (plugin|theme) update

### DIFF
--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -252,6 +252,20 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 		} else {
 			\WP_CLI::error( $line );
 		}
+
+        if ($num_to_update > 0) {
+            $status = array();
+            foreach($items_to_update as $item_to_update => $info) {
+                $status[$item_to_update] = array(
+                    'name' => $info['name'],
+                    'old_version' => $info['version'],
+                    'new_version' => $info['update_version'],
+                    'status' => $result[$item_to_update] !== null ? 'Updated' : 'Error',
+                );
+            }
+            \WP_CLI\Utils\format_items( 'table', $status,
+                array( 'name', 'old_version', 'new_version', 'status' ) );
+        }
 	}
 
 	protected function _list( $_, $assoc_args ) {

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -253,19 +253,19 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			\WP_CLI::error( $line );
 		}
 
-        if ($num_to_update > 0) {
-            $status = array();
-            foreach($items_to_update as $item_to_update => $info) {
-                $status[$item_to_update] = array(
-                    'name' => $info['name'],
-                    'old_version' => $info['version'],
-                    'new_version' => $info['update_version'],
-                    'status' => $result[$item_to_update] !== null ? 'Updated' : 'Error',
-                );
-            }
-            \WP_CLI\Utils\format_items( 'table', $status,
-                array( 'name', 'old_version', 'new_version', 'status' ) );
-        }
+		if ($num_to_update > 0) {
+			$status = array();
+			foreach($items_to_update as $item_to_update => $info) {
+				$status[$item_to_update] = array(
+					'name' => $info['name'],
+					'old_version' => $info['version'],
+					'new_version' => $info['update_version'],
+					'status' => $result[$item_to_update] !== null ? 'Updated' : 'Error',
+				);
+			}
+			\WP_CLI\Utils\format_items( 'table', $status,
+				array( 'name', 'old_version', 'new_version', 'status' ) );
+		}
 	}
 
 	protected function _list( $_, $assoc_args ) {


### PR DESCRIPTION
Example:
Enabling Maintenance mode...
Downloading update from https://downloads.wordpress.org/plugin/akismet.3.0.2.zip...
Using cached file '/home/jeichorn/.wp-cli/cache/plugin/akismet-3.0.2.zip'...
Unpacking the update...
Installing the latest version...
Removing the old version of the plugin...
Plugin updated successfully.
Disabling Maintenance mode...
Success: Updated 1/1 plugins.
+---------+-------------+-------------+---------+
| name    | old_version | new_version | status  |
+---------+-------------+-------------+---------+
| akismet | 3.0.0       | 3.0.2       | Updated |
+---------+-------------+-------------+---------+