### PR TITLE
Accept associative args with no right-side data

### DIFF
--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -89,7 +89,7 @@ class Configurator {
 				$assoc_args[] = array( $matches[1], false );
 			} elseif ( preg_match( '|^--([^=]+)$|', $arg, $matches ) ) {
 				$assoc_args[] = array( $matches[1], true );
-			} elseif ( preg_match( '|^--([^=]+)=(.+)|s', $arg, $matches ) ) {
+			} elseif ( preg_match( '|^--([^=]+)=(.*)|s', $arg, $matches ) ) {
 				$assoc_args[] = array( $matches[1], $matches[2] );
 			} else {
 				$positional_args[] = $arg;

--- a/tests/test-configurator.php
+++ b/tests/test-configurator.php
@@ -1,0 +1,51 @@
+<?php
+
+use WP_CLI\Configurator;
+
+class ConfiguratorTest extends PHPUnit_Framework_TestCase {
+
+  function testExtractAssoc() {
+    $args = Configurator::extract_assoc( array( 'foo', '--bar', '--baz=text' ) );
+
+    $this->assertCount( 1, $args[0] );
+    $this->assertCount( 2, $args[1] );
+
+    $this->assertEquals( 'foo', $args[0][0] );
+
+    $this->assertEquals( 'bar', $args[1][0][0] );
+    $this->assertTrue( $args[1][0][1] );
+
+    $this->assertEquals( 'baz', $args[1][1][0] );
+    $this->assertEquals( 'text', $args[1][1][1] );
+
+  }
+
+  function testExtractAssocNoValue() {
+    $args = Configurator::extract_assoc( array( 'foo', '--bar=', '--baz=text' ) );
+
+    $this->assertCount( 1, $args[0] );
+    $this->assertCount( 2, $args[1] );
+
+    $this->assertEquals( 'foo', $args[0][0] );
+
+    $this->assertEquals( 'bar', $args[1][0][0] );
+    $this->assertEmpty( $args[1][0][1] );
+
+    $this->assertEquals( 'baz', $args[1][1][0] );
+    $this->assertEquals( 'text', $args[1][1][1] );
+
+  }
+
+  function testExtractAssocDoubleDashInValue() {
+    $args = Configurator::extract_assoc( array( '--test=text--text' ) );
+
+    $this->assertCount( 0, $args[0] );
+    $this->assertCount( 1, $args[1] );
+
+    $this->assertEquals( 'test', $args[1][0][0] );
+    $this->assertEquals( 'text--text', $args[1][0][1] );
+
+  }
+
+
+}


### PR DESCRIPTION
Resolves #1894

I may be missing something here, but it didn't seem to me that this had much to do with #1745 as it does with the way args are sorted into positional and associative - there doesn't seem to be a reason to enforce right-side data in associative args so I've just modified the regex. 