### PR TITLE
Add scaffold plugin --activate-network option

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -1,10 +1,8 @@
 Feature: WordPress code scaffolding
 
-  Background:
-    Given a WP install
-
   @theme
   Scenario: Scaffold a child theme
+    Given a WP install
     Given I run `wp theme path`
     And save STDOUT as {THEME_DIR}
 
@@ -14,6 +12,7 @@ Feature: WordPress code scaffolding
 
   @tax @cpt
   Scenario: Scaffold a Custom Taxonomy and Custom Post Type and write it to active theme
+    Given a WP install
     Given I run `wp eval 'echo STYLESHEETPATH;'`
     And save STDOUT as {STYLESHEETPATH}
 
@@ -26,6 +25,7 @@ Feature: WordPress code scaffolding
   # Test for all flags but --label, --theme, --plugin and --raw
   @tax
   Scenario: Scaffold a Custom Taxonomy and attach it to CPTs including one that is prefixed and has a text domain
+    Given a WP install
     When I run `wp scaffold taxonomy zombie-speed --post_types="prefix-zombie,wraith" --textdomain=zombieland`
     Then STDOUT should contain:
       """
@@ -42,6 +42,7 @@ Feature: WordPress code scaffolding
 
   @tax
   Scenario: Scaffold a Custom Taxonomy with label "Speed"
+    Given a WP install
     When I run `wp scaffold taxonomy zombie-speed --label="Speed"`
     Then STDOUT should contain:
         """
@@ -55,6 +56,7 @@ Feature: WordPress code scaffolding
   # Test for all flags but --label, --theme, --plugin and --raw
   @cpt
   Scenario: Scaffold a Custom Post Type
+    Given a WP install
     When I run `wp scaffold post-type zombie --textdomain=zombieland`
     Then STDOUT should contain:
       """
@@ -70,6 +72,7 @@ Feature: WordPress code scaffolding
       """
 
   Scenario: CPT slug is too long
+    Given a WP install
     When I try `wp scaffold post-type slugiswaytoolonginfact`
     Then STDERR should be:
       """
@@ -78,6 +81,7 @@ Feature: WordPress code scaffolding
 
   @cpt
   Scenario: Scaffold a Custom Post Type with label
+    Given a WP install
     When I run `wp scaffold post-type zombie --label="Brain eater"`
     Then STDOUT should contain:
       """
@@ -85,6 +89,7 @@ Feature: WordPress code scaffolding
       """
 
   Scenario: Scaffold a Custom Post Type with dashicon
+    Given a WP install
     When I run `wp scaffold post-type zombie --dashicon="art"`
     Then STDOUT should contain:
       """
@@ -92,6 +97,7 @@ Feature: WordPress code scaffolding
       """
 
   Scenario: Scaffold a plugin
+    Given a WP install
     Given I run `wp plugin path`
     And save STDOUT as {PLUGIN_DIR}
 
@@ -101,6 +107,7 @@ Feature: WordPress code scaffolding
     And the {PLUGIN_DIR}/hello-world/readme.txt file should exist
 
   Scenario: Scaffold a plugin and activate it
+    Given a WP install
     When I run `wp scaffold plugin hello-world --activate`
     Then STDOUT should contain:
       """
@@ -108,6 +115,7 @@ Feature: WordPress code scaffolding
       """
 
   Scenario: Scaffold a plugin and network activate it
+    Given a WP multisite install
     When I run `wp scaffold plugin hello-world --activate-network`
     Then STDOUT should contain:
       """
@@ -115,6 +123,7 @@ Feature: WordPress code scaffolding
       """
 
   Scenario: Scaffold plugin tests
+    Given a WP install
     When I run `wp plugin path`
     Then save STDOUT as {PLUGIN_DIR}
 
@@ -145,6 +154,7 @@ Feature: WordPress code scaffolding
       """
 
   Scenario: Scaffold package tests
+    Given a WP install
     Given a community-command/command.php file:
       """
       <?php
@@ -214,6 +224,7 @@ Feature: WordPress code scaffolding
       """
 
   Scenario: Scaffold starter code for a theme
+    Given a WP install
     Given I run `wp theme path`
     And save STDOUT as {THEME_DIR}
 
@@ -225,6 +236,7 @@ Feature: WordPress code scaffolding
     And the {THEME_DIR}/starter-theme/style.css file should exist
 
   Scenario: Scaffold starter code for a theme with sass
