### PR TITLE
WP-CLI shouldn't use cached WP partials in full upgrades (for v0.18.1)

### DIFF
--- a/php/WP_CLI/CoreUpgrader.php
+++ b/php/WP_CLI/CoreUpgrader.php
@@ -32,13 +32,14 @@ class CoreUpgrader extends \Core_Upgrader {
 		if ( empty( $package ) )
 			return new WP_Error( 'no_package', $this->strings['no_package'] );
 
+		$filename = pathinfo( $package, PATHINFO_FILENAME );
 		$ext = pathinfo( $package, PATHINFO_EXTENSION );
 
 		$temp = sys_get_temp_dir() . '/' . uniqid('wp_') . '.' . $ext;
 
 		$cache = WP_CLI::get_cache();
 		$update = $GLOBALS['wp_cli_update_obj'];
-		$cache_key = "core/{$update->locale}-{$update->version}.{$ext}";
+		$cache_key = "core/{$filename}-{$update->locale}.{$ext}";
 		$cache_file = $cache->has( $cache_key );
 
 		if ( $cache_file ) {

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -147,7 +147,7 @@ class Core_Command extends WP_CLI_Command {
 		WP_CLI::log( sprintf( 'Downloading WordPress %s (%s)...', $version, $locale ) );
 
 		$cache = WP_CLI::get_cache();
-		$cache_key = "core/$locale-$version.tar.gz";
+		$cache_key = "core/wordpress-$version-$locale.tar.gz";
 		$cache_file = $cache->has($cache_key);
 
 		$bad_cache = false;


### PR DESCRIPTION
392aba6 for v0.18.1

See #1898