### PR TITLE
Switch away from using wp_download_language_pack()

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -584,6 +584,12 @@ Feature: Manage WordPress installation
       Success: Language activated.
       """
 
+    When I try `wp core language install invalid_lang`
+    Then STDERR should be:
+      """
+      Error: Language 'invalid_lang' not found.
+      """
+
   @require-wp-4.0
   Scenario: Don't allow active language to be uninstalled
     Given a WP install

--- a/php/WP_CLI/CommandWithTranslation.php
+++ b/php/WP_CLI/CommandWithTranslation.php
@@ -274,7 +274,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 	 * @param string $download Language code to download.
 	 * @return string|WP_Error Returns the language code if successfully downloaded, or a WP_Error object on failure.
 	 */
-	protected function download_language_pack( $download ) {
+	private function download_language_pack( $download ) {
 
 		$translations = $this->get_all_languages();
 


### PR DESCRIPTION
See #1879.

`wp_download_language_pack()` prevents the installation of a language if the `DISALLOW_FILE_MODS` constant is truthy.

This change introduces the `\WP_CLI\CommandWithTranslation::download_language_pack()` method which mostly copies the functionality in `wp_download_language_pack()`.

Also introduces an extra test for installing an invalid language.