### PR TITLE
Alias `wp theme uninstall` to `wp theme delete`

### DIFF
--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -502,6 +502,8 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 	 * ## EXAMPLES
 	 *
 	 *     wp theme delete twentyeleven
+	 *
+	 * @alias uninstall
 	 */
 	function delete( $args ) {
 		foreach ( $this->fetcher->get_many( $args ) as $theme ) {


### PR DESCRIPTION
Even though themes don't have an uninstall process, plugins do. This
brings them to closer interface parity.
