### PR TITLE
install-wp-tests.sh won't work on older Bash: simple fix proposed

### DIFF
--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -60,7 +60,7 @@ install_db() {
 	local EXTRA=""
 
 	if ! [ -z $DB_HOSTNAME ] ; then
-		if [[ "$DB_SOCK_OR_PORT" =~ ^[0-9]+$ ]] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
 			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
 		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
 			EXTRA=" --socket=$DB_SOCK_OR_PORT"


### PR DESCRIPTION
Hi all

On Windows, the most used Bash implementation comes with [msysgit](https://msysgit.github.io/). Problem: this is a fossilized version from 2005 which can't understand `=~` pattern matching so `install-wp-tests.sh` fails on [line 63](https://github.com/wp-cli/wp-cli/blob/master/templates/install-wp-tests.sh#L63):

```
$ bash bin/install-wp-tests.sh wordpress_test root '' localhost latest
bin/install-wp-tests.sh: line 63: conditional binary operator expected
```

without `set -ex`:

```
$ bash bin/install-wp-tests.sh wordpress_test root '' localhost latest
bin/install-wp-tests.sh: line 63: conditional binary operator expected
bin/install-wp-tests.sh: line 63: syntax error near `=~'
bin/install-wp-tests.sh: line 63: `             if [[ "$DB_SOCK_OR_PORT" =~ ^[0-9]+$ ]] ; then'
```

A simple fix is to replace the bash operator `=~` with a call to `grep`, which is part of any environment, no matter how obsolete.

Thoughts?
