### PR TITLE
Prevent error notice in `cli update`

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -24,7 +24,7 @@ function extract_from_phar( $path ) {
 	copy( $path, $tmp_path );
 
 	register_shutdown_function( function() use ( $tmp_path ) {
-		unlink( $tmp_path );
+		@unlink( $tmp_path );
 	} );
 
 	return $tmp_path;


### PR DESCRIPTION
```
PHP Warning:  unlink(/tmp/wp-cli-cacert.pem): No such file or directory
in phar:///home/vagrant/.wp-cli/test.phar/php/utils.php on line 28
```

Because we make a remote request against Github twice, the shutdown
function is registered (and called) twice. The file is deleted the first
time.

See #1914