### PR TITLE
Correctly report the actual HTTP error when one occurs

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -343,3 +343,18 @@ Feature: Manage WordPress plugins
     Then STDOUT should be a table containing rows:
       | name       | version   |
       | akismet    | 2.6.0     |
+
+  Scenario: Attempt to search for a plugin when an HTTP connection is not available
+    Given a WP install
+    And a wp-content/mu-plugins/http-breaker.php file:
+      """
+      <?php
+      define( 'WP_PROXY_HOST', '127.0.0.1' );
+      define( 'WP_PROXY_PORT', 54321 );
+      """
+
+    When I try `wp plugin search foo`
+    Then STDERR should contain:
+      """
+      Error: Failed to connect to 127.0.0.1
+      """

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -225,3 +225,18 @@ Feature: Manage WordPress themes
     Then STDOUT should be a table containing rows:
       | name       | version   |
       | p2         | 1.4.2     |
+
+  Scenario: Attempt to search for a theme when an HTTP connection is not available
+    Given a WP install
+    And a wp-content/mu-plugins/http-breaker.php file:
+      """
+      <?php
+      define( 'WP_PROXY_HOST', '127.0.0.1' );
+      define( 'WP_PROXY_PORT', 54321 );
+      """
+
+    When I try `wp theme search foo`
+    Then STDERR should contain:
+      """
+      Error: Failed to connect to 127.0.0.1
+      """

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -405,7 +405,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 		}
 
 		if ( is_wp_error( $api ) )
-			\WP_CLI::error( $api->get_error_message() . __( ' Try again' ) );
+			\WP_CLI::error( $api->get_error_message() );
 
 		$plural = $this->item_type . 's';
 

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -10,6 +10,8 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	protected $upgrade_refresh;
 	protected $upgrade_transient;
 
+	protected $http_error;
+
 	abstract protected function get_upgrader_class( $force );
 
 	abstract protected function get_item_list();
@@ -28,6 +30,32 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	abstract protected function status_single( $args );
 
 	abstract protected function install_from_repo( $slug, $assoc_args );
+
+	public function __construct() {
+		// hook into wp http api
+		add_action( 'http_api_debug', array( $this, '_action_http_api_debug' ), 10, 5 );
+
+		parent::__construct();
+	}
+
+	public function _action_http_api_debug( $response, $context, $class, $args = null, $url = null ) {
+		if ( 'response' !== $context ) {
+			return $response;
+		}
+		if ( is_wp_error( $response ) ) {
+			$this->http_error = $response;
+		} else {
+			$this->http_error = null;
+		}
+		return $response;
+	}
+
+	public function _filter_wordpress_api_result( $res, $action, $args ) {
+		if ( !empty( $this->http_error ) ) {
+			return $this->http_error;
+		}
+		return $res;
+	}
 
 	function status( $args ) {
 		// Force WordPress to check for updates

--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -24,6 +24,8 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		require_once ABSPATH.'wp-admin/includes/plugin.php';
 		require_once ABSPATH.'wp-admin/includes/plugin-install.php';
 
+		add_filter( 'plugins_api_result', array( $this, '_filter_wordpress_api_result' ), 10, 3 );
+
 		parent::__construct();
 
 		$this->fetcher = new \WP_CLI\Fetchers\Plugin;

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -22,6 +22,9 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 		if ( is_multisite() ) {
 			$this->obj_fields[] = 'enabled';
 		}
+
+		add_filter( 'themes_api_result', array( $this, '_filter_wordpress_api_result' ), 10, 3 );
+
 		parent::__construct();
 
 		$this->fetcher = new \WP_CLI\Fetchers\Theme;


### PR DESCRIPTION
When an HTTP error occurs when connecting to the WordPress.org API, it gets reported back as a generic "An unexpected error occurred".

This change hooks onto the `http_api_debug` hook to catch the actual error, then filters `plugins_api_result` and `themes_api_result` to return that error instead of the generic one.

An unhelpful HTTP error before the patch:

	$ wp theme search foo
	Error: An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://wordpress.org/support/">support forums</a>.

A much more useful HTTP error after the patch:

	$ wp theme search foo
	Error: Failed to connect to 127.0.0.1 port 8888: Connection refused

I've also removed the "Try again" message which gets appended to the output when there's an API error. It's a bit superfluous.

One issue needs addressing before this can be merged. The action and filter callbacks are listed in the available sub-command list for `wp help plugin` and `wp help theme`. Prepending their name with an underscore doesn't hide them, and marking them as private or protected doesn't work because they need to be publicly accessed by the hooks and filters API. Any suggestions?