### PR TITLE
__destruct recognized as a command

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -70,3 +70,50 @@ Feature: Get help about WP-CLI commands
       """
       usage: wp core
       """
+
+  Scenario: Help for commands with magic methods
+    Given a WP install
+    And a wp-content/plugins/test-cli/command.php file:
+      """
+      <?php
+      // Plugin Name: Test CLI Help
+
+      class Test_Magic_Methods extends WP_CLI_Command {
+        /**
+         * A dummy command.
+         *
+         * @subcommand my-command
+         */
+        function my_command() {}
+
+        /**
+         * Magic methods should not appear as commands
+         */
+        function __construct() {}
+        function __destruct() {}
+        function __call( $name, $arguments ) {}
+        function __get( $key ) {}
+        function __set( $key, $value ) {}
+        function __isset( $key ) {}
+        function __unset( $key ) {}
+        function __sleep() {}
+        function __wakeup() {}
+        function __toString() {}
+        function __set_state() {}
+        function __clone() {}
+        function __debugInfo() {}
+      }
+
+      WP_CLI::add_command( 'test-magic-methods', 'Test_Magic_Methods' );
+      """
+    And I run `wp plugin activate test-cli`
+
+    When I run `wp test-magic-methods`
+    Then STDOUT should contain:
+      """
+      usage: wp test-magic-methods my-command
+      """
+    And STDOUT should not contain:
+      """
+      __destruct
+      """

--- a/php/WP_CLI/Dispatcher/CommandFactory.php
+++ b/php/WP_CLI/Dispatcher/CommandFactory.php
@@ -88,7 +88,7 @@ class CommandFactory {
 	 * @return bool
 	 */
 	private static function is_good_method( $method ) {
-		return $method->isPublic() && !$method->isConstructor() && !$method->isStatic();
+		return $method->isPublic() && !$method->isStatic() && 0 !== strpos( $method->getName(), '__' );
 	}
 }
 


### PR DESCRIPTION
As with other magic methods like __construct, __destruct shouldn't be recognized as a command.

```
<?php
class MyCommand extends WP_CLI_Command {
   public function __construct() {
      echo "Init...";
   }
   public function __destruct() {
      echo "Hello world";
   }
}

WP_CLI::add_command('test', 'MyCommand');
```

```
 $ wp test __construct
Error: 'test __construct' is not a registered wp command. See 'wp help'.

 $ wp test __destruct 
Init...
Hello world
Hello world
```
