### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform EOL normalization
-* text=auto
+* text=auto eol=lf


### PR DESCRIPTION
WP-CLI only works well with LF line endings (see e.g. comment parsing) and the original settings cause auto-translation to CRLF on Windows. The `eol=lf` bit fixes that so that the working copy files are LF on Windows too.
