### PR TITLE
Add `\WP_CLI\Utils\ get_flag_value` function

### DIFF
--- a/php/Spyc.php
+++ b/php/Spyc.php
@@ -755,7 +755,7 @@ class Spyc {
       return $this->addArrayInline ($incoming_data, $incoming_indent);
 
     $key = key ($incoming_data);
-    $value = isset($incoming_data[$key]) ? $incoming_data[$key] : null;
+    $value = \WP_CLI\Utils\get_flag_value( $incoming_data, $key );
     if ($key === '__!YAMLZero') $key = '0';
 
     if ($incoming_indent == 0 && !$this->_containsGroupAlias && !$this->_containsGroupAnchor) { // Shortcut for root-level values.

--- a/php/WP_CLI/CommandWithDBObject.php
+++ b/php/WP_CLI/CommandWithDBObject.php
@@ -41,7 +41,7 @@ abstract class CommandWithDBObject extends \WP_CLI_Command {
 			\WP_CLI::error( $obj_id );
 		}
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'porcelain' ) )
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) )
 			\WP_CLI::line( $obj_id );
 		else
 			\WP_CLI::success( "Created $this->obj_type $obj_id." );

--- a/php/WP_CLI/CommandWithDBObject.php
+++ b/php/WP_CLI/CommandWithDBObject.php
@@ -41,7 +41,7 @@ abstract class CommandWithDBObject extends \WP_CLI_Command {
 			\WP_CLI::error( $obj_id );
 		}
 
-		if ( isset( $assoc_args['porcelain'] ) )
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'porcelain' ) )
 			\WP_CLI::line( $obj_id );
 		else
 			\WP_CLI::success( "Created $this->obj_type $obj_id." );

--- a/php/WP_CLI/CommandWithTranslation.php
+++ b/php/WP_CLI/CommandWithTranslation.php
@@ -133,7 +133,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 		if ( $response == $language_code ) {
 			\WP_CLI::success( "Language installed." );
 
-			if ( isset( $assoc_args['activate'] ) ) {
+			if ( \WP_CLI\Utils\check_flag( $assoc_args, 'activate' ) ) {
 				$this->activate( array( $language_code ), array() );
 			}
 		} else {
@@ -199,7 +199,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 		}
 
 		// Only preview which translations would be updated.
-		if ( isset( $assoc_args['dry-run'] ) && $assoc_args['dry-run'] ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'dry-run' ) ) {
 			\WP_CLI::line( sprintf( 'Available %d translations updates:', count( $updates ) ) );
 			\WP_CLI\Utils\format_items( 'table', $updates, array( 'Type', 'Name', 'Version', 'Language' ) );
 

--- a/php/WP_CLI/CommandWithTranslation.php
+++ b/php/WP_CLI/CommandWithTranslation.php
@@ -133,7 +133,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 		if ( $response == $language_code ) {
 			\WP_CLI::success( "Language installed." );
 
-			if ( \WP_CLI\Utils\check_flag( $assoc_args, 'activate' ) ) {
+			if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'activate' ) ) {
 				$this->activate( array( $language_code ), array() );
 			}
 		} else {
@@ -199,7 +199,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 		}
 
 		// Only preview which translations would be updated.
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'dry-run' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run' ) ) {
 			\WP_CLI::line( sprintf( 'Available %d translations updates:', count( $updates ) ) );
 			\WP_CLI\Utils\format_items( 'table', $updates, array( 'Type', 'Name', 'Version', 'Language' ) );
 

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -150,12 +150,12 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			}
 
 			if ( $result ) {
-				if ( isset( $assoc_args['activate-network'] ) ) {
+				if ( \WP_CLI\Utils\check_flag( $assoc_args, 'activate-network' ) ) {
 					\WP_CLI::log( "Network-activating '$slug'..." );
 					$this->activate( array( $slug ), array( 'network' => true ) );
 				}
 
-				if ( isset( $assoc_args['activate'] ) ) {
+				if ( \WP_CLI\Utils\check_flag( $assoc_args, 'activate' ) ) {
 					\WP_CLI::log( "Activating '$slug'..." );
 					$this->activate( array( $slug ) );
 				}
@@ -203,20 +203,20 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	}
 
 	protected function get_upgrader( $assoc_args ) {
-		$upgrader_class = $this->get_upgrader_class( isset( $assoc_args['force'] ) );
+		$upgrader_class = $this->get_upgrader_class( \WP_CLI\Utils\check_flag( $assoc_args, 'force' ) );
 		return \WP_CLI\Utils\get_upgrader( $upgrader_class );
 	}
 
 	protected function update_many( $args, $assoc_args ) {
 		call_user_func( $this->upgrade_refresh );
 
-		if ( ! isset( $assoc_args['all'] ) && empty( $args ) ) {
+		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) && empty( $args ) ) {
 			\WP_CLI::error( "Please specify one or more {$this->item_type}s, or use --all." );
 		}
 
 		$items = $this->get_item_list();
 
-		if ( !isset( $assoc_args['all'] ) ) {
+		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) ) {
 			$items = $this->filter_item_list( $items, $args );
 		}
 
@@ -224,7 +224,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			'update' => true
 		) );
 
-		if ( isset( $assoc_args['dry-run'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'dry-run' ) ) {
 			if ( empty( $items_to_update ) ) {
 				\WP_CLI::line( "No {$this->item_type} updates available." );
 				return;

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -150,12 +150,12 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			}
 
 			if ( $result ) {
-				if ( \WP_CLI\Utils\check_flag( $assoc_args, 'activate-network' ) ) {
+				if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'activate-network' ) ) {
 					\WP_CLI::log( "Network-activating '$slug'..." );
 					$this->activate( array( $slug ), array( 'network' => true ) );
 				}
 
-				if ( \WP_CLI\Utils\check_flag( $assoc_args, 'activate' ) ) {
+				if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'activate' ) ) {
 					\WP_CLI::log( "Activating '$slug'..." );
 					$this->activate( array( $slug ) );
 				}
@@ -203,20 +203,20 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	}
 
 	protected function get_upgrader( $assoc_args ) {
-		$upgrader_class = $this->get_upgrader_class( \WP_CLI\Utils\check_flag( $assoc_args, 'force' ) );
+		$upgrader_class = $this->get_upgrader_class( \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) );
 		return \WP_CLI\Utils\get_upgrader( $upgrader_class );
 	}
 
 	protected function update_many( $args, $assoc_args ) {
 		call_user_func( $this->upgrade_refresh );
 
-		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) && empty( $args ) ) {
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'all' ) && empty( $args ) ) {
 			\WP_CLI::error( "Please specify one or more {$this->item_type}s, or use --all." );
 		}
 
 		$items = $this->get_item_list();
 
-		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) ) {
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'all' ) ) {
 			$items = $this->filter_item_list( $items, $args );
 		}
 
