### PR TITLE
Provide human-friendly error if invalid class is specified for a command

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -9,8 +9,9 @@ Feature: WP-CLI Commands
       WP_CLI::add_command( 'command example', 'Non_Existent_Class' );
       """
 
-    When I run `wp --require=custom-cmd.php help`
-    Then STDOUT should contain:
+    When I try `wp --require=custom-cmd.php help`
+    Then the return code should be 1
+    And STDERR should contain:
       """
-      Error: Class 'Non_Existent_Class' does not exist.
+      Class 'Non_Existent_Class' does not exist.
       """

--- a/features/command.feature
+++ b/features/command.feature
@@ -1,0 +1,16 @@
+Feature: WP-CLI Commands
+
+  Scenario: Invalid class is specified for a command
+    Given an empty directory
+    And a custom-cmd.php file:
+      """
+      <?php
+
+      WP_CLI::add_command( 'command example', 'Non_Existent_Class' );
+      """
+
+    When I run `wp --require=custom-cmd.php help`
+    Then STDOUT should contain:
+      """
+      Error: Class 'Non_Existent_Class' does not exist.
+      """

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -166,6 +166,10 @@ class WP_CLI {
 	 *   'before_invoke' => callback to execute before invoking the command
 	 */
 	public static function add_command( $name, $class, $args = array() ) {
+		if ( ! class_exists( $class ) ) {
+			WP_CLI::error( sprintf( "Class '%s' does not exist.", $class ) );
+		}
+
 		if ( isset( $args['before_invoke'] ) ) {
 			self::add_hook( "before_invoke:$name", $args['before_invoke'] );
 		}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -166,7 +166,7 @@ class WP_CLI {
 	 *   'before_invoke' => callback to execute before invoking the command
 	 */
 	public static function add_command( $name, $class, $args = array() ) {
-		if ( ! class_exists( $class ) ) {
+		if ( is_string( $class ) && ! class_exists( (string) $class ) ) {
 			WP_CLI::error( sprintf( "Class '%s' does not exist.", $class ) );
 		}
 


### PR DESCRIPTION
When non-existent class given to `add_command()`.