### PR TITLE
Drop database before creating it

### DIFF
--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -111,6 +111,9 @@ install_db() {
 		fi
 	fi
 
+	# drop db before re-creating it
+	mysql -u$DB_USER -p$DB_PASS -e "drop database if exists $DB_NAME"
+
 	# create database
 	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }


### PR DESCRIPTION
This is useful if you want to run this script multiple times to have a clean setup each time.