### PR TITLE
Notice on creating user

### DIFF
--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -306,7 +306,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 		if ( is_wp_error( $user_id ) ) {
 			WP_CLI::error( $user_id );
 		} else {
-			if ( false === $role ) {
+			if ( false === $user->role ) {
 				delete_user_option( $user_id, 'capabilities' );
 				delete_user_option( $user_id, 'user_level' );
 			}


### PR DESCRIPTION
Hi.

If I run create user command like
```
$ wp user create "JohnDoe" "john.doe@example.com" --user_pass="password" --first_name="John" --last_name="Doe"
```
it throws a notice `Notice: Undefined variable: role in [path-to-wp-cli]\wp-cli\php\commands\user.php on line 309` since v0.19.

Thanks for feedback.
