### PR TITLE
Support APC cache with WP-CLI,  but only after warning with confirmation

### DIFF
--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -102,7 +102,8 @@ wp_start_object_cache();
 
 // WP-CLI: the APC cache is not available on the command-line, so bail, to prevent cache poisoning
 if ( $GLOBALS['_wp_using_ext_object_cache'] && class_exists( 'APC_Object_Cache' ) ) {
-	WP_CLI::error( 'WP-CLI is not compatible with the APC object cache.' );
+	WP_CLI::warning( 'Running WP-CLI while the APC object cache is activated can result in cache corruption.' );
+	WP_CLI::confirm( 'Given the consequences, do you wish to continue?' );
 }
 
 // Attach the default filters.


### PR DESCRIPTION
Fixes #283