### PR TITLE
2209: Added in_color property to base logger; added relevant unit tests

### DIFF
--- a/php/WP_CLI/Loggers/Base.php
+++ b/php/WP_CLI/Loggers/Base.php
@@ -7,6 +7,8 @@ namespace WP_CLI\Loggers;
  */
 abstract class Base {
 
+	protected $in_color = false;
+
 	abstract public function info( $message );
 
 	abstract public function success( $message );
@@ -14,12 +16,22 @@ abstract class Base {
 	abstract public function warning( $message );
 
 	/**
+	 * Retrieve the runner instance from the base CLI object. This facilitates
+	 * unit testing, where the WP_CLI instance isn't available
+	 *
+	 * @return Runner Instance of the runner class
+	 */
+	protected function getRunner() {
+		return \WP_CLI::get_runner();
+	}
+
+	/**
 	 * Write a message to STDERR, prefixed with "Debug: ".
 	 *
 	 * @param string $message Message to write.
 	 */
 	public function debug( $message ) {
-		if ( \WP_CLI::get_runner()->config['debug'] ) {
+		if ( $this->getRunner()->config['debug'] ) {
 			$time = round( microtime( true ) - WP_CLI_START_MICROTIME, 3 );
 			$this->_line( "$message ({$time}s)", 'Debug', '%B', STDERR );
 		}

--- a/php/WP_CLI/Loggers/Base.php
+++ b/php/WP_CLI/Loggers/Base.php
@@ -21,7 +21,7 @@ abstract class Base {
 	 *
 	 * @return Runner Instance of the runner class
 	 */
-	protected function getRunner() {
+	protected function get_runner() {
 		return \WP_CLI::get_runner();
 	}
 
@@ -31,7 +31,7 @@ abstract class Base {
 	 * @param string $message Message to write.
 	 */
 	public function debug( $message ) {
-		if ( $this->getRunner()->config['debug'] ) {
+		if ( $this->get_runner()->config['debug'] ) {
 			$time = round( microtime( true ) - WP_CLI_START_MICROTIME, 3 );
 			$this->_line( "$message ({$time}s)", 'Debug', '%B', STDERR );
 		}

--- a/tests/test-logging.php
+++ b/tests/test-logging.php
@@ -1,17 +1,48 @@
 <?php
 
-class LoggerMock extends WP_CLI\Loggers\Regular {
+class MockRegularLogger extends WP_CLI\Loggers\Regular {
+
+	protected function getRunner() {
+		return (object) array (
+			'config' => array (
+				'debug' => true
+			)
+		);
+	}
 
 	protected function write( $handle, $str ) {
 		echo $str;
 	}
 }
 
+class MockQuietLogger extends WP_CLI\Loggers\Quiet {
+
+	protected function getRunner() {
+		return (object) array (
+			'config' => array (
+				'debug' => true
+			)
+		);
+	}
+}
 
 class LoggingTests extends PHPUnit_Framework_TestCase {
 
+	function testLogDebug() {
+		define( 'WP_CLI_START_MICROTIME', microtime( true ) );
+		$message = 'This is a test message.';
+
+		$regularLogger = new MockRegularLogger( false );
+		$this->expectOutputRegex( "/Debug: {$message} \(\d+\.*\d*s\)/" );
+		$regularLogger->debug( $message );
+
+		$quietLogger = new MockQuietLogger();
+		$this->expectOutputRegex( "/Debug: {$message} \(\d+\.*\d*s\)/" );
+		$quietLogger->debug( $message );
+	}
+
 	function testLogEscaping() {
-		$logger = new LoggerMock( false );
+		$logger = new MockRegularLogger( false );
 
 		$message = 'foo%20bar';
 
@@ -19,4 +50,3 @@ class LoggingTests extends PHPUnit_Framework_TestCase {
 		$logger->success( $message );
 	}
 }
-

--- a/tests/test-logging.php
+++ b/tests/test-logging.php
@@ -2,7 +2,7 @@
 
 class MockRegularLogger extends WP_CLI\Loggers\Regular {
 
-	protected function getRunner() {
+	protected function get_runner() {
 		return (object) array (
 			'config' => array (
 				'debug' => true
@@ -17,7 +17,7 @@ class MockRegularLogger extends WP_CLI\Loggers\Regular {
 
 class MockQuietLogger extends WP_CLI\Loggers\Quiet {
 
-	protected function getRunner() {
+	protected function get_runner() {
 		return (object) array (
 			'config' => array (
 				'debug' => true


### PR DESCRIPTION
Added `in_color` property to `Base`.

To support unit testing on the loggers, I also created `getRunner` as a protected function. This can be overloaded in the test-logging unit test where `WP_CLI` isn't available.

Fixes #2209