### PR TITLE
Added allow multisite constant to multisite install and convert.

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -636,6 +636,7 @@ class Core_Command extends WP_CLI_Command {
 		if ( !is_multisite() ) {
 			ob_start();
 ?>
+define( 'WP_ALLOW_MULTISITE', true );
 define('MULTISITE', true);
 define('SUBDOMAIN_INSTALL', <?php var_export( $assoc_args['subdomains'] ); ?>);
 $base = '<?php echo $assoc_args['base']; ?>';


### PR DESCRIPTION
The multisite install and convert code does not include:
`define( 'WP_ALLOW_MULTISITE', true );`

If this isn't present, the "Network Settings" and "Network Setup"
menu items are not available in the network admin.

