### PR TITLE
Don't use WP_TESTS_DIR environment variable

### DIFF
--- a/templates/bootstrap.mustache
+++ b/templates/bootstrap.mustache
@@ -1,9 +1,6 @@
 <?php
 
-$_tests_dir = getenv( 'WP_TESTS_DIR' );
-if ( ! $_tests_dir ) {
-	$_tests_dir = '/tmp/wordpress-tests-lib';
-}
+$_tests_dir = '/tmp/wordpress-tests-lib';
 
 require_once $_tests_dir . '/includes/functions.php';
 


### PR DESCRIPTION
By using the environment variable `WP_TESTS_DIR` in bootstrap.php you can get an error `Call to undefined function is_post_type_viewable()`. This happens if the  `WP_TESTS_DIR` points to the WordPress testing framework from a newer WP version as the WordPress version used in the tests.

See https://github.com/wp-cli/wp-cli/issues/2050

This pull request is a proof of concept where the WP_TESTS_DIR (variable) directory is no longer used. The testing framework from the same version as the installed WordPress version is installed in  `/tmp/wordpress-tests-lib`.

This works for local testing but I have no idea if it will work in different environments.
 