### PR TITLE
In `wp theme list`, indicate a parent theme with `status=parent`

### DIFF
--- a/features/theme.feature
+++ b/features/theme.feature
@@ -238,3 +238,14 @@ Feature: Manage WordPress themes
       """
       Error: The 'biker' theme cannot be activated without its parent, 'jolene'.
       """
+
+  Scenario: List an active theme with its parent
+    Given a WP install
+    And I run `wp theme install jolene`
+    And I run `wp theme install --activate biker`
+
+    When I run `wp theme list --fields=name,status`
+    Then STDOUT should be a table containing rows:
+      | name          | status   |
+      | biker         | active   |
+      | jolene        | parent   |

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -107,7 +107,13 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 	}
 
 	protected function get_status( $theme ) {
-		return ( $this->is_active_theme( $theme ) ) ? 'active' : 'inactive';
+		if ( $this->is_active_theme( $theme ) ) {
+			return 'active';
+		} else if ( $theme->get_stylesheet_directory() === get_template_directory() ) {
+			return 'parent';
+		} else {
+			return 'inactive';
+		}
 	}
 
 	/**


### PR DESCRIPTION
This will more clearly distinguish between a genuinely inactive theme
vs. an "inactive" theme being used as a parent theme.

Fixes #2033