### PR TITLE
Suppress notices when using `is_readable()`

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -142,7 +142,7 @@ function find_file_upward( $files, $dir = null, $stop_check = null ) {
 	if ( is_null( $dir ) ) {
 		$dir = getcwd();
 	}
-	while ( is_readable( $dir ) ) {
+	while ( @is_readable( $dir ) ) {
 		// Stop walking up when the supplied callable returns true being passed the $dir
 		if ( is_callable( $stop_check ) && call_user_func( $stop_check, $dir ) ) {
 			return null;


### PR DESCRIPTION
If `open_basedir` is in effect, PHP will throw a notice when
`is_readable()` is used on an unreadable directory. We _could_ have some
more complicated check to see if the path being checked is within
`open_basedir` defined paths, but checking the return value of
`is_readable()` is sufficient for our needs.

Fixes #1332