### PR TITLE
More sensible behavior for scaffolding plugin tests with `--dir=<dir>` arg

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -281,7 +281,7 @@ Feature: WordPress code scaffolding
     When I try `wp scaffold plugin-tests --dir=wp-content/mu-plugins/incorrect-custom-plugin`
     Then STDERR should contain:
       """
-      Error: Invalid plugin specified.
+      Error: Invalid plugin directory specified.
       """
 
     When I run `wp scaffold plugin-tests --dir=wp-content/mu-plugins/custom-plugin`
@@ -294,6 +294,30 @@ Feature: WordPress code scaffolding
     And the wp-content/mu-plugins/custom-plugin/tests/bootstrap.php file should contain:
     """
     require dirname( dirname( __FILE__ ) ) . '/custom-plugin.php';
+    """
+
+  Scenario: Scaffold tests for a plugin with a different slug than plugin directory
+    Given a WP install
+    And a wp-content/mu-plugins/custom-plugin2/custom-plugin-slug.php file:
+      """
+      <?php
+      /**
+       * Plugin Name: Handbook
+       * Description: Features for a handbook, complete with glossary and table of contents
+       * Author: Nacin
+       */
+      """
+
+    When I run `wp scaffold plugin-tests custom-plugin-slug --dir=wp-content/mu-plugins/custom-plugin2`
+    Then STDOUT should contain:
+      """
+      Success: Created test files.
+      """
+    And the wp-content/mu-plugins/custom-plugin2/tests directory should exist
+    And the wp-content/mu-plugins/custom-plugin2/tests/bootstrap.php file should exist
+    And the wp-content/mu-plugins/custom-plugin2/tests/bootstrap.php file should contain:
+    """
+    require dirname( dirname( __FILE__ ) ) . '/custom-plugin-slug.php';
     """
 
   Scenario: Scaffold starter code for a theme and network enable it

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -511,7 +511,7 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * : The name of the plugin to generate test files for.
 	 *
 	 * [--dir=<dirname>]
-	 * : Generate test files for a non-standard plugin path.
+	 * : Generate test files for a non-standard plugin path. If no plugin slug is specified, the directory name is used.
 	 *
 	 * ## EXAMPLE
 	 *
@@ -522,16 +522,22 @@ class Scaffold_Command extends WP_CLI_Command {
 	function plugin_tests( $args, $assoc_args ) {
 		$wp_filesystem = $this->init_wp_filesystem();
 
+		if ( ! empty( $args[0] ) ) {
+			$plugin_slug = $args[0];
+			$plugin_dir = WP_PLUGIN_DIR . "/$plugin_slug";
+		}
+
 		if ( ! empty( $assoc_args['dir'] ) ) {
 			$plugin_dir = $assoc_args['dir'];
 			if ( ! is_dir( $plugin_dir ) ) {
-				WP_CLI::error( 'Invalid plugin specified.' );
+				WP_CLI::error( 'Invalid plugin directory specified.' );
 			}
-			$plugin_slug =  basename( $plugin_dir );
-		} else if ( ! empty( $args[0] ) ) {
-			$plugin_slug = $args[0];
-			$plugin_dir = WP_PLUGIN_DIR . "/$plugin_slug";
-		} else {
+			if ( empty( $plugin_slug ) ) {
+				$plugin_slug = basename( $plugin_dir );
+			}
+		}
+
+		if ( empty( $plugin_slug ) || empty( $plugin_dir ) ) {
 			WP_CLI::error( 'Invalid plugin specified.' );
 		}
 


### PR DESCRIPTION
If a plugin slug is provided, use that instead of the directory
basename. But, if no slug is provided, use directory basename.

See #1828