### PR TITLE
Feature/secure install

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -633,7 +633,7 @@ class Runner {
 		if (
 			count( $this->arguments ) >= 2 &&
 			$this->arguments[0] == 'core' &&
-			in_array( $this->arguments[1], array( 'install', 'multisite-install' ) )
+			in_array( $this->arguments[1], array( 'install', 'multisite-install', 'secure_install' ) )
 		) {
 			define( 'WP_INSTALLING', true );
 

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -469,13 +469,6 @@ class Core_Command extends WP_CLI_Command {
 			\WP_CLI::error( "\nWP_ADMIN_PASSWORD must be defined in ENV" );
 		}
 		$this->install($args, $assoc_args);
-/*
-		if ( $this->_install( $assoc_args ) ) {
-			WP_CLI::success( 'WordPress installed successfully.' );
-		} else {
-			WP_CLI::log( 'WordPress is already installed.' );
-		}
-*/
 	}
 
 	/**

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -439,6 +439,46 @@ class Core_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Create the WordPress tables in the database using WP_ADMIN_PASSWORD from ENV.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --url=<url>
+	 * : The address of the new site.
+	 *
+	 * --title=<site-title>
+	 * : The title of the new site.
+         *
+	 * --title=<site-title>
+	 * : The title of the new site.
+         *
+	 * --admin_user=<username>
+	 * : The name of the admin user.
+	 *
+	 * --admin_email=<email>
+	 * : The email address for the admin user.
+	 * ## EXAMPLES
+	 *
+	 *     WP_ADMIN_PASSWORD=mypassword wp core secure_install --url=url --title=title --admin_user=username --admin_email=email
+	 *
+	 */
+	public function secure_install( $args, $assoc_args ) {
+                if(!empty(getenv('WP_ADMIN_PASSWORD'))) {
+			$assoc_args['admin_password'] = getenv('WP_ADMIN_PASSWORD');
+                } else {
+			\WP_CLI::error( "\nWP_ADMIN_PASSWORD must be defined in ENV" );
+		}
+		$this->install($args, $assoc_args);
+/*
+		if ( $this->_install( $assoc_args ) ) {
+			WP_CLI::success( 'WordPress installed successfully.' );
+		} else {
+			WP_CLI::log( 'WordPress is already installed.' );
+		}
+*/
+	}
+
+	/**
 	 * Transform a single-site install into a multi-site install.
 	 *
 	 * ## OPTIONS


### PR DESCRIPTION
Hello,

I'd like to get some initial feedback on the direction I'm taking here. The goal here is to allow passwords and other sensitive information to be passed to `wp-cli` securely. When `wp-cli core install` is run you can see the `admin_password` in the process list. Environment variables do not display in the process list. 

Example of using `wp core secure_install`:

```shell
WP_ADMIN_PASSWORD=password wp core secure_install --path=/home/wordpress/public --admin_user=admin  --title=my_blog --url=http://wordpress.org --admin_email=me@domain.com

```

This is a **security** issue when you're on a system with other users. While `wp-cli` is running, other users on the system could execute a `ps auxww` and grab your admin password from the process list.

Relates to #129 and #1809 

 