### PR TITLE
Update the Travis notification syntax in tests scaffold

### DIFF
--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 notifications:
-  on_success: never
-  on_failure: change
+  email:
+    on_success: never
+    on_failure: change
 
 php:
   - 5.3


### PR DESCRIPTION
The [Travis linter](http://lint.travis-ci.org/) complains about the `notifications` syntax in the `.travis.yml` file generated by the tests scaffold. This fixes that.