### PR TITLE
Alias update as upgrade

### DIFF
--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -345,6 +345,8 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 *     wp plugin update bbpress --version=dev
 	 *
 	 *     wp plugin update --all
+	 *
+	 * @alias upgrade
 	 */
 	function update( $args, $assoc_args ) {
 		if ( isset( $assoc_args['version'] ) ) {

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -463,6 +463,8 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 	 *     wp theme update twentyeleven twentytwelve
 	 *
 	 *     wp theme update --all
+	 *
+	 * @alias upgrade
 	 */
 	function update( $args, $assoc_args ) {
 		if ( isset( $assoc_args['version'] ) ) {


### PR DESCRIPTION
This is a very simple PR for aliasing the `update` command as `upgrade` for both plugins and themes.

The `core update` command [already has the same alias](https://github.com/wp-cli/wp-cli/blob/3da87744c242c81e978fffe4b12ec23097679467/php/commands/core.php#L881), and I think it makes a lot of sense to allow for either with plugins and themes as well.

1. For consistency with the core command, as well as `apt-get`
2. It would be unintuitive for it to do anything else
