### PR TITLE
Permit space-delimited IDs for `wp export --post__in`

### DIFF
--- a/features/export.feature
+++ b/features/export.feature
@@ -161,6 +161,38 @@ Feature: Export content.
       1
       """
 
+  Scenario: Export multiple posts, separated by spaces
+    Given a WP install
+
+    When I run `wp plugin install wordpress-importer --activate`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp post create --post_title='Test post' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {POST_ID}
+
+    When I run `wp post create --post_title='Test post 2' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {POST_ID_TWO}
+
+    When I run `wp export --post__in="{POST_ID} {POST_ID_TWO}"`
+    And save STDOUT 'Writing to file %s' as {EXPORT_FILE}
+
+    When I run `wp site empty --yes`
+    Then STDOUT should not be empty
+
+    When I run `wp import {EXPORT_FILE} --authors=skip`
+    Then STDOUT should not be empty
+
+    When I run `wp post list --post_type=post --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
   Scenario: Export posts within a given date range
     Given a WP install
 

--- a/php/commands/export.php
+++ b/php/commands/export.php
@@ -40,7 +40,7 @@ class Export_Command extends WP_CLI_Command {
 	 * with a comma. Defaults to none.
 	 *
 	 * [--post__in=<pid>]
-	 * : Export all posts specified as a comma-separated list of IDs.
+	 * : Export all posts specified as a comma- or space-separated list of IDs.
 	 *
 	 * [--start_id=<pid>]
 	 * : Export only posts with IDs greater than or equal to this post ID.
@@ -233,7 +233,8 @@ class Export_Command extends WP_CLI_Command {
 		if ( is_null( $post__in ) )
 			return true;
 
-		$post__in = array_unique( array_map( 'intval', explode( ',', $post__in ) ) );
+		$separator = false !== stripos( $post__in, ' ' ) ? ' ' : ',';
+		$post__in = array_unique( array_map( 'intval', explode( $separator, $post__in ) ) );
 		if ( empty( $post__in ) ) {
 			WP_CLI::warning( "post__in should be comma-separated post IDs" );
 			return false;


### PR DESCRIPTION
This makes it easier to pass IDs returned by one command into export.

Fixes #2103