### PR TITLE
Support MariaDB client library.

### DIFF
--- a/utils/wp-cli-updatedeb.sh
+++ b/utils/wp-cli-updatedeb.sh
@@ -31,7 +31,7 @@ Architecture: all
 Maintainer: Daniel Bachhuber <daniel@handbuilt.co>
 Section: php
 Priority: optional
-Depends: php5-cli, php5-mysql | php5-mysqlnd, mysql-client
+Depends: php5-cli, php5-mysql | php5-mysqlnd, mysql-client | mariadb-client
 Homepage: http://wp-cli.org/
 Description: wp-cli is a set of command-line tools for managing
  WordPress installations. You can update plugins, set up multisite


### PR DESCRIPTION
When mariadb-client is already installed on a system, installing wpcli
currently requires to remove mariadb-client because mariadb-client and
mysql-client are in conflict.