### PR TITLE
Recurse objects by default when replacing inside of serialized data

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -95,6 +95,30 @@ Feature: Do global search/replace
       world, Hello
       """
 
+  Scenario: Search and replace within theme mods
+    Given a WP install
+    And a setup-theme-mod.php file:
+      """
+      <?php
+      set_theme_mod( 'header_image_data', (object) array( 'url' => 'http://subdomain.example.com/foo.jpg' ) );
+      """
+    And I run `wp eval-file setup-theme-mod.php`
+
+    When I run `wp theme mod get header_image_data`
+    Then STDOUT should be a table containing rows:
+      | key               | value                                              |
+      | header_image_data | {"url":"http:\/\/subdomain.example.com\/foo.jpg"}  |
+
+    When I run `wp search-replace subdomain.example.com example.com`
+    Then STDERR should be empty
+    Then STDOUT should be a table containing rows:
+      | Table      | Column       | Replacements | Type       |
+      | wp_options | option_value | 1            | PHP        |
+
+    When I run `wp theme mod get header_image_data`
+    Then STDOUT should be a table containing rows:
+      | key               | value                                           |
+      | header_image_data | {"url":"http:\/\/example.com\/foo.jpg"}  |
 
   Scenario Outline: Large guid search/replace where replacement contains search (or not)
     Given a WP install

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -109,8 +109,12 @@ Feature: Do global search/replace
       | key               | value                                              |
       | header_image_data | {"url":"http:\/\/subdomain.example.com\/foo.jpg"}  |
 
+    When I run `wp search-replace subdomain.example.com example.com --no-recurse-objects`
+    Then STDOUT should be a table containing rows:
+      | Table      | Column       | Replacements | Type       |
+      | wp_options | option_value | 0            | PHP        |
+
     When I run `wp search-replace subdomain.example.com example.com`
-    Then STDERR should be empty
     Then STDOUT should be a table containing rows:
       | Table      | Column       | Replacements | Type       |
       | wp_options | option_value | 1            | PHP        |

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -43,7 +43,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 * : Force the use of PHP (instead of SQL) which is more thorough, but slower. Use if you see issues with serialized data.
 	 *
 	 * [--recurse-objects]
-	 * : Enable recursing into objects to replace strings
+	 * : Enable recursing into objects to replace strings. Defaults to true; pass --no-recurse-objects to disable.
 	 *
 	 * [--all-tables-with-prefix]
 	 * : Enable replacement on any tables that match the table prefix even if not registered on wpdb

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -118,6 +118,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 				if ( $php_only || $regex || NULL !== $serialRow ) {
 					$type = 'PHP';
+					if ( ! empty( $serialRow ) && null === $recurse_objects ) {
+						$recurse_objects = true;
+					}
 					$count = self::php_handle_col( $col, $primary_keys, $table, $old, $new, $dry_run, $recurse_objects, $verbose, $regex );
 				} else {
 					$type = 'SQL';

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -74,7 +74,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$report          = array();
 		$dry_run         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run' );
 		$php_only        = \WP_CLI\Utils\get_flag_value( $assoc_args, 'precise' );
-		$recurse_objects = \WP_CLI\Utils\get_flag_value( $assoc_args, 'recurse-objects' );
+		$recurse_objects = \WP_CLI\Utils\get_flag_value( $assoc_args, 'recurse-objects', true );
 		$verbose         =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'verbose' );
 		$regex           =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex' );
 
@@ -118,9 +118,6 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 				if ( $php_only || $regex || NULL !== $serialRow ) {
 					$type = 'PHP';
-					if ( ! empty( $serialRow ) && null === $recurse_objects ) {
-						$recurse_objects = true;
-					}
 					$count = self::php_handle_col( $col, $primary_keys, $table, $old, $new, $dry_run, $recurse_objects, $verbose, $regex );
 				} else {
 					$type = 'SQL';


### PR DESCRIPTION
This more closely maps to expected behavior.

However, if `--no-recurse-objects` is provided, respect that flag too.

Fixes #1719