### PR TITLE
Unencode plugin names when installing

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -233,3 +233,12 @@ Feature: Manage WordPress plugins
       """
       Warning: Plugin 'akismet' is already network active.
       """
+
+  Scenario: Plugin name with HTML entities
+    Given a WP install
+
+    When I run `wp plugin install debug-bar-list-dependencies`
+    Then STDOUT should contain:
+      """
+      Installing Debug Bar List Script & Style Dependencies
+      """

--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -268,7 +268,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			return new WP_Error( 'already_installed', 'Plugin already installed.' );
 		}
 
-		WP_CLI::log( sprintf( 'Installing %s (%s)', $api->name, $api->version ) );
+		WP_CLI::log( sprintf( 'Installing %s (%s)', html_entity_decode( $api->name ), $api->version ) );
 		if ( !isset( $assoc_args['version'] ) || 'dev' !== $assoc_args['version'] ) {
 			WP_CLI::get_http_cache_manager()->whitelist_package( $api->download_link, $this->item_type, $api->slug, $api->version );
 		}

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -283,7 +283,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 			return new WP_Error( 'already_installed', 'Theme already installed.' );
 		}
 
-		WP_CLI::log( sprintf( 'Installing %s (%s)', $api->name, $api->version ) );
+		WP_CLI::log( sprintf( 'Installing %s (%s)', html_entity_decode( $api->name ), $api->version ) );
 		if ( !isset( $assoc_args['version'] ) || 'dev' !== $assoc_args['version'] ) {
 			WP_CLI::get_http_cache_manager()->whitelist_package( $api->download_link, $this->item_type, $api->slug, $api->version );
 		}


### PR DESCRIPTION
Minor issue.

When installing a plugin with an HTML entity in its name, the entity is displayed in encoded form. Example:

```
wp plugin install debug-bar-list-dependencies
Installing Debug Bar List Script &#38; Style Dependencies (1.0.6)
```

The plugin name should be displayed in unencoded form.
