### PR TITLE
Ensure `$pagenow` global is always set

### DIFF
--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -218,8 +218,9 @@ wp_cookie_constants( );
 // Define and enforce our SSL constants
 wp_ssl_constants( );
 
-// Don't create common globals, but we still need wp_is_mobile()
+// Don't create common globals, but we still need wp_is_mobile() and $pagenow
 // require( ABSPATH . WPINC . '/vars.php' );
+$GLOBALS['pagenow'] = null;
 function wp_is_mobile() {
 	return false;
 }


### PR DESCRIPTION
Core sets the variable in `wp-includes/vars.php`

Fixes #1983