### PR TITLE
Pad export filenames with zeros

### DIFF
--- a/php/commands/export.php
+++ b/php/commands/export.php
@@ -100,7 +100,7 @@ class Export_Command extends WP_CLI_Command {
 		if ( ! empty( $sitename ) ) {
 			$sitename .= '.';
 		}
-		return $sitename . 'wordpress.' . date( 'Y-m-d' ) . '.%d.xml';
+		return $sitename . 'wordpress.' . date( 'Y-m-d' ) . '.%03d.xml';
 	}
 
 	private static function load_export_api() {


### PR DESCRIPTION
It's helpful in many cases to have these files automatically ordered correctly. Without padded zeros, they will be ordered something like:

```
*.1.xml
*.10.xml
*.2.xml
*.3.xml
...
```