### PR TITLE
Skip cache invalidation when generating terms.

### DIFF
--- a/php/commands/term.php
+++ b/php/commands/term.php
@@ -306,6 +306,9 @@ class Term_Command extends WP_CLI_Command {
 
 		$max_id = (int) $wpdb->get_var( "SELECT term_taxonomy_id FROM $wpdb->term_taxonomy ORDER BY term_taxonomy_id DESC LIMIT 1" );
 
+		$suspend_cache_invalidation = wp_suspend_cache_invalidation( true );
+		$created = array();
+
 		for ( $i = $max_id + 1; $i <= $max_id + $count; $i++ ) {
 
 			if ( $hierarchical ) {
@@ -334,13 +337,15 @@ class Term_Command extends WP_CLI_Command {
 			if ( is_wp_error( $term ) ) {
 				WP_CLI::warning( $term );
 			} else {
+				$created[] = $term['term_id'];
 				$previous_term_id = $term['term_id'];
 			}
 
 			$notify->tick();
 		}
 
-		delete_option( $taxonomy . '_children' );
+		wp_suspend_cache_invalidation( $suspend_cache_invalidation );
+		clean_term_cache( $created, $taxonomy );
 
 		$notify->finish();
 	}


### PR DESCRIPTION
When generating terms in a hierarchical category, `clean_term_cache()` triggers
a rebuild of the taxonomy hierarchy with every call to `wp_insert_term()`.
This is extremely slow when the taxonomy has many terms. We only need to bust
the cache once, after all terms have been generated.

See https://core.trac.wordpress.org/changeset/32498.

@danielbachhuber I tried writing a behat test for this, but I couldn't figure out how. I'd need to, say, pull up the term_id + parent of the term last created, and then pull up the taxonomy hierarchy, and then make sure that the hierarchy reflects the term/parent relationships correctly. I tried all sorts of `Then save STDOUT` regex tricks, but got stuck, so here's the PR without any tests. If you have any tips on testing, I'd love to hear them.