### PR TITLE
WP-CLI shouldn't use cached WP partials in full upgrades (for v0.19.3)

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -12,7 +12,7 @@ Feature: Manage WordPress installation
     When I run `wp core download`
     And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION}
     Then the wp-settings.php file should exist
-    And the {SUITE_CACHE_DIR}/core/en_US-{VERSION}.tar.gz file should exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-en_US.tar.gz file should exist
 
     When I run `mkdir inner`
     And I run `cd inner && wp core download`
@@ -23,7 +23,7 @@ Feature: Manage WordPress installation
     Then the wp-settings.php file should exist
     And STDOUT should contain:
     """
-    Using cached file '{SUITE_CACHE_DIR}/core/en_US-{VERSION}.tar.gz'...
+    Using cached file '{SUITE_CACHE_DIR}/core/wordpress-{VERSION}-en_US.tar.gz'...
     """
 
   @download
@@ -33,7 +33,7 @@ Feature: Manage WordPress installation
     When I run `wp core download --locale=de_DE`
     And save STDOUT 'Downloading WordPress ([\d\.]+)' as {VERSION}
     Then the wp-settings.php file should exist
-    And the {SUITE_CACHE_DIR}/core/de_DE-{VERSION}.tar.gz file should exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-de_DE.tar.gz file should exist
 
   Scenario: No wp-config.php
     Given an empty directory
@@ -325,37 +325,39 @@ Feature: Manage WordPress installation
 
     When I run `wp core check-update`
     Then STDOUT should be a table containing rows:
-      | version | update_type | package_url                               |
-      | 4.2.2   | major       | https://wordpress.org/wordpress-4.2.2.zip |
-      | 4.1.5   | major       | https://wordpress.org/wordpress-4.1.5.zip |
-      | 4.0.5   | major       | https://wordpress.org/wordpress-4.0.5.zip |
-      | 3.9.6   | major       | https://wordpress.org/wordpress-3.9.6.zip |
-      | 3.8.8   | minor       | https://wordpress.org/wordpress-3.8.8.zip |
+      | version | update_type | package_url                                |
+      | 4.3     | major       | https://wordpress.org/wordpress-4.3.zip    |
+      | 4.2.4   | major       | https://wordpress.org/wordpress-4.2.4.zip  |
+      | 4.1.7   | major       | https://wordpress.org/wordpress-4.1.7.zip  |
+      | 4.0.7   | major       | https://wordpress.org/wordpress-4.0.7.zip  |
+      | 3.9.8   | major       | https://wordpress.org/wordpress-3.9.8.zip  |
+      | 3.8.10  | minor       | https://wordpress.org/wordpress-3.8.10.zip |
 
     When I run `wp core check-update --format=count`
+    Then STDOUT should be:
+      """
+      6
+      """
+
+    When I run `wp core check-update --major`
+    Then STDOUT should be a table containing rows:
+      | version | update_type | package_url                                |
+      | 4.3     | major       | https://wordpress.org/wordpress-4.3.zip    |
+      | 4.2.4   | major       | https://wordpress.org/wordpress-4.2.4.zip  |
+      | 4.1.7   | major       | https://wordpress.org/wordpress-4.1.7.zip  |
+      | 4.0.7   | major       | https://wordpress.org/wordpress-4.0.7.zip  |
+      | 3.9.8   | major       | https://wordpress.org/wordpress-3.9.8.zip  |
+
+    When I run `wp core check-update --major --format=count`
     Then STDOUT should be:
       """
       5
       """
 
-    When I run `wp core check-update --major`
-    Then STDOUT should be a table containing rows:
-      | version | update_type | package_url                               |
-      | 4.2.2   | major       | https://wordpress.org/wordpress-4.2.2.zip |
-      | 4.1.5   | major       | https://wordpress.org/wordpress-4.1.5.zip |
-      | 4.0.5   | major       | https://wordpress.org/wordpress-4.0.5.zip |
-      | 3.9.6   | major       | https://wordpress.org/wordpress-3.9.6.zip |
-
-    When I run `wp core check-update --major --format=count`
-    Then STDOUT should be:
-      """
-      4
-      """
-
     When I run `wp core check-update --minor`
     Then STDOUT should be a table containing rows:
-      | version | update_type | package_url                               |
-      | 3.8.8   | minor       | https://wordpress.org/wordpress-3.8.8.zip |
+      | version | update_type | package_url                                |
+      | 3.8.10  | minor       | https://wordpress.org/wordpress-3.8.10.zip |
 
     When I run `wp core check-update --minor --format=count`
     Then STDOUT should be:
@@ -422,7 +424,7 @@ Feature: Manage WordPress installation
     When I run `wp core update --version=3.8.1 --force`
     Then STDOUT should contain:
       """
-      Using cached file '{SUITE_CACHE_DIR}/core/en_US-3.8.1.zip'...
+      Using cached file '{SUITE_CACHE_DIR}/core/wordpress-3.8.1-en_US.zip'...
       """
     And STDOUT should not contain:
       """
@@ -595,53 +597,62 @@ Feature: Manage WordPress installation
       Warning: The 'en_GB' language is active.
       """
 
