### PR TITLE
Load REST API based off `$wp_db_version`

### DIFF
--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -191,7 +191,10 @@ require( ABSPATH . WPINC . '/widgets.php' );
 require( ABSPATH . WPINC . '/nav-menu.php' );
 require( ABSPATH . WPINC . '/nav-menu-template.php' );
 require( ABSPATH . WPINC . '/admin-bar.php' );
-Utils\maybe_require( '4.4-alpha-34928', ABSPATH . WPINC . '/rest-api.php' );
+// Utils\maybe_require( '4.4-alpha-34928', ABSPATH . WPINC . '/rest-api.php' );
+if ( $wp_db_version > 34928 ) {
+	require_once ABSPATH . WPINC . '/rest-api.php';
+}
 
 // Load multisite-specific files.
 if ( is_multisite() ) {


### PR DESCRIPTION
`$wp_version` hasn't yet been incremented in core

Previously #2127