### PR TITLE
When testing WP-Cron, correctly set the `sslverify` argument

### DIFF
--- a/php/commands/cron.php
+++ b/php/commands/cron.php
@@ -509,7 +509,9 @@ class Cron_Command extends WP_CLI_Command {
 	 * @return WP_Error|array The response or WP_Error on failure.
 	 */
 	protected static function get_cron_spawn() {
+		global $wp_version;
 
+		$sslverify     = version_compare( $wp_version, 4.0, '>=' );
 		$doing_wp_cron = sprintf( '%.22F', microtime( true ) );
 
 		$cron_request = apply_filters( 'cron_request', array(
@@ -518,7 +520,7 @@ class Cron_Command extends WP_CLI_Command {
 			'args' => array(
 				'timeout'   => 3,
 				'blocking'  => true,
-				'sslverify' => apply_filters( 'https_local_ssl_verify', true )
+				'sslverify' => apply_filters( 'https_local_ssl_verify', $sslverify )
 			)
 		) );
 


### PR DESCRIPTION
In WordPress 4.0, the value of the `sslverify` argument when spawning cron was changed from `true` to `false`. This means that currently, the `wp cron test` command can return a false negative for a site which has an untrusted SSL certificate.

Ref: https://core.trac.wordpress.org/changeset/28781