### PR TITLE
Switch php-cli-tools to latest release in preparation for 0.17.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	],
 	"require": {
 		"php": ">=5.3.2",
-		"wp-cli/php-cli-tools": "0.10.0",
+		"wp-cli/php-cli-tools": "0.10.1",
 		"mustache/mustache": "~2.4",
 		"rhumsaa/array_column": "~1.1",
 		"rmccue/requests": "~1.6",


### PR DESCRIPTION
See
- https://github.com/wp-cli/php-cli-tools/releases/tag/v0.10.0
- https://github.com/wp-cli/php-cli-tools/releases/tag/v0.10.1

Previously #1313
Fixes #1370
