### PR TITLE
Scaffolded plugin header should follow WPCS Docs standards

### DIFF
--- a/templates/plugin-gruntfile.mustache
+++ b/templates/plugin-gruntfile.mustache
@@ -5,7 +5,7 @@ module.exports = function( grunt ) {
 	// Project configuration
 	grunt.initConfig( {
 
-		pkg:    grunt.file.readJSON( 'package.json' ),
+		pkg: grunt.file.readJSON( 'package.json' ),
 
 		addtextdomain: {
 			options: {
@@ -46,7 +46,7 @@ module.exports = function( grunt ) {
 	grunt.loadNpmTasks( 'grunt-wp-i18n' );
 	grunt.loadNpmTasks( 'grunt-wp-readme-to-markdown' );
 	grunt.registerTask( 'i18n', ['addtextdomain', 'makepot'] );
-	grunt.registerTask( 'readme', ['wp_readme_to_markdown']);
+	grunt.registerTask( 'readme', ['wp_readme_to_markdown'] );
 
 	grunt.util.linefeed = '\n';
 

--- a/templates/plugin.mustache
+++ b/templates/plugin.mustache
@@ -1,12 +1,12 @@
 <?php
-/*
-Plugin Name: {{plugin_name}}
-Version: 0.1-alpha
-Description: PLUGIN DESCRIPTION HERE
-Author: YOUR NAME HERE
-Author URI: YOUR SITE HERE
-Plugin URI: PLUGIN SITE HERE
-Text Domain: {{textdomain}}
-Domain Path: /languages
-*/
-
+/**
+ * Plugin Name: {{plugin_name}}
+ * Version: 0.1-alpha
+ * Description: PLUGIN DESCRIPTION HERE
+ * Author: YOUR NAME HERE
+ * Author URI: YOUR SITE HERE
+ * Plugin URI: PLUGIN SITE HERE
+ * Text Domain: {{textdomain}}
+ * Domain Path: /languages
+ * @package {{plugin_name}}
+ */


### PR DESCRIPTION
This PR updates the main plugin file to pass WPCS standards using the "WordPress" standard.

* Add `@package` tag
* Use `/** */` block comment
* Also fixes two whitespace inconsistencies in the scaffolded Gruntfile.