### PR TITLE
Generic args for `wp comment create` should always be optional

### DIFF
--- a/php/commands/comment.php
+++ b/php/commands/comment.php
@@ -32,7 +32,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 *
 	 * ## OPTIONS
 	 *
-	 * --<field>=<value>
+	 * [--<field>=<value>]
 	 * : Associative args for the new comment. See wp_insert_comment().
 	 *
 	 * [--porcelain]
@@ -44,10 +44,12 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 */
 	public function create( $args, $assoc_args ) {
 		parent::_create( $args, $assoc_args, function ( $params ) {
-			$post_id = $params['comment_post_ID'];
-			$post = get_post( $post_id );
-			if ( !$post ) {
-				return new WP_Error( 'no_post', "Can't find post $post_id." );
+			if ( isset( $params['comment_post_ID'] ) ) {
+				$post_id = $params['comment_post_ID'];
+				$post = get_post( $post_id );
+				if ( !$post ) {
+					return new WP_Error( 'no_post', "Can't find post $post_id." );
+				}
 			}
 
 			// We use wp_insert_comment() instead of wp_new_comment() to stay at a low level and


### PR DESCRIPTION
... including setting a post ID

See #725