### PR TITLE
Correctly enqueue parent and child themes in functions.php

### DIFF
--- a/templates/child_theme_functions.mustache
+++ b/templates/child_theme_functions.mustache
@@ -1,8 +1,8 @@
 <?php
 
-add_action( 'wp_enqueue_scripts', 'theme_enqueue_styles' );
+add_action( 'wp_enqueue_scripts', '{{parent_theme}}_parent_theme_enqueue_styles' );
 
-function theme_enqueue_styles() {
+function {{parent_theme}}_parent_theme_enqueue_styles() {
     wp_enqueue_style( '{{parent_theme}}-style', get_template_directory_uri() . '/style.css' );
     wp_enqueue_style( '{{slug}}-style',
         get_stylesheet_directory_uri() . '/style.css',

--- a/templates/child_theme_functions.mustache
+++ b/templates/child_theme_functions.mustache
@@ -1,7 +1,12 @@
 <?php
 
-add_action( 'wp_enqueue_scripts', '{{parent_theme}}_parent_theme_enqueue_styles' );
+add_action( 'wp_enqueue_scripts', 'theme_enqueue_styles' );
 
-function {{parent_theme}}_parent_theme_enqueue_styles() {
+function theme_enqueue_styles() {
     wp_enqueue_style( '{{parent_theme}}-style', get_template_directory_uri() . '/style.css' );
+    wp_enqueue_style( '{{slug}}-style',
+        get_stylesheet_directory_uri() . '/style.css',
+        array('{{parent_theme}}-style')
+    );
+
 }


### PR DESCRIPTION
The generated code was returning an error of an undefined function, and without enqueueing the child theme in its functions.php file, style changes in the child theme's styles.css file were not reflected on the site.

Completes #1706