### PR TITLE
Don't instantiate the `Import_Command` class when registering

### DIFF
--- a/php/commands/import.php
+++ b/php/commands/import.php
@@ -378,5 +378,5 @@ class Import_Command extends WP_CLI_Command {
 
 }
 
-WP_CLI::add_command( 'import', new Import_Command );
+WP_CLI::add_command( 'import', 'Import_Command' );
 


### PR DESCRIPTION
Proper use is to provide the class name as a string

From #1645