### PR TITLE
Deactivate and uninstall a plugin in one go

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -282,7 +282,7 @@ Feature: Manage WordPress plugins
       must-use
       """
 
-  Scenario: Deactivate and uninstall a plugin
+  Scenario: Deactivate and uninstall a plugin, part one
     Given a WP install
     And these installed and active plugins:
       """
@@ -294,6 +294,27 @@ Feature: Manage WordPress plugins
       """
       Success: Plugin 'akismet' deactivated.
       Uninstalling 'akismet'...
+      Success: Uninstalled and deleted 'akismet' plugin.
+      """
+
+    When I try `wp plugin get akismet`
+    Then STDERR should be:
+      """
+      Error: The 'akismet' plugin could not be found.
+      """
+
+  Scenario: Deactivate and uninstall a plugin, part two
+    Given a WP install
+    And these installed and active plugins:
+      """
+      akismet
+      """
+
+    When I run `wp plugin uninstall akismet --deactivate`
+    Then STDOUT should contain:
+      """
+      Deactivating 'akismet'...
+      Success: Plugin 'akismet' deactivated.
       Success: Uninstalled and deleted 'akismet' plugin.
       """
 

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -282,6 +282,28 @@ Feature: Manage WordPress plugins
       must-use
       """
 
+  Scenario: Deactivate and uninstall a plugin
+    Given a WP install
+    And these installed and active plugins:
+      """
+      akismet
+      """
+
+    When I run `wp plugin deactivate akismet --uninstall`
+    Then STDOUT should contain:
+      """
+      Success: Plugin 'akismet' deactivated.
+      Uninstalling 'akismet'...
+      Success: Uninstalled and deleted 'akismet' plugin.
+      """
+
+    When I try `wp plugin get akismet`
+    Then STDERR should be:
+      """
+      Error: The 'akismet' plugin could not be found.
+      """
+
+
   Scenario: Uninstall a plugin without deleting
     Given a WP install
 

--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -495,6 +495,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * <plugin>...
 	 * : One or more plugins to uninstall.
 	 *
+	 * [--deactivate]
+	 * : Deactivate the plugin before uninstalling. Default behavior is to warn and skip if the plugin is active.
+	 *
 	 * [--skip-delete]
 	 * : If set, the plugin files will not be deleted. Only the uninstall procedure
 	 * will be run.
@@ -505,9 +508,14 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 */
 	function uninstall( $args, $assoc_args = array() ) {
 		foreach ( $this->fetcher->get_many( $args ) as $plugin ) {
-			if ( is_plugin_active( $plugin->file ) ) {
+			if ( is_plugin_active( $plugin->file ) && ! WP_CLI\Utils\get_flag_value( $assoc_args, 'deactivate' ) ) {
 				WP_CLI::warning( "The '{$plugin->name}' plugin is active." );
 				continue;
+			}
+
+			if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'deactivate' ) ) {
+				WP_CLI::log( "Deactivating '{$plugin->name}'..." );
+				$this->deactivate( array( $plugin->name ) );
 			}
 
 			uninstall_plugin( $plugin->file );

--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -194,6 +194,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * [<plugin>...]
 	 * : One or more plugins to deactivate.
 	 *
+	 * [--uninstall]
+	 * : Uninstall the plugin after deactivation.
+	 *
 	 * [--all]
 	 * : If set, all plugins will be deactivated.
 	 *
@@ -227,6 +230,12 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 			deactivate_plugins( $plugin->file, false, $network_wide );
 
 			$this->active_output( $plugin->name, $plugin->file, $network_wide, "deactivate" );
+
+			if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'uninstall' ) ) {
+				WP_CLI::log( "Uninstalling '{$plugin->name}'..." );
+				$this->uninstall( array( $plugin->name ) );
+			}
+
 		}
 	}
 


### PR DESCRIPTION
Adds `--uninstall` flag to `wp plugin deactivate`, and `--deactivate` flag to `wp plugin uninstall`.

Fixes #1249