### PR TITLE
Append git short hash to alpha versions

### DIFF
--- a/ci/prepare.sh
+++ b/ci/prepare.sh
@@ -6,9 +6,17 @@ set -ex
 
 composer install --no-interaction --prefer-source
 
+CLI_VERSION=$(head -n 1 VERSION)
+if [[ $CLI_VERSION == *"-alpha"* ]]
+then
+	GIT_HASH=$(git rev-parse HEAD)
+	GIT_SHORT_HASH=${GIT_HASH:0:7}
+	CLI_VERSION="$CLI_VERSION-$GIT_SHORT_HASH"
+fi
+
 # the Behat test suite will pick up the executable found in $WP_CLI_BIN_DIR
 mkdir -p $WP_CLI_BIN_DIR
-php -dphar.readonly=0 utils/make-phar.php wp-cli.phar --quiet
+php -dphar.readonly=0 utils/make-phar.php wp-cli.phar --quiet --version=$CLI_VERSION
 mv wp-cli.phar $WP_CLI_BIN_DIR/wp
 chmod +x $WP_CLI_BIN_DIR/wp
 


### PR DESCRIPTION
When using `wp cli update --nightly`, the short hash will be helpful for
keeping track of which version you're running.

See #1800