### PR TITLE
Permit categories to be assigned with `wp post update`

### DIFF
--- a/features/post.feature
+++ b/features/post.feature
@@ -216,3 +216,14 @@ Feature: Manage WordPress posts
       """
       1
       """
+
+  Scenario: Update categories on a post
+    When I run `wp term create category "Test Category" --porcelain`
+    Then save STDOUT as {TERM_ID}
+
+    When I run `wp post update 1 --post_category={TERM_ID}`
+    And I run `wp post term list 1 category --format=json --fields=name`
+    Then STDOUT should be:
+      """
+      [{"name":"Test Category"}]
+      """

--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -107,6 +107,10 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 			break;
 		}
 
+		if ( isset( $assoc_args['post_category'] ) ) {
+			$assoc_args['post_category'] = explode( ',', $assoc_args['post_category'] );
+		}
+
 		parent::_update( $args, $assoc_args, function ( $params ) {
 			return wp_update_post( $params, true );
 		} );


### PR DESCRIPTION
Fixes #1944