### PR TITLE
Load WordPress with `WP_CLI\Runner::load_wordpress()`

### DIFF
--- a/features/framework.feature
+++ b/features/framework.feature
@@ -13,3 +13,37 @@ Feature: Load WP-CLI
 
     When I run `wp option get home`
     Then STDOUT should not be empty
+
+  Scenario: A command loaded before WordPress then calls WordPress to load
+    Given a WP install
+    And a custom-cmd.php file:
+      """
+      <?php
+      class Load_WordPress_Command_Class extends WP_CLI_Command {
+
+          /**
+           * @when before_wp_load
+           */
+          public function __invoke() {
+              if ( ! function_exists( 'update_option' ) ) {
+                  WP_CLI::log( 'WordPress not loaded.' );
+              }
+              WP_CLI::get_runner()->load_wordpress();
+              if ( function_exists( 'update_option' ) ) {
+                  WP_CLI::log( 'WordPress loaded!' );
+              }
+              WP_CLI::get_runner()->load_wordpress();
+              WP_CLI::log( 'load_wordpress() can safely be called twice.' );
+          }
+
+      }
+      WP_CLI::add_command( 'load-wordpress', 'Load_WordPress_Command_Class' );
+      """
+
+    When I run `wp --require=custom-cmd.php load-wordpress`
+    Then STDOUT should be:
+      """
+      WordPress not loaded.
+      WordPress loaded!
+      load_wordpress() can safely be called twice.
+      """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -685,9 +685,7 @@ class Runner {
 	public function load_wordpress() {
 		static $wp_cli_is_loaded;
 		// Globals not explicitly globalized in WordPress
-		global $wpdb, $wp, $wp_rewrite, $wp_version, $wp_db_version,
-			$current_site, $current_blog, $tinymce_version, $required_php_version,
-			$shortcode_tags, $required_mysql_version, $wp_local_package;
+		global $current_site, $current_blog, $shortcode_tags;
 
 		if ( ! empty( $wp_cli_is_loaded ) ) {
 			return;

--- a/php/wp-cli.php
+++ b/php/wp-cli.php
@@ -17,21 +17,4 @@ include WP_CLI_ROOT . '/php/class-wp-cli-command.php';
 
 \WP_CLI\Utils\load_dependencies();
 
-WP_CLI::get_runner()->before_wp_load();
-
-// Load wp-config.php code, in the global scope
-eval( WP_CLI::get_runner()->get_wp_config_code() );
-
-WP_CLI::get_runner()->maybe_update_url_from_domain_constant();
-
-// Load Core, mu-plugins, plugins, themes etc.
-require WP_CLI_ROOT . '/php/wp-settings-cli.php';
-
-// Fix memory limit. See http://core.trac.wordpress.org/ticket/14889
-@ini_set( 'memory_limit', -1 );
-
-// Load all the admin APIs, for convenience
-require ABSPATH . 'wp-admin/includes/admin.php';
-
-WP_CLI::get_runner()->after_wp_load();
-
+WP_CLI::get_runner()->start();

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -15,6 +15,13 @@ define( 'WPINC', 'wp-includes' );
 // Include files required for initialization.
 require( ABSPATH . WPINC . '/load.php' );
 require( ABSPATH . WPINC . '/default-constants.php' );
+
+/*
+ * These can't be directly globalized in version.php. When updating,
+ * we're including version.php from another install and don't want
+ * these values to be overridden if already set.
+ */
+global $wp_version, $wp_db_version, $tinymce_version, $required_php_version, $required_mysql_version;
 require( ABSPATH . WPINC . '/version.php' );
 
 // Set initial default constants including WP_MEMORY_LIMIT, WP_MAX_MEMORY_LIMIT, WP_DEBUG, WP_CONTENT_DIR and WP_CACHE.
@@ -271,7 +278,7 @@ do_action( 'sanitize_comment_cookies' );
  * @global object $wp_the_query
  * @since 2.0.0
  */
-$wp_the_query = new WP_Query();
+$GLOBALS['wp_the_query'] = new WP_Query();
 
 /**
  * Holds the reference to @see $wp_the_query
@@ -279,7 +286,7 @@ $wp_the_query = new WP_Query();
  * @global object $wp_query
  * @since 1.5.0
  */
-$wp_query = $wp_the_query;
+$GLOBALS['wp_query'] = $wp_the_query;
 
 /**
  * Holds the WordPress Rewrite object for creating pretty URLs
@@ -293,7 +300,7 @@ $GLOBALS['wp_rewrite'] = new WP_Rewrite();
  * @global object $wp
  * @since 2.0.0
  */
-$wp = new WP();
+$GLOBALS['wp'] = new WP();
 
 /**
  * WordPress Widget Factory Object
@@ -347,7 +354,7 @@ if ( ! defined( 'WP_INSTALLING' ) || 'wp-activate.php' === $pagenow ) {
 do_action( 'after_setup_theme' );
 
 // Set up current user.
-$wp->init();
+$GLOBALS['wp']->init();
 
 /**
  * Most of WP is loaded at this stage, and the user is authenticated. WP continues

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -286,7 +286,7 @@ $GLOBALS['wp_the_query'] = new WP_Query();
  * @global object $wp_query
  * @since 1.5.0
  */
-$GLOBALS['wp_query'] = $wp_the_query;
+$GLOBALS['wp_query'] = $GLOBALS['wp_the_query'];
 
 /**
  * Holds the WordPress Rewrite object for creating pretty URLs


### PR DESCRIPTION
This also lets other commands running before WordPress loads to load
WordPress on their own.

Fixes #2089