### PR TITLE
Deliberately flag specific scenarios dependent on Github API

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -1,4 +1,3 @@
-@github-api
 Feature: `wp cli` tasks
 
   Scenario: Ability to set a custom version when building
@@ -16,6 +15,7 @@ Feature: `wp cli` tasks
     {TRUE_VERSION}
     """
 
+  @github-api
   Scenario: Check for updates
     Given an empty directory
     And a new Phar with version "0.0.0"
@@ -27,6 +27,7 @@ Feature: `wp cli` tasks
     """
     And STDERR should be empty
 
+  @github-api
   Scenario: Do WP-CLI Update
     Given an empty directory
     And a new Phar with version "0.0.0"
@@ -39,6 +40,7 @@ Feature: `wp cli` tasks
     And STDERR should be empty
     And the return code should be 0
 
+  @github-api
   Scenario: Patch update from 0.14.0 to 0.14.1
     Given an empty directory
     And a new Phar with version "0.14.0"
@@ -51,6 +53,7 @@ Feature: `wp cli` tasks
     And STDERR should be empty
     And the return code should be 0
 
+  @github-api
   Scenario: Not a patch update from 0.14.0
     Given an empty directory
     And a new Phar with version "0.14.0"
@@ -80,6 +83,7 @@ Feature: `wp cli` tasks
     And STDERR should be empty
     And the return code should be 0
 
+  @github-api
   Scenario: Dump the list of global parameters with values
     Given a WP install
 


### PR DESCRIPTION
The other `cli.feature` scenarios are fine to run each Travis build