### PR TITLE
Adds searchreplace --verbose flag

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -15,6 +15,7 @@ Feature: Do global search/replace
       guid
       """
 
+
   Scenario: Multisite search/replace
     Given a WP multisite install
     And I run `wp site create --slug="foo" --title="foo" --email="foo@example.com"`
@@ -61,6 +62,29 @@ Feature: Do global search/replace
 
     When I run `wp search-replace foo bar --quiet`
     Then STDOUT should be empty
+
+  Scenario: Verbose search/replace
+    Given a WP install
+    And I run `wp post create --post_title='Replace this text' --porcelain`
+    And save STDOUT as {POSTID}
+
+    When I run `wp search-replace 'Replace' 'Replaced' --verbose`
+    Then STDOUT should contain:
+      """
+      Updating wp_posts.post_title from 'Replace' to 'Replaced'
+      """
+
+    When I run `wp search-replace 'Replace' 'Replaced' --verbose --dry-run`
+    Then STDOUT should contain:
+      """
+      This would update wp_posts.post_title from 'Replace' to 'Replaced'
+      """
+
+    When I run `wp search-replace 'Replace' 'Replaced' --verbose --precise`
+    Then STDOUT should contain:
+      """
+      Updating wp_posts.post_title from 'Replace' to 'Replaced'
+      """
 
   Scenario Outline: Large guid search/replace where replacement contains search (or not)
     Given a WP install

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -71,19 +71,15 @@ Feature: Do global search/replace
     When I run `wp search-replace 'Replace' 'Replaced' --verbose`
     Then STDOUT should contain:
       """
-      Updating wp_posts.post_title from 'Replace' to 'Replaced'
-      """
-
-    When I run `wp search-replace 'Replace' 'Replaced' --verbose --dry-run`
-    Then STDOUT should contain:
-      """
-      This would update wp_posts.post_title from 'Replace' to 'Replaced'
+      Checking wp_posts.post_title
+      1 rows affected
       """
 
     When I run `wp search-replace 'Replace' 'Replaced' --verbose --precise`
     Then STDOUT should contain:
       """
-      Updating wp_posts.post_title from 'Replace' to 'Replaced'
+      Checking wp_posts.post_title
+      1 rows affected
       """
 
   Scenario Outline: Large guid search/replace where replacement contains search (or not)

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -71,14 +71,14 @@ Feature: Do global search/replace
     When I run `wp search-replace 'Replace' 'Replaced' --verbose`
     Then STDOUT should contain:
       """
-      Checking wp_posts.post_title
+      Checking: wp_posts.post_title
       1 rows affected
       """
 
     When I run `wp search-replace 'Replace' 'Replaced' --verbose --precise`
     Then STDOUT should contain:
       """
