### PR TITLE
Improve `.travis.yml` for plugin scaffolding

### DIFF
--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -1,5 +1,9 @@
 language: php
 
+notifications:
+  on_success: never
+  on_failure: change
+
 php:
   - 5.3
   - 5.5

--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -1,16 +1,16 @@
 language: php
 
 php:
-    - 5.3
-    - 5.5
+  - 5.3
+  - 5.5
 
 env:
-    - WP_VERSION=latest WP_MULTISITE=0
-    - WP_VERSION=latest WP_MULTISITE=1
-    - WP_VERSION=3.8 WP_MULTISITE=0
-    - WP_VERSION=3.8 WP_MULTISITE=1
+  - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=latest WP_MULTISITE=1
+  - WP_VERSION=3.8 WP_MULTISITE=0
+  - WP_VERSION=3.8 WP_MULTISITE=1
 
 before_script:
-    - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION 
+  - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION 
 
 script: phpunit

--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -10,9 +10,11 @@ php:
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
-  - WP_VERSION=latest WP_MULTISITE=1
-  - WP_VERSION=3.8 WP_MULTISITE=0
-  - WP_VERSION=3.8 WP_MULTISITE=1
+
+matrix:
+  include:
+    - php: 5.3
+      env: WP_VERSION=latest WP_MULTISITE=1
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION 


### PR DESCRIPTION
* [x] Only notify developers on build failure. Github has a nice green light for success.
* [x] Make the matrix smarter about the builds it spawns.
* [x] Switch indentation to two spaces instead of four.