### PR TITLE
Fix running as sudo error message to be consistent in how help files sho...

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -547,7 +547,7 @@ class Runner {
 			"If you'd like to run it as the user that this site is under, you can " .
 			"run the following to become the respective user:\n" .
 			"\n" .
-			"    sudo -u USER -i -- wp ...\n" .
+			"    sudo -u USER -i -- wp <command>\n" .
 			"\n"
 		);
 	}


### PR DESCRIPTION
When you run as sudo, WP-CLI shows you how to run as the user WP is installed as, but the syntax it shows isn't consistent with everywhere else showing the place to run a command.

changes it from 

`sudo -u USER -i -- wp ...`

to

`sudo -u USER -i -- wp <command>`
