### PR TITLE
Fix 1631

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -332,7 +332,7 @@ class Runner {
 			}
 
 			// exclude potential problems by only running variable definitions (issue:1631)
-        		if ( preg_match( '/(define\(.*,.*\)|\$\w+\s*=\s['"].*['"];)/', $line ) ) {
+        		if ( preg_match( '/(define\(.*,.*\)|\$\w+\s*=\s[\'"].*[\'"];)/', $line ) ) {
                 		$lines_to_run[] = $line;
         		}
 		}

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -331,7 +331,10 @@ class Runner {
 				continue;
 			}
 
-			$lines_to_run[] = $line;
+			// exclude potential problems by only running variable definitions (issue:1631)
+        		if ( preg_match( '/(define\(.*,.*\)|\$\w+\s*=\s['"].*['"];)/', $line ) ) {
+                		$lines_to_run[] = $line;
+        		}
 		}
 
 		if ( !$found_wp_settings ) {


### PR DESCRIPTION
This code may solve the issues presented in https://github.com/wp-cli/wp-cli/issues/1631

Given that:
> Before WP-CLI can load wp-settings-cli.php, it needs to know all of the constants defined in wp-config.php (database connection details and so on).

We need to include all the constants and variable definitions, but we should try to avoid executing some of the more risky parts of this file as WordPress is not actually loaded at this time.
Issues such as:
https://github.com/wp-cli/wp-cli/issues/1586
https://github.com/wp-cli/wp-cli/issues/1453

Essentially this is a whitelist to allow calls to define() and variable declarations.  All other commands will be ignored.  This may need to be augmented for other important calls.