### PR TITLE
Fix PHP notice when calling `wp export` with --category parameter

### DIFF
--- a/features/export.feature
+++ b/features/export.feature
@@ -187,6 +187,10 @@ Feature: Export content.
 
     When I run `wp export --post_type=post --category=apple`
     And save STDOUT 'Writing to file %s' as {EXPORT_FILE}
+    Then the {EXPORT_FILE} file should contain:
+      """
+      <wp:category_nicename>apple</wp:category_nicename>
+      """
 
     When I run `wp site empty --yes`
     Then STDOUT should not be empty

--- a/php/export/class-wp-export-query.php
+++ b/php/export/class-wp-export-query.php
@@ -72,7 +72,7 @@ class WP_Export_Query {
 
 	public function categories() {
 		if ( $this->category ) {
-			return $this->category;
+			return array( $this->category );
 		}
 		if ( $this->filters['post_type'] ) {
 			return array();


### PR DESCRIPTION
When using `wp export` with --category parameter I was getting the PHP notice below:

PHP Notice:  Trying to get property of non-object in php/export/class-wp-export-wxr-formatter.php on line 117

This resulted in several empty `<wp:category>` tags in the generated file. To fix it I had to revert a change made in aa27fd943291dd750a662a80599f8e65e6684488 which I'm not sure if it was intentional or not. 
