### PR TITLE
Backtick `wp rewrite flush` snippet, so it gets formatted in docs

### DIFF
--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -17,8 +17,8 @@ class Rewrite_Command extends WP_CLI_Command {
 	 * To regenerate a .htaccess file with WP-CLI, you'll need to add the mod_rewrite module
 	 * to your wp-cli.yml or config.yml. For example:
 	 *
-	 * apache_modules:
-	 *   - mod_rewrite
+	 * `apache_modules:
+	 *   - mod_rewrite`
 	 *
 	 * ## OPTIONS
 	 *


### PR DESCRIPTION
See #1884