### PR TITLE
[fix #1703] Find the right token to modify wp-config.php

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -698,8 +698,13 @@ define('BLOG_ID_CURRENT_SITE', 1);
 
 	private static function modify_wp_config( $content ) {
 		$wp_config_path = Utils\locate_wp_config();
+		$wp_config_sample_path = Utils\locate_wp_config_sample();
 
-		$token = "/* That's all, stop editing!";
+		// first, find the right token in wp-config-sample.php as it is language-dependant
+		$string_to_match = "define('WP_DEBUG', false);";
+		$match = explode( $string_to_match, file_get_contents( $wp_config_sample_path ) );
+		$match2 = explode( "*/", trim( $match[1] ) );
+		$token = trim( $match2[0] );
 
 		list( $before, $after ) = explode( $token, file_get_contents( $wp_config_path ) );
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -201,6 +201,24 @@ function locate_wp_config() {
 	return $path;
 }
 
+function locate_wp_config_sample() {
+	static $path;
+
+	if ( null === $path ) {
+		if ( file_exists( ABSPATH . 'wp-config-sample.php' ) )
+			$path = ABSPATH . 'wp-config-sample.php';
+		elseif ( file_exists( ABSPATH . '../wp-config-sample.php' ) && ! file_exists( ABSPATH . '/../wp-settings.php' ) )
+			$path = ABSPATH . '../wp-config-sample.php';
+		else
+			$path = false;
+
+		if ( $path )
+			$path = realpath( $path );
+	}
+
+	return $path;
+}
+
 /**
  * Output items in a table, JSON, CSV, ids, or the total count
  *


### PR DESCRIPTION
The comments in `wp-config.php` file are translated in the user language language in localized versions, so we cannot rely on it to modify the file content.
The fix look into the `wp-config-sample.php` file for the right token to search in the `wp-config.php` file.

There is perhaps more work to do on the method to find the `wp-config-sample.php` file path. Unit tests could also be updated to test this case. Finally, some simple checks could be added to the found `$token` to avoid silent failure. 

See #1703 