### PR TITLE
Add the docroot option to the synopsis so wp-cli parses it as a valid option

### DIFF
--- a/php/commands/server.php
+++ b/php/commands/server.php
@@ -27,7 +27,6 @@ class Server_Command extends WP_CLI_Command {
 	 *     sudo wp server --host=localhost.localdomain --port=80
 	 *
 	 * @when before_wp_load
-	 * @synopsis [--host=<host>] [--port=<port>] [--docroot=<docroot>]
 	 */
 	function __invoke( $_, $assoc_args ) {
 		$min_version = '5.4';

--- a/php/commands/server.php
+++ b/php/commands/server.php
@@ -27,7 +27,7 @@ class Server_Command extends WP_CLI_Command {
 	 *     sudo wp server --host=localhost.localdomain --port=80
 	 *
 	 * @when before_wp_load
-	 * @synopsis [--host=<host>] [--port=<port>]
+	 * @synopsis [--host=<host>] [--port=<port>] [--docroot=<docroot>]
 	 */
 	function __invoke( $_, $assoc_args ) {
 		$min_version = '5.4';


### PR DESCRIPTION
Was getting the following error when trying to run the `server` command:

```bash
$ php wp-cli-nightly.phar server --host=0.0.0.0 --port=8888 --docroot=web/wp
Error: Parameter errors:
 unknown --docroot parameter
```

This addresses that by adding the option to the `@synopsis` annotation, allowing `wp-cli` to parse it and use it as a valid option.