### PR TITLE
Don't force update check on plugin install

### DIFF
--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -108,8 +108,6 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	}
 
 	function install( $args, $assoc_args ) {
-		// Force WordPress to check for updates
-		call_user_func( $this->upgrade_refresh );
 
 		foreach ( $args as $slug ) {
 			$local_or_remote_zip_file = false;


### PR DESCRIPTION
This reduces our dependency on WordPress.org API for installing.

The genesis of this call appears to be a copy and paste error:
1.
https://github.com/wp-cli/wp-cli/commit/1e2b9ee2384139c16aadb772ce0ccbcd7df52acb#diff-59ccae364a062cc72d61b0199f525e79R112
2.
https://github.com/wp-cli/wp-cli/commit/1e2b9ee2384139c16aadb772ce0ccbcd7df52acb#diff-78c563be62d40fb1c0c180515eef9636L60

See #1493
