### PR TITLE
Use `--all-tables` search-replace flag to do all tables in the db

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -24,12 +24,18 @@ Feature: Do global search/replace
       | wp_2_posts | guid   | 2            | SQL  |
       | wp_blogs   | path   | 1            | SQL  |
 
-  Scenario: Don't run on unregistered tables
+  Scenario: Don't run on unregistered tables by default
     Given a WP install
-    And I run `wp db query "CREATE TABLE wp_awesome ( id int(11) unsigned NOT NULL AUTO_INCREMENT, PRIMARY KEY (id) ) ENGINE=InnoDB DEFAULT CHARSET=latin1;"`
+    And I run `wp db query "CREATE TABLE wp_awesome ( id int(11) unsigned NOT NULL AUTO_INCREMENT, awesome_stuff TEXT, PRIMARY KEY (id) ) ENGINE=InnoDB DEFAULT CHARSET=latin1;"`
 
     When I run `wp search-replace foo bar`
     Then STDOUT should not contain:
+      """
+      wp_awesome
+      """
+
+    When I run `wp search-replace foo bar --all-tables`
+    Then STDOUT should contain:
       """
       wp_awesome
       """

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -43,6 +43,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 * [--recurse-objects]
 	 * : Enable recursing into objects to replace strings
 	 *
+	 * [--all-tables]
+	 * : Enable replacement on any tables that match the table prefix even if not registered on wpdb
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp search-replace 'http://example.dev' 'http://example.com' --skip-columns=guid
@@ -70,7 +73,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		// never mess with hashed passwords
 		$skip_columns[] = 'user_pass';
 
-		$tables = self::get_table_list( $args, isset( $assoc_args['network'] ) );
+		$tables = self::get_table_list( $args, isset( $assoc_args['network'] ), isset( $assoc_args['all-tables'] ) );
 
 		foreach ( $tables as $table ) {
 			list( $primary_keys, $columns ) = self::get_columns( $table );
@@ -118,7 +121,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		}
 	}
 
-	private static function get_table_list( $args, $network ) {
+	private static function get_table_list( $args, $network, $all ) {
 		global $wpdb;
 
 		if ( !empty( $args ) )
@@ -126,6 +129,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 		$prefix = $network ? $wpdb->base_prefix : $wpdb->prefix;
 		$matching_tables = $wpdb->get_col( $wpdb->prepare( "SHOW TABLES LIKE %s", $prefix . '%' ) );
+
+		if ( $all ) {
+			return $matching_tables;
+		}
 
 		$allowed_tables = array();
 		$allowed_table_types = array( 'tables', 'global_tables' );


### PR DESCRIPTION
with issue https://github.com/wp-cli/wp-cli/pull/1304 released in wpcli 0.17 search-replace only applies to tables registered on wpdb

the problem is that plugins can create and use different tables non registered on wpdb, so it should be possible to run the command on all tables without explicitly listing them, with some optional flag like `--all-tables`

makes sense?

the optional behaviour could be:
- all the tables with the prefix in use (like pre-0.17)
- all the tables in the db

preferences? both with different flags?