### PR TITLE
Use `--debug` for more verbosity during WP-CLI bootstrap process

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -223,6 +223,10 @@ Feature: Have a config file
       """
       Loaded WordPress
       """
+    And STDERR should contain:
+      """
+      Running command: option get
+      """
 
   Scenario: Missing required files should not fatal WP-CLI
     Given an empty directory

--- a/features/config.feature
+++ b/features/config.feature
@@ -199,6 +199,31 @@ Feature: Have a config file
     When I run `WP_CLI_CONFIG_PATH=test-dir/config.yml wp help`
 	  Then STDERR should be empty
 
+  Scenario: Load WordPress with `--debug`
+    Given a WP install
+
+    When I run `wp option get home --debug`
+    Then STDERR should contain:
+      """
+      No readable global config found
+      """
+    Then STDERR should contain:
+      """
+      No project config found
+      """
+    And STDERR should contain:
+      """
+      Begin WordPress load
+      """
+    And STDERR should contain:
+      """
+      wp-config.php path:
+      """
+    And STDERR should contain:
+      """
+      Loaded WordPress
+      """
+
   Scenario: Missing required files should not fatal WP-CLI
     Given an empty directory
     And a wp-cli.yml file:

--- a/features/flags.feature
+++ b/features/flags.feature
@@ -97,7 +97,7 @@ Feature: Global flags
       """
 
     When I try `wp --require=custom-logger.php is-installed`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       log: called 'error' method
       """

--- a/php/WP_CLI/Loggers/Base.php
+++ b/php/WP_CLI/Loggers/Base.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace WP_CLI\Loggers;
+
+/**
+ * Base logger class
+ */
+abstract class Base {
+
+	abstract public function info( $message );
+
+	abstract public function success( $message );
+
+	abstract public function warning( $message );
+
+	/**
+	 * Write a message to STDERR, prefixed with "Debug: ".
+	 *
+	 * @param string $message Message to write.
+	 */
+	public function debug( $message ) {
+		if ( \WP_CLI::get_runner()->config['debug'] ) {
+			$time = round( microtime( true ) - WP_CLI_START_MICROTIME, 3 );
+			$this->_line( "$message ({$time}s)", 'Debug', '%B', STDERR );
+		}
+	}
+
+	/**
+	 * Write a string to a resource.
+	 *
+	 * @param resource $handle Commonly STDOUT or STDERR.
+	 * @param string $str Message to write.
+	 */
+	protected function write( $handle, $str ) {
+		fwrite( $handle, $str );
+	}
+
+	/**
+	 * Output one line of message to a resource.
+	 *
+	 * @param string $message Message to write.
+	 * @param string $label Prefix message with a label.
+	 * @param string $color Colorize label with a given color.
+	 * @param resource $handle Resource to write to. Defaults to STDOUT.
+	 */
+	protected function _line( $message, $label, $color, $handle = STDOUT ) {
+		$label = \cli\Colors::colorize( "$color$label:%n", $this->in_color );
+		$this->write( $handle, "$label $message\n" );
+	}
+
+}

--- a/php/WP_CLI/Loggers/Quiet.php
+++ b/php/WP_CLI/Loggers/Quiet.php
@@ -26,6 +26,18 @@ class Quiet {
 	}
 
 	/**
+	 * Write a message to STDERR, prefixed with "Debug: ".
+	 *
+	 * @param string $message Message to write.
+	 */
+	public function debug( $message ) {
+		if ( \WP_CLI::get_runner()->config['debug'] ) {
+			$time = round( microtime( true ) - WP_CLI_START_MICROTIME, 3 );
+			$this->_line( "$message ({$time}s)", 'Debug', '%B', STDERR );
+		}
+	}
+
+	/**
 	 * Warning messages aren't logged.
 	 *
 	 * @param string $message Message to write.

--- a/php/WP_CLI/Loggers/Quiet.php
+++ b/php/WP_CLI/Loggers/Quiet.php
@@ -5,7 +5,7 @@ namespace WP_CLI\Loggers;
 /**
  * Quiet logger only logs errors.
  */
