### PR TITLE
Bail early if there's no `file` set

### DIFF
--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -234,6 +234,10 @@ class Media_Command extends WP_CLI_Command {
 
 		$metadata = wp_get_attachment_metadata( $att_id );
 
+		if ( empty( $metadata['file'] ) ) {
+			return;
+		}
+
 		$dir_path = $wud['basedir'] . '/' . dirname( $metadata['file'] ) . '/';
 		$original_path = $dir_path . basename( $metadata['file'] );
 


### PR DESCRIPTION
We need it to continue with the operation

Fixes #1782