### PR TITLE
Check if proc_open() can be used before calling it

### DIFF
--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -89,7 +89,7 @@ class Help_Command extends WP_CLI_Command {
 	}
 
 	private static function pass_through_pager( $out ) {
-		if ( Utils\is_windows() ) {
+		if ( Utils\is_windows() || !function_exists('proc_open') ) {
 			// no paging for Windows cmd.exe; sorry
 			echo $out;
 			return 0;


### PR DESCRIPTION
In a environment that `proc_open()` is disabled, the `wp` command itself could not show any help text:

<pre># wp
PHP Notice:  Undefined variable: pipes in phar:///usr/local/bin/wp/php/commands/help.php on line 106
PHP Warning:  proc_open() has been disabled for security reasons in phar:///usr/local/bin/wp/php/commands/help.php on line 106
PHP Warning:  proc_close() expects parameter 1 to be resource, null given in phar:///usr/local/bin/wp/php/commands/help.php on line 106</pre>