+    Given a WP install
     Given I run `wp theme path`
     And save STDOUT as {THEME_DIR}
 
@@ -236,6 +248,7 @@ Feature: WordPress code scaffolding
     And the {THEME_DIR}/starter-theme/sass directory should exist
 
   Scenario: Scaffold starter code for a theme and activate it
+    Given a WP install
     When I run `wp scaffold _s starter-theme --activate`
     Then STDOUT should contain:
       """

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -107,6 +107,13 @@ Feature: WordPress code scaffolding
       Plugin 'hello-world' activated.
       """
 
+  Scenario: Scaffold a plugin and network activate it
+    When I run `wp scaffold plugin hello-world --activate-network`
+    Then STDOUT should contain:
+      """
+      Plugin 'hello-world' network activated.
+      """
+
   Scenario: Scaffold plugin tests
     When I run `wp plugin path`
     Then save STDOUT as {PLUGIN_DIR}

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -10,6 +10,15 @@ Feature: WordPress code scaffolding
     Then STDOUT should not be empty
     And the {THEME_DIR}/zombieland/style.css file should exist
 
+  Scenario: Scaffold a child theme and network enable it
+    Given a WP multisite install
+
+    When I run `wp scaffold child-theme zombieland --parent_theme=umbrella --theme_name=Zombieland --author=Tallahassee --author_uri=http://www.wp-cli.org --theme_uri=http://www.zombieland.com --enable-network`
+    Then STDOUT should contain:
+      """
+      Success: Network enabled the 'Zombieland' theme.
+      """
+
   @tax @cpt
   Scenario: Scaffold a Custom Taxonomy and Custom Post Type and write it to active theme
     Given a WP install

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -263,3 +263,11 @@ Feature: WordPress code scaffolding
       """
       Switched to 'Starter-theme' theme.
       """
+
+  Scenario: Scaffold starter code for a theme and network enable it
+    Given a WP multisite install
+    When I run `wp scaffold _s starter-theme --enable-network`
+    Then STDOUT should contain:
+      """
+      Success: Network enabled the 'Starter-theme' theme.
+      """

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -252,5 +252,5 @@ Feature: WordPress code scaffolding
     When I run `wp scaffold _s starter-theme --activate`
     Then STDOUT should contain:
       """
-      Switched to 'Starter-theme' theme.
+      Success: Switched to 'Starter-theme' theme.
       """

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -10,15 +10,6 @@ Feature: WordPress code scaffolding
     Then STDOUT should not be empty
     And the {THEME_DIR}/zombieland/style.css file should exist
 
-  Scenario: Scaffold a child theme and network enable it
-    Given a WP multisite install
-
-    When I run `wp scaffold child-theme zombieland --parent_theme=umbrella --theme_name=Zombieland --author=Tallahassee --author_uri=http://www.wp-cli.org --theme_uri=http://www.zombieland.com --enable-network`
-    Then STDOUT should contain:
-      """
-      Success: Network enabled the 'Zombieland' theme.
-      """
-
   @tax @cpt
   Scenario: Scaffold a Custom Taxonomy and Custom Post Type and write it to active theme
     Given a WP install
@@ -262,12 +253,4 @@ Feature: WordPress code scaffolding
     Then STDOUT should contain:
       """
       Switched to 'Starter-theme' theme.
-      """
-
-  Scenario: Scaffold starter code for a theme and network enable it
-    Given a WP multisite install
-    When I run `wp scaffold _s starter-theme --enable-network`
-    Then STDOUT should contain:
-      """
-      Success: Network enabled the 'Starter-theme' theme.
       """

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -263,6 +263,9 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * [--activate]
 	 * : Activate the newly created child theme.
 	 *
