### PR TITLE
Adding multisite.xml file PHPUnit files

### DIFF
--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -472,10 +472,12 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		$plugin_dir = WP_PLUGIN_DIR . "/$plugin_slug";
 		$tests_dir = "$plugin_dir/tests";
+		$phpunit_dir = "$plugin_dir/tests/phpunit";
 		$bin_dir = "$plugin_dir/bin";
 
 		$wp_filesystem->mkdir( $tests_dir );
 		$wp_filesystem->mkdir( $bin_dir );
+		$wp_filesystem->mkdir( $phpunit_dir );
 
 		$this->create_file( "$tests_dir/bootstrap.php",
 			Utils\mustache_render( 'bootstrap.mustache', compact( 'plugin_slug' ) ) );
@@ -484,6 +486,7 @@ class Scaffold_Command extends WP_CLI_Command {
 			'install-wp-tests.sh' => $bin_dir,
 			'.travis.yml' => $plugin_dir,
 			'phpunit.xml' => $plugin_dir,
+			'multisite.xml' => $phpunit_dir,
 			'test-sample.php' => $tests_dir,
 		);
 

--- a/templates/multisite.xml
+++ b/templates/multisite.xml
@@ -1,0 +1,15 @@
+<phpunit
+		bootstrap="../../tests/bootstrap.php"
+        backupGlobals="false"
+        colors="true"
+        >
+    <php>
+        <const name="WP_TESTS_MULTISITE" value="1" />
+    </php>
+    <testsuites>
+        <!-- Default test suite to run all tests -->
+        <testsuite>
+            <directory suffix=".php">../../tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
As soon as you install the PHPUnit tests, WP Tests Suite is installed too. This suite allows Multisite tests but there's no way to execute unit tests under a multisite once everything is set up.

When you execute `phpunit` for your plugin a message like this is displayed:

**Running as single site... To run multisite, use -c tests/phpunit/multisite.xml**

Currently, the scaffold command does not create that file so this pull request tries to add one for the tests, not in the most elegant way, I know, but could be better than nothing.

The idea is to create a new folder called phpunit inside tests folder and a basic multisite.xml file on it when we execute the scaffold plugin-tests command.

I hope is useful.

Cheers.