### PR TITLE
Correct the error message text in `wp cli update`

### DIFF
--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -177,7 +177,7 @@ class CLI_Command extends WP_CLI_Command {
 		if ( 0 !== $status ) {
 			WP_CLI::error_multi_line( $output );
 
-			WP_CLI::error( 'The downloaded PHAR is broken, try running wp cli self-update again.' );
+			WP_CLI::error( 'The downloaded PHAR is broken, try running wp cli update again.' );
 		}
 
 		WP_CLI::log( 'New version works. Proceeding to replace.' );


### PR DESCRIPTION
If the `wp cli update` command errors, it tells you to attempt `wp cli self-update` again, which is incorrect.