### PR TITLE
Package rhumsaa/array_column is abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		"php": ">=5.3.2",
 		"wp-cli/php-cli-tools": "0.10.4",
 		"mustache/mustache": "~2.4",
-		"rhumsaa/array_column": "~1.1",
+		"ramsey/array_column": "~1.1",
 		"rmccue/requests": "~1.6",
 		"symfony/finder": "~2.3",
 		"nb/oxymel": "0.1.0"


### PR DESCRIPTION
Package rhumsaa/array_column is abandoned, you should avoid using it. Use ramsey/array_column instead.