### PR TITLE
Fixed mkdir command in `wp core download` on Windows

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -125,7 +125,8 @@ class Core_Command extends WP_CLI_Command {
 
 		if ( !is_dir( ABSPATH ) ) {
 			WP_CLI::log( sprintf( 'Creating directory %s', ABSPATH ) );
-			WP_CLI::launch( Utils\esc_cmd( 'mkdir -p %s', ABSPATH ) );
+			$mkdir = \WP_CLI\Utils\is_windows() ? 'mkdir %s' : 'mkdir -p %s';
+			WP_CLI::launch( Utils\esc_cmd( $mkdir, ABSPATH ) );
 		}
 
 		$locale = isset( $assoc_args['locale'] ) ? $assoc_args['locale'] : 'en_US';


### PR DESCRIPTION
Simple implementation that expects `mkdir` behavior on Windows to be recursive, which it probably almost always is according to [this](http://stackoverflow.com/questions/905226/mkdir-p-linux-windows).
