### PR TITLE
Support downloading via curl or wget in install-wp-tests.sh

### DIFF
--- a/templates/install-package-tests.sh
+++ b/templates/install-package-tests.sh
@@ -8,7 +8,7 @@ install_wp_cli() {
 
 	# the Behat test suite will pick up the executable found in $WP_CLI_BIN_DIR
 	mkdir -p $WP_CLI_BIN_DIR
-	wget https://github.com/wp-cli/builds/raw/gh-pages/phar/wp-cli-nightly.phar
+	curl -s https://github.com/wp-cli/builds/raw/gh-pages/phar/wp-cli-nightly.phar
 	mv wp-cli-nightly.phar $WP_CLI_BIN_DIR/wp
 	chmod +x $WP_CLI_BIN_DIR/wp
 

--- a/templates/install-package-tests.sh
+++ b/templates/install-package-tests.sh
@@ -4,12 +4,19 @@ set -ex
 
 PACKAGE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
 
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
 install_wp_cli() {
 
 	# the Behat test suite will pick up the executable found in $WP_CLI_BIN_DIR
 	mkdir -p $WP_CLI_BIN_DIR
-	curl -s https://github.com/wp-cli/builds/raw/gh-pages/phar/wp-cli-nightly.phar
-	mv wp-cli-nightly.phar $WP_CLI_BIN_DIR/wp
+	download https://github.com/wp-cli/builds/raw/gh-pages/phar/wp-cli-nightly.phar $WP_CLI_BIN_DIR/wp
 	chmod +x $WP_CLI_BIN_DIR/wp
 
 }
@@ -30,7 +37,8 @@ set_package_context() {
 download_behat() {
 
 	cd $PACKAGE_DIR
-	curl -s https://getcomposer.org/installer | php
+	download https://getcomposer.org/installer installer
+	php installer
 	php composer.phar require --dev behat/behat='~2.5'
 
 }

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -16,6 +16,14 @@ WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
 
 set -ex
 
+download() {
+	if [ `which curl` ]; then
+		curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+    	wget -nv -O "$2" "$1"
+	fi
+}
+
 install_wp() {
 	mkdir -p $WP_CORE_DIR
 
@@ -25,10 +33,10 @@ install_wp() {
 		local ARCHIVE_NAME="wordpress-$WP_VERSION"
 	fi
 
-	wget -nv -O /tmp/wordpress.tar.gz https://wordpress.org/${ARCHIVE_NAME}.tar.gz
+	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
 	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
 
-	wget -nv -O $WP_CORE_DIR/wp-content/db.php https://raw.github.com/markoheijnen/wp-mysqli/master/db.php
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
 
 install_test_suite() {
@@ -44,7 +52,7 @@ install_test_suite() {
 	cd $WP_TESTS_DIR
 	svn co --quiet https://develop.svn.wordpress.org/trunk/tests/phpunit/includes/
 
-	wget -nv -O wp-tests-config.php https://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php
+	download https://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php wp-tests-config.php
 	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" wp-tests-config.php
 	sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" wp-tests-config.php
 	sed $ioption "s/yourusernamehere/$DB_USER/" wp-tests-config.php

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -17,11 +17,11 @@ WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
 set -ex
 
 download() {
-	if [ `which curl` ]; then
-		curl -s "$1" > "$2";
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
     elif [ `which wget` ]; then
-    	wget -nv -O "$2" "$1"
-	fi
+        wget -nv -O "$2" "$1"
+    fi
 }
 
 install_wp() {


### PR DESCRIPTION
This also removes the wget-call from install-package-tests as curl is
already a requirement.