### PR TITLE
Add `--format=ids` to `wp post term list`

### DIFF
--- a/features/post-term.feature
+++ b/features/post-term.feature
@@ -26,6 +26,12 @@ Feature: Manage post term
       | foo  | foo  | category |
       | bar  | bar  | category |
 
+    When I run `wp post term list 1 category --format=ids`
+    Then STDOUT should be:
+      """
+      3 2 1
+      """
+
     When I try `wp post term list 1 foo2`
     Then STDERR should be:
       """

--- a/features/user-term.feature
+++ b/features/user-term.feature
@@ -39,6 +39,12 @@ Feature: Manage user term
       | foo  | foo  | user_type |
       | bar  | bar  | user_type |
 
+    When I run `wp user term list 1 user_type --format=ids`
+    Then STDOUT should be:
+      """
+      3 2
+      """
+
     When I run `wp user term set 1 user_type new`
     Then STDOUT should be:
       """

--- a/php/WP_CLI/CommandWithTerms.php
+++ b/php/WP_CLI/CommandWithTerms.php
@@ -44,7 +44,7 @@ abstract class CommandWithTerms extends \WP_CLI_Command {
 	 * : Limit the output to specific row fields.
 	 *
 	 * [--format=<format>]
-	 * : Accepted values: table, csv, json, count. Default: table
+	 * : Accepted values: table, csv, json, count, ids. Default: table
 	 *
 	 * ## AVAILABLE FIELDS
 	 *
@@ -69,6 +69,7 @@ abstract class CommandWithTerms extends \WP_CLI_Command {
 
 		$object_id      = array_shift( $args );
 		$taxonomy_names = $args;
+		$taxonomy_args = array();
 
 		$this->set_obj_id( $object_id );
 
@@ -76,7 +77,11 @@ abstract class CommandWithTerms extends \WP_CLI_Command {
 			$this->taxonomy_exists( $taxonomy );
 		}
 
-		$items = wp_get_object_terms( $object_id, $taxonomy_names );
+		if ( $assoc_args['format'] == 'ids' ) {
+			$taxonomy_args['fields'] = 'ids';
+		}
+
+		$items = wp_get_object_terms( $object_id, $taxonomy_names, $taxonomy_args );
 
 		$formatter = $this->get_formatter( $assoc_args );
 		$formatter->display_items( $items );


### PR DESCRIPTION
Should I add support to `--ids` as well?