### PR TITLE
Enable the export command to specify a starting post ID

### DIFF
--- a/features/export.feature
+++ b/features/export.feature
@@ -227,3 +227,41 @@ Feature: Export content.
       """
       Test User
       """
+
+  Scenario: Export posts from a given starting post ID
+    Given a WP install
+
+    When I run `wp plugin install wordpress-importer --activate`
+    Then STDERR should not contain:
+      """
+      Warning:
+      """
+
+    When I run `wp site empty --yes`
+    And I run `wp post generate --post_type=post --count=10`
+    And I run `wp post list --post_type=post --format=count`
+    Then STDOUT should be:
+      """
+      10
+      """
+
+    When I run `wp export --start_id=6`
+    And save STDOUT 'Writing to file %s' as {EXPORT_FILE}
+
+    When I run `wp site empty --yes`
+    Then STDOUT should not be empty
+
+    When I run `wp post list --post_type=post --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp import {EXPORT_FILE} --authors=skip`
+    Then STDOUT should not be empty
+
+    When I run `wp post list --post_type=post --format=count`
+    Then STDOUT should be:
+      """
+      5
+      """

--- a/php/commands/export.php
+++ b/php/commands/export.php
@@ -207,6 +207,10 @@ class Export_Command extends WP_CLI_Command {
 	}
 
 	private function check_start_id( $start_id ) {
+		if ( is_null( $start_id ) ) {
+			return true;
+		}
+
 		$start_id = intval( $start_id );
 
 		// Post IDs must be greater than 0

--- a/php/commands/export.php
+++ b/php/commands/export.php
@@ -37,6 +37,9 @@ class Export_Command extends WP_CLI_Command {
 	 * [--post__in=<pid>]
 	 * : Export all posts specified as a comma-separated list of IDs.
 	 *
+	 * [--start_id=<pid>]
+	 * : Export only posts with IDs greater than or equal to this post ID.
+	 *
 	 * [--author=<author>]
 	 * : Export only posts by this author. Can be either user login or user ID.
 	 *
@@ -62,6 +65,7 @@ class Export_Command extends WP_CLI_Command {
 			'category'        => NULL,
 			'post_status'     => NULL,
 			'post__in'        => NULL,
+			'start_id'        => NULL,
 			'skip_comments'   => NULL,
 			'max_file_size'   => 15,
 		);
@@ -199,6 +203,19 @@ class Export_Command extends WP_CLI_Command {
 		}
 		// New exporter uses a different argument
 		$this->export_args['post_ids'] = $post__in;
+		return true;
+	}
+
+	private function check_start_id( $start_id ) {
+		$start_id = intval( $start_id );
+
+		// Post IDs must be greater than 0
+		if ( 0 >= $start_id ) {
+			WP_CLI::warning( sprintf( __( 'Invalid start ID: %d' ), $start_id ) );
+			return false;
+		}
+
+		$this->export_args['start_id'] = $start_id;
 		return true;
 	}
 

--- a/php/export/class-wp-export-query.php
+++ b/php/export/class-wp-export-query.php
@@ -14,6 +14,7 @@ class WP_Export_Query {
 		'author' => null,
 		'start_date' => null,
 		'end_date' => null,
+		'start_id' => null,
 		'category' => null,
 	);
 
@@ -146,6 +147,7 @@ class WP_Export_Query {
 		$this->author_where();
 		$this->start_date_where();
 		$this->end_date_where();
+		$this->start_id_where();
 		$this->category_where();
 
 		$where = implode( ' AND ', array_filter( $this->wheres ) );
@@ -210,6 +212,16 @@ class WP_Export_Query {
 			return;
 		}
 		$this->wheres[] = $wpdb->prepare( 'p.post_date <= %s', date( 'Y-m-d 23:59:59', $timestamp ) );
+	}
+
+	private function start_id_where() {
+		global $wpdb;
+
+		$start_id = absint( $this->filters['start_id'] );
+		if ( 0 === $start_id ) {
+			return;
+		}
+		$this->wheres[] = $wpdb->prepare( 'p.ID >= %d', $start_id );
 	}
 
 	private function get_timestamp_for_the_last_day_of_a_month( $yyyy_mm ) {


### PR DESCRIPTION
Ran into this issue when sending files to WordPress.com VIP:

Over time, as more and more data is being imported from WXRs, the process slows down as each database check becomes more an more intensive. Eventually, we decided that a greater number of smaller WXR files would be necessary to keep the import process (of a rather large site) running without completely exhausting system resources.

Not wanting to throw away the content that had already been imported, we needed a way to specify a starting post ID to re-export using a lower `--max-file-size` value, hence the `--start_id` argument was born.

Props to @ryanmarkel for his assistance on this.