+	 * [--enable-network]
+	 * : Enable the newly created child theme for the entire network.
+	 *
 	 * @subcommand child-theme
 	 */
 	function child_theme( $args, $assoc_args ) {
@@ -288,8 +291,11 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		WP_CLI::success( "Created $theme_dir" );
 
-		if ( isset( $assoc_args['activate'] ) )
+		if ( isset( $assoc_args['activate'] ) ) {
 			WP_CLI::run_command( array( 'theme', 'activate', $theme_slug ) );
+		} else if ( isset( $assoc_args['enable-network'] ) ) {
+			WP_CLI::run_command( array( 'theme', 'enable', $theme_slug ), array( 'network' => true ) );
+		}
 	}
 
 	private function get_output_path( $assoc_args, $subdir ) {

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -173,6 +173,9 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * [--activate]
 	 * : Activate the newly downloaded theme.
 	 *
+	 * [--enable-network]
+	 * : Enable the newly downloaded theme for the entire network.
+	 *
 	 * [--theme_name=<title>]
 	 * : What to put in the 'Theme Name:' header in style.css
 	 *
@@ -232,9 +235,11 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		WP_CLI::success( "Created theme '{$data['theme_name']}'." );
 
-		if ( isset( $assoc_args['activate'] ) )
+		if ( isset( $assoc_args['activate'] ) ) {
 			WP_CLI::run_command( array( 'theme', 'activate', $theme_slug ) );
-
+		} else if ( isset( $assoc_args['enable-network'] ) ) {
+			WP_CLI::run_command( array( 'theme', 'enable', $theme_slug ), array( 'network' => true ) );
+		}
 	}
 
 	/**

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -449,9 +449,7 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		if ( isset( $assoc_args['activate'] ) ) {
 			WP_CLI::run_command( array( 'plugin', 'activate', $plugin_slug ) );
-		}
-
-		if ( isset( $assoc_args['activate-network'] ) ) {
+		} else if ( isset( $assoc_args['activate-network'] ) ) {
 			WP_CLI::run_command( array( 'plugin', 'activate', $plugin_slug), array( 'network' => true ) );
 		}
 	}

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -419,6 +419,9 @@ class Scaffold_Command extends WP_CLI_Command {
 	 *
 	 * [--activate]
 	 * : Activate the newly generated plugin.
+	 *
+	 * [--activate-network]
+	 * : Network activate the newly generated plugin.
 	 */
 	function plugin( $args, $assoc_args ) {
 		$plugin_slug = $args[0];
@@ -446,6 +449,10 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		if ( isset( $assoc_args['activate'] ) ) {
 			WP_CLI::run_command( array( 'plugin', 'activate', $plugin_slug ) );
+		}
+
+		if ( isset( $assoc_args['activate-network'] ) ) {
+			WP_CLI::run_command( array( 'plugin', 'activate', $plugin_slug), array( 'network' => true ) );
 		}
 	}
 

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -173,9 +173,6 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * [--activate]
 	 * : Activate the newly downloaded theme.
 	 *
-	 * [--enable-network]
-	 * : Enable the newly downloaded theme for the entire network.
-	 *
 	 * [--theme_name=<title>]
 	 * : What to put in the 'Theme Name:' header in style.css
 	 *
@@ -235,11 +232,9 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		WP_CLI::success( "Created theme '{$data['theme_name']}'." );
 
-		if ( isset( $assoc_args['activate'] ) ) {
+		if ( isset( $assoc_args['activate'] ) )
 			WP_CLI::run_command( array( 'theme', 'activate', $theme_slug ) );
-		} else if ( isset( $assoc_args['enable-network'] ) ) {
-			WP_CLI::run_command( array( 'theme', 'enable', $theme_slug ), array( 'network' => true ) );
-		}
+
 	}
 
 	/**
@@ -268,9 +263,6 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * [--activate]
 	 * : Activate the newly created child theme.
 	 *
-	 * [--enable-network]
-	 * : Enable the newly created child theme for the entire network.
-	 *
 	 * @subcommand child-theme
 	 */
 	function child_theme( $args, $assoc_args ) {
@@ -296,11 +288,8 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		WP_CLI::success( "Created $theme_dir" );
 
-		if ( isset( $assoc_args['activate'] ) ) {
+		if ( isset( $assoc_args['activate'] ) )
 			WP_CLI::run_command( array( 'theme', 'activate', $theme_slug ) );
-		} else if ( isset( $assoc_args['enable-network'] ) ) {
-			WP_CLI::run_command( array( 'theme', 'enable', $theme_slug ), array( 'network' => true ) );
-		}
 	}
 
 	private function get_output_path( $assoc_args, $subdir ) {


### PR DESCRIPTION
Includes new functional test for `wp scaffold _s --activate`; I’m planning on also creating a parallel issue for that command, though I’m not sure what the option should be called, because the nomenclature seems different (`wp theme enable` vs `wp plugin activate`).

See #1709