### PR TITLE
Super admin dupe warning

### DIFF
--- a/features/super-admin.feature
+++ b/features/super-admin.feature
@@ -17,6 +17,14 @@ Feature: Manage super admins associated with a multisite instance
     superadmin
     """
 
+    When I run `wp super-admin add superadmin`
+    And I run `wp super-admin list`
+    Then STDOUT should be:
+    """
+		admin
+		superadmin
+    """
+
     When I run `wp super-admin remove admin`
     And I run `wp super-admin list`
     Then STDOUT should be:

--- a/features/super-admin.feature
+++ b/features/super-admin.feature
@@ -18,7 +18,12 @@ Feature: Manage super admins associated with a multisite instance
     """
 
     When I run `wp super-admin add superadmin`
-    And I run `wp super-admin list`
+    Then STDERR should contain:
+    """
+    Warning: User superadmin already has super-admin capabilities.
+    """
+
+    When I run `wp super-admin list`
     Then STDOUT should be:
     """
     admin

--- a/features/super-admin.feature
+++ b/features/super-admin.feature
@@ -21,8 +21,8 @@ Feature: Manage super admins associated with a multisite instance
     And I run `wp super-admin list`
     Then STDOUT should be:
     """
-		admin
-		superadmin
+    admin
+    superadmin
     """
 
     When I run `wp super-admin remove admin`

--- a/php/commands/super-admin.php
+++ b/php/commands/super-admin.php
@@ -32,6 +32,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 		$users = $this->fetcher->get_many( $args );
 		$user_logins = wp_list_pluck( $users, 'user_login' );
 		$super_admins = self::get_admins();
+		$num_super_admins = count( $super_admins );
 
 		foreach ( $user_logins as $user_login ) {
 			$user = get_user_by( 'login', $user_login );
@@ -49,8 +50,14 @@ class Super_Admin_Command extends WP_CLI_Command {
 			$super_admins[] = $user->user_login;
 		}
 
-		if ( update_site_option( 'site_admins' , $super_admins ) ) {
-			WP_CLI::success( 'Granted super-admin capabilities.' );
+		if ( $num_super_admins === count( $super_admins ) ) {
+			WP_CLI::log( 'No changes.' );
+		} else {
+			if ( update_site_option( 'site_admins' , $super_admins ) ) {
+				WP_CLI::success( 'Granted super-admin capabilities.' );
+			} else {
+				WP_CLI::error( 'Site options update failed!' );
+			}
 		}
 	}
 

--- a/php/commands/super-admin.php
+++ b/php/commands/super-admin.php
@@ -49,8 +49,9 @@ class Super_Admin_Command extends WP_CLI_Command {
 			$super_admins[] = $user->user_login;
 		}
 
-		update_site_option( 'site_admins' , $super_admins );
-		WP_CLI::success( 'Granted super-admin capabilities.' );
+		if ( update_site_option( 'site_admins' , $super_admins ) ) {
+			WP_CLI::success( 'Granted super-admin capabilities.' );
+		}
 	}
 
 	/**

--- a/php/commands/super-admin.php
+++ b/php/commands/super-admin.php
@@ -35,11 +35,18 @@ class Super_Admin_Command extends WP_CLI_Command {
 
 		foreach ( $user_logins as $user_login ) {
 			$user = get_user_by( 'login', $user_login );
+
 			if ( !$user ) {
 				WP_CLI::warning( "Couldn't find {$user_login} user." );
-			} else {
-				$super_admins[] = $user->user_login;
+				continue;
 			}
+
+			if ( in_array( $user->user_login, $super_admins ) ) {
+				WP_CLI::warning( "User {$user_login} already has super-admin capabilities." );
+				continue;
+			}
+
+			$super_admins[] = $user->user_login;
 		}
 
 		update_site_option( 'site_admins' , $super_admins );


### PR DESCRIPTION
I noticed "plugin activate" doesn't try to activate plugins that are already active but rather outputs a warning. I changed "super-admin add" to do the same thing when trying to add a super-admin who is already a super-admin. I also updated the success message output so it only outputs if something actually changed (if update_site_option() returns true).