### PR TITLE
core::_read() needs error handling

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -224,7 +224,12 @@ class Core_Command extends WP_CLI_Command {
 
 	private static function _read( $url ) {
 		$headers = array('Accept' => 'application/json');
-		return Utils\http_request( 'GET', $url, null, $headers, array( 'timeout' => 30 ) )->body;
+		$response = Utils\http_request( 'GET', $url, null, $headers, array( 'timeout' => 30 ) );
+		if ( 200 === $response->status_code ) {
+			return $response->body;
+		} else {
+			WP_CLI::error( "Couldn't fetch response from {$url} (HTTP code {$response->status_code})" );
+		}
 	}
 
 	private function get_download_offer( $locale ) {


### PR DESCRIPTION
https://github.com/wp-cli/wp-cli/blob/master/php/commands/core.php#L137-L140
