### PR TITLE
Check for version and wp-config.php inside of `Runner::load_wordpress()`

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -693,6 +693,14 @@ class Runner {
 
 		$wp_cli_is_loaded = true;
 
+		$this->check_wp_version();
+
+		if ( !Utils\locate_wp_config() ) {
+			WP_CLI::error(
+				"wp-config.php not found.\n" .
+				"Either create one manually or use `wp core config`." );
+		}
+
 		// Load wp-config.php code, in the global scope
 		eval( $this->get_wp_config_code() );
 


### PR DESCRIPTION
Because commands can call this method directly, we want to make sure
everything is set up as expected.

See #2089