### PR TITLE
Updated array_column package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		"php": ">=5.3.2",
 		"wp-cli/php-cli-tools": "0.10.4",
 		"mustache/mustache": "~2.4",
-		"rhumsaa/array_column": "~1.1",
+		"ramsey/array_column": "~1.1",
 		"rmccue/requests": "~1.6",
 		"symfony/finder": "~2.3",
 		"nb/oxymel": "0.1.0"


### PR DESCRIPTION
Author had changed the package name and old one now results in warning on Composer install/update.