### PR TITLE
sanitize option before checking value equality

### DIFF
--- a/php/commands/option.php
+++ b/php/commands/option.php
@@ -204,8 +204,9 @@ class Option_Command extends WP_CLI_Command {
 		$value = WP_CLI::read_value( $value, $assoc_args );
 
 		$value = sanitize_option( $key, $value );
+		$old_value = sanitize_option( $key, get_option( $key ) );
 
-		if ( $value === get_option( $key ) ) {
+		if ( $value === $old_value ) {
 			WP_CLI::success( "Value passed for '$key' option is unchanged." );
 		} else {
 			if ( update_option( $key, $value ) ) {

--- a/php/commands/option.php
+++ b/php/commands/option.php
@@ -203,6 +203,8 @@ class Option_Command extends WP_CLI_Command {
 		$value = WP_CLI::get_value_from_arg_or_stdin( $args, 1 );
 		$value = WP_CLI::read_value( $value, $assoc_args );
 
+		$value = sanitize_option( $key, $value );
+
 		if ( $value === get_option( $key ) ) {
 			WP_CLI::success( "Value passed for '$key' option is unchanged." );
 		} else {
@@ -246,4 +248,3 @@ class Option_Command extends WP_CLI_Command {
 }
 
 WP_CLI::add_command( 'option', 'Option_Command' );
-


### PR DESCRIPTION
If a plugin defines a sanitize_option filter, the equality check in 'wp
option update' may indicate that the the new option value is different
from the original when in fact it is not.  The result is a spurious
error message on an unchanged option, instead of succeeding with 'Value
passed for 'foo' option is unchanged'.

I see this with the Yoast SEO plugin which defines this filter.

I would write a test but it seems like a hard thing to test easily.