### PR TITLE
Fix invalid synopsis part for `wp option list`

### DIFF
--- a/php/commands/option.php
+++ b/php/commands/option.php
@@ -94,9 +94,7 @@ class Option_Command extends WP_CLI_Command {
 	 * : Limit the output to specific object fields.
 	 *
 	 * [--format=<format>]
-	 * : The serialization format for the value.
-	 * : total_bytes displays the total size of matching options in bytes.
-	 * : Accepted values: table, json, csv, count, total_bytes. Default: table
+	 * : The serialization format for the value. total_bytes displays the total size of matching options in bytes. Accepted values: table, json, csv, count, total_bytes. Default: table
 	 *
 	 * ## EXAMPLES
 	 *


### PR DESCRIPTION
```
salty-wordpress ➜  wordpress-test.dev  wp option list --search="apple"
Warning: The `wp option list` command has an invalid synopsis part: The
Warning: The `wp option list` command has an invalid synopsis part:
serialization
Warning: The `wp option list` command has an invalid synopsis part:
format
Warning: The `wp option list` command has an invalid synopsis part: for
Warning: The `wp option list` command has an invalid synopsis part: the
Warning: The `wp option list` command has an invalid synopsis part:
value.
Warning: The `wp option list` command has an invalid synopsis part:
total_bytes
Warning: The `wp option list` command has an invalid synopsis part:
displays
Warning: The `wp option list` command has an invalid synopsis part: the
Warning: The `wp option list` command has an invalid synopsis part:
total
Warning: The `wp option list` command has an invalid synopsis part: size
Warning: The `wp option list` command has an invalid synopsis part: of
Warning: The `wp option list` command has an invalid synopsis part:
matching
Warning: The `wp option list` command has an invalid synopsis part:
options
Warning: The `wp option list` command has an invalid synopsis part: in
Warning: The `wp option list` command has an invalid synopsis part:
bytes.
```