### PR TITLE
Strip tags and decode entities from output

### DIFF
--- a/php/WP_CLI/Loggers/Regular.php
+++ b/php/WP_CLI/Loggers/Regular.php
@@ -21,7 +21,17 @@ class Regular {
 	 * @param string $str Message to write.
 	 */
 	protected function write( $handle, $str ) {
-		fwrite( $handle, $str );
+		fwrite( $handle, self::format( $str ) );
+	}
+
+	/**
+	 * Format a string for output.
+	 *
+	 * @param  string $str Message to output.
+	 * @return string      Formatted message to output.
+	 */
+	protected function format( $str ) {
+		return html_entity_decode( strip_tags( $str ) );
 	}
 
 	/**


### PR DESCRIPTION
This may have side effects, but I've not found any yet.

If a command results in an error which contains HTML markup (yeah, about that...), the markup is present in the console output. In addition, HTML entities aren't decoded. This can result in ugly error messages:

```
$ wp plugin search foo
Error: An unexpected error occurred. Something may be wrong with WordPress.org
or this server&#8217;s configuration. If you continue to have problems, please
try the <a href="https://wordpress.org/support/">support forums</a>. Try again
```

With the change in this PR, this output becomes:

```
$ wp plugin search foo
Error: An unexpected error occurred. Something may be wrong with WordPress.org
or this server’s configuration. If you continue to have problems, please
try the support forums. Try again
```