### PR TITLE
Switch from rhumsaa/array_column to ramsey/array_column

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		"php": ">=5.3.2",
 		"wp-cli/php-cli-tools": "0.10.4",
 		"mustache/mustache": "~2.4",
-		"rhumsaa/array_column": "~1.1",
+		"ramsey/array_column": "~1.1",
 		"rmccue/requests": "~1.6",
 		"symfony/finder": "~2.3",
 		"nb/oxymel": "0.1.0"

--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -69,7 +69,7 @@ $finder
 	->in('./vendor/composer')
 	->in('./vendor/symfony/finder')
 	->in('./vendor/nb/oxymel')
-	->in('./vendor/rhumsaa/array_column')
+	->in('./vendor/ramsey/array_column')
 	->exclude('test')
 	->exclude('tests')
 	->exclude('Tests')


### PR DESCRIPTION
`rhumsaa/array_column` isn't supported by the author, and he recommends switching to `ramsey/array_column` (same author, different Composer username).

See #1724.