### PR TITLE
Regex support for search-replace

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -81,6 +81,20 @@ Feature: Do global search/replace
       Checking: wp_posts.post_title
       1 rows affected
       """
+  @wip
+  Scenario: Regex search/replace
+    Given a WP install
+    When I run `wp search-replace '(Hello)\s(world)' '$2, $1' --regex`
+    Then STDOUT should contain:
+      """
+      wp_posts
+      """
+    When I run `wp post list --fields=post_title`
+    Then STDOUT should contain:
+      """
+      world, Hello
+      """
+
 
   Scenario Outline: Large guid search/replace where replacement contains search (or not)
     Given a WP install

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -81,7 +81,7 @@ Feature: Do global search/replace
       Checking: wp_posts.post_title
       1 rows affected
       """
-  @wip
+
   Scenario: Regex search/replace
     Given a WP install
     When I run `wp search-replace '(Hello)\s(world)' '$2, $1' --regex`

--- a/php/WP_CLI/Iterators/Query.php
+++ b/php/WP_CLI/Iterators/Query.php
@@ -36,7 +36,7 @@ class Query implements \Iterator {
 	 */
 	public function __construct( $query, $chunk_size = 500 ) {
 		$this->query = $query;
-		
+
 		$this->count_query = preg_replace( '/^.*? FROM /', 'SELECT COUNT(*) FROM ', $query, 1, $replacements );
 		if ( $replacements != 1 )
 			$this->count_query = '';

--- a/php/WP_CLI/Iterators/Table.php
+++ b/php/WP_CLI/Iterators/Table.php
@@ -51,7 +51,6 @@ class Table extends Query {
 		$conditions = self::build_where_conditions( $args['where'] );
 		$where_sql = $conditions ? " WHERE $conditions" : '';
 		$query = "SELECT $fields FROM $table $where_sql";
-
 		parent::__construct( $query, $args['chunk_size'] );
 	}
 

--- a/php/WP_CLI/Iterators/Table.php
+++ b/php/WP_CLI/Iterators/Table.php
@@ -51,6 +51,7 @@ class Table extends Query {
 		$conditions = self::build_where_conditions( $args['where'] );
 		$where_sql = $conditions ? " WHERE $conditions" : '';
 		$query = "SELECT $fields FROM $table $where_sql";
+
 		parent::__construct( $query, $args['chunk_size'] );
 	}
 

--- a/php/WP_CLI/SearchReplacer.php
+++ b/php/WP_CLI/SearchReplacer.php
@@ -82,9 +82,9 @@ class SearchReplacer {
 
 			else if ( is_string( $data ) ) {
 				if ( $this->regex ) {
-					$data = preg_replace( "/$from/", $to, $data );
+					$data = preg_replace( "/$this->from/", $this->to, $data );
 				} else {
-					$data = str_replace( $from, $to, $data );
+					$data = str_replace( $this->from, $this->to, $data );
 				}
 			}
 

--- a/php/WP_CLI/SearchReplacer.php
+++ b/php/WP_CLI/SearchReplacer.php
@@ -81,7 +81,11 @@ class SearchReplacer {
 			}
 
 			else if ( is_string( $data ) ) {
-				$data = $this->str_replace( $this->from, $this->to, $data );
+				if ( $this->regex ) {
+					$data = preg_replace( "/$from/", $to, $data );
+				} else {
+					$data = str_replace( $from, $to, $data );
+				}
 			}
 
 			if ( $serialised )
@@ -92,14 +96,6 @@ class SearchReplacer {
 		}
 
 		return $data;
-	}
-
-	private function str_replace( $from, $to, $data ) {
-		if ( $this->regex ) {
-			return preg_replace( "/$from/", $to, $data );
-		} else {
-			return str_replace( $from, $to, $data );
-		}
 	}
 }
 

--- a/php/WP_CLI/SearchReplacer.php
+++ b/php/WP_CLI/SearchReplacer.php
@@ -13,10 +13,11 @@ class SearchReplacer {
 	 * @param string  $to              What we want it to be replaced with.
 	 * @param bool    $recurse_objects Should objects be recursively replaced?
 	 */
-	function __construct( $from, $to, $recurse_objects = false ) {
+	function __construct( $from, $to, $recurse_objects = false, $regex = false ) {
 		$this->from = $from;
 		$this->to = $to;
 		$this->recurse_objects = $recurse_objects;
+		$this->regex = $regex;
 
 		// Get the XDebug nesting level. Will be zero (no limit) if no value is set
 		$this->max_recursion = intval( ini_get( 'xdebug.max_nesting_level' ) );
@@ -80,7 +81,7 @@ class SearchReplacer {
 			}
 
 			else if ( is_string( $data ) ) {
-				$data = str_replace( $this->from, $this->to, $data );
+				$data = $this->str_replace( $this->from, $this->to, $data );
 			}
 
 			if ( $serialised )
@@ -91,6 +92,14 @@ class SearchReplacer {
 		}
 
 		return $data;
+	}
+
+	private function str_replace( $from, $to, $data ) {
+		if ( $this->regex ) {
+			return preg_replace( "/$from/", $to, $data );
+		} else {
+			return str_replace( $from, $to, $data );
+		}
 	}
 }
 

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -53,7 +53,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 * : Prints rows to the console as they're updated.
 	 *
 	 * [--regex]
-	 * : Runs the search using a regular expression. Using --regex slows the search-replace down significantly.
+	 * : Runs the search using a regular expression. Warning: search-replace will take about 15-20x longer when using --regex.
 	 *
 	 * ## EXAMPLES
 	 *

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -52,6 +52,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 * [--verbose]
 	 * : Prints rows to the console as they're updated.
 	 *
+	 * [--regex]
+	 * : Runs the search using a regular expression. Using --regex slows the search-replace down significantly.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp search-replace 'http://example.dev' 'http://example.com' --skip-columns=guid
@@ -71,6 +74,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$php_only        = \WP_CLI\Utils\get_flag_value( $assoc_args, 'precise' );
 		$recurse_objects = \WP_CLI\Utils\get_flag_value( $assoc_args, 'recurse-objects' );
 		$verbose         =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'verbose' );
+		$regex           =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex' );
 
 		$skip_columns = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-columns' ) );
 
@@ -110,9 +114,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 					$serialRow = $wpdb->get_row( "SELECT * FROM `$table` WHERE `$col` REGEXP '^[aiO]:[1-9]' LIMIT 1" );
 				}
 
