### PR TITLE
Update php-cli-tools to v0.10.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	],
 	"require": {
 		"php": ">=5.3.2",
-		"wp-cli/php-cli-tools": "0.10.2",
+		"wp-cli/php-cli-tools": "0.10.3",
 		"mustache/mustache": "~2.4",
 		"rhumsaa/array_column": "~1.1",
 		"rmccue/requests": "~1.6",


### PR DESCRIPTION
Release notes: https://github.com/wp-cli/php-cli-tools/releases/tag/v0.10.3

Fixes #1537
