### PR TITLE
Fix example in `wp menu item delete`

### DIFF
--- a/php/commands/menu.php
+++ b/php/commands/menu.php
@@ -471,7 +471,7 @@ class Menu_Item_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp menu item remove 45
+	 *     wp menu item delete 45
 	 *
 	 * @subcommand delete
 	 */


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli.github.com/pull/63