### PR TITLE
Kill background server process after test is complete

### DIFF
--- a/features/server.feature
+++ b/features/server.feature
@@ -14,3 +14,6 @@ Feature: Serve WordPress locally
     When I run `curl -sS localhost:8181/license.txt > /tmp/license.txt`
     And I run `cmp /tmp/license.txt license.txt`
     Then STDOUT should be empty
+
+    When I run `ps a|grep 'php[0-9]\? -S'|awk '{print $1}'|xargs -r kill`
+    Then STDERR should be empty


### PR DESCRIPTION
While this won't kill the process on failure, it solves our immediate
need.

Fixes #2111