### PR TITLE
Add icon argument to scaffold post-type command

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -64,6 +64,10 @@ Feature: WordPress code scaffolding
       """
       __( 'Zombies', 'zombieland'
       """
+    And STDOUT should contain:
+      """
+      'menu_icon'         => 'dashicons-admin-post',
+      """
 
   Scenario: CPT slug is too long
     When I try `wp scaffold post-type slugiswaytoolonginfact`
@@ -78,6 +82,13 @@ Feature: WordPress code scaffolding
     Then STDOUT should contain:
       """
       __( 'Brain eaters'
+      """
+
+  Scenario: Scaffold a Custom Post Type with icon
+    When I run `wp scaffold post-type zombie --icon="art"`
+    Then STDOUT should contain:
+      """
+      'menu_icon'         => 'dashicons-art',
       """
 
   Scenario: Scaffold a plugin

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -24,6 +24,9 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * [--textdomain=<textdomain>]
 	 * : The textdomain to use for the labels.
 	 *
+	 * [--icon=<icon>]
+	 * : The dashicon to use in the menu.
+	 *
 	 * [--theme]
 	 * : Create a file in the active theme directory, instead of sending to
 	 * STDOUT. Specify a theme with `--theme=<theme>` to have the file placed in that theme.
@@ -46,6 +49,7 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		$defaults = array(
 			'textdomain' => '',
+			'icon'       => 'admin-post',
 		);
 
 		$this->_scaffold( $args[0], $assoc_args, $defaults, '/post-types/', array(

--- a/templates/post_type.mustache
+++ b/templates/post_type.mustache
@@ -22,4 +22,5 @@
 		'has_archive'       => true,
 		'rewrite'           => true,
 		'query_var'         => true,
+		'menu_icon'         => 'dashicons-admin-post',
 	) );

--- a/templates/post_type.mustache
+++ b/templates/post_type.mustache
@@ -22,5 +22,5 @@
 		'has_archive'       => true,
 		'rewrite'           => true,
 		'query_var'         => true,
-		'menu_icon'         => 'dashicons-admin-post',
+		'menu_icon'         => 'dashicons-{{icon}}',
 	) );


### PR DESCRIPTION
Right now no `menu_icon` is set during the scaffolding of `post_types`. 

I implemented a new optional argument for `$ wp scaffold post-type` to give developers the option to add an icon from the official [dashicons](https://developer.wordpress.org/resource/dashicons/) in a very easy way. 

I also implemented a default value that is equal to the standard value so the icon argument is optional. But by adding the extra line in the generated `post_type` code the developer is hinted to the existence of this easily customisable icon. 

Lastly I added some behat tests to test with and without the argument.

The command can be used like so:
```
$ wp scaffold post-type zombie --icon="cloud"
```

This will put the [cloud](https://developer.wordpress.org/resource/dashicons/#cloud) dashicon in front of the post_type zombie