### PR TITLE
Throw hard error if importing a file returns WP_Error

### DIFF
--- a/php/commands/import.php
+++ b/php/commands/import.php
@@ -55,7 +55,7 @@ class Import_Command extends WP_CLI_Command {
 			$ret = $this->import_wxr( $file, $assoc_args );
 
 			if ( is_wp_error( $ret ) ) {
-				WP_CLI::warning( $ret );
+				WP_CLI::error( $ret );
 			} else {
 				WP_CLI::line(); // WXR import ends with HTML, so make sure message is on next line
 				WP_CLI::success( "Finished importing from $file file." );


### PR DESCRIPTION
`create_author_mapping_file()` uses WP_Error to report that an author
mapping file needs to be updated. However, when importing a directory of
WXR files, only using `::warning()` means the second file will use the
author mapping file of the first, which should've been edited.

Fixes #1682