### PR TITLE
Only run `help` early when WordPress isn't loaded

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -129,3 +129,31 @@ Feature: Get help about WP-CLI commands
       """
       __destruct
       """
+
+  Scenario: Help for commands loaded into existing namespaces
+    Given a WP install
+    And a wp-content/plugins/test-cli/command.php file:
+      """
+      <?php
+      // Plugin Name: Test CLI Extra Site Command
+
+      class Test_CLI_Extra_Site_Command extends WP_CLI_Command {
+
+        /**
+         * A dummy command.
+         *
+         * @subcommand my-command
+         */
+        function my_command() {}
+
+      }
+
+      WP_CLI::add_command( 'site test-extra', 'Test_CLI_Extra_Site_Command' );
+      """
+    And I run `wp plugin activate test-cli`
+
+    When I run `wp help site`
+    Then STDOUT should contain:
+      """
+      test-extra
+      """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -596,7 +596,7 @@ class Runner {
 		self::set_wp_root( $this->find_wp_root() );
 
 		// First try at showing man page
-		if ( 'help' === $this->arguments[0] && ( isset( $this->arguments[1] ) || !$this->wp_exists() ) ) {
+		if ( 'help' === $this->arguments[0] && ! $this->wp_exists() ) {
 			$this->_run_command();
 		}
 


### PR DESCRIPTION
When WordPress is loaded, we may have a plugin adding commands to a
namespace

See #1795