### PR TITLE
Return a more useful error message when running `wp scaffold plugin-tests` with an invalid plugin slug.

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -349,3 +349,11 @@ Feature: WordPress code scaffolding
     """
     Replacing
     """
+  Scenario: Scaffold tests for invalid plugin directory
+    Given a WP install
+  
+    When I try `wp scaffold plugin-tests incorrect-custom-plugin`
+    Then STDERR should contain:
+      """
+      Error: Invalid plugin directory specified.
+      """

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -603,6 +603,10 @@ class Scaffold_Command extends WP_CLI_Command {
 			WP_CLI::error( 'Invalid plugin specified.' );
 		}
 
+		if ( ! is_dir( $plugin_dir ) ) {
+			WP_CLI::error( 'Invalid plugin directory specified.' );
+		}
+
 		$tests_dir = "$plugin_dir/tests";
 		$bin_dir = "$plugin_dir/bin";
 


### PR DESCRIPTION
If you run `wp scaffold plugin-tests foo` and the `foo` plugin doesn't exist, you get the following not very helpful error message:

`Error: Error creating file: ~wp-content/plugins/foo/tests/bootstrap.php`

If you haven't realised you've made a typo in the plugin slug, you might waste time investigating file permission errors.

This change tests for the existence of the plugin's directory and returns a more useful error message if it doesn't exist.