-      Checking wp_posts.post_title
+      Checking: wp_posts.post_title
       1 rows affected
       """
 

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -213,7 +213,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		} else {
 			$count = $wpdb->query( $wpdb->prepare( "UPDATE `$table` SET `$col` = REPLACE(`$col`, %s, %s);", $old, $new ) );
 		}
-		if ( $count && $verbose ) {
+		if ( $verbose ) {
 			self::log_verbose_details( $table, $col, $count );
 		}
 		return $count;
@@ -260,7 +260,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 			}
 		}
 
-		if ( $count && $verbose ) {
+		if ( $verbose ) {
 			self::log_verbose_details( $table, $col, $count );
 		}
 

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -209,14 +209,14 @@ class Search_Replace_Command extends WP_CLI_Command {
 		global $wpdb;
 
 		if ( $dry_run ) {
-			$result = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(`$col`) FROM `$table` WHERE `$col` LIKE %s;", '%' . self::esc_like( $old ) . '%' ) );
+			$count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(`$col`) FROM `$table` WHERE `$col` LIKE %s;", '%' . self::esc_like( $old ) . '%' ) );
 		} else {
-			$result = $wpdb->query( $wpdb->prepare( "UPDATE `$table` SET `$col` = REPLACE(`$col`, %s, %s);", $old, $new ) );
+			$count = $wpdb->query( $wpdb->prepare( "UPDATE `$table` SET `$col` = REPLACE(`$col`, %s, %s);", $old, $new ) );
 		}
-		if ( $result && $verbose ) {
-			self::log_verbose_details( $table, $col, $old, $new, $dry_run );
+		if ( $count && $verbose ) {
+			self::log_verbose_details( $table, $col, $count );
 		}
-		return $result;
+		return $count;
 	}
 
 	private static function php_handle_col( $col, $primary_keys, $table, $old, $new, $dry_run, $recurse_objects, $verbose ) {
@@ -261,7 +261,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		}
 
 		if ( $count && $verbose ) {
-			self::log_verbose_details( $table, $col, $old, $new, $dry_run );
+			self::log_verbose_details( $table, $col, $count );
 		}
 
 		return $count;
@@ -313,10 +313,8 @@ class Search_Replace_Command extends WP_CLI_Command {
 		return $old;
 	}
 
-	private static function log_verbose_details( $table, $col, $old, $new, $dry_run ) {
-		$action = $dry_run ? 'This would update' : 'Updating';
-		$verbose_output = "$action $table.$col from '$old' to '$new'\r\n";
-		WP_CLI::log( $verbose_output );
+	private static function log_verbose_details( $table, $col, $count ) {
+		WP_CLI::log( sprintf( 'Checking: %s.%s' . PHP_EOL . '%d rows affected', $table, $col, $count ) );
 	}
 
 }

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -49,6 +49,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 * [--all-tables]
 	 * : Enable replacement on ALL tables in the database, regardless of the prefix. Overrides --network and --all-tables-with-prefix.
 	 *
+	 * [--verbose]
+	 * : Prints rows to the console as they're updated.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp search-replace 'http://example.dev' 'http://example.com' --skip-columns=guid
@@ -67,6 +70,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$dry_run         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run' );
 		$php_only        = \WP_CLI\Utils\get_flag_value( $assoc_args, 'precise' );
 		$recurse_objects = \WP_CLI\Utils\get_flag_value( $assoc_args, 'recurse-objects' );
+		$verbose         =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'verbose' );
 
 		$skip_columns = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-columns' ) );
 
@@ -108,10 +112,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 				if ( $php_only || NULL !== $serialRow ) {
 					$type = 'PHP';
-					$count = self::php_handle_col( $col, $primary_keys, $table, $old, $new, $dry_run, $recurse_objects );
+					$count = self::php_handle_col( $col, $primary_keys, $table, $old, $new, $dry_run, $recurse_objects, $verbose );
 				} else {
 					$type = 'SQL';
-					$count = self::sql_handle_col( $col, $table, $old, $new, $dry_run );
+					$count = self::sql_handle_col( $col, $table, $old, $new, $dry_run, $verbose );
 				}
 
 				$report[] = array( $table, $col, $count, $type );
@@ -201,17 +205,21 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 	}
 
-	private static function sql_handle_col( $col, $table, $old, $new, $dry_run ) {
+	private static function sql_handle_col( $col, $table, $old, $new, $dry_run, $verbose ) {
 		global $wpdb;
 
 		if ( $dry_run ) {
-			return $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(`$col`) FROM `$table` WHERE `$col` LIKE %s;", '%' . self::esc_like( $old ) . '%' ) );
+			$result = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(`$col`) FROM `$table` WHERE `$col` LIKE %s;", '%' . self::esc_like( $old ) . '%' ) );
 		} else {
-			return $wpdb->query( $wpdb->prepare( "UPDATE `$table` SET `$col` = REPLACE(`$col`, %s, %s);", $old, $new ) );
+			$result = $wpdb->query( $wpdb->prepare( "UPDATE `$table` SET `$col` = REPLACE(`$col`, %s, %s);", $old, $new ) );
 		}
+		if ( $result && $verbose ) {
+			self::log_verbose_details( $table, $col, $old, $new, $dry_run );
+		}
+		return $result;
 	}
 
-	private static function php_handle_col( $col, $primary_keys, $table, $old, $new, $dry_run, $recurse_objects ) {
+	private static function php_handle_col( $col, $primary_keys, $table, $old, $new, $dry_run, $recurse_objects, $verbose ) {
 		global $wpdb;
 
 		// We don't want to have to generate thousands of rows when running the test suite
@@ -250,6 +258,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 				$count += $wpdb->update( $table, array( $col => $value ), $where );
 			}
+		}
+
+		if ( $count && $verbose ) {
+			self::log_verbose_details( $table, $col, $old, $new, $dry_run );
 		}
 
 		return $count;
@@ -299,6 +311,12 @@ class Search_Replace_Command extends WP_CLI_Command {
 		}
 
 		return $old;
+	}
+
+	private static function log_verbose_details( $table, $col, $old, $new, $dry_run ) {
+		$action = $dry_run ? 'This would update' : 'Updating';
+		$verbose_output = "$action $table.$col from '$old' to '$new'\r\n";
+		WP_CLI::log( $verbose_output );
 	}
 
 }


### PR DESCRIPTION
Hi there,
I took a stab at #1429 for my first issue :)

If you run `wp search-replace foo bar --verbose` it will log the table and column being updated (not the row). Not sure how useful this is in it's current form?

Thanks!
k