### PR TITLE
Disable colors by default when being run under Windows

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -453,7 +453,7 @@ class Runner {
 
 	private function init_colorization() {
 		if ( 'auto' === $this->config['color'] ) {
-			$this->colorize = !\cli\Shell::isPiped();
+			$this->colorize = ( !\cli\Shell::isPiped() && !\WP_CLI\Utils\is_windows() );
 		} else {
 			$this->colorize = $this->config['color'];
 		}


### PR DESCRIPTION
#267 added the `--no-color` argument but colors should be disabled by default on Windows, otherwise you end up with messages like this:

```
D:\Webserver\htdocs\plugin-development\wordpress>wp plugin activate akismet
←[32;1mSuccess:←[0m Plugin 'akismet' activated.
```

_Hope I did this right -- this is my first contribution to WP-CLI and my first pull request in a very long time. :wink:_
