### PR TITLE
Pass any `rewrite flush` warnings when using `rewrite structure`

### DIFF
--- a/features/rewrite.feature
+++ b/features/rewrite.feature
@@ -75,3 +75,9 @@ Feature: Manage WordPress rewrites
       """
       Warning: WordPress can't generate .htaccess file for a multisite install.
       """
+
+    When I try `wp rewrite structure /%year%/%monthnum%/%day%/%postname%/ --hard`
+    Then STDERR should contain:
+      """
+      Warning: WordPress can't generate .htaccess file for a multisite install.
+      """

--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -129,7 +129,11 @@ class Rewrite_Command extends WP_CLI_Command {
 			}
 		}
 
-		\WP_CLI::launch_self( 'rewrite flush', array(), $new_assoc_args );
+		$process_run = WP_CLI::launch_self( 'rewrite flush', array(), $new_assoc_args, true, true, array( 'apache_modules', WP_CLI::get_config( 'apache_modules' ) ) );
+		if ( ! empty( $process_run->stderr ) ) {
+			// Strip "Warning: "
+			WP_CLI::warning( substr( $process_run->stderr, 9 ) );
+		}
 
 		WP_CLI::success( "Rewrite structure set." );
 	}


### PR DESCRIPTION
Previously https://github.com/wp-cli/wp-cli/pull/2017#issuecomment-135852742