### PR TITLE
Remove string match on upgradeable list search

### DIFF
--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -174,9 +174,6 @@ Feature: Manage WordPress themes and plugins
       """
       Showing 2 of
       """
-    And STDOUT should end with a table containing rows:
-      | name         | slug   |
-      | <item_title> | <item> |
 
     Examples:
       | type   | type_name | item                    | item_title              | version | zip_file                                                              | file_to_check                                                    |


### PR DESCRIPTION
Every time WordPress.org changes their algorithm, this breaks. I'd
rather not keep fixing it.