### PR TITLE
Use env variable for WP_CORE_DIR if set

### DIFF
--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -12,7 +12,7 @@ DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
 
 WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
-WP_CORE_DIR=/tmp/wordpress/
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
 
 set -ex
 


### PR DESCRIPTION
Hi!

Another simple tweak to help folks using Windows: set a directory for `WP_CORE_DIR`, just as `WP_TESTS_DIR` is.

Without this I couldn't get phpunit tests to run because the `require '/tmp/wordpress/...'` bits were not making my install too happy :-Þ

Side note: I'm preparing a WordCamp speech about plugin unit testing and there will be things specifically for people on Windows. When I'm done, I'll write a blog post about it and will let you know, this would be probably helpful for other windowsians as well :)