### PR TITLE
In `wp term generate`, try to generate unique term names.

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -326,11 +326,11 @@ Feature: Manage WordPress installation
     When I run `wp core check-update`
     Then STDOUT should be a table containing rows:
       | version | update_type | package_url                               |
-      | 4.2.1   | major       | https://wordpress.org/wordpress-4.2.1.zip |
-      | 4.1.4   | major       | https://wordpress.org/wordpress-4.1.4.zip |
-      | 4.0.4   | major       | https://wordpress.org/wordpress-4.0.4.zip |
-      | 3.9.5   | major       | https://wordpress.org/wordpress-3.9.5.zip |
-      | 3.8.7   | minor       | https://wordpress.org/wordpress-3.8.7.zip |
+      | 4.2.2   | major       | https://wordpress.org/wordpress-4.2.2.zip |
+      | 4.1.5   | major       | https://wordpress.org/wordpress-4.1.5.zip |
+      | 4.0.5   | major       | https://wordpress.org/wordpress-4.0.5.zip |
+      | 3.9.6   | major       | https://wordpress.org/wordpress-3.9.6.zip |
+      | 3.8.8   | minor       | https://wordpress.org/wordpress-3.8.8.zip |
 
     When I run `wp core check-update --format=count`
     Then STDOUT should be:
@@ -341,10 +341,10 @@ Feature: Manage WordPress installation
     When I run `wp core check-update --major`
     Then STDOUT should be a table containing rows:
       | version | update_type | package_url                               |
-      | 4.2.1   | major       | https://wordpress.org/wordpress-4.2.1.zip |
-      | 4.1.4   | major       | https://wordpress.org/wordpress-4.1.4.zip |
-      | 4.0.4   | major       | https://wordpress.org/wordpress-4.0.4.zip |
-      | 3.9.5   | major       | https://wordpress.org/wordpress-3.9.5.zip |
+      | 4.2.2   | major       | https://wordpress.org/wordpress-4.2.2.zip |
+      | 4.1.5   | major       | https://wordpress.org/wordpress-4.1.5.zip |
+      | 4.0.5   | major       | https://wordpress.org/wordpress-4.0.5.zip |
+      | 3.9.6   | major       | https://wordpress.org/wordpress-3.9.6.zip |
 
     When I run `wp core check-update --major --format=count`
     Then STDOUT should be:
@@ -355,7 +355,7 @@ Feature: Manage WordPress installation
     When I run `wp core check-update --minor`
     Then STDOUT should be a table containing rows:
       | version | update_type | package_url                               |
-      | 3.8.7   | minor       | https://wordpress.org/wordpress-3.8.7.zip |
+      | 3.8.8   | minor       | https://wordpress.org/wordpress-3.8.8.zip |
 
     When I run `wp core check-update --minor --format=count`
     Then STDOUT should be:

--- a/features/term.feature
+++ b/features/term.feature
@@ -77,6 +77,15 @@ Feature: Manage WordPress terms
       11
       """
 
+  Scenario: Generating terms when terms already exist
+    When I run `wp term generate category --count=10`
+    And I run `wp term generate category --count=10`
+    And I run `wp term list category --format=count`
+    Then STDOUT should be:
+      """
+      21
+      """
+
   Scenario: Term with a non-existent parent
     When I try `wp term create category Apple --parent=99 --porcelain`
     Then STDERR should be:

--- a/php/commands/term.php
+++ b/php/commands/term.php
@@ -306,7 +306,7 @@ class Term_Command extends WP_CLI_Command {
 
 		$max_id = (int) $wpdb->get_var( "SELECT term_taxonomy_id FROM $wpdb->term_taxonomy ORDER BY term_taxonomy_id DESC LIMIT 1" );
 
-		for ( $i = $max_id; $i <= $max_id + $count; $i++ ) {
+		for ( $i = $max_id + 1; $i <= $max_id + $count; $i++ ) {
 
 			if ( $hierarchical ) {
 

--- a/php/commands/term.php
+++ b/php/commands/term.php
@@ -278,6 +278,8 @@ class Term_Command extends WP_CLI_Command {
 	 *     wp term generate --count=10
 	 */
 	public function generate( $args, $assoc_args ) {
+		global $wpdb;
+
 		list ( $taxonomy ) = $args;
 
 		$defaults = array(
@@ -302,6 +304,8 @@ class Term_Command extends WP_CLI_Command {
 		$current_parent = 0;
 		$current_depth = 1;
 
+		$max_id = (int) $wpdb->get_var( "SELECT term_taxonomy_id FROM $wpdb->term_taxonomy ORDER BY term_taxonomy_id DESC LIMIT 1" );
+
 		for ( $i = 0; $i < $count; $i++ ) {
 
 			if ( $hierarchical ) {
@@ -325,7 +329,9 @@ class Term_Command extends WP_CLI_Command {
 				'slug' => $slug . "-$i",
 			);
 
-			$term = wp_insert_term( "$label $i", $taxonomy, $args );
+			// Try to generate a unique term name.
+			$name = $label . ' ' . ( $max_id + $i + 1 );
+			$term = wp_insert_term( $name, $taxonomy, $args );
 			if ( is_wp_error( $term ) ) {
 				WP_CLI::warning( $term );
 			} else {

--- a/php/commands/term.php
+++ b/php/commands/term.php
@@ -306,7 +306,7 @@ class Term_Command extends WP_CLI_Command {
 
 		$max_id = (int) $wpdb->get_var( "SELECT term_taxonomy_id FROM $wpdb->term_taxonomy ORDER BY term_taxonomy_id DESC LIMIT 1" );
 
-		for ( $i = 0; $i < $count; $i++ ) {
+		for ( $i = $max_id; $i <= $max_id + $count; $i++ ) {
 
 			if ( $hierarchical ) {
 
@@ -329,8 +329,7 @@ class Term_Command extends WP_CLI_Command {
 				'slug' => $slug . "-$i",
 			);
 
-			// Try to generate a unique term name.
-			$name = $label . ' ' . ( $max_id + $i + 1 );
+			$name = "$label $i";
 			$term = wp_insert_term( $name, $taxonomy, $args );
 			if ( is_wp_error( $term ) ) {
 				WP_CLI::warning( $term );


### PR DESCRIPTION
When running `wp term generate` against a database that already has terms, the current method of generating term names results in a `WP_Error` being thrown: "A term with the name provided already exists in this taxonomy". This is due to the fact that the label is being generated using the `$i` loop iterator, which always starts from 0.

My suggested fix is to grab the max existing `term_taxonomy_id` and pad it. This should ensure unique labels in all but the weirdest situations.