### PR TITLE
Provide human-friendly output when rewrite rules successfully flush

### DIFF
--- a/features/rewrite.feature
+++ b/features/rewrite.feature
@@ -50,7 +50,10 @@ Feature: Manage WordPress rewrites
 
     When I run `wp rewrite structure /%year%/%monthnum%/%day%/%postname%/`
     Then I run `wp rewrite flush`
-    Then STDOUT should be empty
+    Then STDOUT should be:
+      """
+      Success: Rewrite rules flushed.
+      """
 
   Scenario: Generate .htaccess on hard flush
     Given a WP install

--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -41,6 +41,8 @@ class Rewrite_Command extends WP_CLI_Command {
 
 		if ( ! get_option( 'rewrite_rules' ) ) {
 			WP_CLI::warning( "Rewrite rules are empty, possibly because of a missing permalink_structure option. Use 'wp rewrite list' to verify, or 'wp rewrite structure' to update permalink_structure." );
+		} else {
+			WP_CLI::success( 'Rewrite rules flushed.' );
 		}
 	}
 


### PR DESCRIPTION
This makes `wp rewrite flush` more consistent with other commands.