### PR TITLE
Allow custom token in multisite-convert command

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -447,11 +447,12 @@ class Core_Command extends WP_CLI_Command {
 	 * @alias install-network
 	 */
 	public function multisite_convert( $args, $assoc_args ) {
-		if ( is_multisite() )
+		if ( is_multisite() ) {
 			WP_CLI::error( 'This already is a multisite install.' );
+		}
 
 		$assoc_args = self::_set_multisite_defaults( $assoc_args );
-		if ( !isset( $assoc_args['title'] ) ) {
+		if ( ! isset( $assoc_args['title'] ) ) {
 			$assoc_args['title'] = sprintf( _x('%s Sites', 'Default network name' ), get_option( 'blogname' ) );
 		}
 
@@ -539,9 +540,9 @@ class Core_Command extends WP_CLI_Command {
 	private static function _set_multisite_defaults( $assoc_args ) {
 		$defaults = array(
 			'subdomains' => false,
-			'base' => '/',
-			'site_id' => 1,
-			'blog_id' => 1,
+			'base'       => '/',
+			'site_id'    => 1,
+			'blog_id'    => 1,
 		);
 
 		return array_merge( $defaults, $assoc_args );

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -443,6 +443,9 @@ class Core_Command extends WP_CLI_Command {
 	 * [--subdomains]
 	 * : If passed, the network will use subdomains, instead of subdirectories. Doesn't work with 'localhost'.
 	 *
+	 * [--token=<unique-token>]
+	 * : The unique line in the wp-config.php file where the Multisite constants should be added immediately ABOVE. Defaults to "/* That's all, stop editing!".
+	 *
 	 * @subcommand multisite-convert
 	 * @alias install-network
 	 */
@@ -543,6 +546,7 @@ class Core_Command extends WP_CLI_Command {
 			'base'       => '/',
 			'site_id'    => 1,
 			'blog_id'    => 1,
+			'token'      => "/* That's all, stop editing!",
 		);
 
 		return array_merge( $defaults, $assoc_args );

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -653,8 +653,12 @@ define('BLOG_ID_CURRENT_SITE', 1);
 <?php
 			$ms_config = ob_get_clean();
 
-			self::modify_wp_config( $ms_config );
-			WP_CLI::log( 'Added multisite constants to wp-config.php.' );
+			$result = self::modify_wp_config( $ms_config, $assoc_args['token'] );
+			if ( $result ) {
+				WP_CLI::log( 'Added multisite constants to wp-config.php.' );
+			} else {
+				WP_CLI::warning( "You must manually add these lines to your wp-config.php file:\n{$ms_config}" );
+			}
 		}
 
 		return true;


### PR DESCRIPTION
### Summary

Add a parameter `--token` to the `core multisite-convert` command so that a custom location in the `wp-config.php` file may be specified.

### Details

For most installs of WordPress, the default version of the `wp-config.php` file is used as a template. This includes the following line as a way of saying "don't change anything past this point":

```php
/* That's all, stop editing! Happy blogging. */
```

In some environments, an entirely custom `wp-config.php` file is created, and the above line is not present. There is often a different line instead. For that reason, it would be nice for WP CLI to have the ability to specify a different file "token" instead of hard-coding the default.

This pull request does the following:

* Adds the `--token` flag to the `wp core multisite-convert` command.
* Modifies the `Core_Command::modify_wp_config()` method to accept a custom token value.
* Adds checking for the token into `Core_Command::modify_wp_config()` so that it can be determined if writing to the `wp-config.php` file was successful.
* Updates the `Core_Command::_multisite_convert()` method to take advantage of the updated `modify_wp_config()` method.