### PR TITLE
Add --format parameter to `url` subcommands

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -126,7 +126,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	}
 
 	public function replace_variables( $str ) {
-		return preg_replace_callback( '/\{([A-Z_]+)\}/', array( $this, '_replace_var' ), $str );
+		return preg_replace_callback( '/\{([A-Z_0-9]+)\}/', array( $this, '_replace_var' ), $str );
 	}
 
 	private function _replace_var( $matches ) {

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -28,7 +28,8 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	private static $db_settings = array(
 		'dbname' => 'wp_cli_test',
 		'dbuser' => 'wp_cli_test',
-		'dbpass' => 'password1'
+		'dbpass' => 'password1',
+		'dbhost' => '127.0.0.1',
 	);
 
 	public $variables = array();
@@ -169,7 +170,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	private static function run_sql( $sql ) {
 		Utils\run_mysql_command( 'mysql --no-defaults', array(
 			'execute' => $sql,
-			'host' => 'localhost',
+			'host' => self::$db_settings['dbhost'],
 			'user' => self::$db_settings['dbuser'],
 			'pass' => self::$db_settings['dbpass'],
 		) );

--- a/features/comment.feature
+++ b/features/comment.feature
@@ -23,45 +23,19 @@ Feature: Manage WordPress comments
       Johnny
       """
 
-    When I run `wp comment delete {COMMENT_ID}`
-    Then STDOUT should be:
-      """
-	  Success: Deleted comment {COMMENT_ID}.
-      """
-      
-    When I run `wp comment create --comment_post_ID=1`
-    And I run `wp comment create --comment_post_ID=1`
-    And I run `wp comment delete 3 4`
-    Then STDOUT should be:
-      """
-      Success: Deleted comment 3.
-      Success: Deleted comment 4.
-      """
-  
-  Scenario: Get details about an existing comment
-    When I run `wp comment get 1`
-    Then STDOUT should be a table containing rows:
-      | Field           | Value          |
-      | comment_author  | Mr WordPress   |
-
     When I run `wp comment get 1 --fields=comment_author,comment_author_email --format=json`
     Then STDOUT should be:
       """
       {"comment_author":"Mr WordPress","comment_author_email":""}
       """
 
-    When I run `wp comment list --fields=comment_approved,comment_author`
-    Then STDOUT should be a table containing rows:
-      | comment_approved | comment_author |
-      | 1                | Mr WordPress   |
-
-    When I run `wp comment list --field=approved`
+    When I run `wp comment delete {COMMENT_ID}`
     Then STDOUT should be:
       """
-      1
+	  Success: Deleted comment {COMMENT_ID}.
       """
-
-    When I run `wp comment list --format=ids`
+      
+    When I run `wp comment list --field=approved`
     Then STDOUT should be:
       """
       1
@@ -73,7 +47,22 @@ Feature: Manage WordPress comments
       http://example.com/?p=1#comment-1
       """
 
-  Scenario: Count  comments
+    When I run `wp comment url --format=table 1 {COMMENT_ID}`
+    Then STDOUT should be a table containing rows:
+      | id           | url                               |
+      | 1            | http://example.com/?p=1#comment-1 |
+      | {COMMENT_ID} | http://example.com/?p=1#comment-2 |
+
+    When I run `wp comment create --comment_post_ID=1`
+    And I run `wp comment create --comment_post_ID=1`
+    And I run `wp comment delete 3 4`
+    Then STDOUT should be:
+      """
+      Success: Deleted comment 3.
+      Success: Deleted comment 4.
+      """
+  
+  Scenario: Count comments
     When I run `wp comment count 1`
     Then STDOUT should be:
       """

--- a/features/post.feature
+++ b/features/post.feature
@@ -108,6 +108,12 @@ Feature: Manage WordPress posts
       http://example.com/?p=3
       """
 
+    When I run `wp post url --format=table 1 {POST_ID}`
+    Then STDOUT should be a table containing rows:
+      | id        | url                     |
+      | 1         | http://example.com/?p=1 |
+      | {POST_ID} | http://example.com/?p=3 |
+
   Scenario: Update a post from file or STDIN
     Given a content.html file:
       """

--- a/features/site.feature
+++ b/features/site.feature
@@ -103,6 +103,18 @@ Feature: Manage sites in a multisite installation
       http://example.com/first
       """
 
+    When I run `wp site url {SITE_ID}`
+    Then STDOUT should be:
+      """
+      http://example.com/first
+      """
+
+    When I run `wp site url --format=table 1 {SITE_ID}`
+    Then STDOUT should be a table containing rows:
+      | id         | url                       |
+      | 1  | http://example.com  |
+      | {SITE_ID}  | http://example.com/first  |
+
   Scenario: Archive/unarchive a site
     Given a WP multisite install
     And I run `wp site create --slug=first --porcelain`

--- a/features/term.feature
+++ b/features/term.feature
@@ -49,6 +49,16 @@ Feature: Manage WordPress terms
       | name      | Test term  |
       | taxonomy  | post_tag   |
 
+    When I run `wp term create post_tag 'Another term' --slug=another --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {TERM_ID2}
+
+    When I run `wp term url post_tag {TERM_ID} {TERM_ID2} --format=table`
+    Then STDOUT should be a table containing rows:
+      | id        | url                              |
+      | {TERM_ID} | http://example.com/?tag=test     |
+      | {TERM_ID2} | http://example.com/?tag=another |
+
   Scenario: Creating/deleting a term
     When I run `wp term create post_tag 'Test delete term' --slug=test-delete --description='This is a test term to be deleted' --porcelain`
     Then STDOUT should be a number

--- a/php/WP_CLI/CommandWithDBObject.php
+++ b/php/WP_CLI/CommandWithDBObject.php
@@ -153,10 +153,26 @@ abstract class CommandWithDBObject extends \WP_CLI_Command {
 	 * @param array $args One or more object references.
 	 * @param string $callback Function to get URL for the object.
 	 */
-	protected function _url( $args, $callback ) {
-		foreach ( $args as $obj_id ) {
-			$object = $this->fetcher->get_check( $obj_id );
-			\WP_CLI::line( $callback( $object->{$this->obj_id_key} ) );
+	protected function _url( $args, $assoc_args, $callback ) {
+		$rows = array();
+
+		foreach ( $args as $obj_ref ) {
+			$object = $this->fetcher->get_check( $obj_ref );
+			$obj_id = $object->{$this->obj_id_key};
+
+			$rows[] = array(
+				'id' => $obj_id,
+				'url' => $callback( $obj_id ),
+			);
+		}
+
+		if ( empty( $assoc_args['format'] ) ) {
+			foreach ( $rows as $row ) {
+				\WP_CLI::line( $row['url'] );
+			}
+		} else {
+			$formatter = new \WP_CLI\Formatter( $assoc_args, array( 'id', 'url' ), $this->obj_type );
+			$formatter->display_items( $rows );
 		}
 	}
 }

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -195,7 +195,7 @@ class Formatter {
 		}
 
 		if ( ! isset( $key ) ) {
-			\WP_CLI::error( "Invalid field: $field." );
+			throw new \Exception( "Invalid field: $field." );
 		}
 
 		return $key;

--- a/php/commands/comment.php
+++ b/php/commands/comment.php
@@ -446,14 +446,17 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 * ## OPTIONS
 	 *
 	 * <id>...
-	 * : One or more IDs of comments to get the URL.
+	 * : One or more IDs of comments to get the URL for.
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, json, csv. Default: none
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp comment url 123
 	 */
-	public function url( $args ) {
-		parent::_url( $args, 'get_comment_link' );
+	public function url( $args, $assoc_args ) {
+		parent::_url( $args, $assoc_args, 'get_comment_link' );
 	}
 }
 

--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -426,16 +426,19 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 * ## OPTIONS
 	 *
 	 * <id>...
-	 * : One or more IDs of posts get the URL.
+	 * : One or more IDs of posts to get the URL for.
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, json, csv. Default: none
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp post url 123
 	 *
-	 *     wp post url 123 324
+	 *     wp post url --format=csv $(wp post list --format=ids)
 	 */
-	public function url( $args ) {
-		parent::_url( $args, 'get_permalink' );
+	public function url( $args, $assoc_args ) {
+		parent::_url( $args, $assoc_args, 'get_permalink' );
 	}
 
 	private function maybe_make_child() {

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -427,18 +427,21 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 	 * ## OPTIONS
 	 *
 	 * <id>...
-	 * : One or more IDs of sites to get the URL.
+	 * : One or more IDs of sites to get the URL for.
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, json, csv. Default: none
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp site url 123
 	 */
-	public function url( $args ) {
+	public function url( $args, $assoc_args ) {
 		if ( !is_multisite() ) {
 			WP_CLI::error( 'This is not a multisite install.' );
 		}
 
-		parent::_url( $args, 'get_site_url' );
+		parent::_url( $args, $assoc_args, 'get_site_url' );
 	}
 
 	/**

--- a/php/commands/term.php
+++ b/php/commands/term.php
@@ -354,7 +354,10 @@ class Term_Command extends WP_CLI_Command {
 	 * : Taxonomy of the term(s) to get.
 	 *
 	 * <term-id>...
-	 * : One or more IDs of terms to get the URL.
+	 * : One or more IDs of terms to get the URL for.
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, json, csv. Default: none
 	 *
 	 * ## EXAMPLES
 	 *
@@ -362,12 +365,34 @@ class Term_Command extends WP_CLI_Command {
 	 *
 	 *     wp term url post_tag 123 324
 	 */
-	public function url( $args ) {
-		$term_link = get_term_link( (int)$args[1], $args[0] );
-		if ( $term_link && ! is_wp_error( $term_link ) ) {
-			WP_CLI::line( $term_link );
+	public function url( $args, $assoc_args ) {
+		$taxonomy = array_shift( $args );
+
+		$rows = array();
+
+		foreach ( $args as $obj_ref ) {
+			$obj_id = (int) $obj_ref;
+
+			$url = get_term_link( $obj_id, $taxonomy );
+
+			if ( is_wp_error( $url ) ) {
+				WP_CLI::warning( "Invalid term: $obj_ref" );
+				continue;
+			}
+
+			$rows[] = array(
+				'id' => $obj_id,
+				'url' => $url
+			);
+		}
+
+		if ( empty( $assoc_args['format'] ) ) {
+			foreach ( $rows as $row ) {
+				\WP_CLI::line( $row['url'] );
+			}
 		} else {
-			WP_CLI::error( "Invalid term." );
+			$formatter = new \WP_CLI\Formatter( $assoc_args, array( 'id', 'url' ), 'term' );
+			$formatter->display_items( $rows );
 		}
 	}
 


### PR DESCRIPTION
Currently, when you do `wp post url 123`, you get the URL - nothing more, nothing less. This is great for bash scripting. However, when you want to get multiple URLs, you probably want to know which URL belongs to which post ID.

The same argument holds for the other subcommands: `term url`, `comment url`, `site url`.

TODO:

* [ ] decide if the id field should simply be "id" or `$obj_id_key`