### PR TITLE
Support wildcards / globs in table names for search-replace

### DIFF
--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -26,7 +26,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 * : The new string.
 	 *
 	 * [<table>...]
-	 * : List of database tables to restrict the replacement to.
+	 * : List of database tables to restrict the replacement to. Wildcards are support, e.g. wp_*_options
 	 *
 	 * [--network]
 	 * : Search/replace through all the tables in a multisite install.


### PR DESCRIPTION
With very large multisite networks, `search-replace` can take a very long time. It's nice to be able to target `*_options` and `*_posts` when replace URLs for dev environments.