### PR TITLE
Use safe version of parent theme slug for child enequeue function

### DIFF
--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -318,6 +318,8 @@ class Scaffold_Command extends WP_CLI_Command {
 			'author_uri' => "",
 			'theme_uri'  => ""
 		) );
+		$data['slug'] = $theme_slug;
+		$data['parent_theme_function_safe'] = str_replace( '-', '_', $data['parent_theme'] );
 
 		$data['description'] = ucfirst( $data['parent_theme'] ) . " child theme.";
 

--- a/templates/child_theme_functions.mustache
+++ b/templates/child_theme_functions.mustache
@@ -1,8 +1,8 @@
 <?php
 
-add_action( 'wp_enqueue_scripts', '{{parent_theme}}_parent_theme_enqueue_styles' );
+add_action( 'wp_enqueue_scripts', '{{parent_theme_function_safe}}_parent_theme_enqueue_styles' );
 
-function {{parent_theme}}_parent_theme_enqueue_styles() {
+function {{parent_theme_function_safe}}_parent_theme_enqueue_styles() {
     wp_enqueue_style( '{{parent_theme}}-style', get_template_directory_uri() . '/style.css' );
     wp_enqueue_style( '{{slug}}-style',
         get_stylesheet_directory_uri() . '/style.css',


### PR DESCRIPTION
A parent theme can include dashes, which aren't safe for a function.

Also passes `slug` to the template, so the ID for the child theme
stylesheet is populated.

Fixes #2195