### PR TITLE
Deprecate `@synopsis` for `cap`, `eval`, `help`, `option`, and others

### DIFF
--- a/php/commands/cap.php
+++ b/php/commands/cap.php
@@ -19,13 +19,15 @@ class Capabilities_Command extends WP_CLI_Command {
 	/**
 	 * List capabilities for a given role.
 	 *
+	 * <role>
+	 * : Key for the role.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Display alphabetical list of bbPress moderator capabilities
 	 *     wp cap list 'bbp_moderator' | sort
 	 *
 	 * @subcommand list
-	 * @synopsis <role>
 	 */
 	public function list_( $args ) {
 		$role_obj = self::get_role( $args[0] );
@@ -37,7 +39,11 @@ class Capabilities_Command extends WP_CLI_Command {
 	/**
 	 * Add capabilities to a given role.
 	 *
-	 * @synopsis <role> <cap>...
+	 * <role>
+	 * : Key for the role.
+	 *
+	 * <cap>...
+	 * : One or more capabilities to add.
 	 */
 	public function add( $args ) {
 		self::persistence_check();
@@ -63,7 +69,11 @@ class Capabilities_Command extends WP_CLI_Command {
 	/**
 	 * Remove capabilities from a given role.
 	 *
-	 * @synopsis <role> <cap>...
+	 * <role>
+	 * : Key for the role.
+	 *
+	 * <cap>...
+	 * : One or more capabilities to remove.
 	 */
 	public function remove( $args ) {
 		self::persistence_check();

--- a/php/commands/eval.php
+++ b/php/commands/eval.php
@@ -5,11 +5,12 @@ class Eval_Command extends WP_CLI_Command {
 	/**
 	 * Execute arbitrary PHP code after loading WordPress.
 	 *
+	 * <php-code>
+	 * : The code to execute, as a string.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp eval 'echo WP_CONTENT_DIR;'
-	 *
-	 * @synopsis <php-code>
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		eval( $args[0] );

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -6,7 +6,10 @@ use \WP_CLI\Dispatcher;
 class Help_Command extends WP_CLI_Command {
 
 	/**
-	 * Get help on a certain command.
+	 * Get help on WP-CLI, or on a specific. command.
+	 *
+	 * [<command>...]
+	 * : Get help on a specific command.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -15,8 +18,6 @@ class Help_Command extends WP_CLI_Command {
 	 *
 	 *     # get help for `core download` subcommand
 	 *     wp help core download
-	 *
-	 * @synopsis [<command>...]
 	 */
 	function __invoke( $args, $assoc_args ) {
 		$command = self::find_subcommand( $args );

--- a/php/commands/option.php
+++ b/php/commands/option.php
@@ -23,7 +23,11 @@ class Option_Command extends WP_CLI_Command {
 	/**
 	 * Get an option.
 	 *
-	 * @synopsis <key> [--format=<format>]
+	 * <key>
+	 * : Key for the option
+	 *
+	 * [--format=<format>]
+	 * : Get value as var_export() or JSON. Default: var_export()
 	 */
 	public function get( $args, $assoc_args ) {
 		list( $key ) = $args;
@@ -118,7 +122,6 @@ class Option_Command extends WP_CLI_Command {
 	 * * size_bytes
 	 *
 	 * @subcommand list
-	 * @synopsis [--search=<glob-style-pattern>] [--autoload=<value>] [--fields=<fields>] [--format=<format>]
 	 */
 	public function list_( $args, $assoc_args ) {
 
@@ -220,7 +223,8 @@ class Option_Command extends WP_CLI_Command {
 	/**
 	 * Delete an option.
 	 *
-	 * @synopsis <key>
+	 * <key>
+	 * : Key for the option.
 	 */
 	public function delete( $args ) {
 		list( $key ) = $args;

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -191,22 +191,20 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 	 * --slug=<slug>
 	 * : Path for the new site. Subdomain on subdomain installs, directory on subdirectory installs.
 	 *
-	 * --title=<title>
+	 * [--title=<title>]
 	 * : Title of the new site. Default: prettified slug.
 	 *
-	 * --email=<email>
+	 * [--email=<email>]
 	 * : Email for Admin user. User will be created if none exists. Assignement to Super Admin if not included.
 	 *
-	 * --network_id=<network-id>
+	 * [--network_id=<network-id>]
 	 * : Network to associate new site with. Defaults to current network (typically 1).
 	 *
-	 * --private
+	 * [--private]
 	 * : If set, the new site will be non-public (not indexed)
 	 *
-	 * --porcelain
+	 * [--porcelain]
 	 * : If set, only the site id will be output on success.
-	 *
-	 * @synopsis --slug=<slug> [--title=<title>] [--email=<email>] [--network_id=<network-id>] [--private] [--porcelain]
 	 */
 	public function create( $_, $assoc_args ) {
 		if ( !is_multisite() ) {

--- a/php/commands/transient.php
+++ b/php/commands/transient.php
@@ -12,7 +12,11 @@ class Transient_Command extends WP_CLI_Command {
 	/**
 	 * Get a transient value.
 	 *
-	 * @synopsis <key> [--json]
+	 * <key>
+	 * : Key for the transient.
+	 *
+	 * [--json]
+	 * : Format output as JSON.
 	 */
 	public function get( $args, $assoc_args ) {
 		list( $key ) = $args;
@@ -30,7 +34,14 @@ class Transient_Command extends WP_CLI_Command {
 	/**
 	 * Set a transient value. <expiration> is the time until expiration, in seconds.
 	 *
-	 * @synopsis <key> <value> [<expiration>]
+	 * <key>
+	 * : Key for the transient.
+	 *
+	 * <value>
+	 * : Value to be set for the transient.
+	 *
+	 * [<expiration]
+	 * : Time until expiration, in seconds.
 	 */
 	public function set( $args ) {
 		list( $key, $value ) = $args;
@@ -46,7 +57,8 @@ class Transient_Command extends WP_CLI_Command {
 	/**
 	 * Delete a transient value.
 	 *
-	 * @synopsis <key>
+	 * <key>
+	 * : Key for the transient.
 	 */
 	public function delete( $args ) {
 		list( $key ) = $args;

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -796,8 +796,6 @@ class User_Meta_Command extends \WP_CLI\CommandWithMeta {
 	 *
 	 * [--format=<format>]
 	 * : Accepted values: table, json. Default: table
-	 *
-	 * @synopsis <user> <key> [--format=<format>]
 	 */
 	public function get( $args, $assoc_args ) {
 		$args = $this->replace_login_with_user_id( $args );
@@ -832,8 +830,6 @@ class User_Meta_Command extends \WP_CLI\CommandWithMeta {
 	 *
 	 * <value>
 	 * : The new metadata value.
-	 *
-	 * @synopsis <user> <key> <value> [--format=<format>]
 	 */
 	public function add( $args, $assoc_args ) {
 		$args = $this->replace_login_with_user_id( $args );
@@ -853,7 +849,6 @@ class User_Meta_Command extends \WP_CLI\CommandWithMeta {
 	 * : The new metadata value.
 	 *
 	 * @alias set
-	 * @synopsis <user> <key> <value> [--format=<format>]
 	 */
 	public function update( $args, $assoc_args ) {
 		$args = $this->replace_login_with_user_id( $args );

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -830,6 +830,9 @@ class User_Meta_Command extends \WP_CLI\CommandWithMeta {
 	 *
 	 * <value>
 	 * : The new metadata value.
+	 *
+	 * [--format=<format>]
+	 * : The serialization format for the value. Default is plaintext.
 	 */
 	public function add( $args, $assoc_args ) {
 		$args = $this->replace_login_with_user_id( $args );
@@ -847,6 +850,9 @@ class User_Meta_Command extends \WP_CLI\CommandWithMeta {
 	 *
 	 * <value>
 	 * : The new metadata value.
+	 *
+	 * [--format=<format>]
+	 * : The serialization format for the value. Default is plaintext.
 	 *
 	 * @alias set
 	 */


### PR DESCRIPTION
See #1969