### PR TITLE
Bugfix : wp help <command> didnt load wp-settings, plugins and subcommands were not showing

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -595,7 +595,7 @@ class Runner {
 		// Handle --path parameter
 		self::set_wp_root( $this->find_wp_root() );
 
-		// First try at showing man page
+		// IF WP does not exists
 		if ( !$this->wp_exists() ) {
 			$this->_run_command();
 		}

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -596,7 +596,7 @@ class Runner {
 		self::set_wp_root( $this->find_wp_root() );
 
 		// First try at showing man page
-		if ( 'help' === $this->arguments[0] && ( isset( $this->arguments[1] ) || !$this->wp_exists() ) ) {
+		if ( !$this->wp_exists() ) {
 			$this->_run_command();
 		}
 


### PR DESCRIPTION
`WP_CLI::get_runner()->before_wp_load();` is called before `require WP_CLI_ROOT . '/php/wp-settings-cli.php';` and it catch the command `wp help <any_command>` here : https://github.com/wp-cli/wp-cli/blob/master/php/WP_CLI/Runner.php#L598 .

It is why  `wp help <any_command>` would not list all the subcommands, especially subcommands added by plugins.

See the difference : 

With master branch :
```
$ wp help site

NAME

  wp site

DESCRIPTION

  Perform site-wide operations.

SYNOPSIS

  wp site <command>

SUBCOMMANDS

  create      Create a site in a multisite install.
  delete      Delete a site in a multisite install.
  empty       Empty a site of its content (posts, comments, and terms).
  list        List all sites in a multisite install.
  url         Get site url

```

With my commits :
```
$ wp help site

NAME

  wp site

DESCRIPTION

  Perform site-wide operations.

SYNOPSIS

  wp site <command>

SUBCOMMANDS

  activate        Activate one or more sites
  archive         Archive one or more sites
  create          Create a site in a multisite install.
  deactivate      Deactivate one or more sites
  delete          Delete a site in a multisite install.
  duplicate       Duplicate a site in a multisite install.
  empty           Empty a site of its content (posts, comments, and terms).
  list            List all sites in a multisite install.
  spam            Mark one or more sites as spam
  unarchive       Unarchive one or more sites
  unspam          Remove one or more sites from spam
  url             Get site url


```

[See related issue on wp-cli github](https://github.com/wp-cli/wp-cli/issues/1767)