### PR TITLE
Remove extra lines before global parameters when calling `wp post --help`

### DIFF
--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -235,6 +235,10 @@ class CompositeCommand {
 		$binding = array();
 		$binding['root_command'] = $root_command;
 
+		if (! $this->can_have_subcommands() || ( is_object( $this->parent ) && get_class( $this->parent ) == 'WP_CLI\Dispatcher\CompositeCommand' )) {
+			$binding['is_subcommand'] = true;
+		}
+
 		foreach ( \WP_CLI::get_configurator()->get_spec() as $key => $details ) {
 			if ( false === $details['runtime'] )
 				continue;

--- a/templates/man-params.mustache
+++ b/templates/man-params.mustache
@@ -1,7 +1,7 @@
-{{^root_command}}
+{{#is_subcommand}}
 
 
-{{/root_command}}
+{{/is_subcommand}}
 ## GLOBAL PARAMETERS
 
 {{#parameters}}


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/pull/1515#discussion_r21326157

