### PR TITLE
apply option unchanged logic to post meta

### DIFF
--- a/features/post-meta.feature
+++ b/features/post-meta.feature
@@ -22,7 +22,10 @@ Feature: Manage post custom fields
     Then STDOUT should not be empty
 
     When I run the previous command again
-    Then STDOUT should not be empty
+    Then STDOUT should be:
+      """
+      Success: Value passed for custom field 'foo' is unchanged.
+      """
 
     When I run `wp post-meta get 1 foo --format=json`
     Then STDOUT should be:

--- a/features/post-meta.feature
+++ b/features/post-meta.feature
@@ -21,6 +21,9 @@ Feature: Manage post custom fields
     When I run `wp post-meta set 1 foo '[ "1", "2" ]' --format=json`
     Then STDOUT should not be empty
 
+    When I run the previous command again
+    Then STDOUT should not be empty
+
     When I run `wp post-meta get 1 foo --format=json`
     Then STDOUT should be:
       """

--- a/php/WP_CLI/CommandWithMeta.php
+++ b/php/WP_CLI/CommandWithMeta.php
@@ -181,13 +181,22 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 
 		$object_id = $this->check_object_id( $object_id );
 
-		$success = \update_metadata( $this->meta_type, $object_id, $meta_key, $meta_value );
+		$meta_value = sanitize_meta( $meta_key, $meta_value, $this->meta_type );
+		$old_value = sanitize_meta( $meta_key, get_metadata( $this->meta_type, $object_id, $meta_key, true ), $this->meta_type );
 
-		if ( $success ) {
-			\WP_CLI::success( "Updated custom field." );
+		if ( $meta_value === $old_value ) {
+			\WP_CLI::success( "Value passed for custom field '$meta_key' is unchanged." );
 		} else {
-			\WP_CLI::error( "Failed to update custom field." );
+			$success = \update_metadata( $this->meta_type, $object_id, $meta_key, $meta_value );
+
+			if ( $success ) {
+				\WP_CLI::success( "Updated custom field '$meta_key'." );
+			} else {
+				\WP_CLI::error( "Failed to update custom field '$meta_key'." );
+			}
+
 		}
+
 	}
 
 	/**
@@ -214,4 +223,3 @@ abstract class CommandWithMeta extends \WP_CLI_Command {
 	}
 
 }
-


### PR DESCRIPTION
check for unchanged value, rather than failing with error