### PR TITLE
Escape backslashes so that wp_unslash() will unescape them down the …

### DIFF
--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -108,7 +108,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 		}
 
 		parent::_update( $args, $assoc_args, function ( $params ) {
-			return wp_update_post( $params, true );
+			return wp_update_post( $this->escape( $params ), true );
 		} );
 	}
 
@@ -464,6 +464,15 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 			$readfile = 'php://stdin';
 		}
 		return file_get_contents( $readfile );
+	}
+
+	/**
+	 * Preserve text content by escaping backslashes that get unescaped by wp_unslash() down the line.
+	 * @param string $str  The string to be escaped
+	 * @return string  The escaped string
+	 */
+	private function escape($str) {
+		return str_replace( '\\', '\\\\', $str );
 	}
 }
 

--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -108,7 +108,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 		}
 
 		parent::_update( $args, $assoc_args, function ( $params ) {
-			return wp_update_post( $this->escape( $params ), true );
+			return wp_update_post( self::escape( $params ), true );
 		} );
 	}
 
@@ -471,7 +471,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 * @param string $str  The string to be escaped
 	 * @return string  The escaped string
 	 */
-	private function escape($str) {
+	private static function escape($str) {
 		return str_replace( '\\', '\\\\', $str );
 	}
 }

--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -471,7 +471,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 * @param string $str  The string to be escaped
 	 * @return string  The escaped string
 	 */
-	private static function escape($str) {
+	public static function escape($str) {
 		return str_replace( '\\', '\\\\', $str );
 	}
 }

--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -108,7 +108,7 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 		}
 
 		parent::_update( $args, $assoc_args, function ( $params ) {
-			return wp_update_post( self::escape( $params ), true );
+			return wp_update_post( Post_Command::escape( $params ), true );
 		} );
 	}
 


### PR DESCRIPTION
… line, resulting in the original content.

This fix prevents wp-cli (or rather WordPress) to bastardize embedded JavaScript code like
`var isEmailValid = /^\S+@\S+\.\S+$/.test(email);`
as
`var isEmailValid = /^S+@S+.S+$/.test(email);`