### PR TITLE
Adds confirms to scaffold

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -336,3 +336,17 @@ Feature: WordPress code scaffolding
     """
     Error: Could not decompress your theme files
     """
+
+  @wip
+  Scenario: Overwrite existing files
+    Given a WP install
+    When I run `wp scaffold plugin test`
+    And I run `wp scaffold plugin test --force`
+    Then STDERR should contain:
+    """
+    already exists
+    """
+    And STDOUT should contain:
+    """
+    Replaced
+    """

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -337,7 +337,6 @@ Feature: WordPress code scaffolding
     Error: Could not decompress your theme files
     """
 
-  @wip
   Scenario: Overwrite existing files
     Given a WP install
     When I run `wp scaffold plugin test`

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -347,5 +347,5 @@ Feature: WordPress code scaffolding
     """
     And STDOUT should contain:
     """
-    Replaced
+    Replacing
     """

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -286,21 +286,21 @@ class WP_CLI {
 		}
 	}
 
-    /**
-     * Prompt before continuing.
-     *
-     * @param string $question The question to pose
-     * @param bool $default The default response
-     * @param array $answers when the users responds with $answers[0] return false, with $answers[1] return true
-     * @param bool $hide Hide the user's response
-     * @return bool
-     */
+	/**
+	 * Prompt before continuing.
+	 *
+	 * @param string $question The question to pose
+	 * @param bool $default The default response
+	 * @param array $answers when the users responds with $answers[0] return false, with $answers[1] return true
+	 * @param bool $hide Hide the user's response
+	 * @return bool
+	 */
 	public static function prompt( $question, $default = false, $answers = array( 'no', 'yes' ), $hide = false ) {
-        $marker = '[' . implode( '/', $answers ) . ']: ';
+		$marker = '[' . implode( '/', $answers ) . ']: ';
 
-        do {
-            $answer = cli\prompt( $question, $default, $marker, $hide );
-        } while ( ! in_array( $answer, $answers ) );
+		do {
+			$answer = cli\prompt( $question, $default, $marker, $hide );
+		} while ( ! in_array( $answer, $answers ) );
 
 		return $answers[ 1 ] === $answer;
 	}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -287,6 +287,19 @@ class WP_CLI {
 	}
 
 	/**
+	 * Prompt before continuing.
+	 */
+	public static function prompt( $question, $assoc_args = array() ) {
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) ) {
+			fwrite( STDOUT, $question . " [s/r] " );
+
+			$answer = trim( fgets( STDIN ) );
+
+			return ( 'r' == $answer );
+		}
+	}
+
+	/**
 	 * Read value from a positional argument or from STDIN.
 	 *
 	 * @param array $args The list of positional arguments.

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -287,25 +287,6 @@ class WP_CLI {
 	}
 
 	/**
-	 * Prompt before continuing.
-	 *
-	 * @param string $question The question to pose
-	 * @param bool $default The default response
-	 * @param array $answers when the users responds with $answers[0] return false, with $answers[1] return true
-	 * @param bool $hide Hide the user's response
-	 * @return bool
-	 */
-	public static function prompt( $question, $default = false, $answers = array( 'no', 'yes' ), $hide = false ) {
-		$marker = '[' . implode( '/', $answers ) . ']: ';
-
-		do {
-			$answer = cli\prompt( $question, $default, $marker, $hide );
-		} while ( ! in_array( $answer, $answers ) );
-
-		return $answers[ 1 ] === $answer;
-	}
-
-	/**
 	 * Read value from a positional argument or from STDIN.
 	 *
 	 * @param array $args The list of positional arguments.

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -286,17 +286,23 @@ class WP_CLI {
 		}
 	}
 
-	/**
-	 * Prompt before continuing.
-	 */
-	public static function prompt( $question, $assoc_args = array() ) {
-		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) ) {
-			fwrite( STDOUT, $question . " [s/r] " );
+    /**
+     * Prompt before continuing.
+     *
+     * @param string $question The question to pose
+     * @param bool $default The default response
+     * @param array $answers when the users responds with $answers[0] return false, with $answers[1] return true
+     * @param bool $hide Hide the user's response
+     * @return bool
+     */
+	public static function prompt( $question, $default = false, $answers = array( 'no', 'yes' ), $hide = false ) {
+        $marker = '[' . implode( '/', $answers ) . ']: ';
 
-			$answer = trim( fgets( STDIN ) );
+        do {
+            $answer = cli\prompt( $question, $default, $marker, $hide );
+        } while ( ! in_array( $answer, $answers ) );
 
-			return ( 'r' == $answer );
-		}
+		return $answers[ 1 ] === $answer;
 	}
 
 	/**

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -574,6 +574,9 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		$wp_filesystem->mkdir( dirname( $filename ) );
 
+		if ( file_exists( $filename ) ) {
+			WP_CLI::confirm( 'Scaffold will overwrite "' . $filename . '". Continue?' );
+		}
 		if ( ! $wp_filesystem->put_contents( $filename, $contents ) ) {
 			WP_CLI::error( "Error creating file: $filename" );
 		}

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -681,7 +681,7 @@ class Scaffold_Command extends WP_CLI_Command {
 			$should_write_file = 'r' === $answer;
 		}
 
-		$outcome = $should_write_file ? 'Replaced' : 'Skipped';
+		$outcome = $should_write_file ? 'Replacing' : 'Skipping';
 		WP_CLI::log( $outcome . PHP_EOL );
 
 		return $should_write_file;

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -453,7 +453,9 @@ class Scaffold_Command extends WP_CLI_Command {
 
 			$force = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' );
 			$should_write_file = $this->prompt_if_files_will_be_overwritten( $file_path, $force );
-			if ( ! $should_write_file ) continue;
+			if ( ! $should_write_file ) {
+				continue;
+			}
 			$files_written[] = $file_path;
 
 			$result    = Process::create( Utils\esc_cmd( 'touch %s', $file_path ) )->run();

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -154,7 +154,7 @@ class Scaffold_Command extends WP_CLI_Command {
 			$filename = $path . $slug . '.php';
 
 			$files_written = $this->create_files( array( $filename => $final_output ) );
-			log_whether_files_written(
+			$this->log_whether_files_written(
 				$files_written, 
 				$skip_message = "Skipped creating $filename",
 				$success_message = "Created $filename"
@@ -316,7 +316,7 @@ class Scaffold_Command extends WP_CLI_Command {
 			$theme_style_path => Utils\mustache_render( 'child_theme.mustache', $data ),
 			$theme_functions_path => Utils\mustache_render( 'child_theme_functions.mustache', $data )
 		) );
-		log_whether_files_written(
+		$this->log_whether_files_written(
 			$files_written, 
 			$skip_message = 'All theme files were skipped.',
 			$success_message = "Created $theme_dir."
@@ -442,7 +442,7 @@ class Scaffold_Command extends WP_CLI_Command {
 				Process::create( Utils\esc_cmd( 'chmod +x %s', $file_path ) )->run();
 			}
 		}
-		log_whether_files_written(
+		$this->log_whether_files_written(
 			$files_written, 
 			$skip_message = 'All package tests were skipped.',
 			$success_message = 'Created test files.'
@@ -503,7 +503,7 @@ class Scaffold_Command extends WP_CLI_Command {
 			"$plugin_dir/Gruntfile.js" => Utils\mustache_render( 'plugin-gruntfile.mustache', $data ),
 		) );
 
-		log_whether_files_written(
+		$this->log_whether_files_written(
 			$files_written, 
 			$skip_message = 'All plugin files were skipped.',
 			$success_message = 'Created plugin files.'
@@ -603,7 +603,7 @@ class Scaffold_Command extends WP_CLI_Command {
 				}
 			}
 		}
-		log_whether_files_written(
+		$this->log_whether_files_written(
 			$files_written, 
 			$skip_message = 'All test files were skipped.',
 			$success_message = 'Created test files.'

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -665,7 +665,8 @@ class Scaffold_Command extends WP_CLI_Command {
 			return true;
 		}
 
-		WP_CLI::warning( $filename . ' already exists.' );
+		WP_CLI::warning( 'File already exists' );
+		WP_CLI::log( $filename );
 		if ( ! $force ) {
 			$should_write_file = WP_CLI::prompt(
 				$question = 'Skip this file, or replace it with scaffolding?',
@@ -674,7 +675,8 @@ class Scaffold_Command extends WP_CLI_Command {
 				$hide = false
 			);
 		}
-		WP_CLI::log( $should_write_file ? 'Replaced' : 'Skipped' );
+		$outcome = $should_write_file ? 'Replaced' : 'Skipped';
+		WP_CLI::log( $outcome . PHP_EOL );
 
 		return $should_write_file;
 	}


### PR DESCRIPTION
For issue #1797 

Uses `WP_CLI::confirm()` so there's a `--yes` flag.

Output looks like this:
```
Warning: Scaffold will overwrite: 
/Users/kevindoole/code/htdocs/agcanada/wp-content/plugins/blah/blah.php
/Users/kevindoole/code/htdocs/agcanada/wp-content/plugins/blah/readme.txt
/Users/kevindoole/code/htdocs/agcanada/wp-content/plugins/blah/package.json
/Users/kevindoole/code/htdocs/agcanada/wp-content/plugins/blah/Gruntfile.js
Overwrite files and continue? [y/n] y
Success: Created /Users/kevindoole/code/htdocs/agcanada/wp-content/plugins/blah
Warning: Scaffold will overwrite: 
/Users/kevindoole/code/htdocs/agcanada/wp-content/plugins/blah/tests/bootstrap.php
Overwrite files and continue? [y/n] y
Success: Created test files.
```

In the first commit, it warned about overwriting files one at a time, and saying "no" would cause the process to exit. So, taking the above example, if you said yes to 'blah.php' then no to 'readme.txt' the process would exit without even trying the remaining files.

I think grouping the files is a little better so you get to see everything that will get overwritten at once. The one exception, shown above, is for `wp scaffold plugin` where the plugin tests generate a separate rewrite warning. Seems ok.

Thoughts?