### PR TITLE
Only run `wp core update-db --network` on active sites

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -293,6 +293,15 @@ Feature: Manage WordPress installation
     Given a WP multisite install
     And I run `wp site create --slug=foo`
     And I run `wp site create --slug=bar`
+    And I run `wp site create --slug=burrito --porcelain`
+    And save STDOUT as {BURRITO_ID}
+    And I run `wp site create --slug=taco --porcelain`
+    And save STDOUT as {TACO_ID}
+    And I run `wp site create --slug=pizza --porcelain`
+    And save STDOUT as {PIZZA_ID}
+    And I run `wp site archive {BURRITO_ID}`
+    And I run `wp site spam {TACO_ID}`
+    And I run `wp site delete {PIZZA_ID} --yes`
 
     When I run `wp core update-db --network`
     Then STDOUT should contain:

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -987,6 +987,7 @@ EOT;
 		if ( $network ) {
 			$iterator_args = array(
 				'table' => $wpdb->blogs,
+				'where' => array( 'spam' => 0, 'deleted' => 0, 'archived' => 0 ),
 			);
 			$it = new \WP_CLI\Iterators\Table( $iterator_args );
 			$success = $total = 0;


### PR DESCRIPTION
Fixes #2094