### PR TITLE
Get the currently active language

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -427,6 +427,12 @@ Feature: Manage WordPress installation
       Success: Language activated.
       """
 
+    When I run `wp core language list --field=language --status=active`
+    Then STDOUT should be:
+      """
+      en_GB
+      """
+
     When I run `wp core language list --fields=language,english_name,status`
     Then STDOUT should be a table containing rows:
       | language  | english_name     | status        |

--- a/php/WP_CLI/CommandWithTranslation.php
+++ b/php/WP_CLI/CommandWithTranslation.php
@@ -22,6 +22,12 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 	/**
 	 * List all languages available.
 	 *
+	 * [--field=<field>]
+	 * : Display the value of a single field
+	 *
+	 * [--<field>=<value>]
+	 * : Filter results by key=value pairs.
+	 *
 	 * [--fields=<fields>]
 	 * : Limit the output to specific fields.
 	 *
@@ -61,6 +67,16 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 			}
 			return $translation;
 		}, $translations );
+
+		foreach( $translations as $key => $translation ) {
+
+			$fields = array_keys( $translation );
+			foreach( $fields as $field ) {
+				if ( isset( $assoc_args[ $field ] ) && $assoc_args[ $field ] != $translation[ $field ] ) {
+					unset( $translations[ $key ] );
+				}
+			}
+		}
 
 		$formatter = $this->get_formatter( $assoc_args );
 		$formatter->display_items( $translations );


### PR DESCRIPTION
It would be nice to filter languages.

``` php
wp core language list --fields=language --status=active
// avoid this way:
wp eval 'echo get_locale();'
```
