### PR TITLE
`eval` or `eval-file` without WordPress via `--skip-wordpress`

### DIFF
--- a/features/eval.feature
+++ b/features/eval.feature
@@ -20,3 +20,38 @@ Feature: Evaluating PHP code and files.
       """
       foo bar
       """
+
+  Scenario: Eval without WordPress install
+    Given an empty directory
+
+    When I try `wp eval 'var_dump(defined("WP_CONTENT_DIR"));'`
+    Then STDERR should contain:
+      """
+      Error: This does not seem to be a WordPress install.
+      """
+
+    When I run `wp eval 'var_dump(defined("WP_CONTENT_DIR"));' --skip-wordpress`
+    Then STDOUT should be:
+      """
+      bool(false)
+      """
+
+  Scenario: Eval file without WordPress install
+    Given an empty directory
+    And a script.php file:
+      """
+      <?php
+      var_dump(defined("WP_CONTENT_DIR"));
+      """
+
+    When I try `wp eval-file script.php`
+    Then STDERR should contain:
+      """
+      Error: This does not seem to be a WordPress install.
+      """
+
+    When I run `wp eval-file script.php --skip-wordpress`
+    Then STDOUT should be:
+      """
+      bool(false)
+      """

--- a/php/commands/eval-file.php
+++ b/php/commands/eval-file.php
@@ -3,7 +3,7 @@
 class EvalFile_Command extends WP_CLI_Command {
 
 	/**
-	 * Load and execute a PHP file after loading WordPress.
+	 * Load and execute a PHP file.
 	 *
 	 * ## OPTIONS
 	 *
@@ -13,15 +13,24 @@ class EvalFile_Command extends WP_CLI_Command {
 	 * [<arg>...]
 	 * : One or more arguments to pass to the file. They are placed in the $args variable.
 	 *
+	 * [--skip-wordpress]
+	 * : Load and execute file without loading WordPress.
+	 *
+	 * @when before_wp_load
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp eval-file my-code.php value1 value2
 	 */
-	public function __invoke( $args ) {
+	public function __invoke( $args, $assoc_args ) {
 		$file = array_shift( $args );
 
 		if ( !file_exists( $file ) ) {
 			WP_CLI::error( "'$file' does not exist." );
+		}
+
+		if ( null === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-wordpress' ) ) {
+			WP_CLI::get_runner()->load_wordpress();
 		}
 
 		self::_eval( $file, $args );

--- a/php/commands/eval.php
+++ b/php/commands/eval.php
@@ -3,16 +3,26 @@
 class Eval_Command extends WP_CLI_Command {
 
 	/**
-	 * Execute arbitrary PHP code after loading WordPress.
+	 * Execute arbitrary PHP code.
 	 *
 	 * <php-code>
 	 * : The code to execute, as a string.
+	 *
+	 * [--skip-wordpress]
+	 * : Execute code without loading WordPress.
+	 *
+	 * @when before_wp_load
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp eval 'echo WP_CONTENT_DIR;'
 	 */
 	public function __invoke( $args, $assoc_args ) {
+
+		if ( null === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-wordpress' ) ) {
+			WP_CLI::get_runner()->load_wordpress();
+		}
+
 		eval( $args[0] );
 	}
 }


### PR DESCRIPTION
Fixes #2116