### PR TITLE
Use --no-auto-rehash for MySQL commands by default, for performance boost

### DIFF
--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -109,7 +109,7 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args['execute'] = $args[0];
 		}
 
-		self::run( 'mysql --no-auto-rehash --no-defaults', $assoc_args );
+		self::run( 'mysql  --no-defaults --no-auto-rehash', $assoc_args );
 	}
 
 	/**
@@ -192,7 +192,7 @@ class DB_Command extends WP_CLI_Command {
 			);
 		}
 
-		self::run( 'mysql --no-auto-rehash --no-defaults', array(
+		self::run( 'mysql  --no-defaults --no-auto-rehash', array(
 			'database' => DB_NAME
 		), $descriptors );
 
@@ -244,7 +244,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	private static function run_query( $query ) {
-		self::run( 'mysql --no-auto-rehash --no-defaults', array( 'execute' => $query ) );
+		self::run( 'mysql  --no-defaults --no-auto-rehash', array( 'execute' => $query ) );
 	}
 
 	private static function run( $cmd, $assoc_args = array(), $descriptors = null ) {

--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -109,7 +109,7 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args['execute'] = $args[0];
 		}
 
-		self::run( 'mysql --no-defaults', $assoc_args );
+		self::run( 'mysql --no-auto-rehash --no-defaults', $assoc_args );
 	}
 
 	/**
@@ -192,7 +192,7 @@ class DB_Command extends WP_CLI_Command {
 			);
 		}
 
-		self::run( 'mysql --no-defaults', array(
+		self::run( 'mysql --no-auto-rehash --no-defaults', array(
 			'database' => DB_NAME
 		), $descriptors );
 
@@ -244,7 +244,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	private static function run_query( $query ) {
-		self::run( 'mysql --no-defaults', array( 'execute' => $query ) );
+		self::run( 'mysql --no-auto-rehash --no-defaults', array( 'execute' => $query ) );
 	}
 
 	private static function run( $cmd, $assoc_args = array(), $descriptors = null ) {

--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -109,7 +109,7 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args['execute'] = $args[0];
 		}
 
-		self::run( 'mysql  --no-defaults --no-auto-rehash', $assoc_args );
+		self::run( 'mysql --no-defaults --no-auto-rehash', $assoc_args );
 	}
 
 	/**
@@ -192,7 +192,7 @@ class DB_Command extends WP_CLI_Command {
 			);
 		}
 
-		self::run( 'mysql  --no-defaults --no-auto-rehash', array(
+		self::run( 'mysql --no-defaults --no-auto-rehash', array(
 			'database' => DB_NAME
 		), $descriptors );
 
@@ -244,7 +244,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	private static function run_query( $query ) {
-		self::run( 'mysql  --no-defaults --no-auto-rehash', array( 'execute' => $query ) );
+		self::run( 'mysql --no-defaults --no-auto-rehash', array( 'execute' => $query ) );
 	}
 
 	private static function run( $cmd, $assoc_args = array(), $descriptors = null ) {


### PR DESCRIPTION
Add --no-auto-rehash to mysql CLI options, disabling name completion to speed up non-interactive query processing.