### PR TITLE
Deprecate `wp site url` in favor of `wp site list --field=url`

### DIFF
--- a/features/site.feature
+++ b/features/site.feature
@@ -18,15 +18,15 @@ Feature: Manage sites in a multisite installation
 
     When I run `wp site list --fields=blog_id,url`
     Then STDOUT should be a table containing rows:
-      | blog_id | url                |
-      | 1       | example.com/       |
-      | 2       | example.com/first/ |
+      | blog_id | url                       |
+      | 1       | http://example.com/       |
+      | 2       | http://example.com/first/ |
 
     When I run `wp site list --field=url`
     Then STDOUT should be:
       """
-      example.com/
-      example.com/first/
+      http://example.com/
+      http://example.com/first/
       """
 
     When I run `wp site delete {SITE_ID} --yes`
@@ -44,14 +44,14 @@ Feature: Manage sites in a multisite installation
 
     When I run `wp site list --fields=blog_id,url`
     Then STDOUT should be a table containing rows:
-      | blog_id | url                |
-      | 1       | example.com/       |
-      | 2       | example.com/first/ |
+      | blog_id | url                       |
+      | 1       | http://example.com/       |
+      | 2       | http://example.com/first/ |
 
     When I run `wp site list --field=url --blog_id=2`
     Then STDOUT should be:
       """
-      example.com/first/
+      http://example.com/first/
       """
 
   Scenario: Delete a site by slug
@@ -100,7 +100,18 @@ Feature: Manage sites in a multisite installation
     When I run `wp site url {SITE_ID}`
     Then STDOUT should be:
       """
-      http://example.com/first
+      http://example.com/first/
+      """
+
+    When I run `wp site create --slug=second --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {SECOND_ID}
+
+    When I run `wp site url {SECOND_ID} {SITE_ID}`
+    Then STDOUT should be:
+      """
+      http://example.com/second/
+      http://example.com/first/
       """
 
   Scenario: Archive/unarchive a site

--- a/php/WP_CLI/Iterators/Table.php
+++ b/php/WP_CLI/Iterators/Table.php
@@ -36,11 +36,13 @@ class Table extends Query {
 	 *			= string – this will be the where clause
 	 *			= array – each element is treated as a condition if it's positional, or as column => value if
 	 *				it's a key/value pair. In the latter case the value is automatically quoted and escaped
+	 *      append - add arbitrary extra SQL
 	 */
 	function __construct( $args = array() ) {
 		$defaults = array(
 			'fields' => '*',
 			'where' => array(),
+			'append' => '',
 			'table' => null,
 			'chunk_size' => 500
 		);
@@ -50,7 +52,7 @@ class Table extends Query {
 		$fields = self::build_fields( $args['fields'] );
 		$conditions = self::build_where_conditions( $args['where'] );
 		$where_sql = $conditions ? " WHERE $conditions" : '';
-		$query = "SELECT $fields FROM $table $where_sql";
+		$query = "SELECT $fields FROM $table $where_sql {$args['append']}";
 
 		parent::__construct( $query, $args['chunk_size'] );
 	}
@@ -67,10 +69,13 @@ class Table extends Query {
 		if ( is_array( $where ) ) {
 			$conditions = array();
 			foreach( $where as $key => $value ) {
-				if ( is_numeric( $key ) )
+				if ( is_array( $value ) ) {
+					$conditions[]  = $key . ' IN (' . $wpdb->escape( implode( ',', $value ) ) . ')';
+				} else if ( is_numeric( $key ) ) {
 					$conditions[] = $value;
-				else
+				} else {
 					$conditions[] = $key . ' = "' . $wpdb->escape( $value ) .'"';
+				}
 			}
 			$where = implode( ' AND ', $conditions );
 		}

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -453,14 +453,24 @@ class Runner {
 			}
 		}
 
-		// post url  -->  post list --post__in --field=url
-		if ( count( $args ) >= 2 && 'post' === $args[0] && 'url' === $args[1] ) {
-			$post_ids = array_slice( $args, 2 );
-			$args = array( 'post', 'list' );
-			$assoc_args['post__in'] = implode( ',', $post_ids );
-			$assoc_args['post_type'] = 'any';
-			$assoc_args['orderby'] = 'post__in';
-			$assoc_args['field'] = 'url';
+		// (post|site) url  --> (post|site) list --*__in --field=url
+		if ( count( $args ) >= 2 && in_array( $args[0], array( 'post', 'site' ) ) && 'url' === $args[1] ) {
+			switch ( $args[0] ) {
+				case 'post':
+					$post_ids = array_slice( $args, 2 );
+					$args = array( 'post', 'list' );
+					$assoc_args['post__in'] = implode( ',', $post_ids );
+					$assoc_args['post_type'] = 'any';
+					$assoc_args['orderby'] = 'post__in';
+					$assoc_args['field'] = 'url';
+					break;
+				case 'site':
+					$site_ids = array_slice( $args, 2 );
+					$args = array( 'site', 'list' );
+					$assoc_args['site__in'] = implode( ',', $site_ids );
+					$assoc_args['field'] = 'url';
+					break;
+			}
 		}
 
 		return array( $args, $assoc_args );

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -394,12 +394,18 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 		$assoc_args = array_merge( $defaults, $assoc_args );
 
 		$where = array();
+		$append = '';
 
 		$site_cols = array( 'blog_id', 'url', 'last_updated', 'registered', 'site_id', 'domain', 'path', 'public', 'archived', 'mature', 'spam', 'deleted', 'lang_id' );
 		foreach( $site_cols as $col ) {
 			if ( isset( $assoc_args[ $col ] ) ) {
 				$where[ $col ] = $assoc_args[ $col ];
 			}
+		}
+
+		if ( isset( $assoc_args['site__in'] ) ) {
+			$where['blog_id'] = explode( ',', $assoc_args['site__in'] );
+			$append = "ORDER BY FIELD( blog_id, " . implode( ',', array_map( 'intval', $where['blog_id'] ) ) . " )";
 		}
 
 		if ( isset( $assoc_args['network'] ) ) {
@@ -409,36 +415,17 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 		$iterator_args = array(
 			'table' => $wpdb->blogs,
 			'where' => $where,
+			'append' => $append,
 		);
 		$it = new \WP_CLI\Iterators\Table( $iterator_args );
 
 		$it = \WP_CLI\Utils\iterator_map( $it, function( $blog ) {
-			$blog->url = $blog->domain . $blog->path;
+			$blog->url = trailingslashit( get_site_url( $blog->blog_id ) );
 			return $blog;
 		} );
 
 		$formatter = new \WP_CLI\Formatter( $assoc_args, null, 'site' );
 		$formatter->display_items( $it );
-	}
-
-	/**
-	 * Get site url
-	 *
-	 * ## OPTIONS
-	 *
-	 * <id>...
-	 * : One or more IDs of sites to get the URL.
-	 *
-	 * ## EXAMPLES
-	 *
-	 *     wp site url 123
-	 */
-	public function url( $args ) {
-		if ( !is_multisite() ) {
-			WP_CLI::error( 'This is not a multisite install.' );
-		}
-
-		parent::_url( $args, 'get_site_url' );
 	}
 
 	/**


### PR DESCRIPTION
Also uses `get_site_url()` to produce `url` in `wp site list` for
consistency with other resources

See #2070