### PR TITLE
Filter taxonomy terms by `term_id`

### DIFF
--- a/features/term.feature
+++ b/features/term.feature
@@ -92,3 +92,14 @@ Feature: Manage WordPress terms
       """
       Error: Parent term does not exist.
       """
+
+  Scenario: Filter terms by term_id
+    When I run `wp term generate category --count=10`
+    And I run `wp term create category "My Test Category" --porcelain`
+    And save STDOUT as {TERM_ID}
+
+    When I run `wp term list category --term_id={TERM_ID} --field=name`
+    Then STDOUT should be:
+      """
+      My Test Category
+      """

--- a/php/commands/term.php
+++ b/php/commands/term.php
@@ -66,7 +66,12 @@ class Term_Command extends WP_CLI_Command {
 		);
 		$assoc_args = array_merge( $defaults, $assoc_args );
 
-		$terms = get_terms( $args, $assoc_args );
+		if ( ! empty( $assoc_args['term_id'] ) ) {
+			$term = get_term_by( 'id', $assoc_args['term_id'], $args[0] );
+			$terms = array( $term );
+		} else {
+			$terms = get_terms( $args, $assoc_args );
+		}
 
 		if ( 'ids' == $formatter->format ) {
 			$terms = wp_list_pluck( $terms, 'term_id' );


### PR DESCRIPTION
It's a bit hacky, but that's alright. We can work around WP core.

See #1818