### PR TITLE
Update `wp cli check-update` to accommodate major releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
 		"php": ">=5.3.2",
 		"wp-cli/php-cli-tools": "0.10.5",
 		"mustache/mustache": "~2.4",
+		"composer/semver": "1.0.0",
 		"ramsey/array_column": "~1.1",
 		"rmccue/requests": "~1.6",
 		"symfony/finder": "~2.3",

--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -1,7 +1,6 @@
 <?php
 
 use \Composer\Semver\Comparator;
-use \Composer\Semver\Semver;
 use \WP_CLI\Dispatcher;
 use \WP_CLI\Utils;
 
@@ -246,7 +245,7 @@ class CLI_Command extends WP_CLI_Command {
 				$release_version = ltrim( $release_version, 'v' );
 			}
 
-			$update_type = $this->get_named_sem_ver( $release_version );
+			$update_type = Utils\get_named_sem_ver( $release_version, WP_CLI_VERSION );
 			if ( ! $update_type ) {
 				continue;
 			}
@@ -336,30 +335,6 @@ class CLI_Command extends WP_CLI_Command {
 		$line = substr( $assoc_args['line'], 0, $assoc_args['point'] );
 		$compl = new \WP_CLI\Completions( $line );
 		$compl->render();
-	}
-
-	/**
-	 * Get the named semantic version
-	 *
-	 * @param string $version
-	 * @return string $name 'major', 'minor', 'patch'
-	 */
-	private function get_named_sem_ver( $version ) {
-
-		if ( ! Comparator::greaterThan( $version, WP_CLI_VERSION ) ) {
-			return '';
-		}
-
-		$parts = explode( '-', WP_CLI_VERSION );
-		list( $major, $minor, $patch ) = explode( '.', $parts[0] );
-
-		if ( Semver::satisfies( $version, "{$major}.{$minor}.x" ) ) {
-			return 'patch';
-		} else if ( Semver::satisfies( $version, "{$major}.x.x" ) ) {
-			return 'minor';
-		} else {
-			return 'major';
-		}
 	}
 
 	/**

--- a/php/utils.php
+++ b/php/utils.php
@@ -4,6 +4,8 @@
 
 namespace WP_CLI\Utils;
 
+use \Composer\Semver\Comparator;
+use \Composer\Semver\Semver;
 use \WP_CLI\Dispatcher;
 use \WP_CLI\Iterators\Transform;
 
@@ -533,6 +535,31 @@ function increment_version( $current_version, $new_version ) {
 	$current_version    = implode( '-', $current_version );
 
 	return $current_version;
+}
+
+/**
+ * Compare two version strings to get the named semantic version
+ *
+ * @param string $new_version
+ * @param string $original_version
+ * @return string $name 'major', 'minor', 'patch'
+ */
+function get_named_sem_ver( $new_version, $original_version ) {
+
+	if ( ! Comparator::greaterThan( $new_version, $original_version ) ) {
+		return '';
+	}
+
+	$parts = explode( '-', $original_version );
+	list( $major, $minor, $patch ) = explode( '.', $parts[0] );
+
+	if ( Semver::satisfies( $new_version, "{$major}.{$minor}.x" ) ) {
+		return 'patch';
+	} else if ( Semver::satisfies( $new_version, "{$major}.x.x" ) ) {
+		return 'minor';
+	} else {
+		return 'major';
+	}
 }
 
 /**

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -33,5 +33,16 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testGetSemVer() {
+		$original_version = '0.19.1';
+		$this->assertEmpty( Utils\get_named_sem_ver( '0.18.0', $original_version ) );
+		$this->assertEmpty( Utils\get_named_sem_ver( '0.19.1', $original_version ) );
+		$this->assertEquals( 'patch', Utils\get_named_sem_ver( '0.19.2', $original_version ) );
+		$this->assertEquals( 'minor', Utils\get_named_sem_ver( '0.20.0', $original_version ) );
+		$this->assertEquals( 'minor', Utils\get_named_sem_ver( '0.20.3', $original_version ) );
+		$this->assertEquals( 'major', Utils\get_named_sem_ver( '1.0.0', $original_version ) );
+		$this->assertEquals( 'major', Utils\get_named_sem_ver( '1.1.1', $original_version ) );
+	}
+
 }
 

--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -72,6 +72,7 @@ $finder
 	->in(WP_CLI_ROOT . '/vendor/symfony/finder')
 	->in(WP_CLI_ROOT . '/vendor/nb/oxymel')
 	->in(WP_CLI_ROOT . '/vendor/ramsey/array_column')
+	->in(WP_CLI_ROOT . '/vendor/composer/semver')
 	->exclude('test')
 	->exclude('tests')
 	->exclude('Tests')


### PR DESCRIPTION
Also, if `--major`, `--minor` or `--patch` is specified in a check, then
success message will parrot the supplied flag.

Fixes #1390
Previously #1547