### PR TITLE
Force https when accessing WordPress.org

### DIFF
--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -167,6 +167,10 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 		if ( $response->version == $version )
 			return;
 
+		// WordPress.org forces https, but still sometimes returns http
+		// See https://twitter.com/nacin/status/512362694205140992
+		$response->download_link = str_replace( 'http://', 'https://', $response->download_link );
+
 		list( $link ) = explode( $response->slug, $response->download_link );
 
 		if ( false !== strpos( $response->download_link, 'theme' ) )

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -35,7 +35,7 @@ class Core_Command extends WP_CLI_Command {
 		$versions_path = ABSPATH . 'wp-includes/version.php';
 		include $versions_path;
 
-		$url = 'http://api.wordpress.org/core/stable-check/1.0/';
+		$url = 'https://api.wordpress.org/core/stable-check/1.0/';
 
 		$options = array(
 			'timeout' => 30


### PR DESCRIPTION
WordPress.org started redirecting to https anyway. Sometimes WordPress.org
APIs return http though.
