### PR TITLE
Package command: using composer

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -570,7 +570,14 @@ class Runner {
 
 		// Load bundled commands early, so that they're forced to use the same
 		// APIs as non-bundled commands.
+
 		Utils\load_command( $this->arguments[0] );
+
+		$packages_autoloader = getenv( 'HOME' ) . '/.wp-cli/vendor/autoload.php';
+
+		if ( file_exists( $packages_autoloader ) ) {
+			Utils\load_file( $packages_autoloader );
+		}
 
 		if ( isset( $this->config['require'] ) ) {
 			foreach ( $this->config['require'] as $path ) {

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -133,6 +133,9 @@ class Package_Command extends WP_CLI_Command {
 	private function remove_package( $package ) {
 		chdir( $this->home );
 
+		// let composer know where to find this package
+		exec( "composer config --unset repositories.{$package} vcs {$repo_url}" );
+
 		exec( "composer remove {$package}" );
 
 		exec( 'composer update' );

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -9,136 +9,136 @@ use WP_CLI\Process;
  * @package wp-cli
  */
 class Package_Command extends WP_CLI_Command {
-  private $home;
-  private $current_patj;
+	private $home;
+	private $current_patj;
 
-  public function __construct() {
-    $this->home    = getenv( 'HOME' ) . '/.wp-cli';
-    $this->current = getcwd();
-  }
+	public function __construct() {
+		$this->home    = getenv( 'HOME' ) . '/.wp-cli';
+		$this->current = getcwd();
+	}
 
-  /**
-   * Install a community package
-   *
-   * ## OPTIONS
-   *
-   * <package>
-   * : the slug of the package
-   *
-   * [--repo=<url>]
-   * : The package repository url
-   *
-   * [--version=<version>]
-   * : The package version/tag
-   *
-   * @subcommand install
-   *
-   * @when before_wp_load
-   */
-  public function install( $args, $assoc_args ) {
-    extract( $assoc_args );
-    $type = 'packagist';
+	/**
+	 * Install a community package
+	 *
+	 * ## OPTIONS
+	 *
+	 * <package>
+	 * : the slug of the package
+	 *
+	 * [--repo=<url>]
+	 * : The package repository url
+	 *
+	 * [--version=<version>]
+	 * : The package version/tag
+	 *
+	 * @subcommand install
+	 *
+	 * @when before_wp_load
+	 */
+	public function install( $args, $assoc_args ) {
+		extract( $assoc_args );
+		$type = 'packagist';
 
-    if ( ! isset( $version ) ) {
-      $version = 'dev-master';
-    }
+		if ( ! isset( $version ) ) {
+			$version = 'dev-master';
+		}
 
-    // when a repo has been provided set the type
-    if ( isset( $repo ) ) {
-      $type = 'vcs';
-    }
+		// when a repo has been provided set the type
+		if ( isset( $repo ) ) {
+			$type = 'vcs';
+		}
 
-    if ( ! file_exists( $this->home ) ) {
-      mkdir( $this->home );
-    }
+		if ( ! file_exists( $this->home ) ) {
+			mkdir( $this->home );
+		}
 
-    if ( ! file_exists( $this->home . '/composer.json' ) ) {
-      $this->create_composer_file();
-    }
+		if ( ! file_exists( $this->home . '/composer.json' ) ) {
+			$this->create_composer_file();
+		}
 
-    $package = $args[0];
+		$package = $args[0];
 
-    switch ( $type ) {
-      case 'vcs':
-        $this->install_vcs_package( $package, $version, $repo );
-        break;
+		switch ( $type ) {
+			case 'vcs':
+				$this->install_vcs_package( $package, $version, $repo );
+				break;
 
-      default:
-        $this->install_packagist_package( $package, $version );
-        break;
-    }
+			default:
+				$this->install_packagist_package( $package, $version );
+				break;
+		}
 
-  }
+	}
 
-  /**
-   * Remove a community package
-   *
-   * ## OPTIONS
-   *
-   * <package>
-   * : the slug of the package
-   *
-   * @subcommand remove
-   *
-   * @when before_wp_load
-   */
-  public function remove( $args, $assoc_args ) {
-    $package = $args[0];
+	/**
+	 * Remove a community package
+	 *
+	 * ## OPTIONS
+	 *
+	 * <package>
+	 * : the slug of the package
+	 *
+	 * @subcommand remove
+	 *
+	 * @when before_wp_load
+	 */
+	public function remove( $args, $assoc_args ) {
+		$package = $args[0];
 
-    $this->remove_package( $package );
-  }
+		$this->remove_package( $package );
+	}
 
-  private function create_composer_file() {
-    chdir( $this->home );
+	private function create_composer_file() {
+		chdir( $this->home );
 
-    exec( 'composer init --no-interaction --name="wp-cli/packages" --description="WP-CLI community packages"' );
+		exec( 'composer init --no-interaction --name="wp-cli/packages" --description="WP-CLI community packages"' );
 
-    chdir( $this->current );
-  }
+		chdir( $this->current );
+	}
 
-  private function install_packagist_package( $package, $version ) {
-    chdir( $this->home );
+	private function install_packagist_package( $package, $version ) {
+		chdir( $this->home );
 
-    // [TODO] implement packagist installs
-    exec( "composer require {$package}:{$version}" );
+		// [TODO] implement packagist installs
+		exec( "composer require {$package}:{$version}" );
 
-    exec( 'composer update' );
+		exec( 'composer update' );
 
-    chdir( $this->current );
-  }
+		chdir( $this->current );
+	}
 
-  private function install_satis_package( $package, $type, $url ) {
-    chdir( $this->home );
+	private function install_satis_package( $package, $type, $url ) {
+		chdir( $this->home );
 
-    // [TODO] implement Satis installs
+		// [TODO] implement Satis installs
 
-    chdir( $this->current );
-  }
+		chdir( $this->current );
+	}
 
-  private function install_vcs_package( $package, $version, $repo_url ) {
-    chdir( $this->home );
+	private function install_vcs_package( $package, $version, $repo_url ) {
+		chdir( $this->home );
 
-    // let composer know where to find this package
-    exec( "composer config repositories.{$package} vcs {$repo_url}" );
+		// let composer know where to find this package
+		exec( "composer config repositories.{$package} vcs {$repo_url}" );
 
-    // add the package to the require dependencies
-    exec( "composer require {$package}:{$version}" );
+		// add the package to the require dependencies
+		exec( "composer require {$package}:{$version}" );
 
-    // create/update the lock file
-    exec( 'composer update' );
+		// create/update the lock file
+		exec( 'composer update' );
 
-    chdir( $this->current );
-  }
+		chdir( $this->current );
+	}
 
-  private function remove_package( $package ) {
-    chdir( $this->home );
+	private function remove_package( $package ) {
+		chdir( $this->home );
 
-    exec( "composer remove {$package}" );
+		exec( "composer remove {$package}" );
 
-    exec( 'composer update' );
+		exec( 'composer update' );
 
-    chdir( $this->current );
-  }
+		chdir( $this->current );
+	}
 
 }
 

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -1,0 +1,145 @@
+<?php
+
+use WP_CLI\Utils;
+use WP_CLI\Process;
+
+/**
+ * Manage community commands
+ *
+ * @package wp-cli
+ */
+class Package_Command extends WP_CLI_Command {
+  private $home;
+  private $current_patj;
+
+  public function __construct() {
+    $this->home    = getenv( 'HOME' ) . '/.wp-cli';
+    $this->current = getcwd();
+  }
+
+  /**
+   * Install a community package
+   *
+   * ## OPTIONS
+   *
+   * <package>
+   * : the slug of the package
+   *
+   * [--repo=<url>]
+   * : The package repository url
+   *
+   * [--version=<version>]
+   * : The package version/tag
+   *
+   * @subcommand install
+   *
+   * @when before_wp_load
+   */
+  public function install( $args, $assoc_args ) {
+    extract( $assoc_args );
+    $type = 'packagist';
+
+    if ( ! isset( $version ) ) {
+      $version = 'dev-master';
+    }
+
+    // when a repo has been provided set the type
+    if ( isset( $repo ) ) {
+      $type = 'vcs';
+    }
+
+    if ( ! file_exists( $this->home ) ) {
+      mkdir( $this->home );
+    }
+
+    if ( ! file_exists( $this->home . '/composer.json' ) ) {
+      $this->create_composer_file();
+    }
+
+    $package = $args[0];
+
+    switch ( $type ) {
+      case 'vcs':
+        $this->install_vcs_package( $package, $version, $repo );
+        break;
+
+      default:
+        $this->install_packagist_package( $package, $version );
+        break;
+    }
+
+  }
+
+  /**
+   * Remove a community package
+   *
+   * ## OPTIONS
+   *
+   * <package>
+   * : the slug of the package
+   *
+   * @subcommand remove
+   *
+   * @when before_wp_load
+   */
+  public function remove( $args, $assoc_args ) {
+    $package = $args[0];
+
+    $this->remove_package( $package );
+  }
+
+  private function create_composer_file() {
+    chdir( $this->home );
+
+    exec( 'composer init --no-interaction --name="wp-cli/packages" --description="WP-CLI community packages"' );
+
+    chdir( $this->current );
+  }
+
+  private function install_packagist_package( $package, $version ) {
+    chdir( $this->home );
+
+    // [TODO] implement packagist installs
+    exec( "composer require {$package}:{$version}" );
+
+    exec( 'composer update' );
+
+    chdir( $this->current );
+  }
+
+  private function install_satis_package( $package, $type, $url ) {
+    chdir( $this->home );
+
+    // [TODO] implement Satis installs
+
+    chdir( $this->current );
+  }
+
+  private function install_vcs_package( $package, $version, $repo_url ) {
+    chdir( $this->home );
+
+    // let composer know where to find this package
+    exec( "composer config repositories.{$package} vcs {$repo_url}" );
+
+    // add the package to the require dependencies
+    exec( "composer require {$package}:{$version}" );
+
+    // create/update the lock file
+    exec( 'composer update' );
+
+    chdir( $this->current );
+  }
+
+  private function remove_package( $package ) {
+    chdir( $this->home );
+
+    exec( "composer remove {$package}" );
+
+    exec( 'composer update' );
+
+    chdir( $this->current );
+  }
+
+}
+
+WP_CLI::add_command( 'package', 'Package_Command' );


### PR DESCRIPTION
Package command to manage community commands. It uses composer to manage the packages and provided wrappers around these composer commands to allow for easier installing/removing of commands.

By leaving composer intact in the `~/.wp-cli` directory it remains possible to do more complicated package management with composer itself when navigating to the  `~/.wp-cli` directory.

This way we provide a nice and simpler interface for package management but we also provide the maximum power of composer itself.

Current features:
- can install commands from packagist
- can install commands from VCS: git, svn, mercurial (any type composer provides is possible)
- can also install commands from private github/bitbucket repositories. No limitations, again composer supports this so we support it.
- manage complicated packages directly in  `~/.wp-cli/composer.json` or by using `$ composer` in `~/.wp-cli/`

Todo:
- Add Satis support to easily find community commands? `search` subcommand?
- Composer's output is current not displayed, maybe suppressed by WP-CLI? @danielbachhuber 
- How to test the phar version of wp-cli? I'm not sure about the paths in that instance @danielbachhuber
- I didn't really know when to load the commands, I've added it to the runner. Maybe that should be done in a nicer way? @danielbachhuber 

I hope you like the approach. If not, I'm looking forward to the feedback :)
