### PR TITLE
Proper example for deleting all spam comments

### DIFF
--- a/php/commands/comment.php
+++ b/php/commands/comment.php
@@ -6,7 +6,7 @@
  * ## EXAMPLES
  *
  *     # delete all spam comments.
- *     wp comment delete $(wp comment list --status=spam --format=ids)
+ *     wp comment delete $(wp comment list --status=spam --field=ID)
  *
  * @package wp-cli
  */


### PR DESCRIPTION
The example for deleting all of the spam comments doesn't work. Changing to this makes the command work, so I'm guessing it just needs the minor update.
