### PR TITLE
Don't permit child themes to be activated without their parent

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -6,7 +6,7 @@ Feature: WordPress code scaffolding
     Given I run `wp theme path`
     And save STDOUT as {THEME_DIR}
 
-    When I run `wp scaffold child-theme zombieland --parent_theme=umbrella --theme_name=Zombieland --author=Tallahassee --author_uri=http://www.wp-cli.org --theme_uri=http://www.zombieland.com --activate`
+    When I run `wp scaffold child-theme zombieland --parent_theme=umbrella --theme_name=Zombieland --author=Tallahassee --author_uri=http://www.wp-cli.org --theme_uri=http://www.zombieland.com`
     Then STDOUT should not be empty
     And the {THEME_DIR}/zombieland/style.css file should exist
 

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -225,3 +225,12 @@ Feature: Manage WordPress themes
     Then STDOUT should be a table containing rows:
       | name       | version   |
       | p2         | 1.4.2     |
+
+  Scenario: Install and attempt to activate a child theme without its parent
+    Given a WP install
+
+    When I try `wp theme install biker --activate`
+    Then STDERR should contain:
+      """
+      Error: The 'biker' theme cannot be activated without its parent, 'jolene'.
+      """

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -228,8 +228,10 @@ Feature: Manage WordPress themes
 
   Scenario: Install and attempt to activate a child theme without its parent
     Given a WP install
+    And I run `wp theme install biker`
+    And I run `rm -rf wp-content/themes/jolene`
 
-    When I try `wp theme install biker --activate`
+    When I try `wp theme activate biker`
     Then STDERR should contain:
       """
       Error: The 'biker' theme cannot be activated without its parent, 'jolene'.

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -128,6 +128,10 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 			exit;
 		}
 
+		if ( $theme->get_stylesheet() != $theme->get_template() && ! $this->fetcher->get( $theme->get_template() ) ) {
+			WP_CLI::error( "The '{$theme->get_stylesheet()}' theme cannot be activated without its parent, '{$theme->get_template()}'." );
+		}
+
 		switch_theme( $theme->get_template(), $theme->get_stylesheet() );
 
 		if ( $this->is_active_theme( $theme ) ) {


### PR DESCRIPTION
If a child theme is dependent on parent functions, WP can fatal.

Fixes #1765