@@ -224,7 +224,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			'update' => true
 		) );
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'dry-run' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run' ) ) {
 			if ( empty( $items_to_update ) ) {
 				\WP_CLI::line( "No {$this->item_type} updates available." );
 				return;

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -394,7 +394,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 		$items = $api->$plural;
 
-		$count = isset( $api->info['results'] ) ? $api->info['results'] : 'unknown';
+		$count = \WP_CLI\Utils\get_flag_value( $api->info, 'results', 'unknown' );
 		\WP_CLI::success( sprintf( 'Showing %s of %s %s.', count( $items ), $count, $plural ) );
 
 		$formatter->display_items( $items );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -99,7 +99,7 @@ class WP_CLI {
 
 	private static function set_url_params( $url_parts ) {
 		$f = function( $key ) use ( $url_parts ) {
-			return isset( $url_parts[ $key ] ) ? $url_parts[ $key ] : '';
+			return \WP_CLI\Utils\get_flag_value( $url_parts, $key, '' );
 		};
 
 		if ( isset( $url_parts['host'] ) ) {
@@ -116,7 +116,7 @@ class WP_CLI {
 		}
 
 		$_SERVER['REQUEST_URI'] = $f('path') . ( isset( $url_parts['query'] ) ? '?' . $url_parts['query'] : '' );
-		$_SERVER['SERVER_PORT'] = isset( $url_parts['port'] ) ? $url_parts['port'] : '80';
+		$_SERVER['SERVER_PORT'] = \WP_CLI\Utils\get_flag_value( $url_parts, 'port', '80' );
 		$_SERVER['QUERY_STRING'] = $f('query');
 	}
 
@@ -295,15 +295,12 @@ class WP_CLI {
 	 * @return string
 	 */
 	public static function get_value_from_arg_or_stdin( $args, $index ) {
-		if ( isset( $args[ $index ] ) ) {
-			$raw_value = $args[ $index ];
-		} else {
-			// We don't use file_get_contents() here because it doesn't handle
-			// Ctrl-D properly, when typing in the value interactively.
-			$raw_value = '';
-			while ( ( $line = fgets( STDIN ) ) !== false ) {
-				$raw_value .= $line;
-			}
+		$raw_value = \WP_CLI\Utils\get_flag_value( $args, $index, '' );
+
+		// We don't use file_get_contents() here because it doesn't handle
+		// Ctrl-D properly, when typing in the value interactively.
+		while ( ( $line = fgets( STDIN ) ) !== false ) {
+			$raw_value .= $line;
 		}
 
 		return $raw_value;

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -295,12 +295,15 @@ class WP_CLI {
 	 * @return string
 	 */
 	public static function get_value_from_arg_or_stdin( $args, $index ) {
-		$raw_value = \WP_CLI\Utils\get_flag_value( $args, $index, '' );
-
-		// We don't use file_get_contents() here because it doesn't handle
-		// Ctrl-D properly, when typing in the value interactively.
-		while ( ( $line = fgets( STDIN ) ) !== false ) {
-			$raw_value .= $line;
+		if ( isset( $args[ $index ] ) ) {
+			$raw_value = $args[ $index ];
+		} else {
+			// We don't use file_get_contents() here because it doesn't handle
+			// Ctrl-D properly, when typing in the value interactively.
+			$raw_value = '';
+			while ( ( $line = fgets( STDIN ) ) !== false ) {
+				$raw_value .= $line;
+			}
 		}
 
 		return $raw_value;

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -274,7 +274,7 @@ class WP_CLI {
 	 * Ask for confirmation before running a destructive operation.
 	 */
 	public static function confirm( $question, $assoc_args = array() ) {
-		if ( !isset( $assoc_args['yes'] ) ) {
+		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'yes' ) ) {
 			fwrite( STDOUT, $question . " [y/n] " );
 
 			$answer = trim( fgets( STDIN ) );
@@ -314,7 +314,7 @@ class WP_CLI {
 	 * @param array $assoc_args
 	 */
 	public static function read_value( $raw_value, $assoc_args = array() ) {
-		if ( isset( $assoc_args['format'] ) && 'json' == $assoc_args['format'] ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'format', 'json' ) ) {
 			$value = json_decode( $raw_value, true );
 			if ( null === $value ) {
 				WP_CLI::error( sprintf( 'Invalid JSON: %s', $raw_value ) );
@@ -333,7 +333,7 @@ class WP_CLI {
 	 * @param array $assoc_args
 	 */
 	public static function print_value( $value, $assoc_args = array() ) {
-		if ( isset( $assoc_args['format'] ) && 'json' == $assoc_args['format'] ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'format', 'json' ) ) {
 			$value = json_encode( $value );
 		} elseif ( is_array( $value ) || is_object( $value ) ) {
 			$value = var_export( $value );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -276,7 +276,7 @@ class WP_CLI {
 	 * Ask for confirmation before running a destructive operation.
 	 */
 	public static function confirm( $question, $assoc_args = array() ) {
-		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'yes' ) ) {
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'yes' ) ) {
 			fwrite( STDOUT, $question . " [y/n] " );
 
 			$answer = trim( fgets( STDIN ) );
@@ -316,7 +316,7 @@ class WP_CLI {
 	 * @param array $assoc_args
 	 */
 	public static function read_value( $raw_value, $assoc_args = array() ) {
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'format', 'json' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' ) === 'json' ) {
 			$value = json_decode( $raw_value, true );
 			if ( null === $value ) {
 				WP_CLI::error( sprintf( 'Invalid JSON: %s', $raw_value ) );
@@ -335,7 +335,7 @@ class WP_CLI {
 	 * @param array $assoc_args
 	 */
 	public static function print_value( $value, $assoc_args = array() ) {
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'format', 'json' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' ) === 'json' ) {
 			$value = json_encode( $value );
 		} elseif ( is_array( $value ) || is_object( $value ) ) {
 			$value = var_export( $value );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -465,18 +465,6 @@ class WP_CLI {
 		self::get_runner()->run_command( $args, $assoc_args );
 	}
 
-	/**
-	 * Check if the flag is set and has the expected value.
-	 *
-	 * @param array	 $args The arguments array to check.
-	 * @param string $flag The flag to check for.
-	 * @param mixed	 $expected The expected value for the flag. Default: TRUE
-	 * @return bool
-	 */
-	public static function check_flag( $args, $flag, $expected = true ) {
-		return isset( $args[ $flag ] ) && $args[ $flag ] == $expected;
-	}
-
 
 
 	// DEPRECATED STUFF

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -465,6 +465,18 @@ class WP_CLI {
 		self::get_runner()->run_command( $args, $assoc_args );
 	}
 
+	/**
+	 * Check if the flag is set and has the expected value.
+	 *
+	 * @param array	 $args The arguments array to check.
+	 * @param string $flag The flag to check for.
+	 * @param mixed	 $expected The expected value for the flag. Default: TRUE
+	 * @return bool
+	 */
+	public static function check_flag( $args, $flag, $expected = true ) {
+		return isset( $args[ $flag ] ) && $args[ $flag ] == $expected;
+	}
+
 
 
 	// DEPRECATED STUFF

--- a/php/commands/cache.php
+++ b/php/commands/cache.php
@@ -19,9 +19,9 @@ class Cache_Command extends WP_CLI_Command {
 	public function add( $args, $assoc_args ) {
 		list( $key, $value ) = $args;
 
-		$group = ( isset( $args[2] ) ) ? $args[2] : '';
+		$group = \WP_CLI\Utils\get_flag_value( $args, 2, '' );
 
-		$expiration = ( isset( $args[3] ) ) ? $args[3] : 0;
+		$expiration = \WP_CLI\Utils\get_flag_value( $args, 3, 0 );
 
 		if ( ! wp_cache_add( $key, $value, $group, $expiration ) ) {
 			WP_CLI::error( "Could not add object '$key' in group '$group'. Does it already exist?" );
@@ -38,9 +38,9 @@ class Cache_Command extends WP_CLI_Command {
 	public function decr( $args, $assoc_args ) {
 		$key = $args[0];
 
-		$offset = ( isset( $args[1] ) ) ? $args[1] : 1;
+		$offset = \WP_CLI\Utils\get_flag_value( $args, 1, 1 );
 
-		$group = ( isset( $args[2] ) ) ? $args[2] : '';
+		$group = \WP_CLI\Utils\get_flag_value( $args, 2, '' );
 
 		$value = wp_cache_decr( $key, $offset, $group );
 
@@ -59,7 +59,7 @@ class Cache_Command extends WP_CLI_Command {
 	public function delete( $args, $assoc_args ) {
 		$key = $args[0];
 
-		$group = ( isset( $args[1] ) ) ? $args[1] : '';
+		$group = \WP_CLI\Utils\get_flag_value( $args, 1, '' );
 
 		$result = wp_cache_delete( $key, $group );
 
@@ -91,7 +91,7 @@ class Cache_Command extends WP_CLI_Command {
 	public function get( $args, $assoc_args ) {
 		$key = $args[0];
 
-		$group = ( isset( $args[1] ) ) ? $args[1] : '';
+		$group = \WP_CLI\Utils\get_flag_value( $args, 1, '' );
 
 		$value = wp_cache_get( $key, $group );
 
@@ -110,9 +110,9 @@ class Cache_Command extends WP_CLI_Command {
 	public function incr( $args, $assoc_args ) {
 		$key = $args[0];
 
-		$offset = ( isset( $args[1] ) ) ? $args[1] : 1;
+		$offset = \WP_CLI\Utils\get_flag_value( $args, 1, 1 );
 
-		$group = ( isset( $args[2] ) ) ? $args[2] : '';
+		$group = \WP_CLI\Utils\get_flag_value( $args, 2, '' );
 
 		$value = wp_cache_incr( $key, $offset, $group );
 
@@ -131,9 +131,9 @@ class Cache_Command extends WP_CLI_Command {
 	public function replace( $args, $assoc_args ) {
 		list( $key, $value ) = $args;
 
-		$group = ( isset( $args[2] ) ) ? $args[2] : '';
+		$group = \WP_CLI\Utils\get_flag_value( $args, 2, '' );
 
-		$expiration = ( isset( $args[3] ) ) ? $args[3] : 0;
+		$expiration = \WP_CLI\Utils\get_flag_value( $args, 3, 0 );
 
 		$result = wp_cache_replace( $key, $value, $group, $expiration );
 
@@ -152,9 +152,9 @@ class Cache_Command extends WP_CLI_Command {
 	public function set( $args, $assoc_args ) {
 		list( $key, $value ) = $args;
 
-		$group = ( isset( $args[2] ) ) ? $args[2] : '';
+		$group = \WP_CLI\Utils\get_flag_value( $args, 2, '' );
 
-		$expiration = ( isset( $args[3] ) ) ? $args[3] : 0;
+		$expiration = \WP_CLI\Utils\get_flag_value( $args, 3, 0 );
 
 		$result = wp_cache_set( $key, $value, $group, $expiration );
 

--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -48,7 +48,7 @@ class CLI_Command extends WP_CLI_Command {
 
 		$runner = WP_CLI::get_runner();
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'format', 'json' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' ) === 'json' ) {
 			$info = array(
 				'php_binary_path' => $php_bin,
 				'global_config_path' => $runner->global_config_path,
@@ -237,10 +237,10 @@ class CLI_Command extends WP_CLI_Command {
 				$update_type = 'patch';
 			}
 
-			if ( ! ( \WP_CLI\Utils\check_flag( $assoc_args, 'patch' ) && 'patch' !== $update_type )
-				&& ! ( \WP_CLI\Utils\check_flag( $assoc_args, 'patch', false ) && 'patch' === $update_type )
-				&& ! ( \WP_CLI\Utils\check_flag( $assoc_args, 'minor' ) && 'minor' !== $update_type )
-				&& ! ( \WP_CLI\Utils\check_flag( $assoc_args, 'minor', false ) && 'minor' === $update_type )
+			if ( ! ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'patch' ) && 'patch' !== $update_type )
+				&& ! ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'patch' ) === false && 'patch' === $update_type )
+				&& ! ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'minor' ) && 'minor' !== $update_type )
+				&& ! ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'minor' ) === false && 'minor' === $update_type )
 				&& ! $this->same_minor_release( $release_parts, $updates )
 				) {
 				$updates[] = array(

--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -48,7 +48,7 @@ class CLI_Command extends WP_CLI_Command {
 
 		$runner = WP_CLI::get_runner();
 
-		if ( isset( $assoc_args['format'] ) && 'json' === $assoc_args['format'] ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'format', 'json' ) ) {
 			$info = array(
 				'php_binary_path' => $php_bin,
 				'global_config_path' => $runner->global_config_path,
@@ -237,10 +237,10 @@ class CLI_Command extends WP_CLI_Command {
 				$update_type = 'patch';
 			}
 
-			if ( ! ( isset( $assoc_args['patch'] ) && $assoc_args['patch'] && 'patch' !== $update_type )
-				&& ! ( isset( $assoc_args['patch'] ) && ! $assoc_args['patch'] && 'patch' === $update_type )
-				&& ! ( isset( $assoc_args['minor'] ) && $assoc_args['minor'] && 'minor' !== $update_type )
-				&& ! ( isset( $assoc_args['minor'] ) && ! $assoc_args['minor'] && 'minor' === $update_type )
+			if ( ! ( \WP_CLI\Utils\check_flag( $assoc_args, 'patch' ) && 'patch' !== $update_type )
+				&& ! ( \WP_CLI\Utils\check_flag( $assoc_args, 'patch', false ) && 'patch' === $update_type )
+				&& ! ( \WP_CLI\Utils\check_flag( $assoc_args, 'minor' ) && 'minor' !== $update_type )
+				&& ! ( \WP_CLI\Utils\check_flag( $assoc_args, 'minor', false ) && 'minor' === $update_type )
 				&& ! $this->same_minor_release( $release_parts, $updates )
 				) {
 				$updates[] = array(

--- a/php/commands/comment.php
+++ b/php/commands/comment.php
@@ -209,7 +209,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 */
 	public function delete( $args, $assoc_args ) {
 		parent::_delete( $args, $assoc_args, function ( $comment_id, $assoc_args ) {
-			$r = wp_delete_comment( $comment_id, isset( $assoc_args['force'] ) );
+			$r = wp_delete_comment( $comment_id, \WP_CLI\Utils\check_flag( $assoc_args, 'force' ) );
 
 			if ( $r ) {
 				return array( 'success', "Deleted comment $comment_id." );

--- a/php/commands/comment.php
+++ b/php/commands/comment.php
@@ -209,7 +209,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 */
 	public function delete( $args, $assoc_args ) {
 		parent::_delete( $args, $assoc_args, function ( $comment_id, $assoc_args ) {
-			$r = wp_delete_comment( $comment_id, \WP_CLI\Utils\check_flag( $assoc_args, 'force' ) );
+			$r = wp_delete_comment( $comment_id, \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) );
 
 			if ( $r ) {
 				return array( 'success', "Deleted comment $comment_id." );

--- a/php/commands/comment.php
+++ b/php/commands/comment.php
@@ -353,7 +353,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 *     wp comment count 42
 	 */
 	public function count( $args, $assoc_args ) {
-		$post_id = isset( $args[0] ) ? $args[0] : 0;
+		$post_id = \WP_CLI\Utils\get_flag_value( $args, 0, 0 );
 
 		$count = wp_count_comments( $post_id );
 

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -350,7 +350,7 @@ class Core_Command extends WP_CLI_Command {
 			) );
 		}
 
-		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'extra-php' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'extra-php' ) === true ) {
 			$assoc_args['extra-php'] = file_get_contents( 'php://stdin' );
 		}
 

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -73,8 +73,8 @@ class Core_Command extends WP_CLI_Command {
 				$update_type = 'minor';
 			}
 
-			if ( ! ( isset( $assoc_args['minor'] ) && 'minor' !== $update_type )
-				&& ! ( isset( $assoc_args['major'] ) && 'major' !== $update_type )
+			if ( ! ( \WP_CLI\Utils\check_flag( $assoc_args, 'minor' ) && 'minor' !== $update_type )
+				&& ! ( \WP_CLI\Utils\check_flag( $assoc_args, 'major' ) && 'major' !== $update_type )
 				) {
 				$updates = $this->remove_same_minor_releases( $release_parts, $updates );
 				$updates[] = array(
@@ -121,7 +121,7 @@ class Core_Command extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function download( $args, $assoc_args ) {
-		if ( !isset( $assoc_args['force'] ) && is_readable( ABSPATH . 'wp-load.php' ) )
+		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'force' ) && is_readable( ABSPATH . 'wp-load.php' ) )
 			WP_CLI::error( 'WordPress files seem to already be present here.' );
 
 		if ( !is_dir( ABSPATH ) ) {
@@ -336,7 +336,7 @@ class Core_Command extends WP_CLI_Command {
 			WP_CLI::error( '--dbprefix can only contain numbers, letters, and underscores.' );
 
 		// Check DB connection
-		if ( !isset( $assoc_args['skip-check'] ) ) {
+		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'skip-check' ) ) {
 			Utils\run_mysql_command( 'mysql --no-defaults', array(
 				'execute' => ';',
 				'host' => $assoc_args['dbhost'],
@@ -345,12 +345,12 @@ class Core_Command extends WP_CLI_Command {
 			) );
 		}
 
-		if ( isset( $assoc_args['extra-php'] ) && $assoc_args['extra-php'] === true ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'extra-php' ) ) {
 			$assoc_args['extra-php'] = file_get_contents( 'php://stdin' );
 		}
 
 		// TODO: adapt more resilient code from wp-admin/setup-config.php
-		if ( ! isset( $assoc_args['skip-salts'] ) ) {
+		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'skip-salts' ) ) {
 			$assoc_args['keys-and-salts'] = self::_read(
 				'https://api.wordpress.org/secret-key/1.1/salt/' );
 		}
@@ -387,7 +387,7 @@ class Core_Command extends WP_CLI_Command {
 	 */
 	public function is_installed( $_, $assoc_args ) {
 
-		if ( isset( $assoc_args['network'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'network' ) ) {
 			if ( is_blog_installed() && is_multisite() ) {
 				exit( 0 );
 			} else {
@@ -735,7 +735,7 @@ define('BLOG_ID_CURRENT_SITE', 1);
 		include $versions_path;
 
 		// @codingStandardsIgnoreStart
-		if ( isset( $assoc_args['extra'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'extra' ) ) {
 			if ( preg_match( '/(\d)(\d+)-/', $tinymce_version, $match ) ) {
 				$human_readable_tiny_mce = $match[1] . '.' . $match[2];
 			} else {
@@ -898,7 +898,7 @@ define('BLOG_ID_CURRENT_SITE', 1);
 			}
 
 		} else if (	version_compare( $wp_version, $assoc_args['version'], '<' )
-					|| isset( $assoc_args['force'] ) ) {
+					|| \WP_CLI\Utils\check_flag( $assoc_args, 'force' ) ) {
 
 			$version = $assoc_args['version'];
 			$locale = isset( $assoc_args['locale'] ) ? $assoc_args['locale'] : get_locale();
@@ -921,7 +921,7 @@ define('BLOG_ID_CURRENT_SITE', 1);
 
 		}
 
-		if ( ! empty( $update ) && ( $update->version != $wp_version || isset( $assoc_args['force'] ) ) ) {
+		if ( ! empty( $update ) && ( $update->version != $wp_version || \WP_CLI\Utils\check_flag( $assoc_args, 'force' ) ) ) {
 
 			require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
 

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -73,8 +73,8 @@ class Core_Command extends WP_CLI_Command {
 				$update_type = 'minor';
 			}
 
-			if ( ! ( \WP_CLI\Utils\check_flag( $assoc_args, 'minor' ) && 'minor' !== $update_type )
-				&& ! ( \WP_CLI\Utils\check_flag( $assoc_args, 'major' ) && 'major' !== $update_type )
+			if ( ! ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'minor' ) && 'minor' !== $update_type )
+				&& ! ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'major' ) && 'major' !== $update_type )
 				) {
 				$updates = $this->remove_same_minor_releases( $release_parts, $updates );
 				$updates[] = array(
@@ -121,7 +121,7 @@ class Core_Command extends WP_CLI_Command {
 	 * @when before_wp_load
 	 */
 	public function download( $args, $assoc_args ) {
-		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'force' ) && is_readable( ABSPATH . 'wp-load.php' ) )
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) && is_readable( ABSPATH . 'wp-load.php' ) )
 			WP_CLI::error( 'WordPress files seem to already be present here.' );
 
 		if ( !is_dir( ABSPATH ) ) {
@@ -341,7 +341,7 @@ class Core_Command extends WP_CLI_Command {
 			WP_CLI::error( '--dbprefix can only contain numbers, letters, and underscores.' );
 
 		// Check DB connection
-		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'skip-check' ) ) {
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-check' ) ) {
 			Utils\run_mysql_command( 'mysql --no-defaults', array(
 				'execute' => ';',
 				'host' => $assoc_args['dbhost'],
@@ -350,12 +350,12 @@ class Core_Command extends WP_CLI_Command {
 			) );
 		}
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'extra-php' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'extra-php' ) ) {
 			$assoc_args['extra-php'] = file_get_contents( 'php://stdin' );
 		}
 
 		// TODO: adapt more resilient code from wp-admin/setup-config.php
-		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'skip-salts' ) ) {
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-salts' ) ) {
 			$assoc_args['keys-and-salts'] = self::_read(
 				'https://api.wordpress.org/secret-key/1.1/salt/' );
 		}
@@ -392,7 +392,7 @@ class Core_Command extends WP_CLI_Command {
 	 */
 	public function is_installed( $_, $assoc_args ) {
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'network' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' ) ) {
 			if ( is_blog_installed() && is_multisite() ) {
 				exit( 0 );
 			} else {
@@ -740,7 +740,7 @@ define('BLOG_ID_CURRENT_SITE', 1);
 		include $versions_path;
 
 		// @codingStandardsIgnoreStart
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'extra' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'extra' ) ) {
 			if ( preg_match( '/(\d)(\d+)-/', $tinymce_version, $match ) ) {
 				$human_readable_tiny_mce = $match[1] . '.' . $match[2];
 			} else {
@@ -903,7 +903,7 @@ define('BLOG_ID_CURRENT_SITE', 1);
 			}
 
 		} else if (	version_compare( $wp_version, $assoc_args['version'], '<' )
-					|| \WP_CLI\Utils\check_flag( $assoc_args, 'force' ) ) {
+					|| \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) ) {
 
 			$version = $assoc_args['version'];
 			$locale = isset( $assoc_args['locale'] ) ? $assoc_args['locale'] : get_locale();
@@ -926,7 +926,7 @@ define('BLOG_ID_CURRENT_SITE', 1);
 
 		}
 
-		if ( ! empty( $update ) && ( $update->version != $wp_version || \WP_CLI\Utils\check_flag( $assoc_args, 'force' ) ) ) {
+		if ( ! empty( $update ) && ( $update->version != $wp_version || \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) ) ) {
 
 			require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
 

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -130,7 +130,7 @@ class Core_Command extends WP_CLI_Command {
 			WP_CLI::launch( Utils\esc_cmd( $mkdir, ABSPATH ) );
 		}
 
-		$locale = isset( $assoc_args['locale'] ) ? $assoc_args['locale'] : 'en_US';
+		$locale = \WP_CLI\Utils\get_flag_value( $assoc_args, 'locale', 'en_US' );
 
 		if ( isset( $assoc_args['version'] ) ) {
 			$version = $assoc_args['version'];
@@ -877,7 +877,7 @@ define('BLOG_ID_CURRENT_SITE', 1);
 		if ( ! empty( $args[0] ) ) {
 
 			$upgrader = 'WP_CLI\\NonDestructiveCoreUpgrader';
-			$version = ! empty( $assoc_args['version'] ) ? $assoc_args['version'] : null;
+			$version = \WP_CLI\Utils\get_flag_value( $assoc_args, 'version' );
 
 			$update = (object) array(
 				'response'      => 'upgrade',
@@ -906,7 +906,7 @@ define('BLOG_ID_CURRENT_SITE', 1);
 					|| \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) ) {
 
 			$version = $assoc_args['version'];
-			$locale = isset( $assoc_args['locale'] ) ? $assoc_args['locale'] : get_locale();
+			$locale = \WP_CLI\Utils\get_flag_value( $assoc_args, 'locale', get_locale() );
 
 			$new_package = $this->get_download_url($version, $locale);
 

--- a/php/commands/cron.php
+++ b/php/commands/cron.php
@@ -94,8 +94,8 @@ class Cron_Event_Command extends WP_CLI_Command {
 	public function schedule( $args, $assoc_args ) {
 
 		$hook = $args[0];
-		$next_run = ( isset( $args[1] ) ) ? $args[1] : 'now';
-		$recurrence = ( isset( $args[2] ) ) ? $args[2] : false;
+		$next_run = \WP_CLI\Utils\get_flag_value( $args, 1, 'now' );
+		$recurrence = \WP_CLI\Utils\get_flag_value( $args, 2, false );
 
 		if ( empty( $next_run ) ) {
 			$timestamp = time();
@@ -294,7 +294,7 @@ class Cron_Event_Command extends WP_CLI_Command {
 						'sig'      => $sig,
 						'args'     => $data['args'],
 						'schedule' => $data['schedule'],
-						'interval' => isset( $data['interval'] ) ? $data['interval'] : null,
+						'interval' => \WP_CLI\Utils\get_flag_value( $data, 'interval' ),
 					);
 
 				}

--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -215,7 +215,7 @@ class DB_Command extends WP_CLI_Command {
 	function tables( $args, $assoc_args ) {
 		global $wpdb;
 
-		$scope = isset( $assoc_args['scope'] ) ? $assoc_args['scope'] : 'all';
+		$scope = \WP_CLI\Utils\get_flag_value( $assoc_args, 'scope', 'all' );
 
 		$tables = $wpdb->tables( $scope );
 

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -162,18 +162,18 @@ class Media_Command extends WP_CLI_Command {
 			}
 
 			// Set as featured image, if --post_id and --featured_image are set
-			if ( $assoc_args['post_id'] && isset( $assoc_args['featured_image'] ) ) {
+			if ( $assoc_args['post_id'] && \WP_CLI\Utils\check_flag( $assoc_args, 'featured_image' ) ) {
 				update_post_meta( $assoc_args['post_id'], '_thumbnail_id', $success );
 			}
 
 			$attachment_success_text = '';
 			if ( $assoc_args['post_id'] ) {
 				$attachment_success_text = " and attached to post {$assoc_args['post_id']}";
-				if ( isset($assoc_args['featured_image']) )
+				if ( \WP_CLI\Utils\check_flag( $assoc_args, 'featured_image' ) )
 					$attachment_success_text .= ' as featured image';
 			}
 
-			if ( isset( $assoc_args['porcelain'] ) ) {
+			if ( \WP_CLI\Utils\check_flag( $assoc_args, 'porcelain' ) ) {
 				WP_CLI::line( $success );
 			} else {
 				WP_CLI::success( sprintf(

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -162,18 +162,18 @@ class Media_Command extends WP_CLI_Command {
 			}
 
 			// Set as featured image, if --post_id and --featured_image are set
-			if ( $assoc_args['post_id'] && \WP_CLI\Utils\check_flag( $assoc_args, 'featured_image' ) ) {
+			if ( $assoc_args['post_id'] && \WP_CLI\Utils\get_flag_value( $assoc_args, 'featured_image' ) ) {
 				update_post_meta( $assoc_args['post_id'], '_thumbnail_id', $success );
 			}
 
 			$attachment_success_text = '';
 			if ( $assoc_args['post_id'] ) {
 				$attachment_success_text = " and attached to post {$assoc_args['post_id']}";
-				if ( \WP_CLI\Utils\check_flag( $assoc_args, 'featured_image' ) )
+				if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'featured_image' ) )
 					$attachment_success_text .= ' as featured image';
 			}
 
-			if ( \WP_CLI\Utils\check_flag( $assoc_args, 'porcelain' ) ) {
+			if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
 				WP_CLI::line( $success );
 			} else {
 				WP_CLI::success( sprintf(

--- a/php/commands/menu.php
+++ b/php/commands/menu.php
@@ -51,7 +51,7 @@ class Menu_Command extends WP_CLI_Command {
 
 		} else {
 
-			if ( isset( $assoc_args['porcelain'] ) ) {
+			if ( \WP_CLI\Utils\check_flag( $assoc_args, 'porcelain' ) ) {
 				WP_CLI::line( $menu_id );
 			} else {
 				WP_CLI::success( "Created menu $menu_id." );

--- a/php/commands/menu.php
+++ b/php/commands/menu.php
@@ -495,7 +495,7 @@ class Menu_Item_Command extends WP_CLI_Command {
 	private function add_or_update_item( $method, $type, $args, $assoc_args ) {
 
 		$menu = $args[0];
-		$menu_item_db_id = ( isset( $args[1] ) ) ? $args[1] : 0;
+		$menu_item_db_id = \WP_CLI\Utils\get_flag_value( $args, 1, 0 );
 
 		$menu = wp_get_nav_menu_object( $menu );
 		if ( ! $menu || is_wp_error( $menu ) ) {
@@ -503,9 +503,7 @@ class Menu_Item_Command extends WP_CLI_Command {
 		}
 
 		// `url` is protected in WP-CLI, so we use `link` instead
-		if ( isset( $assoc_args['link'] ) ) {
-			$assoc_args['url'] = $assoc_args['link'];
-		}
+		$assoc_args['url'] = \WP_CLI\Utils\get_flag_value( $assoc_args, 'link' );
 
 		// Need to persist the menu item data. See https://core.trac.wordpress.org/ticket/28138
 		if ( 'update' == $method ) {
@@ -557,7 +555,7 @@ class Menu_Item_Command extends WP_CLI_Command {
 		foreach( $default_args as $key => $default_value ) {
 			// wp_update_nav_menu_item() has a weird argument prefix
 			$new_key = 'menu-item-' . $key;
-			$menu_item_args[ $new_key ] = isset( $assoc_args[ $key ] ) ? $assoc_args[ $key ] : $default_value;
+			$menu_item_args[ $new_key ] = \WP_CLI\Utils\get_flag_value( $assoc_args, $key, $default_value );
 		}
 
 		$menu_item_args['menu-item-type'] = $type;
@@ -717,7 +715,7 @@ class Menu_Location_Command extends WP_CLI_Command {
 		}
 
 		$locations = get_nav_menu_locations();
-		if ( ! isset( $locations[ $location ] ) || $locations[ $location ] != $menu->term_id ) {
+		if ( \WP_CLI\Utils\get_flag_value( $locations, $location ) != $menu->term_id ) {
 			WP_CLI::error( "Menu isn't assigned to location." );
 		}
 

--- a/php/commands/menu.php
+++ b/php/commands/menu.php
@@ -51,7 +51,7 @@ class Menu_Command extends WP_CLI_Command {
 
 		} else {
 
-			if ( \WP_CLI\Utils\check_flag( $assoc_args, 'porcelain' ) ) {
+			if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
 				WP_CLI::line( $menu_id );
 			} else {
 				WP_CLI::success( "Created menu $menu_id." );

--- a/php/commands/option.php
+++ b/php/commands/option.php
@@ -64,7 +64,7 @@ class Option_Command extends WP_CLI_Command {
 		$value = WP_CLI::get_value_from_arg_or_stdin( $args, 1 );
 		$value = WP_CLI::read_value( $value, $assoc_args );
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'autoload', 'no' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'autoload' ) === 'no' ) {
 			$autoload = 'no';
 		} else {
 			$autoload = 'yes';
@@ -139,7 +139,7 @@ class Option_Command extends WP_CLI_Command {
 			$fields = explode( ',', $assoc_args['fields'] );
 		}
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'format', 'total_bytes' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' ) === 'total_bytes' ) {
 			$fields = array( 'size_bytes' );
 			$size_query = ",SUM(LENGTH(option_value)) AS `size_bytes`";
 		}
@@ -162,7 +162,7 @@ class Option_Command extends WP_CLI_Command {
 			)
 		);
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'format', 'total_bytes' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' ) === 'total_bytes' ) {
 			WP_CLI::line( $results[0]->size_bytes );
 		} else {
 			$formatter = new \WP_CLI\Formatter(

--- a/php/commands/option.php
+++ b/php/commands/option.php
@@ -64,7 +64,7 @@ class Option_Command extends WP_CLI_Command {
 		$value = WP_CLI::get_value_from_arg_or_stdin( $args, 1 );
 		$value = WP_CLI::read_value( $value, $assoc_args );
 
-		if ( isset( $assoc_args['autoload'] ) && $assoc_args['autoload'] == 'no' ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'autoload', 'no' ) ) {
 			$autoload = 'no';
 		} else {
 			$autoload = 'yes';
@@ -139,7 +139,7 @@ class Option_Command extends WP_CLI_Command {
 			$fields = explode( ',', $assoc_args['fields'] );
 		}
 
-		if ( isset( $assoc_args['format'] ) && 'total_bytes' === $assoc_args['format'] ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'format', 'total_bytes' ) ) {
 			$fields = array( 'size_bytes' );
 			$size_query = ",SUM(LENGTH(option_value)) AS `size_bytes`";
 		}
@@ -162,7 +162,7 @@ class Option_Command extends WP_CLI_Command {
 			)
 		);
 
-		if ( isset( $assoc_args['format'] ) && 'total_bytes' === $assoc_args['format'] ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'format', 'total_bytes' ) ) {
 			WP_CLI::line( $results[0]->size_bytes );
 		} else {
 			$formatter = new \WP_CLI\Formatter(

--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -153,9 +153,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * : If set, the plugin will be activated for the entire multisite network.
 	 */
 	function activate( $args, $assoc_args = array() ) {
-		$network_wide = isset( $assoc_args['network'] );
+		$network_wide = \WP_CLI\Utils\check_flag( $assoc_args, 'network' );
 
-		if ( isset( $assoc_args['all'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) ) {
 			$args = array_map( function( $file ){
 				return Utils\get_plugin_name( $file );
 			}, array_keys( get_plugins() ) );
@@ -201,10 +201,10 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * : If set, the plugin will be deactivated for the entire multisite network.
 	 */
 	function deactivate( $args, $assoc_args = array() ) {
-		$network_wide = isset( $assoc_args['network'] );
-		$disable_all = isset( $assoc_args['all'] );
+		$network_wide = \WP_CLI\Utils\check_flag( $assoc_args, 'network' );
+		$disable_all = \WP_CLI\Utils\check_flag( $assoc_args, 'all' );
 
-		if ( isset( $assoc_args['all'] ) ) {
+		if ( $disable_all ) {
 			$args = array_map( function( $file ){
 				return Utils\get_plugin_name( $file );
 			}, array_keys( get_plugins() ) );
@@ -242,7 +242,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * : If set, the plugin will be toggled for the entire multisite network.
 	 */
 	function toggle( $args, $assoc_args = array() ) {
-		$network_wide = isset( $assoc_args['network'] );
+		$network_wide = \WP_CLI\Utils\check_flag( $assoc_args, 'network' );
 
 		foreach ( $this->fetcher->get_many( $args ) as $plugin ) {
 			if ( $this->check_active( $plugin->file, $network_wide ) ) {
@@ -277,7 +277,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			$plugin = $this->fetcher->get_check( $args[0] );
 			$path .= '/' . $plugin->file;
 
-			if ( isset( $assoc_args['dir'] ) )
+			if ( \WP_CLI\Utils\check_flag( $assoc_args, 'dir' ) )
 				$path = dirname( $path );
 		}
 
@@ -297,13 +297,13 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 		$status = install_plugin_install_status( $api );
 
-		if ( !isset( $assoc_args['force'] ) && 'install' != $status['status'] ) {
+		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'force' ) && 'install' != $status['status'] ) {
 			// We know this will fail, so avoid a needless download of the package.
 			return new WP_Error( 'already_installed', 'Plugin already installed.' );
 		}
 
 		WP_CLI::log( sprintf( 'Installing %s (%s)', html_entity_decode( $api->name, ENT_QUOTES ), $api->version ) );
-		if ( !isset( $assoc_args['version'] ) || 'dev' !== $assoc_args['version'] ) {
+		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'version', 'dev' ) ) {
 			WP_CLI::get_http_cache_manager()->whitelist_package( $api->download_link, $this->item_type, $api->slug, $api->version );
 		}
 		$result = $this->get_upgrader( $assoc_args )->install( $api->download_link );
@@ -503,7 +503,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 			uninstall_plugin( $plugin->file );
 
-			if ( !isset( $assoc_args['skip-delete'] ) && $this->_delete( $plugin ) ) {
+			if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'skip-delete' ) && $this->_delete( $plugin ) ) {
 				WP_CLI::success( "Uninstalled and deleted '$plugin->name' plugin." );
 			} else {
 				WP_CLI::success( "Ran uninstall procedure for '$plugin->name' plugin without deleting." );

--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -153,9 +153,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * : If set, the plugin will be activated for the entire multisite network.
 	 */
 	function activate( $args, $assoc_args = array() ) {
-		$network_wide = \WP_CLI\Utils\check_flag( $assoc_args, 'network' );
+		$network_wide = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' );
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'all' ) ) {
 			$args = array_map( function( $file ){
 				return Utils\get_plugin_name( $file );
 			}, array_keys( get_plugins() ) );
@@ -201,8 +201,8 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * : If set, the plugin will be deactivated for the entire multisite network.
 	 */
 	function deactivate( $args, $assoc_args = array() ) {
-		$network_wide = \WP_CLI\Utils\check_flag( $assoc_args, 'network' );
-		$disable_all = \WP_CLI\Utils\check_flag( $assoc_args, 'all' );
+		$network_wide = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' );
+		$disable_all = \WP_CLI\Utils\get_flag_value( $assoc_args, 'all' );
 
 		if ( $disable_all ) {
 			$args = array_map( function( $file ){
@@ -242,7 +242,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * : If set, the plugin will be toggled for the entire multisite network.
 	 */
 	function toggle( $args, $assoc_args = array() ) {
-		$network_wide = \WP_CLI\Utils\check_flag( $assoc_args, 'network' );
+		$network_wide = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' );
 
 		foreach ( $this->fetcher->get_many( $args ) as $plugin ) {
 			if ( $this->check_active( $plugin->file, $network_wide ) ) {
@@ -277,7 +277,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			$plugin = $this->fetcher->get_check( $args[0] );
 			$path .= '/' . $plugin->file;
 
-			if ( \WP_CLI\Utils\check_flag( $assoc_args, 'dir' ) )
+			if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'dir' ) )
 				$path = dirname( $path );
 		}
 
@@ -297,13 +297,13 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 		$status = install_plugin_install_status( $api );
 
-		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'force' ) && 'install' != $status['status'] ) {
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) && 'install' != $status['status'] ) {
 			// We know this will fail, so avoid a needless download of the package.
 			return new WP_Error( 'already_installed', 'Plugin already installed.' );
 		}
 
 		WP_CLI::log( sprintf( 'Installing %s (%s)', html_entity_decode( $api->name, ENT_QUOTES ), $api->version ) );
-		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'version', 'dev' ) ) {
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'version' ) === 'dev' ) {
 			WP_CLI::get_http_cache_manager()->whitelist_package( $api->download_link, $this->item_type, $api->slug, $api->version );
 		}
 		$result = $this->get_upgrader( $assoc_args )->install( $api->download_link );
@@ -503,7 +503,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 
 			uninstall_plugin( $plugin->file );
 
-			if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'skip-delete' ) && $this->_delete( $plugin ) ) {
+			if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-delete' ) && $this->_delete( $plugin ) ) {
 				WP_CLI::success( "Uninstalled and deleted '$plugin->name' plugin." );
 			} else {
 				WP_CLI::success( "Ran uninstall procedure for '$plugin->name' plugin without deleting." );

--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -303,7 +303,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 		}
 
 		WP_CLI::log( sprintf( 'Installing %s (%s)', html_entity_decode( $api->name, ENT_QUOTES ), $api->version ) );
-		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'version' ) === 'dev' ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'version' ) != 'dev' ) {
 			WP_CLI::get_http_cache_manager()->whitelist_package( $api->download_link, $this->item_type, $api->slug, $api->version );
 		}
 		$result = $this->get_upgrader( $assoc_args )->install( $api->download_link );

--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -55,7 +55,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 			$assoc_args['post_content'] = $this->read_from_file_or_stdin( $args[0] );
 		}
 
-		if ( isset( $assoc_args['edit'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'edit' ) ) {
 			$input = isset( $assoc_args['post_content'] ) ?
 				$assoc_args['post_content'] : '';
 
@@ -357,7 +357,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 			$post_author = $user_fetcher->get_check( $post_author )->ID;
 		}
 
-		if ( isset( $assoc_args['post_content'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'post_content' ) ) {
 			$post_content = file_get_contents( 'php://stdin' );
 		}
 

--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -55,7 +55,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 			$assoc_args['post_content'] = $this->read_from_file_or_stdin( $args[0] );
 		}
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'edit' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'edit' ) ) {
 			$input = isset( $assoc_args['post_content'] ) ?
 				$assoc_args['post_content'] : '';
 
@@ -361,7 +361,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 			$post_author = $user_fetcher->get_check( $post_author )->ID;
 		}
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'post_content' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'post_content' ) ) {
 			$post_content = file_get_contents( 'php://stdin' );
 		}
 

--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -56,8 +56,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 		}
 
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'edit' ) ) {
-			$input = isset( $assoc_args['post_content'] ) ?
-				$assoc_args['post_content'] : '';
+			$input = \WP_CLI\Utils\get_flag_value( $assoc_args, 'post_content', '' );
 
 			if ( $output = $this->_edit( $input, 'WP-CLI: New Post' ) )
 				$assoc_args['post_content'] = $output;

--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -28,10 +28,10 @@ class Rewrite_Command extends WP_CLI_Command {
 	public function flush( $args, $assoc_args ) {
 		// make sure we detect mod_rewrite if configured in apache_modules in config
 		self::apache_modules();
-		if ( isset( $assoc_args['hard'] ) && ! in_array( 'mod_rewrite', (array) WP_CLI::get_config( 'apache_modules' ) ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'hard' ) && ! in_array( 'mod_rewrite', (array) WP_CLI::get_config( 'apache_modules' ) ) ) {
 			WP_CLI::warning( "Regenerating a .htaccess file requires special configuration. See usage docs." );
 		}
-		flush_rewrite_rules( isset( $assoc_args['hard'] ) );
+		flush_rewrite_rules( \WP_CLI\Utils\check_flag( $assoc_args, 'hard' ) );
 		if ( ! get_option( 'rewrite_rules' ) ) {
 			WP_CLI::warning( "Rewrite rules are empty, possibly because of a missing permalink_structure option. Use 'wp rewrite list' to verify, or 'wp rewrite structure' to update permalink_structure." );
 		}
@@ -115,7 +115,7 @@ class Rewrite_Command extends WP_CLI_Command {
 		// Launch a new process to flush rewrites because core expects flush
 		// to happen after rewrites are set
 		$new_assoc_args = array();
-		if ( isset( $assoc_args['hard'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'hard' ) ) {
 			$new_assoc_args['hard'] = true;
 			if ( ! in_array( 'mod_rewrite', (array) WP_CLI::get_config( 'apache_modules' ) ) ) {
 				WP_CLI::warning( "Regenerating a .htaccess file requires special configuration. See usage docs." );

--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -28,10 +28,10 @@ class Rewrite_Command extends WP_CLI_Command {
 	public function flush( $args, $assoc_args ) {
 		// make sure we detect mod_rewrite if configured in apache_modules in config
 		self::apache_modules();
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'hard' ) && ! in_array( 'mod_rewrite', (array) WP_CLI::get_config( 'apache_modules' ) ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'hard' ) && ! in_array( 'mod_rewrite', (array) WP_CLI::get_config( 'apache_modules' ) ) ) {
 			WP_CLI::warning( "Regenerating a .htaccess file requires special configuration. See usage docs." );
 		}
-		flush_rewrite_rules( \WP_CLI\Utils\check_flag( $assoc_args, 'hard' ) );
+		flush_rewrite_rules( \WP_CLI\Utils\get_flag_value( $assoc_args, 'hard' ) );
 		if ( ! get_option( 'rewrite_rules' ) ) {
 			WP_CLI::warning( "Rewrite rules are empty, possibly because of a missing permalink_structure option. Use 'wp rewrite list' to verify, or 'wp rewrite structure' to update permalink_structure." );
 		}
@@ -115,7 +115,7 @@ class Rewrite_Command extends WP_CLI_Command {
 		// Launch a new process to flush rewrites because core expects flush
 		// to happen after rewrites are set
 		$new_assoc_args = array();
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'hard' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'hard' ) ) {
 			$new_assoc_args['hard'] = true;
 			if ( ! in_array( 'mod_rewrite', (array) WP_CLI::get_config( 'apache_modules' ) ) ) {
 				WP_CLI::warning( "Regenerating a .htaccess file requires special configuration. See usage docs." );

--- a/php/commands/role.php
+++ b/php/commands/role.php
@@ -169,7 +169,7 @@ class Role_Command extends WP_CLI_Command {
 
 		self::persistence_check();
 
-		if ( ! isset( $assoc_args['all'] ) && empty( $args ) )
+		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) && empty( $args ) )
 			WP_CLI::error( "Role key not provided, or is invalid." );
 
 		if ( ! function_exists( 'populate_roles' ) ) {
@@ -179,7 +179,7 @@ class Role_Command extends WP_CLI_Command {
 		// get our default roles
 		$default_roles = $preserve = array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' );
 
-		if ( isset( $assoc_args['all'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) ) {
 			foreach( $default_roles as $role ) {
 				remove_role( $role );
 			}

--- a/php/commands/role.php
+++ b/php/commands/role.php
@@ -169,7 +169,7 @@ class Role_Command extends WP_CLI_Command {
 
 		self::persistence_check();
 
-		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) && empty( $args ) )
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'all' ) && empty( $args ) )
 			WP_CLI::error( "Role key not provided, or is invalid." );
 
 		if ( ! function_exists( 'populate_roles' ) ) {
@@ -179,7 +179,7 @@ class Role_Command extends WP_CLI_Command {
 		// get our default roles
 		$default_roles = $preserve = array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' );
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'all' ) ) {
 			foreach( $default_roles as $role ) {
 				remove_role( $role );
 			}

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -211,7 +211,7 @@ class Scaffold_Command extends WP_CLI_Command {
 		$body['underscoresme_description']     = $theme_description;
 		$body['underscoresme_generate_submit'] = "Generate";
 		$body['underscoresme_generate']        = "1";
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'sassify' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'sassify' ) ) {
 			$body['underscoresme_sass'] = 1;
 		}
 
@@ -244,9 +244,9 @@ class Scaffold_Command extends WP_CLI_Command {
 			WP_CLI::error( "Could not decompress your theme files ('{$tmpfname}') at '{$theme_path}': {$unzip_result->get_error_message()}" );
 		}
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'activate' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'activate' ) ) {
 			WP_CLI::run_command( array( 'theme', 'activate', $theme_slug ) );
-		} else if ( \WP_CLI\Utils\check_flag( $assoc_args, 'enable-network' ) ) {
+		} else if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'enable-network' ) ) {
 			WP_CLI::run_command( array( 'theme', 'enable', $theme_slug ), array( 'network' => true ) );
 		}
 	}
@@ -305,9 +305,9 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		WP_CLI::success( "Created $theme_dir" );
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'activate' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'activate' ) ) {
 			WP_CLI::run_command( array( 'theme', 'activate', $theme_slug ) );
-		} else if ( \WP_CLI\Utils\check_flag( $assoc_args, 'enable-network' ) ) {
+		} else if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'enable-network' ) ) {
 			WP_CLI::run_command( array( 'theme', 'enable', $theme_slug ), array( 'network' => true ) );
 		}
 	}
@@ -477,13 +477,13 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		WP_CLI::success( "Created $plugin_dir" );
 
-		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'skip-tests' ) ) {
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-tests' ) ) {
 			WP_CLI::run_command( array( 'scaffold', 'plugin-tests', $plugin_slug ), array( 'dir' => $plugin_dir ) );
 		}
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'activate' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'activate' ) ) {
 			WP_CLI::run_command( array( 'plugin', 'activate', $plugin_slug ) );
-		} else if ( \WP_CLI\Utils\check_flag( $assoc_args, 'activate-network' ) ) {
+		} else if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'activate-network' ) ) {
 			WP_CLI::run_command( array( 'plugin', 'activate', $plugin_slug), array( 'network' => true ) );
 		}
 	}

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -652,9 +652,7 @@ class Scaffold_Command extends WP_CLI_Command {
 		$out = array();
 
 		foreach ( $defaults as $key => $value ) {
-			$out[ $key ] = isset( $assoc_args[ $key ] )
-				? $assoc_args[ $key ]
-				: $value;
+			$out[ $key ] = \WP_CLI\Utils\get_flag_value( $assoc_args, $key, $value );
 		}
 
 		return $out;

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -211,7 +211,7 @@ class Scaffold_Command extends WP_CLI_Command {
 		$body['underscoresme_description'] = $theme_description;
 		$body['underscoresme_generate_submit'] = "Generate";
 		$body['underscoresme_generate'] = "1";
-		if ( isset( $assoc_args['sassify'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'sassify' ) ) {
 			$body['underscoresme_sass'] = 1;
 		}
 
@@ -235,9 +235,9 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		WP_CLI::success( "Created theme '{$data['theme_name']}'." );
 
-		if ( isset( $assoc_args['activate'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'activate' ) ) {
 			WP_CLI::run_command( array( 'theme', 'activate', $theme_slug ) );
-		} else if ( isset( $assoc_args['enable-network'] ) ) {
+		} else if ( \WP_CLI\Utils\check_flag( $assoc_args, 'enable-network' ) ) {
 			WP_CLI::run_command( array( 'theme', 'enable', $theme_slug ), array( 'network' => true ) );
 		}
 	}
@@ -296,9 +296,9 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		WP_CLI::success( "Created $theme_dir" );
 
-		if ( isset( $assoc_args['activate'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'activate' ) ) {
 			WP_CLI::run_command( array( 'theme', 'activate', $theme_slug ) );
-		} else if ( isset( $assoc_args['enable-network'] ) ) {
+		} else if ( \WP_CLI\Utils\check_flag( $assoc_args, 'enable-network' ) ) {
 			WP_CLI::run_command( array( 'theme', 'enable', $theme_slug ), array( 'network' => true ) );
 		}
 	}
@@ -454,13 +454,13 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		WP_CLI::success( "Created $plugin_dir" );
 
-		if ( !isset( $assoc_args['skip-tests'] ) ) {
+		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'skip-tests' ) ) {
 			WP_CLI::run_command( array( 'scaffold', 'plugin-tests', $plugin_slug ) );
 		}
 
-		if ( isset( $assoc_args['activate'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'activate' ) ) {
 			WP_CLI::run_command( array( 'plugin', 'activate', $plugin_slug ) );
-		} else if ( isset( $assoc_args['activate-network'] ) ) {
+		} else if ( \WP_CLI\Utils\check_flag( $assoc_args, 'activate-network' ) ) {
 			WP_CLI::run_command( array( 'plugin', 'activate', $plugin_slug), array( 'network' => true ) );
 		}
 	}

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -64,9 +64,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$new             = array_shift( $args );
 		$total           = 0;
 		$report          = array();
-		$dry_run         = self::check_flag( $assoc_args, 'dry-run' );
-		$php_only        = self::check_flag( $assoc_args, 'precise' );
-		$recurse_objects = self::check_flag( $assoc_args, 'recurse-objects' );
+		$dry_run         = \WP_CLI\Utils\check_flag( $assoc_args, 'dry-run' );
+		$php_only        = \WP_CLI\Utils\check_flag( $assoc_args, 'precise' );
+		$recurse_objects = \WP_CLI\Utils\check_flag( $assoc_args, 'recurse-objects' );
 
 		if ( isset( $assoc_args['skip-columns'] ) ) {
 			$skip_columns = explode( ',', $assoc_args['skip-columns'] );
@@ -79,13 +79,13 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 		// Determine how to limit the list of tables. Defaults to 'wordpress'
 		$table_type = 'wordpress';
-		if ( self::check_flag( $assoc_args, 'network' ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'network' ) ) {
 			$table_type = 'network';
 		}
-		if ( self::check_flag( $assoc_args, 'all-tables-with-prefix' ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'all-tables-with-prefix' ) ) {
 			$table_type = 'all-tables-with-prefix';
 		}
-		if ( self::check_flag( $assoc_args, 'all-tables' ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'all-tables' ) ) {
 			$table_type = 'all-tables';
 		}
 
@@ -305,20 +305,6 @@ class Search_Replace_Command extends WP_CLI_Command {
 		return $old;
 	}
 
-	/**
-	 * Determine the boolean value of a flag in an array.
-	 *
-	 * Primarily useful for determining the status of a boolean flag for a command. This is needed because a flag can be
-	 * prefixed with --no- to set it to false. Therefore it is not sufficient to only check whether a flag is set.
-	 *
-	 * @param array  $array The array to check.
-	 * @param string $key   The key to check for.
-	 *
-	 * @return bool True if the key is set in the array and is truthy, false otherwise.
-	 */
-	private static function check_flag( $array, $key ) {
-		return isset( $array[ $key ] ) && $array[ $key ];
-	}
 }
 
 WP_CLI::add_command( 'search-replace', 'Search_Replace_Command' );

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -68,11 +68,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$php_only        = \WP_CLI\Utils\get_flag_value( $assoc_args, 'precise' );
 		$recurse_objects = \WP_CLI\Utils\get_flag_value( $assoc_args, 'recurse-objects' );
 
-		if ( isset( $assoc_args['skip-columns'] ) ) {
-			$skip_columns = explode( ',', $assoc_args['skip-columns'] );
-		} else {
-			$skip_columns = array();
-		}
+		$skip_columns = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-columns' ) );
 
 		// never mess with hashed passwords
 		$skip_columns[] = 'user_pass';

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -64,9 +64,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$new             = array_shift( $args );
 		$total           = 0;
 		$report          = array();
-		$dry_run         = \WP_CLI\Utils\check_flag( $assoc_args, 'dry-run' );
-		$php_only        = \WP_CLI\Utils\check_flag( $assoc_args, 'precise' );
-		$recurse_objects = \WP_CLI\Utils\check_flag( $assoc_args, 'recurse-objects' );
+		$dry_run         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run' );
+		$php_only        = \WP_CLI\Utils\get_flag_value( $assoc_args, 'precise' );
+		$recurse_objects = \WP_CLI\Utils\get_flag_value( $assoc_args, 'recurse-objects' );
 
 		if ( isset( $assoc_args['skip-columns'] ) ) {
 			$skip_columns = explode( ',', $assoc_args['skip-columns'] );
@@ -79,13 +79,13 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 		// Determine how to limit the list of tables. Defaults to 'wordpress'
 		$table_type = 'wordpress';
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'network' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' ) ) {
 			$table_type = 'network';
 		}
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'all-tables-with-prefix' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'all-tables-with-prefix' ) ) {
 			$table_type = 'all-tables-with-prefix';
 		}
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'all-tables' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'all-tables' ) ) {
 			$table_type = 'all-tables';
 		}
 

--- a/php/commands/shell.php
+++ b/php/commands/shell.php
@@ -21,7 +21,7 @@ class Shell_Command extends \WP_CLI_Command {
 			'\\WP_CLI\\REPL',
 		);
 
-		if ( isset( $assoc_args['basic'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'basic' ) ) {
 			$class = '\\WP_CLI\\REPL';
 		} else {
 			foreach ( $implementations as $candidate ) {

--- a/php/commands/shell.php
+++ b/php/commands/shell.php
@@ -21,7 +21,7 @@ class Shell_Command extends \WP_CLI_Command {
 			'\\WP_CLI\\REPL',
 		);
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'basic' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'basic' ) ) {
 			$class = '\\WP_CLI\\REPL';
 		} else {
 			foreach ( $implementations as $candidate ) {

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -178,7 +178,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 
 		WP_CLI::confirm( "Are you sure you want to delete the $blog->siteurl site?", $assoc_args );
 
-		wpmu_delete_blog( $blog->blog_id, !isset( $assoc_args['keep-tables'] ) );
+		wpmu_delete_blog( $blog->blog_id, ! \WP_CLI\Utils\check_flag( $assoc_args, 'keep-tables' ) );
 
 		WP_CLI::success( "The site at $blog->siteurl was deleted." );
 	}
@@ -231,7 +231,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 			$network = $current_site;
 		}
 
-		$public = !isset( $assoc_args['private'] );
+		$public = ! \WP_CLI\Utils\check_flag( $assoc_args, 'private' );
 
 		// Sanitize
 		if ( preg_match( '|^([a-zA-Z0-9-])+$|', $base ) ) {
@@ -301,7 +301,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 			WP_CLI::error( $id->get_error_message() );
 		}
 
-		if ( isset( $assoc_args['porcelain'] ) )
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'porcelain' ) )
 			WP_CLI::line( $id );
 		else
 			WP_CLI::success( "Site $id created: $url" );

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -216,7 +216,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 		global $wpdb, $current_site;
 
 		$base = $assoc_args['slug'];
-		$title = isset( $assoc_args['title'] ) ? $assoc_args['title'] : ucfirst( $base );
+		$title = \WP_CLI\Utils\get_flag_value( $assoc_args, 'title', ucfirst( $base ) );
 
 		$email = empty( $assoc_args['email'] ) ? '' : $assoc_args['email'];
 

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -178,7 +178,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 
 		WP_CLI::confirm( "Are you sure you want to delete the $blog->siteurl site?", $assoc_args );
 
-		wpmu_delete_blog( $blog->blog_id, ! \WP_CLI\Utils\check_flag( $assoc_args, 'keep-tables' ) );
+		wpmu_delete_blog( $blog->blog_id, ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'keep-tables' ) );
 
 		WP_CLI::success( "The site at $blog->siteurl was deleted." );
 	}
@@ -231,7 +231,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 			$network = $current_site;
 		}
 
-		$public = ! \WP_CLI\Utils\check_flag( $assoc_args, 'private' );
+		$public = ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'private' );
 
 		// Sanitize
 		if ( preg_match( '|^([a-zA-Z0-9-])+$|', $base ) ) {
@@ -301,7 +301,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 			WP_CLI::error( $id->get_error_message() );
 		}
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'porcelain' ) )
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) )
 			WP_CLI::line( $id );
 		else
 			WP_CLI::success( "Site $id created: $url" );

--- a/php/commands/term.php
+++ b/php/commands/term.php
@@ -114,12 +114,8 @@ class Term_Command extends WP_CLI_Command {
 		);
 		$assoc_args = wp_parse_args( $assoc_args, $defaults );
 
-		if ( isset( $assoc_args['porcelain'] ) ) {
-			$porcelain = true;
-			unset( $assoc_args['porcelain'] );
-		} else {
-			$porcelain = false;
-		}
+		$porcelain = \WP_CLI\Utils\check_flag( $assoc_args, 'porcelain' );
+		unset( $assoc_args['porcelain'] );
 
 		// Compatibility for < WP 4.0
 		if ( $assoc_args['parent'] > 0 && ! term_exists( (int) $assoc_args['parent'] ) ) {

--- a/php/commands/term.php
+++ b/php/commands/term.php
@@ -114,7 +114,7 @@ class Term_Command extends WP_CLI_Command {
 		);
 		$assoc_args = wp_parse_args( $assoc_args, $defaults );
 
-		$porcelain = \WP_CLI\Utils\check_flag( $assoc_args, 'porcelain' );
+		$porcelain = \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' );
 		unset( $assoc_args['porcelain'] );
 
 		// Compatibility for < WP 4.0

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -260,7 +260,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 
 			$path = $theme->get_stylesheet_directory();
 
-			if ( !isset( $assoc_args['dir'] ) )
+			if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'dir' ) )
 				$path .= '/style.css';
 		}
 
@@ -278,13 +278,13 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 			self::alter_api_response( $api, $assoc_args['version'] );
 		}
 
-		if ( !isset( $assoc_args['force'] ) && wp_get_theme( $slug )->exists() ) {
+		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'force' ) && wp_get_theme( $slug )->exists() ) {
 			// We know this will fail, so avoid a needless download of the package.
 			return new WP_Error( 'already_installed', 'Theme already installed.' );
 		}
 
 		WP_CLI::log( sprintf( 'Installing %s (%s)', html_entity_decode( $api->name, ENT_QUOTES ), $api->version ) );
-		if ( !isset( $assoc_args['version'] ) || 'dev' !== $assoc_args['version'] ) {
+		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'version', 'dev' ) ) {
 			WP_CLI::get_http_cache_manager()->whitelist_package( $api->download_link, $this->item_type, $api->slug, $api->version );
 		}
 		$result = $this->get_upgrader( $assoc_args )->install( $api->download_link );
@@ -597,11 +597,11 @@ class Theme_Mod_command extends WP_CLI_Command {
 	 */
 	public function get( $args = array(), $assoc_args = array() ) {
 
-		if ( ! isset( $assoc_args['all'] ) && empty( $args ) ) {
+		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) && empty( $args ) ) {
 			WP_CLI::error( "You must specify at least one mod or use --all." );
 		}
 
-		if ( isset( $assoc_args['all'] ) && $assoc_args['all'] ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) ) {
 			$args = array();
 		}
 
@@ -657,11 +657,11 @@ class Theme_Mod_command extends WP_CLI_Command {
 	 */
 	public function remove( $args = array(), $assoc_args = array() ) {
 
-		if ( ! isset( $assoc_args['all'] ) && empty( $args ) ) {
+		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) && empty( $args ) ) {
 			WP_CLI::error( "You must specify at least one mod or use --all." );
 		}
 
-		if ( isset( $assoc_args['all'] ) && $assoc_args['all'] ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) ) {
 			remove_theme_mods();
 			WP_CLI::success( 'Theme mods removed.' );
 			return;

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -458,7 +458,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 				if ( is_wp_error( $r ) ) {
 					WP_CLI::warning( $r );
 				} else {
-					$assoc_args['force'] = 1;
+					$assoc_args['force'] = true;
 					$this->install( array( $theme->stylesheet ), $assoc_args );
 				}
 			}

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -284,7 +284,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 		}
 
 		WP_CLI::log( sprintf( 'Installing %s (%s)', html_entity_decode( $api->name, ENT_QUOTES ), $api->version ) );
-		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'version' ) === 'dev' ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'version' ) != 'dev' ) {
 			WP_CLI::get_http_cache_manager()->whitelist_package( $api->download_link, $this->item_type, $api->slug, $api->version );
 		}
 		$result = $this->get_upgrader( $assoc_args )->install( $api->download_link );

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -260,7 +260,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 
 			$path = $theme->get_stylesheet_directory();
 
-			if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'dir' ) )
+			if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'dir' ) )
 				$path .= '/style.css';
 		}
 
@@ -278,13 +278,13 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 			self::alter_api_response( $api, $assoc_args['version'] );
 		}
 
-		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'force' ) && wp_get_theme( $slug )->exists() ) {
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) && wp_get_theme( $slug )->exists() ) {
 			// We know this will fail, so avoid a needless download of the package.
 			return new WP_Error( 'already_installed', 'Theme already installed.' );
 		}
 
 		WP_CLI::log( sprintf( 'Installing %s (%s)', html_entity_decode( $api->name, ENT_QUOTES ), $api->version ) );
-		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'version', 'dev' ) ) {
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'version' ) === 'dev' ) {
 			WP_CLI::get_http_cache_manager()->whitelist_package( $api->download_link, $this->item_type, $api->slug, $api->version );
 		}
 		$result = $this->get_upgrader( $assoc_args )->install( $api->download_link );
@@ -597,11 +597,11 @@ class Theme_Mod_command extends WP_CLI_Command {
 	 */
 	public function get( $args = array(), $assoc_args = array() ) {
 
-		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) && empty( $args ) ) {
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'all' ) && empty( $args ) ) {
 			WP_CLI::error( "You must specify at least one mod or use --all." );
 		}
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'all' ) ) {
 			$args = array();
 		}
 
@@ -657,11 +657,11 @@ class Theme_Mod_command extends WP_CLI_Command {
 	 */
 	public function remove( $args = array(), $assoc_args = array() ) {
 
-		if ( ! \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) && empty( $args ) ) {
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'all' ) && empty( $args ) ) {
 			WP_CLI::error( "You must specify at least one mod or use --all." );
 		}
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'all' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'all' ) ) {
 			remove_theme_mods();
 			WP_CLI::success( 'Theme mods removed.' );
 			return;

--- a/php/commands/transient.php
+++ b/php/commands/transient.php
@@ -35,7 +35,7 @@ class Transient_Command extends WP_CLI_Command {
 	public function set( $args ) {
 		list( $key, $value ) = $args;
 
-		$expiration = isset( $args[2] ) ? $args[2] : 0;
+		$expiration = \WP_CLI\Utils\get_flag_value( $args, 2, 0 );
 
 		if ( set_transient( $key, $value, $expiration ) )
 			WP_CLI::success( 'Transient added.' );

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -81,7 +81,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	 */
 	public function list_( $args, $assoc_args ) {
 
-		if ( isset( $assoc_args['network'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'network' ) ) {
 			if ( ! is_multisite() ) {
 				WP_CLI::error( 'This is not a multisite install.' );
 			}
@@ -175,7 +175,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	 *     wp user delete 123 --reassign=567
 	 */
 	public function delete( $args, $assoc_args ) {
-		$network = isset( $assoc_args['network'] ) && is_multisite();
+		$network = \WP_CLI\Utils\check_flag( $assoc_args, 'network' ) && is_multisite();
 		$reassign = isset( $assoc_args['reassign'] ) ? $assoc_args['reassign'] : null;
 
 		if ( $network && $reassign ) {
@@ -287,7 +287,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 		$user->role = $role;
 
 		$user_id = wp_insert_user( $user );
-		if ( isset( $assoc_args['send-email'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'send-email' ) ) {
 			wp_new_user_notification( $user_id, $user->user_pass );
 		}
 
@@ -300,7 +300,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 			}
 		}
 
-		if ( isset( $assoc_args['porcelain'] ) ) {
+		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'porcelain' ) ) {
 			WP_CLI::line( $user_id );
 		} else {
 			WP_CLI::success( "Created user $user_id." );
@@ -668,7 +668,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 				$existing_user = get_user_by( 'login', $new_user['user_login'] );
 			}
 
-			if ( $existing_user && isset( $assoc_args['skip-update'] ) ) {
+			if ( $existing_user && \WP_CLI\Utils\check_flag( $assoc_args, 'skip-update' ) ) {
 
 				WP_CLI::log( "{$existing_user->user_login} exists and has been skipped" );
 				continue;
@@ -687,7 +687,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 			} else {
 				unset( $new_user['ID'] ); // Unset else it will just return the ID
 				$user_id = wp_insert_user( $new_user );
-				if ( isset( $assoc_args['send-email'] ) ) {
+				if ( \WP_CLI\Utils\check_flag( $assoc_args, 'send-email' ) ) {
 					wp_new_user_notification( $user_id, $new_user['user_pass'] );
 				}
 			}

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -176,7 +176,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	 */
 	public function delete( $args, $assoc_args ) {
 		$network = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' ) && is_multisite();
-		$reassign = isset( $assoc_args['reassign'] ) ? $assoc_args['reassign'] : null;
+		$reassign = \WP_CLI\Utils\get_flag_value( $assoc_args, 'reassign' );
 
 		if ( $network && $reassign ) {
 			WP_CLI::error('Reassigning content to a different user is not supported on multisite.');
@@ -259,17 +259,17 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 			WP_CLI::error( "The '{$user->user_email}' email address is invalid." );
 		}
 
-		$user->user_registered = isset( $assoc_args['user_registered'] )
-			? $assoc_args['user_registered'] : strftime( "%F %T", current_time('timestamp') );
+		$user->user_registered = \WP_CLI\Utils\get_flag_value(
+			$assoc_args,
+			'user_registered',
+			strftime( "%F %T", current_time('timestamp') )
+		);
 
-		$user->display_name = isset( $assoc_args['display_name'] )
-			? $assoc_args['display_name'] : false;
+		$user->display_name = \WP_CLI\Utils\get_flag_value( $assoc_args, 'display_name', false );
 
-		$user->first_name = isset( $assoc_args['first_name'] )
-			? $assoc_args['first_name'] : false;
+		$user->first_name = \WP_CLI\Utils\get_flag_value( $assoc_args, 'first_name', false );
 
-		$user->last_name = isset( $assoc_args['last_name'] )
-			? $assoc_args['last_name'] : false;
+		$user->last_name = \WP_CLI\Utils\get_flag_value( $assoc_args, 'last_name', false );
 
 		if ( isset( $assoc_args['user_pass'] ) ) {
 			$user->user_pass = $assoc_args['user_pass'];
@@ -278,13 +278,8 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 			$generated_pass = true;
 		}
 
-		if ( isset( $assoc_args['role'] ) ) {
-			$role = $assoc_args['role'];
-			self::validate_role( $role );
-		} else {
-			$role = get_option('default_role');
-		}
-		$user->role = $role;
+		$user->role = \WP_CLI\Utils\get_flag_value( $assoc_args, 'role', get_option('default_role') );
+		self::validate_role( $user->role );
 
 		if ( is_multisite() ) {
 			$ret = wpmu_validate_user_signup( $user->user_login, $user->user_email );
@@ -432,7 +427,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	public function set_role( $args, $assoc_args ) {
 		$user = $this->fetcher->get_check( $args[0] );
 
-		$role = isset( $args[1] ) ? $args[1] : get_option( 'default_role' );
+		$role = \WP_CLI\Utils\get_flag_value( $args, 1, get_option('default_role') );
 
 		self::validate_role( $role );
 

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -81,7 +81,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	 */
 	public function list_( $args, $assoc_args ) {
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'network' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' ) ) {
 			if ( ! is_multisite() ) {
 				WP_CLI::error( 'This is not a multisite install.' );
 			}
@@ -175,7 +175,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	 *     wp user delete 123 --reassign=567
 	 */
 	public function delete( $args, $assoc_args ) {
-		$network = \WP_CLI\Utils\check_flag( $assoc_args, 'network' ) && is_multisite();
+		$network = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' ) && is_multisite();
 		$reassign = isset( $assoc_args['reassign'] ) ? $assoc_args['reassign'] : null;
 
 		if ( $network && $reassign ) {
@@ -304,7 +304,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 			$user_id = wp_insert_user( $user );
 		}
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'send-email' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'send-email' ) ) {
 			wp_new_user_notification( $user_id, $user->user_pass );
 		}
 
@@ -317,7 +317,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 			}
 		}
 
-		if ( \WP_CLI\Utils\check_flag( $assoc_args, 'porcelain' ) ) {
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
 			WP_CLI::line( $user_id );
 		} else {
 			WP_CLI::success( "Created user $user_id." );
@@ -685,7 +685,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 				$existing_user = get_user_by( 'login', $new_user['user_login'] );
 			}
 
-			if ( $existing_user && \WP_CLI\Utils\check_flag( $assoc_args, 'skip-update' ) ) {
+			if ( $existing_user && \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-update' ) ) {
 
 				WP_CLI::log( "{$existing_user->user_login} exists and has been skipped" );
 				continue;
@@ -725,7 +725,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 					$user_id = wp_insert_user( $new_user );
 				}
 
-				if ( \WP_CLI\Utils\check_flag( $assoc_args, 'send-email' ) ) {
+				if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'send-email' ) ) {
 					wp_new_user_notification( $user_id, $new_user['user_pass'] );
 				}
 			}

--- a/php/commands/widget.php
+++ b/php/commands/widget.php
@@ -97,7 +97,7 @@ class Widget_Command extends WP_CLI_Command {
 	public function add( $args, $assoc_args ) {
 
 		list( $name, $sidebar_id ) = $args;
-		$position = ( isset( $args[2] ) ) ? (int) $args[2] - 1 : 0;
+		$position = \WP_CLI\Utils\get_flag_value( $args, 2, 1 ) - 1;
 		$this->validate_sidebar( $sidebar_id );
 
 		if ( false == ( $widget = $this->get_widget_obj( $name ) ) ) {

--- a/php/export/class-wp-export-query.php
+++ b/php/export/class-wp-export-query.php
@@ -118,7 +118,7 @@ class WP_Export_Query {
 
 	public function exportify_post( $post ) {
 		$GLOBALS['wp_query']->in_the_loop = true;
-		$previous_global_post = isset( $GLOBALS['post'] )? $GLOBALS['post'] : null;
+		$previous_global_post = \WP_CLI\Utils\get_flag_value( $GLOBALS, 'post' );
 		$GLOBALS['post'] = $post;
 		setup_postdata( $post );
 		$post->post_content = apply_filters( 'the_content_export', $post->post_content );

--- a/php/utils.php
+++ b/php/utils.php
@@ -506,13 +506,13 @@ function increment_version( $current_version, $new_version ) {
 }
 
 /**
- * Check if the flag is set and has the expected value.
+ * Return the flag value or, if it's not set, the $default value.
  *
- * @param array  $args The arguments array to check.
- * @param string $flag The flag to check for.
- * @param mixed  $expected The expected value for the flag. Default: TRUE
- * @return bool
+ * @param array  $args    Arguments array.
+ * @param string $flag    Flag to get the value.
+ * @param mixed  $default Default value for the flag. Default: NULL
+ * @return mixed
  */
-function check_flag( $args, $flag, $expected = true ) {
-	return isset( $args[ $flag ] ) && ( $args[ $flag ] === $expected );
+function get_flag_value( $args, $flag, $default = null ) {
+    return isset( $args[ $flag ] ) ? $args[ $flag ] : $default;
 }

--- a/php/utils.php
+++ b/php/utils.php
@@ -514,5 +514,5 @@ function increment_version( $current_version, $new_version ) {
  * @return mixed
  */
 function get_flag_value( $args, $flag, $default = null ) {
-    return isset( $args[ $flag ] ) ? $args[ $flag ] : $default;
+	return isset( $args[ $flag ] ) ? $args[ $flag ] : $default;
 }

--- a/php/utils.php
+++ b/php/utils.php
@@ -504,3 +504,15 @@ function increment_version( $current_version, $new_version ) {
 
 	return $current_version;
 }
+
+/**
+ * Check if the flag is set and has the expected value.
+ *
+ * @param array  $args The arguments array to check.
+ * @param string $flag The flag to check for.
+ * @param mixed  $expected The expected value for the flag. Default: TRUE
+ * @return bool
+ */
+function check_flag( $args, $flag, $expected = true ) {
+	return isset( $args[ $flag ] ) && ( $args[ $flag ] === $expected );
+}


### PR DESCRIPTION
Function to check if a command flag is set and has the expected value.

This should work as addressed by @JPry in https://github.com/wp-cli/wp-cli/issues/1696#issuecomment-79081557 and fixed by him for the `wp search-replace` command in #1697.

Should I replace the following uses in this PR or do it in another, if this is merged?

```php
$flag = isset( $args['flag'] ) && $args['flag'];
// by
$flag = \WP_CLI::check_flag( $args, 'flag' );

// and

$flag = isset( $args['flag'] ) && $args['flag'] == 'yes';
// by
$flag = \WP_CLI::check_flag( $args, 'flag', 'yes' );

// and

$flag = isset( $args['flag'] ) && $args['flag'] != 0;
// by
$flag = ! \WP_CLI::check_flag( $args, 'flag', 0 );
```