-  Scenario: Ensure file cache isn't corrupted by a ZIP masquerading as a gzipped TAR, part one
+  Scenario: Ensure cached partial upgrades aren't used in full upgrade
     Given a WP install
     And an empty cache
-    And I run `mkdir -p {SUITE_CACHE_DIR}/core; wget -O {SUITE_CACHE_DIR}/core/en_US-4.0.tar.gz https://wordpress.org/wordpress-4.0.zip; touch {SUITE_CACHE_DIR}/core/en_US-4.0.tar.gz`
+    And a wp-content/mu-plugins/upgrade-override.php file:
+      """
+      <?php
+      add_filter( 'pre_site_transient_update_core', function(){
+        return (object) array(
+          'updates' => array(
+              (object) array(
+                'response' => 'autoupdate',
+                'download' => 'https://downloads.wordpress.org/release/wordpress-4.2.4.zip',
+                'locale' => 'en_US',
+                'packages' => (object) array(
+                  'full' => 'https://downloads.wordpress.org/release/wordpress-4.2.4.zip',
+                  'no_content' => 'https://downloads.wordpress.org/release/wordpress-4.2.4-no-content.zip',
+                  'new_bundled' => 'https://downloads.wordpress.org/release/wordpress-4.2.4-new-bundled.zip',
+                  'partial' => 'https://downloads.wordpress.org/release/wordpress-4.2.4-partial-1.zip',
+                  'rollback' => 'https://downloads.wordpress.org/release/wordpress-4.2.4-rollback-1.zip',
+                ),
+                'current' => '4.2.4',
+                'version' => '4.2.4',
+                'php_version' => '5.2.4',
+                'mysql_version' => '5.0',
+                'new_bundled' => '4.1',
+                'partial_version' => '4.2.1',
+                'support_email' => 'updatehelp42@wordpress.org',
+                'new_files' => '',
+             ),
+          ),
+        );
+      });
+      """
 
-    When I run `wp core download --version=4.0 --force`
-    Then STDOUT should contain:
+    When I run `wp core download --version=4.2.1 --force`
+    And I run `wp core update`
+    Then STDOUT should not be empty
+    And the {SUITE_CACHE_DIR}/core directory should contain:
       """
-      Success: WordPress downloaded
-      """
-    And STDERR should contain:
-      """
-      Warning: Extraction failed, downloading a new copy...
+      wordpress-4.2.1-en_US.tar.gz
+      wordpress-4.2.4-partial-1-en_US.zip
       """
 
-    When I run `wp core version`
+    When I run `wp core download --version=4.1.1 --force`
+    And I run `wp core update`
+    And I run `wp core verify-checksums`
     Then STDOUT should be:
       """
-      4.0
+      Success: WordPress install verifies against checksums.
       """
-
-  Scenario: Ensure file cache isn't corrupted by core update, part two
-    Given a WP install
-    And an empty cache
-
-    When I run `wp core download --version=4.0 --force`
-    Then STDOUT should contain:
+    And the {SUITE_CACHE_DIR}/core directory should contain:
       """
-      Success: WordPress downloaded
-      """
-
-    When I run `wp core version`
-    Then STDOUT should be:
-      """
-      4.0
-      """
-
-    When I run `wp core update --version=4.0 --force`
-    Then STDOUT should contain:
-      """
-      Success: WordPress updated successfully
-      """
-
-    When I run `wp core version`
-    Then STDOUT should be:
-      """
-      4.0
+      wordpress-4.1.1-en_US.tar.gz
+      wordpress-4.2.1-en_US.tar.gz
+      wordpress-4.2.4-no-content-en_US.zip
+      wordpress-4.2.4-partial-1-en_US.zip
       """
 
   Scenario: Catch download of non-existent WP version

--- a/php/WP_CLI/CoreUpgrader.php
+++ b/php/WP_CLI/CoreUpgrader.php
@@ -32,13 +32,14 @@ class CoreUpgrader extends \Core_Upgrader {
 		if ( empty( $package ) )
 			return new WP_Error( 'no_package', $this->strings['no_package'] );
 
+		$filename = pathinfo( $package, PATHINFO_FILENAME );
 		$ext = pathinfo( $package, PATHINFO_EXTENSION );
 
 		$temp = sys_get_temp_dir() . '/' . uniqid('wp_') . '.' . $ext;
 
 		$cache = WP_CLI::get_cache();
 		$update = $GLOBALS['wp_cli_update_obj'];
-		$cache_key = "core/{$update->locale}-{$update->version}.{$ext}";
+		$cache_key = "core/{$filename}-{$update->locale}.{$ext}";
 		$cache_file = $cache->has( $cache_key );
 
 		if ( $cache_file ) {

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -147,7 +147,7 @@ class Core_Command extends WP_CLI_Command {
 		WP_CLI::log( sprintf( 'Downloading WordPress %s (%s)...', $version, $locale ) );
 
 		$cache = WP_CLI::get_cache();
-		$cache_key = "core/$locale-$version.tar.gz";
+		$cache_key = "core/wordpress-$version-$locale.tar.gz";
 		$cache_file = $cache->has($cache_key);
 
 		$bad_cache = false;


### PR DESCRIPTION
392aba6 for v0.19.3

See #1898