### PR TITLE
Add `--skip-delete` flag to `wp media regenerate`

### DIFF
--- a/features/media.feature
+++ b/features/media.feature
@@ -53,3 +53,62 @@ Feature: Manage WordPress attachments
       """
       My imported attachment
       """
+
+  Scenario: Delete existing thumbnails when media is regenerated
+    Given download:
+      | path                        | url                                              |
+      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
+    And a wp-content/mu-plugins/media-settings.php file:
+      """
+      <?php
+      add_action( 'after_setup_theme', function(){
+        add_image_size( 'test1', 100, 100, true );
+      });
+      """
+    And I run `wp option update uploads_use_yearmonth_folders 0`
+
+    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported attachment" --porcelain`
+    Then save STDOUT as {ATTACHMENT_ID}
+    And the wp-content/uploads/large-image-100x100.jpg file should exist
+
+    Given a wp-content/mu-plugins/media-settings.php file:
+      """
+      <?php
+      add_action( 'after_setup_theme', function(){
+        add_image_size( 'test1', 200, 200, true );
+      });
+      """
+    When I run `wp media regenerate --yes`
+    Then STDOUT should not be empty
+    And the wp-content/uploads/large-image-100x100.jpg file should not exist
+    And the wp-content/uploads/large-image-200x200.jpg file should exist
+
+  Scenario: Skip deletion of existing thumbnails when media is regenerated
+    Given download:
+      | path                        | url                                              |
+      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
+    And a wp-content/mu-plugins/media-settings.php file:
+      """
+      <?php
+      add_action( 'after_setup_theme', function(){
+        add_image_size( 'test1', 100, 100, true );
+      });
+      """
+    And I run `wp option update uploads_use_yearmonth_folders 0`
+
+    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported attachment" --porcelain`
+    Then save STDOUT as {ATTACHMENT_ID}
+    And the wp-content/uploads/large-image-100x100.jpg file should exist
+
+    Given a wp-content/mu-plugins/media-settings.php file:
+      """
+      <?php
+      add_action( 'after_setup_theme', function(){
+        add_image_size( 'test1', 200, 200, true );
+      });
+      """
+    When I run `wp media regenerate --skip-delete --yes`
+    Then STDOUT should not be empty
+    And the wp-content/uploads/large-image-100x100.jpg file should exist
+    And the wp-content/uploads/large-image-200x200.jpg file should exist
+


### PR DESCRIPTION
This allows old thumbnails to remain around afterwards, which can be
important on many sites.

Fixes #1712