### PR TITLE
Periodically clear object cache on import

### DIFF
--- a/php/commands/import.php
+++ b/php/commands/import.php
@@ -171,10 +171,18 @@ class Import_Command extends WP_CLI_Command {
 		} );
 
 		add_action( 'wp_import_insert_post', function( $post_id, $original_post_ID, $post, $postdata ) {
-			if ( is_wp_error( $post_id ) )
+			global $wpcli_import_counts;
+			if ( is_wp_error( $post_id ) ) {
 				WP_CLI::warning( "-- Error importing post: " . $post_id->get_error_code() );
-			else
+			} else {
 				WP_CLI::line( "-- Imported post as post_id #{$post_id}" );
+			}
+
+			if ( $wpcli_import_counts['current_post'] % 500 === 0 ) {
+				WP_CLI\Utils\wp_clear_object_cache();
+				WP_CLI::line( "-- Cleared object cache." );
+			}
+
 		}, 10, 4 );
 
 		add_action( 'wp_import_insert_term', function( $t, $import_term, $post_id, $post ) {

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -131,3 +131,25 @@ function wp_register_unused_sidebar() {
 	));
 
 }
+
+/**
+ * Clear all of the caches for memory management
+ */
+function wp_clear_object_cache() {
+	global $wpdb, $wp_object_cache;
+
+	$wpdb->queries = array(); // or define( 'WP_IMPORTING', true );
+
+	if ( ! is_object( $wp_object_cache ) ) {
+		return;
+	}
+
+	$wp_object_cache->group_ops = array();
+	$wp_object_cache->stats = array();
+	$wp_object_cache->memcache_debug = array();
+	$wp_object_cache->cache = array();
+
+	if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
+		$wp_object_cache->__remoteset(); // important
+	}
+}


### PR DESCRIPTION
WordPress' internal object cache can grow until all memory is consumed
because cache invalidation is disabled. On large imports, this can fatal
the import.

See #1791, #1704