### PR TITLE
Warn on cli update when directory isn't writeable

### DIFF
--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -146,6 +146,8 @@ class CLI_Command extends WP_CLI_Command {
 
 		if ( ! is_writable( $old_phar ) ) {
 			WP_CLI::error( sprintf( "%s is not writable by current user", $old_phar ) );
+		} else if ( ! is_writeable( dirname( $old_phar ) ) ) {
+			WP_CLI::error( sprintf( "%s is not writable by current user", dirname( $old_phar ) ) );
 		}
 
 		if ( isset( $assoc_args['nightly'] ) ) {


### PR DESCRIPTION
`rename()` requires both the file and directory to be writeable.
Erroring earlier is more helpful to the end user.

See #1962