### PR TITLE
Allow missing active plugins to be deactivated

### DIFF
--- a/php/WP_CLI/Fetchers/Plugin.php
+++ b/php/WP_CLI/Fetchers/Plugin.php
@@ -27,6 +27,16 @@ class Plugin extends Base {
 			}
 		}
 
+		$active_plugins = (array) get_option('active_plugins');
+		$network_plugins = (array) get_site_option('active_sitewide_plugins');
+		$all_plugins = array_unique( array_merge( array_values( $active_plugins ), array_keys( $network_plugins ) ) );
+
+		foreach ( $all_plugins as $plugin ) {
+			if ( dirname( $plugin ) === $name && $name !== '.' ) {
+				return (object) array('name' => $plugin, 'file' => $plugin);
+			}
+		}
+
 		return false;
 	}
 }


### PR DESCRIPTION
Proof of concept fix for #1673.

In the code below, the patched version of wp-cli is called with `_wp`.

```
$ wp --info
PHP binary:	/Applications/MAMP/bin/php/php5.5.18/bin/php
PHP version:	5.5.18
php.ini used:	/Applications/MAMP/bin/php/php5.5.18/conf/php.ini
WP-CLI root dir:	phar://wp-cli.phar
WP-CLI global config:
WP-CLI project config:
WP-CLI version:	0.18.0
$ _wp --info
PHP binary:	/Applications/MAMP/bin/php/php5.5.18/bin/php
PHP version:	5.5.18
php.ini used:	/Applications/MAMP/bin/php/php5.5.18/conf/php.ini
WP-CLI root dir:	/Users/aaemnnosttv/forks/wp-cli
WP-CLI global config:
WP-CLI project config:
WP-CLI version:	0.18.0

$ _wp plugin install --activate wordpress-importer
Installing WordPress Importer (0.6.1)
Downloading install package from https://downloads.wordpress.org/plugin/wordpress-importer.0.6.1.zip...
Using cached file '/Users/aaemnnosttv/.wp-cli/cache/plugin/wordpress-importer-0.6.1.zip'...
Unpacking the package...
Installing the plugin...
Plugin installed successfully.
Activating 'wordpress-importer'...
Success: Plugin 'wordpress-importer' activated.
$ rm -rf wp-content/plugins/wordpress-importer/
$ _wp plugin list
+---------+----------+-----------+---------+
| name    | status   | update    | version |
+---------+----------+-----------+---------+
| akismet | inactive | available | 3.0.4   |
| hello   | active   | none      | 1.6     |
+---------+----------+-----------+---------+
$ _wp plugin deactivate hello
Success: Plugin 'hello' deactivated.
$ wp plugin deactivate wordpress-importer
Warning: The 'wordpress-importer' plugin could not be found.
$ _wp plugin deactivate wordpress-importer
Success: Plugin 'wordpress-importer/wordpress-importer.php' deactivated.
```