### PR TITLE
Fix failing tests due to WordPress version update

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -272,7 +272,7 @@ Feature: Manage WordPress installation
       | version | update_type | package_url                               |
       | 4.0.1   | major       | https://wordpress.org/wordpress-4.0.1.zip |
       | 3.9.3   | major       | https://wordpress.org/wordpress-3.9.3.zip |
-      | 3.8.1   | minor       | https://wordpress.org/wordpress-3.8.1.zip |
+      | 3.8.5   | minor       | https://wordpress.org/wordpress-3.8.5.zip |
 
     When I run `wp core check-update --field=version | wc -l`
     Then STDOUT should be:
@@ -295,7 +295,7 @@ Feature: Manage WordPress installation
     When I run `wp core check-update --minor`
     Then STDOUT should be a table containing rows:
       | version | update_type | package_url                               |
-      | 3.8.1   | minor       | https://wordpress.org/wordpress-3.8.1.zip |
+      | 3.8.5   | minor       | https://wordpress.org/wordpress-3.8.5.zip |
 
     When I run `wp core check-update --minor --field=version | wc -l`
     Then STDOUT should be:

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -52,7 +52,7 @@ class Core_Command extends WP_CLI_Command {
 		$release_data = json_decode( $response->body );
 		$release_versions = array_keys( (array) $release_data );
 		usort( $release_versions, function( $a, $b ){
-			return ! version_compare( $a, $b );
+			return 1 === version_compare( $a, $b );
 		});
 
 		$locale = get_locale();
@@ -86,6 +86,7 @@ class Core_Command extends WP_CLI_Command {
 		}
 
 		if ( $updates ) {
+			$updates = array_reverse( $updates );
 			$formatter = new \WP_CLI\Formatter(
 				$assoc_args,
 				array( 'version', 'update_type', 'package_url' )


### PR DESCRIPTION
Also fixes use of `version_compare()` to sort WordPress versions.
