### PR TITLE
Clarify documentation for `wp cache flush`

### DIFF
--- a/php/commands/cache.php
+++ b/php/commands/cache.php
@@ -95,6 +95,9 @@ class Cache_Command extends WP_CLI_Command {
 
 	/**
 	 * Flush the object cache.
+	 *
+	 * For sites using a persistent object cache, because WordPress Multisite simply adds a blog id
+	 * to the cache key, flushing cache is typically a global operation.
 	 */
 	public function flush( $args, $assoc_args ) {
 		$value = wp_cache_flush();


### PR DESCRIPTION
When using a persistent object cache with Multisite, flushing is
typically a global operation.