### PR TITLE
Elaborated error message

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -24,7 +24,7 @@ function load_dependencies() {
 	}
 
 	if ( !$has_autoload ) {
-		fputs( STDERR, "Internal error: Can't find Composer autoloader.\n" );
+		fputs( STDERR, "Internal error: Can't find Composer autoloader.\nTry running: composer install\n" );
 		exit(3);
 	}
 }


### PR DESCRIPTION
See #1434

When we download the `non-phar` version of `wp-cli` we have to run `composer install` to install it's dependencies.
If we try to run `wp` when we haven't run `composer install`, we get this error:

`Internal error: Can't find Composer autoloader.`

which doesn't help. Instead I added:

`Try running: composer install\n`
Giving:

`Internal error: Can't find Composer autoloader.\nTry running: composer install\n`

Which makes more sense.