### PR TITLE
Can't create or edit a post using vim

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -279,7 +279,12 @@ function launch_editor_for_input( $input, $title = 'WP-CLI' ) {
 			$editor = 'vi';
 	}
 
-	\WP_CLI::launch( "$editor " . escapeshellarg( $tmpfile ) );
+	$descriptorspec = array( STDIN, STDOUT, STDERR );
+	$process = proc_open( "$editor " . escapeshellarg( $tmpfile ), $descriptorspec, $pipes );
+	$r = proc_close( $process );
+	if ( $r ) {
+		exit( $r );
+	}
 
 	$output = file_get_contents( $tmpfile );
 


### PR DESCRIPTION
Editing a post using wp post edit <ID> is failing for me in 0.17.  I have vim set as my system editor and the shell just hangs.  Swapping to nano and the shell returns immediately without firing up nano.  This also happens for wp post create.

I use Arch Linux/zsh locally and Debian/bash on my servers.  Both local and remote have the same issue with v0.17.  Reverting to v0.16 and the issue goes away. 
