### PR TITLE
Add error message when trying to use `wp rewrite flush --hard` on a multisite install

### DIFF
--- a/features/rewrite.feature
+++ b/features/rewrite.feature
@@ -73,5 +73,5 @@ Feature: Manage WordPress rewrites
     When I try `wp rewrite flush --hard`
     Then STDERR should be:
       """
-      Error: WordPress can't generate .htaccess file for a multisite install.
+      Warning: WordPress can't generate .htaccess file for a multisite install.
       """

--- a/features/rewrite.feature
+++ b/features/rewrite.feature
@@ -62,3 +62,16 @@ Feature: Manage WordPress rewrites
     When I run `wp rewrite structure /%year%/%monthnum%/%day%/%postname%/`
     And I run `wp rewrite flush --hard`
     Then the .htaccess file should exist
+
+  Scenario: Error when trying to generate .htaccess on a multisite install
+    Given a WP multisite install
+    And a wp-cli.yml file:
+      """
+      apache_modules: [mod_rewrite]
+      """
+
+    When I try `wp rewrite flush --hard`
+    Then STDERR should be:
+      """
+      Error: WordPress can't generate .htaccess file for a multisite install.
+      """

--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -23,15 +23,22 @@ class Rewrite_Command extends WP_CLI_Command {
 	 * ## OPTIONS
 	 *
 	 * [--hard]
-	 * : Perform a hard flush - update `.htaccess` rules as well as rewrite rules in database.
+	 * : Perform a hard flush - update `.htaccess` rules as well as rewrite rules in database. Works only on single site installs.
 	 */
 	public function flush( $args, $assoc_args ) {
 		// make sure we detect mod_rewrite if configured in apache_modules in config
 		self::apache_modules();
+
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'hard' ) && ! in_array( 'mod_rewrite', (array) WP_CLI::get_config( 'apache_modules' ) ) ) {
 			WP_CLI::warning( "Regenerating a .htaccess file requires special configuration. See usage docs." );
 		}
+
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'hard' ) && is_multisite() ) {
+			WP_CLI::error( "WordPress can't generate .htaccess file for a multisite install." );
+		}
+
 		flush_rewrite_rules( \WP_CLI\Utils\get_flag_value( $assoc_args, 'hard' ) );
+
 		if ( ! get_option( 'rewrite_rules' ) ) {
 			WP_CLI::warning( "Rewrite rules are empty, possibly because of a missing permalink_structure option. Use 'wp rewrite list' to verify, or 'wp rewrite structure' to update permalink_structure." );
 		}

--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -34,7 +34,7 @@ class Rewrite_Command extends WP_CLI_Command {
 		}
 
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'hard' ) && is_multisite() ) {
-			WP_CLI::error( "WordPress can't generate .htaccess file for a multisite install." );
+			WP_CLI::warning( "WordPress can't generate .htaccess file for a multisite install." );
 		}
 
 		flush_rewrite_rules( \WP_CLI\Utils\get_flag_value( $assoc_args, 'hard' ) );


### PR DESCRIPTION
WordPress don't generate .htaccess for multisite installs:

https://github.com/WordPress/WordPress/blob/ce557062f4123d8513378cf415b4e8b612c33ccc/wp-admin/includes/misc.php#L162