### PR TITLE
Add `--all-tables` flag to `search-replace` command

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -40,6 +40,22 @@ Feature: Do global search/replace
       wp_awesome
       """
 
+  Scenario: Run on unregistered, unprefixed tables with --all-tables flag
+    Given a WP install
+    And I run `wp db query "CREATE TABLE awesome_table ( id int(11) unsigned NOT NULL AUTO_INCREMENT, awesome_stuff TEXT, PRIMARY KEY (id) ) ENGINE=InnoDB DEFAULT CHARSET=latin1;"`
+
+    When I run `wp search-replace foo bar`
+    Then STDOUT should not contain:
+      """
+      awesome_table
+      """
+
+    When I run `wp search-replace foo bar --all-tables`
+    Then STDOUT should contain:
+      """
+      awesome_table
+      """
+
   Scenario: Quiet search/replace
     Given a WP install
 

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -136,11 +136,23 @@ class Search_Replace_Command extends WP_CLI_Command {
 		}
 	}
 
-	private static function get_table_list( $args, $network, $all_with_prefix ) {
+	/**
+	 * Retrieve a list of tables from the database.
+	 *
+	 * @param array $assoc_args Array of options passed to this command.
+	 *
+	 * @return array The array of table names.
+	 */
+	private static function get_table_list( $assoc_args ) {
 		global $wpdb;
 
-		if ( !empty( $args ) )
-			return $args;
+		$network         = \WP_CLI\Utils\flag( $assoc_args, 'network' );
+		$all_tables      = \WP_CLI\Utils\flag( $assoc_args, 'all-tables' );
+		$all_with_prefix = \WP_CLI\Utils\flag( $assoc_args, 'all-tables-with-prefix' );
+
+		if ( $all_tables ) {
+			return $wpdb->get_col( 'SHOW TABLES' );
+		}
 
 		$prefix = $network ? $wpdb->base_prefix : $wpdb->prefix;
 		$matching_tables = $wpdb->get_col( $wpdb->prepare( "SHOW TABLES LIKE %s", $prefix . '%' ) );

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -78,7 +78,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$skip_columns[] = 'user_pass';
 
 		// Get the array of tables to work with. If there is anything left in $args, assume those are table names to use
-		$tables = empty( $args ) ? self::get_table_list( $args, $assoc_args ) : $args;
+		$tables = empty( $args ) ? self::get_table_list( $assoc_args ) : $args;
 		foreach ( $tables as $table ) {
 			list( $primary_keys, $columns ) = self::get_columns( $table );
 

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -60,12 +60,12 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		global $wpdb;
-		$old = array_shift( $args );
-		$new = array_shift( $args );
-		$total = 0;
-		$report = array();
-		$dry_run = \WP_CLI\Utils\flag( $assoc_args, 'dry-run' );
-		$php_only = \WP_CLI\Utils\flag( $assoc_args, 'precise' );
+		$old             = array_shift( $args );
+		$new             = array_shift( $args );
+		$total           = 0;
+		$report          = array();
+		$dry_run         = \WP_CLI\Utils\flag( $assoc_args, 'dry-run' );
+		$php_only        = \WP_CLI\Utils\flag( $assoc_args, 'precise' );
 		$recurse_objects = \WP_CLI\Utils\flag( $assoc_args, 'recurse-objects' );
 
 		if ( isset( $assoc_args['skip-columns'] ) ) {

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -77,17 +77,8 @@ class Search_Replace_Command extends WP_CLI_Command {
 		// never mess with hashed passwords
 		$skip_columns[] = 'user_pass';
 
-		if ( $all_tables ) {
-			WP_CLI::confirm( "Will run against ALL tables in the database, not only WordPress tables. Continue?" );
-			$tables = $wpdb->get_col( 'SHOW TABLES' );
-		} else {
-			$tables = self::get_table_list(
-				$args,
-				isset( $assoc_args['network'] ),
-				isset( $assoc_args['all-tables-with-prefix'] )
-			);
-		}
-
+		// Get the array of tables to work with. If there is anything left in $args, assume those are table names to use
+		$tables = empty( $args ) ? self::get_table_list( $args, $assoc_args ) : $args;
 		foreach ( $tables as $table ) {
 			list( $primary_keys, $columns ) = self::get_columns( $table );
 

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -69,10 +69,11 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$recurse_objects = isset( $assoc_args['recurse-objects'] );
 		$all_tables = isset( $assoc_args['all-tables'] );
 
-		if ( isset( $assoc_args['skip-columns'] ) )
+		if ( isset( $assoc_args['skip-columns'] ) ) {
 			$skip_columns = explode( ',', $assoc_args['skip-columns'] );
-		else
+		} else {
 			$skip_columns = array();
+		}
 
 		// never mess with hashed passwords
 		$skip_columns[] = 'user_pass';
@@ -128,8 +129,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 			$table->setRows( $report );
 			$table->display();
 
-			if ( !$dry_run )
+			if ( ! $dry_run ) {
 				WP_CLI::success( "Made $total replacements." );
+			}
 
 		}
 	}

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -64,10 +64,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$new = array_shift( $args );
 		$total = 0;
 		$report = array();
-		$dry_run = isset( $assoc_args['dry-run'] );
-		$php_only = isset( $assoc_args['precise'] );
-		$recurse_objects = isset( $assoc_args['recurse-objects'] );
-		$all_tables = isset( $assoc_args['all-tables'] );
+		$dry_run = \WP_CLI\Utils\flag( $assoc_args, 'dry-run' );
+		$php_only = \WP_CLI\Utils\flag( $assoc_args, 'precise' );
+		$recurse_objects = \WP_CLI\Utils\flag( $assoc_args, 'recurse-objects' );
 
 		if ( isset( $assoc_args['skip-columns'] ) ) {
 			$skip_columns = explode( ',', $assoc_args['skip-columns'] );

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -129,6 +129,8 @@ class Search_Replace_Command extends WP_CLI_Command {
 	/**
 	 * Retrieve a list of tables from the database.
 	 *
+	 * @global wpdb $wpdb
+	 *
 	 * @param array $assoc_args Array of options passed to this command.
 	 *
 	 * @return array The array of table names.

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -64,9 +64,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$new             = array_shift( $args );
 		$total           = 0;
 		$report          = array();
-		$dry_run         = \WP_CLI\Utils\flag( $assoc_args, 'dry-run' );
-		$php_only        = \WP_CLI\Utils\flag( $assoc_args, 'precise' );
-		$recurse_objects = \WP_CLI\Utils\flag( $assoc_args, 'recurse-objects' );
+		$dry_run         = self::check_flag( $assoc_args, 'dry-run' );
+		$php_only        = self::check_flag( $assoc_args, 'precise' );
+		$recurse_objects = self::check_flag( $assoc_args, 'recurse-objects' );
 
 		if ( isset( $assoc_args['skip-columns'] ) ) {
 			$skip_columns = explode( ',', $assoc_args['skip-columns'] );
@@ -138,9 +138,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 	private static function get_table_list( $assoc_args ) {
 		global $wpdb;
 
-		$network         = \WP_CLI\Utils\flag( $assoc_args, 'network' );
-		$all_tables      = \WP_CLI\Utils\flag( $assoc_args, 'all-tables' );
-		$all_with_prefix = \WP_CLI\Utils\flag( $assoc_args, 'all-tables-with-prefix' );
+		$network         = self::check_flag( $assoc_args, 'network' );
+		$all_tables      = self::check_flag( $assoc_args, 'all-tables' );
+		$all_with_prefix = self::check_flag( $assoc_args, 'all-tables-with-prefix' );
 
 		if ( $all_tables ) {
 			return $wpdb->get_col( 'SHOW TABLES' );
@@ -289,6 +289,21 @@ class Search_Replace_Command extends WP_CLI_Command {
 		}
 
 		return $old;
+	}
+
+	/**
+	 * Determine the boolean value of a flag in an array.
+	 *
+	 * Primarily useful for determining the status of a boolean flag for a command. This is needed because a flag can be
+	 * prefixed with --no- to set it to false. Therefore it is not sufficient to only check whether a flag is set.
+	 *
+	 * @param array  $array The array to check.
+	 * @param string $key   The key to check for.
+	 *
+	 * @return bool True if the key is set in the array and is truthy, false otherwise.
+	 */
+	private static function check_flag( $array, $key ) {
+		return isset( $array[ $key ] ) && $array[ $key ];
 	}
 }
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -504,3 +504,18 @@ function increment_version( $current_version, $new_version ) {
 
 	return $current_version;
 }
+
+/**
+ * Determine the boolean value of a flag in an array.
+ *
+ * Primarily useful for determining the status of a boolean flag for a command. This is needed because a flag can be
+ * prefixed with --no- to set it to false. Therefore it is not sufficient to only check whether a flag is set.
+ *
+ * @param array  $array The array to check.
+ * @param string $key   The key to check for.
+ *
+ * @return bool True if the key is set in the array and is truthy, false otherwise.
+ */
+function flag( $array, $key ) {
+	return isset( $array[ $key ] ) && $array[ $key ];
+}

--- a/php/utils.php
+++ b/php/utils.php
@@ -504,18 +504,3 @@ function increment_version( $current_version, $new_version ) {
 
 	return $current_version;
 }
-
-/**
- * Determine the boolean value of a flag in an array.
- *
- * Primarily useful for determining the status of a boolean flag for a command. This is needed because a flag can be
- * prefixed with --no- to set it to false. Therefore it is not sufficient to only check whether a flag is set.
- *
- * @param array  $array The array to check.
- * @param string $key   The key to check for.
- *
- * @return bool True if the key is set in the array and is truthy, false otherwise.
- */
-function flag( $array, $key ) {
-	return isset( $array[ $key ] ) && $array[ $key ];
-}


### PR DESCRIPTION
### Approach

Adds a new flag, `--all-tables`, to the `search-replace` command. This allows the command to be run against all tables in the database, rather than strictly WordPress tables or even prefixed tables. Because of the possibility for destruction, the flag also prompts the user to confirm the action.

There are also some Behat tests to cover the functionality.

### Tests
- [x] Functional