### PR TITLE
Report HTTP error code on failure to install

### DIFF
--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -187,10 +187,11 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 			// check if the requested version exists
 			$response = wp_remote_head( $response->download_link );
-			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			$response_code = wp_remote_retrieve_response_code( $response );
+			if ( 200 !== $response_code ) {
 				\WP_CLI::error( sprintf(
-					"Can't find the requested %s's version %s in the WordPress.org %s repository.",
-					$download_type, $version, $download_type ) );
+					"Can't find the requested %s's version %s in the WordPress.org %s repository (HTTP code %d).",
+					$download_type, $version, $download_type, $response_code ) );
 			}
 		}
 	}


### PR DESCRIPTION
This gives the end user more information as to why their command failed.

See #1493