-				if ( $php_only || NULL !== $serialRow ) {
+				if ( $php_only || $regex || NULL !== $serialRow ) {
 					$type = 'PHP';
-					$count = self::php_handle_col( $col, $primary_keys, $table, $old, $new, $dry_run, $recurse_objects, $verbose );
+					$count = self::php_handle_col( $col, $primary_keys, $table, $old, $new, $dry_run, $recurse_objects, $verbose, $regex );
 				} else {
 					$type = 'SQL';
 					$count = self::sql_handle_col( $col, $table, $old, $new, $dry_run, $verbose );
@@ -219,7 +223,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		return $count;
 	}
 
-	private static function php_handle_col( $col, $primary_keys, $table, $old, $new, $dry_run, $recurse_objects, $verbose ) {
+	private static function php_handle_col( $col, $primary_keys, $table, $old, $new, $dry_run, $recurse_objects, $verbose, $regex ) {
 		global $wpdb;
 
 		// We don't want to have to generate thousands of rows when running the test suite
@@ -231,7 +235,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$args = array(
 			'table' => $table,
 			'fields' => $fields,
-			'where' => "`$col`" . ' LIKE "%' . self::esc_like( $old ) . '%"',
+			'where' => $regex ? '' : "`$col`" . ' LIKE "%' . self::esc_like( $old ) . '%"',
 			'chunk_size' => $chunk_size
 		);
 
@@ -239,7 +243,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 		$count = 0;
 
-		$replacer = new \WP_CLI\SearchReplacer( $old, $new, $recurse_objects );
+		$replacer = new \WP_CLI\SearchReplacer( $old, $new, $recurse_objects, $regex );
 
 		foreach ( $it as $row ) {
 			if ( '' === $row->$col )


### PR DESCRIPTION
This aims to address #1600 

It's going to be remarkably slower, given instead of only acting on rows that have values needing replacement, it has to go through all rows. MySQL's REGEXP operator is quite a bit different than PHP's...

Thoughts?