### PR TITLE
Throw error when converting multisite to subdomains with "localhost"

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -247,6 +247,18 @@ Feature: Manage WordPress installation
       example.com
       """
 
+  Scenario: Install multisite with subdomains on localhost
+    Given an empty directory
+    And WP files
+    And wp-config.php
+    And a database
+
+    When I try `wp core multisite-install --url=http://localhost/ --title=Test --admin_user=wpcli --admin_email=admin@example.com --admin_password=1 --subdomains`
+    Then STDERR should contain:
+      """
+      Error: Multisite with subdomains cannot be configured when domain is 'localhost'.
+      """
+
   Scenario: Update from a ZIP file
     Given a WP install
 

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -441,7 +441,7 @@ class Core_Command extends WP_CLI_Command {
 	 * Default: '/'
 	 *
 	 * [--subdomains]
-	 * : If passed, the network will use subdomains, instead of subdirectories.
+	 * : If passed, the network will use subdomains, instead of subdirectories. Doesn't work with 'localhost'.
 	 *
 	 * @subcommand multisite-convert
 	 * @alias install-network
@@ -473,7 +473,7 @@ class Core_Command extends WP_CLI_Command {
 	 * Default: '/'
 	 *
 	 * [--subdomains]
-	 * : If passed, the network will use subdomains, instead of subdirectories.
+	 * : If passed, the network will use subdomains, instead of subdirectories. Doesn't work with 'localhost'.
 	 *
 	 * --title=<site-title>
 	 * : The title of the new site.
@@ -595,13 +595,17 @@ class Core_Command extends WP_CLI_Command {
 
 		require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
 
+		$domain = self::get_clean_basedomain();
+		if ( 'localhost' === $domain && ! empty( $assoc_args['subdomains'] ) ) {
+			WP_CLI::error( "Multisite with subdomains cannot be configured when domain is 'localhost'." );
+		}
+
 		// need to register the multisite tables manually for some reason
 		foreach ( $wpdb->tables( 'ms_global' ) as $table => $prefixed_table )
 			$wpdb->$table = $prefixed_table;
 
 		install_network();
 
-		$domain = self::get_clean_basedomain();
 		$result = populate_network(
 			$assoc_args['site_id'],
 			$domain,


### PR DESCRIPTION
Subdomains don't work at all when the domain is "localhost"

Fixes #1506, previously #1522
