### PR TITLE
Fix wp theme enable|disable child-theme

### DIFF
--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -175,7 +175,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 		$allowed_themes = call_user_func( "get{$_site}_option", 'allowedthemes' );
 		if ( empty( $allowed_themes ) )
 			$allowed_themes = array();
-		$allowed_themes[ $theme->get_template() ] = true;
+		$allowed_themes[ $theme->get_stylesheet() ] = true;
 		call_user_func( "update{$_site}_option", 'allowedthemes', $allowed_themes );
 
 		if ( ! empty( $assoc_args['network'] ) )
@@ -221,8 +221,8 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 
 		# Add the current theme to the allowed themes option or site option
 		$allowed_themes = call_user_func( "get{$_site}_option", 'allowedthemes' );
-		if ( ! empty( $allowed_themes[ $theme->get_template() ] ) )
-			unset( $allowed_themes[ $theme->get_template() ] );
+		if ( ! empty( $allowed_themes[ $theme->get_stylesheet() ] ) )
+			unset( $allowed_themes[ $theme->get_stylesheet() ] );
 		call_user_func( "update{$_site}_option", 'allowedthemes', $allowed_themes );
 
 		if ( ! empty( $assoc_args['network'] ) )


### PR DESCRIPTION
```php
// wp-includes/class-wp-theme.php
final class WP_Theme implements ArrayAccess {

  /**
   * The directory name of the theme's "stylesheet" files, inside the theme root.
   *
   * In the case of a child theme, this is directory name of the child theme.
   * Otherwise, get_stylesheet() is the same as get_template().
   *
   * @since 3.4.0
   * @access public
   *
   * @return string Stylesheet
   */
  public function get_stylesheet() {
          return $this->stylesheet;
  }

  /**
   * The directory name of the theme's "template" files, inside the theme root.
   * 
   * In the case of a child theme, this is the directory name of the parent theme.
   * Otherwise, the get_template() is the same as get_stylesheet().
   *
   * @since 3.4.0
   * @access public
   *
   * @return string Template
   */
  public function get_template() {
          return $this->template;
  }

}
```