### PR TITLE
Catch failure to extract WordPress archive file

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -178,7 +178,12 @@ class Core_Command extends WP_CLI_Command {
 			} else if ( 20 != substr( $response->status_code, 0, 2 ) ) {
 				WP_CLI::error( "Couldn't access download URL (HTTP code {$response->status_code})" );
 			}
-			self::_extract( $temp, ABSPATH );
+
+			try {
+				self::_extract( $temp, ABSPATH );
+			} catch ( Exception $e ) {
+				WP_CLI::error( "Couldn't extract WordPress archive. " . $e->getMessage() );
+			}
 			$cache->import( $cache_key, $temp );
 			unlink($temp);
 		}


### PR DESCRIPTION
And provide a helpful error message

See #1892