### PR TITLE
Globalize `$blog_id`, `$site_id`, and `$public` before loading WordPress

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -685,7 +685,7 @@ class Runner {
 	public function load_wordpress() {
 		static $wp_cli_is_loaded;
 		// Globals not explicitly globalized in WordPress
-		global $current_site, $current_blog, $shortcode_tags;
+		global $blog_id, $current_site, $current_blog, $shortcode_tags;
 
 		if ( ! empty( $wp_cli_is_loaded ) ) {
 			return;

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -685,7 +685,7 @@ class Runner {
 	public function load_wordpress() {
 		static $wp_cli_is_loaded;
 		// Globals not explicitly globalized in WordPress
-		global $blog_id, $current_site, $current_blog, $shortcode_tags;
+		global $blog_id, $site_id, $public, $current_site, $current_blog, $shortcode_tags;
 
 		if ( ! empty( $wp_cli_is_loaded ) ) {
 			return;


### PR DESCRIPTION
Without `$blog_id` globalized, users with persistent object cache
drop-ins experience cache pollution.

```
vagrant@vip:/srv/www$ wp option get home
http://vip.local
vagrant@vip:/srv/www$ sudo service memcached restart
Restarting memcached: memcached.
vagrant@vip:/srv/www$ wp option get home
http://vip.local/fusion
vagrant@vip:/srv/www$ wp option get home --url=vip.local
http://vip.local/fusion
vagrant@vip:/srv/www$ sudo service memcached restart
Restarting memcached: memcached.
vagrant@vip:/srv/www$ wp option get home --url=vip.local
http://vip.local
```

Somewhere, there's usage of `$blog_id` in WordPress that should be
explicitly globalized, but isn't.

See https://github.com/wp-cli/wp-cli/issues/2089#issuecomment-146289129