-class Quiet {
+class Quiet extends Base {
 
 	/**
 	 * Informational messages aren't logged.
@@ -26,18 +26,6 @@ class Quiet {
 	}
 
 	/**
-	 * Write a message to STDERR, prefixed with "Debug: ".
-	 *
-	 * @param string $message Message to write.
-	 */
-	public function debug( $message ) {
-		if ( \WP_CLI::get_runner()->config['debug'] ) {
-			$time = round( microtime( true ) - WP_CLI_START_MICROTIME, 3 );
-			$this->_line( "$message ({$time}s)", 'Debug', '%B', STDERR );
-		}
-	}
-
-	/**
 	 * Warning messages aren't logged.
 	 *
 	 * @param string $message Message to write.
@@ -52,7 +40,7 @@ class Quiet {
 	 * @param string $message Message to write.
 	 */
 	public function error( $message ) {
-		fwrite( STDERR, \WP_CLI::colorize( "%RError:%n $message\n" ) );
+		$this->write( STDERR, \WP_CLI::colorize( "%RError:%n $message\n" ) );
 	}
 
 	/**
@@ -63,7 +51,7 @@ class Quiet {
 	public function error_multi_line( $message_lines ) {
 		$message = implode( "\n", $message_lines );
 
-		fwrite( STDERR, \WP_CLI::colorize( "%RError:%n\n$message\n" ) );
-		fwrite( STDERR, \WP_CLI::colorize( "%R---------%n\n\n" ) );
+		$this->write( STDERR, \WP_CLI::colorize( "%RError:%n\n$message\n" ) );
+		$this->write( STDERR, \WP_CLI::colorize( "%R---------%n\n\n" ) );
 	}
 }

--- a/php/WP_CLI/Loggers/Regular.php
+++ b/php/WP_CLI/Loggers/Regular.php
@@ -56,6 +56,18 @@ class Regular {
 	}
 
 	/**
+	 * Write a message to STDERR, prefixed with "Debug: ".
+	 *
+	 * @param string $message Message to write.
+	 */
+	public function debug( $message ) {
+		if ( \WP_CLI::get_runner()->config['debug'] ) {
+			$time = round( microtime( true ) - WP_CLI_START_MICROTIME, 3 );
+			$this->_line( "$message ({$time}s)", 'Debug', '%B', STDERR );
+		}
+	}
+
+	/**
 	 * Write a warning message to STDERR, prefixed with "Warning: ".
 	 *
 	 * @param string $message Message to write.

--- a/php/WP_CLI/Loggers/Regular.php
+++ b/php/WP_CLI/Loggers/Regular.php
@@ -5,36 +5,13 @@ namespace WP_CLI\Loggers;
 /**
  * Default logger for success, warning, error, and standard messages.
  */
-class Regular {
+class Regular extends Base {
 
 	/**
 	 * @param bool $in_color Whether or not to Colorize strings.
 	 */
 	function __construct( $in_color ) {
 		$this->in_color = $in_color;
-	}
-
-	/**
-	 * Write a string to a resource.
-	 *
-	 * @param resource $handle Commonly STDOUT or STDERR.
-	 * @param string $str Message to write.
-	 */
-	protected function write( $handle, $str ) {
-		fwrite( $handle, $str );
-	}
-
-	/**
-	 * Output one line of message to a resource.
-	 *
-	 * @param string $message Message to write.
-	 * @param string $label Prefix message with a label.
-	 * @param string $color Colorize label with a given color.
-	 * @param resource $handle Resource to write to. Defaults to STDOUT.
-	 */
-	private function _line( $message, $label, $color, $handle = STDOUT ) {
-		$label = \cli\Colors::colorize( "$color$label:%n", $this->in_color );
-		$this->write( $handle, "$label $message\n" );
 	}
 
 	/**
@@ -53,18 +30,6 @@ class Regular {
 	 */
 	public function success( $message ) {
 		$this->_line( $message, 'Success', '%G' );
-	}
-
-	/**
-	 * Write a message to STDERR, prefixed with "Debug: ".
-	 *
-	 * @param string $message Message to write.
-	 */
-	public function debug( $message ) {
-		if ( \WP_CLI::get_runner()->config['debug'] ) {
-			$time = round( microtime( true ) - WP_CLI_START_MICROTIME, 3 );
-			$this->_line( "$message ({$time}s)", 'Debug', '%B', STDERR );
-		}
 	}
 
 	/**

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -306,6 +306,7 @@ class Runner {
 			$extra_args = array();
 		}
 
+		WP_CLI::debug( 'Running command: ' . $name );
 		try {
 			$command->invoke( $final_args, $assoc_args, $extra_args );
 		} catch ( WP_CLI\Iterators\Exception $e ) {

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -21,6 +21,10 @@ class Runner {
 
 	private $_early_invoke = array();
 
+	private $_global_config_path_debug;
+
+	private $_project_config_path_debug;
+
 	public function __get( $key ) {
 		if ( '_' === $key[0] )
 			return null;
@@ -60,20 +64,25 @@ class Runner {
 	 *
 	 * @return string|false
 	 */
-	private static function get_global_config_path() {
-		$config_path = getenv( 'WP_CLI_CONFIG_PATH' );
+	private function get_global_config_path() {
+
 		if ( isset( $runtime_config['config'] ) ) {
 			$config_path = $runtime_config['config'];
-		}
-
-		if ( !$config_path ) {
+			$this->_global_config_path_debug = 'Using global config from config runtime arg: ' . $config_path;
+		} else if ( getenv( 'WP_CLI_CONFIG_PATH' ) ) {
+			$config_path = getenv( 'WP_CLI_CONFIG_PATH' );
+			$this->_global_config_path_debug = 'Using global config from WP_CLI_CONFIG_PATH env var: ' . $config_path;
+		} else {
 			$config_path = getenv( 'HOME' ) . '/.wp-cli/config.yml';
+			$this->_global_config_path_debug = 'Using default global config: ' . $config_path;
 		}
 
-		if ( !is_readable( $config_path ) )
+		if ( is_readable( $config_path ) ) {
+			return $config_path;
+		} else {
+			$this->_global_config_path_debug = 'No readable global config found';
 			return false;
-
-		return $config_path;
+		}
 	}
 
 	/**
@@ -83,7 +92,7 @@ class Runner {
 	 *
 	 * @return string|false
 	 */
-	private static function get_project_config_path() {
+	private function get_project_config_path() {
 		$config_files = array(
 			'wp-cli.local.yml',
 			'wp-cli.yml'
@@ -91,7 +100,7 @@ class Runner {
 
 		// Stop looking upward when we find we have emerged from a subdirectory
 		// install into a parent install
-		return Utils\find_file_upward( $config_files, getcwd(), function ( $dir ) {
+		$project_config_path = Utils\find_file_upward( $config_files, getcwd(), function ( $dir ) {
 			static $wp_load_count = 0;
 			$wp_load_path = $dir . DIRECTORY_SEPARATOR . 'wp-load.php';
 			if ( file_exists( $wp_load_path ) ) {
@@ -99,6 +108,12 @@ class Runner {
 			}
 			return $wp_load_count > 1;
 		} );
+		if ( ! empty( $project_config_path ) ) {
+			$this->_project_config_path_debug = 'Using project config: ' . $project_config_path;
+		} else {
+			$this->_project_config_path_debug = 'No project config found';
+		}
+		return $project_config_path;
 	}
 
 	/**
@@ -171,6 +186,7 @@ class Runner {
 	 */
 	private static function set_wp_root( $path ) {
 		define( 'ABSPATH', rtrim( $path, '/' ) . '/' );
+		WP_CLI::debug( 'ABSPATH defined: ' . ABSPATH );
 
 		$_SERVER['DOCUMENT_ROOT'] = realpath( $path );
 	}
@@ -514,8 +530,8 @@ class Runner {
 
 		// File config
 		{
-			$this->global_config_path = self::get_global_config_path();
-			$this->project_config_path = self::get_project_config_path();
+			$this->global_config_path = $this->get_global_config_path();
+			$this->project_config_path = $this->get_project_config_path();
 
 			$configurator->merge_yml( $this->global_config_path );
 			$configurator->merge_yml( $this->project_config_path );
@@ -567,6 +583,9 @@ class Runner {
 		$this->init_colorization();
 		$this->init_logger();
 
+		WP_CLI::debug( $this->_global_config_path_debug );
+		WP_CLI::debug( $this->_project_config_path_debug );
+
 		$this->check_root();
 
 		if ( empty( $this->arguments ) )
@@ -588,6 +607,7 @@ class Runner {
 					WP_CLI::error( sprintf( "Required file '%s' doesn't exist", basename( $path ) ) );
 				}
 				Utils\load_file( $path );
+				WP_CLI::debug( 'Required file from config: ' . $path );
 			}
 		}
 
@@ -693,13 +713,18 @@ class Runner {
 
 		$wp_cli_is_loaded = true;
 
+		WP_CLI::debug( 'Begin WordPress load' );
+
 		$this->check_wp_version();
 
-		if ( !Utils\locate_wp_config() ) {
+		$wp_config_path = Utils\locate_wp_config();
+		if ( ! $wp_config_path ) {
 			WP_CLI::error(
 				"wp-config.php not found.\n" .
 				"Either create one manually or use `wp core config`." );
 		}
+
+		WP_CLI::debug( 'wp-config.php path: ' . $wp_config_path );
 
 		// Load wp-config.php code, in the global scope
 		eval( $this->get_wp_config_code() );
@@ -721,6 +746,8 @@ class Runner {
 		if ( ! defined( 'WP_INSTALLING' ) ) {
 			self::set_user( $this->config );
 		}
+
+		WP_CLI::debug( 'Loaded WordPress' );
 
 	}
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -93,6 +93,7 @@ class WP_CLI {
 	 * Set the context in which WP-CLI should be run
 	 */
 	public static function set_url( $url ) {
+		WP_CLI::debug( 'Set URL: ' . $url );
 		$url_parts = Utils\parse_url( $url );
 		self::set_url_params( $url_parts );
 	}
@@ -234,6 +235,15 @@ class WP_CLI {
 	 */
 	public static function success( $message ) {
 		self::$logger->success( $message );
+	}
+
+	/**
+	 * Log debug information
+	 *
+	 * @param string $message
+	 */
+	public static function debug( $message ) {
+		self::$logger->debug( self::error_to_string( $message ) );
 	}
 
 	/**

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -67,7 +67,7 @@ return array(
 		'runtime' => '',
 		'file' => '<bool>',
 		'default' => false,
-		'desc' => 'Show all PHP errors',
+		'desc' => 'Show all PHP errors; add verbosity to WP-CLI bootstrap',
 	),
 
 	'prompt' => array(

--- a/php/wp-cli.php
+++ b/php/wp-cli.php
@@ -3,6 +3,7 @@
 // Can be used by plugins/themes to check if WP-CLI is running or not
 define( 'WP_CLI', true );
 define( 'WP_CLI_VERSION', trim( file_get_contents( WP_CLI_ROOT . '/VERSION' ) ) );
+define( 'WP_CLI_START_MICROTIME', microtime( true ) );
 
 // Set common headers, to prevent warnings from plugins
 $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.0';


### PR DESCRIPTION
```
salty-wordpress ➜  wordpress-test.dev  wp option get home --debug
Debug: Using default global config: /home/vagrant/.wp-cli/config.yml
(0.057s)
Debug: Using project config: /srv/www/wordpress-test.dev/wp-cli.yml
(0.061s)
Debug: Required file from config: /srv/www/wp-rest-cli/wp-rest-cli.php
(0.144s)
Debug: ABSPATH defined: /srv/www/wordpress-test.dev/ (0.145s)
Debug: Begin WordPress load (0.148s)
Debug: wp-config.php path: /srv/www/wordpress-test.dev/wp-config.php
(0.15s)
Debug: Set URL: wordpress-test.dev/ (0.152s)
Debug: Loaded WordPress (0.925s)
http://wordpress-test.dev
```

Fixes #1022