### PR TITLE
Let `help` run early when WP is detected, but not installed

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -27,6 +27,16 @@ Feature: Get help about WP-CLI commands
       wp post list
       """
 
+  Scenario: Help when WordPress is downloaded but not installed
+    Given an empty directory
+
+    When I run `wp core download`
+    And I run `wp help core config`
+    Then STDOUT should contain:
+      """
+      wp core config
+      """
+
   Scenario: Help for nonexistent commands
     Given a WP install
     

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -627,7 +627,7 @@ class Runner {
 		self::set_wp_root( $this->find_wp_root() );
 
 		// First try at showing man page
-		if ( 'help' === $this->arguments[0] && ! $this->wp_exists() ) {
+		if ( 'help' === $this->arguments[0] && ( ! $this->wp_exists() || ! Utils\locate_wp_config() ) ) {
 			$this->_run_command();
 		}
 


### PR DESCRIPTION
Permits use of `wp core config --help` when you've downloaded WordPress. 

Bug introduced in #1877