### PR TITLE
Use `stylesheet` to track enabled themes

### DIFF
--- a/features/theme.feature
+++ b/features/theme.feature
@@ -128,73 +128,72 @@ Feature: Manage WordPress themes
 
   Scenario: Enabling and disabling a theme
   	Given a WP multisite install
-
-    When I run `wp theme install p2`
-    Then STDOUT should not be empty
+    And I run `wp theme install jolene`
+    And I run `wp theme install biker`
 
     When I try `wp option get allowedthemes`
     Then the return code should be 1
     And STDERR should be empty
 
-    When I run `wp theme enable p2`
+    When I run `wp theme enable biker`
     Then STDOUT should contain:
        """
-       Success: Enabled the 'P2' theme.
+       Success: Enabled the 'Biker' theme.
        """
 
     When I run `wp option get allowedthemes`
     Then STDOUT should contain:
        """
-       'p2' => true
+       'biker' => true
        """
 
-    When I run `wp theme disable p2`
+    When I run `wp theme disable biker`
     Then STDOUT should contain:
        """
-       Success: Disabled the 'P2' theme.
+       Success: Disabled the 'Biker' theme.
        """
 
     When I run `wp option get allowedthemes`
     Then STDOUT should not contain:
        """
-       'p2' => true
+       'biker' => true
        """
 
-    When I run `wp theme enable p2 --activate`
+    When I run `wp theme enable biker --activate`
     Then STDOUT should contain:
        """
-       Success: Enabled the 'P2' theme.
-       Success: Switched to 'P2' theme.
+       Success: Enabled the 'Biker' theme.
+       Success: Switched to 'Biker' theme.
        """
 
     When I run `wp network-meta get 1 allowedthemes`
     Then STDOUT should not contain:
        """
-       'p2' => true
+       'biker' => true
        """
 
-    When I run `wp theme enable p2 --network`
+    When I run `wp theme enable biker --network`
     Then STDOUT should contain:
        """
-       Success: Network enabled the 'P2' theme.
+       Success: Network enabled the 'Biker' theme.
        """
 
     When I run `wp network-meta get 1 allowedthemes`
     Then STDOUT should contain:
        """
-       'p2' => true
+       'biker' => true
        """
 
-    When I run `wp theme disable p2 --network`
+    When I run `wp theme disable biker --network`
     Then STDOUT should contain:
        """
-       Success: Network disabled the 'P2' theme.
+       Success: Network disabled the 'Biker' theme.
        """
 
     When I run `wp network-meta get 1 allowedthemes`
     Then STDOUT should not contain:
        """
-       'p2' => true
+       'biker' => true
        """
 
   Scenario: Enabling and disabling a theme without multisite

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -179,7 +179,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 		$allowed_themes = call_user_func( "get{$_site}_option", 'allowedthemes' );
 		if ( empty( $allowed_themes ) )
 			$allowed_themes = array();
-		$allowed_themes[ $theme->get_template() ] = true;
+		$allowed_themes[ $theme->get_stylesheet() ] = true;
 		call_user_func( "update{$_site}_option", 'allowedthemes', $allowed_themes );
 
 		if ( ! empty( $assoc_args['network'] ) )
@@ -225,8 +225,8 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 
 		# Add the current theme to the allowed themes option or site option
 		$allowed_themes = call_user_func( "get{$_site}_option", 'allowedthemes' );
-		if ( ! empty( $allowed_themes[ $theme->get_template() ] ) )
-			unset( $allowed_themes[ $theme->get_template() ] );
+		if ( ! empty( $allowed_themes[ $theme->get_stylesheet() ] ) )
+			unset( $allowed_themes[ $theme->get_stylesheet() ] );
 		call_user_func( "update{$_site}_option", 'allowedthemes', $allowed_themes );
 
 		if ( ! empty( $assoc_args['network'] ) )


### PR DESCRIPTION
`template` is shared by parent and child themes, which means the child
theme couldn't ever be enabled

Previously #1670