### PR TITLE
Prevent undefined notice when no `--format=<format>` is supplied

### DIFF
--- a/php/WP_CLI/CommandWithTerms.php
+++ b/php/WP_CLI/CommandWithTerms.php
@@ -67,6 +67,11 @@ abstract class CommandWithTerms extends \WP_CLI_Command {
 	 */
 	public function list_( $args, $assoc_args ) {
 
+		$defaults = array(
+			'format'      => 'table',
+			);
+		$assoc_args = array_merge( $defaults, $assoc_args );
+
 		$object_id      = array_shift( $args );
 		$taxonomy_names = $args;
 		$taxonomy_args = array();


### PR DESCRIPTION
```
PHP Notice:  Undefined index: format in
/home/vagrant/.wp-cli/php/WP_CLI/CommandWithTerms.php on line 80
```