### PR TITLE
Provide more verbosity when updating core database schema

### DIFF
--- a/features/core-update-db.feature
+++ b/features/core-update-db.feature
@@ -8,13 +8,13 @@ Feature: Update core's database
     When I run `wp core update-db`
     Then STDOUT should contain:
       """
-      Success: WordPress database upgraded successfully from 29630 to 30133
+      Success: WordPress database upgraded successfully from db version 29630 to 30133
       """
 
     When I run `wp core update-db`
     Then STDOUT should contain:
       """
-      Success: WordPress database already at latest version 30133
+      Success: WordPress database already at latest db version 30133
       """
 
   Scenario: Update db across network

--- a/features/core-update-db.feature
+++ b/features/core-update-db.feature
@@ -1,0 +1,21 @@
+Feature: Update core's database
+
+  Scenario: Update db across network
+    Given a WP multisite install
+    And I run `wp site create --slug=foo`
+    And I run `wp site create --slug=bar`
+    And I run `wp site create --slug=burrito --porcelain`
+    And save STDOUT as {BURRITO_ID}
+    And I run `wp site create --slug=taco --porcelain`
+    And save STDOUT as {TACO_ID}
+    And I run `wp site create --slug=pizza --porcelain`
+    And save STDOUT as {PIZZA_ID}
+    And I run `wp site archive {BURRITO_ID}`
+    And I run `wp site spam {TACO_ID}`
+    And I run `wp site delete {PIZZA_ID} --yes`
+
+    When I run `wp core update-db --network`
+    Then STDOUT should contain:
+      """
+      Success: WordPress database upgraded on 3/3 sites.
+      """

--- a/features/core-update-db.feature
+++ b/features/core-update-db.feature
@@ -1,5 +1,22 @@
 Feature: Update core's database
 
+  Scenario: Update db on a single site
+    Given a WP install
+    And I run `wp core download --version=4.1 --force`
+    And I run `wp option update db_version 29630`
+
+    When I run `wp core update-db`
+    Then STDOUT should contain:
+      """
+      Success: WordPress database upgraded successfully from 29630 to 30133
+      """
+
+    When I run `wp core update-db`
+    Then STDOUT should contain:
+      """
+      Success: WordPress database already at latest version 30133
+      """
+
   Scenario: Update db across network
     Given a WP multisite install
     And I run `wp site create --slug=foo`
@@ -17,5 +34,5 @@ Feature: Update core's database
     When I run `wp core update-db --network`
     Then STDOUT should contain:
       """
-      Success: WordPress database upgraded on 3/3 sites.
+      Success: WordPress database upgraded on 3/3 sites
       """

--- a/features/core.feature
+++ b/features/core.feature
@@ -289,26 +289,6 @@ Feature: Manage WordPress installation
       Error: Multisite with subdomains cannot be configured when domain is 'localhost'.
       """
 
-  Scenario: Update db across network
-    Given a WP multisite install
-    And I run `wp site create --slug=foo`
-    And I run `wp site create --slug=bar`
-    And I run `wp site create --slug=burrito --porcelain`
-    And save STDOUT as {BURRITO_ID}
-    And I run `wp site create --slug=taco --porcelain`
-    And save STDOUT as {TACO_ID}
-    And I run `wp site create --slug=pizza --porcelain`
-    And save STDOUT as {PIZZA_ID}
-    And I run `wp site archive {BURRITO_ID}`
-    And I run `wp site spam {TACO_ID}`
-    And I run `wp site delete {PIZZA_ID} --yes`
-
-    When I run `wp core update-db --network`
-    Then STDOUT should contain:
-      """
-      Success: WordPress database upgraded on 3/3 sites.
-      """
-
   Scenario: Update from a ZIP file
     Given a WP install
 


### PR DESCRIPTION
It can be helpful to know what version we were at, and what we updated to.

```
salty-wordpress ➜  wordpress-test.dev  wp core update-db --network
WordPress database already at latest db version 30135 on wordpress-test.dev/
WordPress database upgraded successfully from db version 33056 to 30135 on wordpress-test.dev/foo/
WordPress database upgraded successfully from db version 33056 to 30135 on wordpress-test.dev/bar/
Success: WordPress database upgraded on 3/3 sites
```

See #2171