### PR TITLE
Remove url guesswork

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -196,7 +196,7 @@ class Runner {
 	 * @param array $assoc_args
 	 * @return string|false
 	 */
-	private static function guess_url( $assoc_args ) {
+	private static function load_url( $assoc_args ) {
 		if ( isset( $assoc_args['blog'] ) ) {
 			$assoc_args['url'] = $assoc_args['blog'];
 		}
@@ -206,30 +206,6 @@ class Runner {
 			if ( true === $url ) {
 				WP_CLI::warning( 'The --url parameter expects a value.' );
 			}
-		} elseif ( $wp_config_path = Utils\locate_wp_config() ) {
-			// Try to find the blog parameter in the wp-config file
-			$wp_config_file = file_get_contents( $wp_config_path );
-			$hit = array();
-
-			$re_define = "#.*define\s*\(\s*(['|\"]{1})(.+)(['|\"]{1})\s*,\s*(['|\"]{1})(.+)(['|\"]{1})\s*\)\s*;#iU";
-
-			if ( preg_match_all( $re_define, $wp_config_file, $matches ) ) {
-				foreach ( $matches[2] as $def_key => $def_name ) {
-					if ( 'DOMAIN_CURRENT_SITE' == $def_name )
-						$hit['domain'] = $matches[5][$def_key];
-					if ( 'PATH_CURRENT_SITE' == $def_name )
-						$hit['path'] = $matches[5][$def_key];
-				}
-			}
-
-			if ( !empty( $hit ) && isset( $hit['domain'] ) ) {
-				$url = $hit['domain'];
-				if ( isset( $hit['path'] ) )
-					$url .= $hit['path'];
-			}
-		}
-
-		if ( isset( $url ) ) {
 			return $url;
 		}
 
@@ -592,7 +568,7 @@ class Runner {
 		}
 
 		// Handle --url parameter
-		$url = self::guess_url( $this->config );
+		$url = self::load_url( $this->config );
 		if ( $url )
 			\WP_CLI::set_url( $url );
 
@@ -652,6 +628,18 @@ class Runner {
 
 		if ( $this->cmd_starts_with( array( 'plugin' ) ) ) {
 			$GLOBALS['pagenow'] = 'plugins.php';
+		}
+	}
+
+	public function maybe_update_url() {
+		if ( empty( $this->config['url'] ) && empty( $this->config['blog'] ) ) {
+			if ( defined( 'DOMAIN_CURRENT_SITE' ) ) {
+				$url = DOMAIN_CURRENT_SITE;
+				if ( defined( 'PATH_CURRENT_SITE' ) ) {
+					$url .= PATH_CURRENT_SITE;
+				}
+				\WP_CLI::set_url( $url );
+			}
 		}
 	}
 

--- a/php/wp-cli.php
+++ b/php/wp-cli.php
@@ -22,6 +22,8 @@ WP_CLI::get_runner()->before_wp_load();
 // Load wp-config.php code, in the global scope
 eval( WP_CLI::get_runner()->get_wp_config_code() );
 
+WP_CLI::get_runner()->maybe_update_url();
+
 // Load Core, mu-plugins, plugins, themes etc.
 require WP_CLI_ROOT . '/php/wp-settings-cli.php';
 


### PR DESCRIPTION
When working with a multisite installation with variable wp-config files, e.g.

```php
if ( file_exists( dirname( __FILE__ ) . '/wp-config-local.php' ) ) {
	require_once dirname( __FILE__ ) . '/wp-config-local.php';
} else {
	...
}
```

or even variable `DOMAIN_CURRENT_SITE` declarations, WP-CLI doesn't correctly parse the url (and, in fact, fails silently). To resolve this, WP_CLI requires using the `--url` flag, or using a yaml config to explicitly set the url.

This PR aims to resolve that by removing the guess, and setting the URL after the config is loaded. Perhaps there's rationale as to why the url must be set before the config is loaded; if so, can anyone explain why that is? 

If there's interest in moving forward with this, I'll write tests for it.

Refs #263.