### PR TITLE
Ignore `disable_functions` from `php.ini`

### DIFF
--- a/bin/wp
+++ b/bin/wp
@@ -43,4 +43,4 @@ fi
 # to use if it re-launches itself to run other commands.
 export WP_CLI_PHP_USED="$php"
 
-exec "$php" --define disable_functions= $WP_CLI_PHP_ARGS "$SCRIPT_PATH" "$@"
+exec "$php" --define disable_functions="" $WP_CLI_PHP_ARGS "$SCRIPT_PATH" "$@"

--- a/bin/wp.bat
+++ b/bin/wp.bat
@@ -1,2 +1,2 @@
 @ECHO OFF
-php --define disable_functions= "%~dp0../php/boot-fs.php" %*
+php --define disable_functions="" "%~dp0../php/boot-fs.php" %*


### PR DESCRIPTION
For security reasons, some production environments have a long list of disabled functions.

A simple `wp` would fail when `proc_open()` is disabled.

Reminder: `--no-php-ini` is more dangerous as it will ignore `open_basedir` directives thus allowing cross-site worms to spread.
