### PR TITLE
Implement #1011

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -45,7 +45,8 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		$bin_dir = getenv( 'WP_CLI_BIN_DIR' ) ?: realpath( __DIR__ . "/../../bin" );
 		$env = array(
 			'PATH' =>  $bin_dir . ':' . getenv( 'PATH' ),
-			'BEHAT_RUN' => 1
+			'BEHAT_RUN' => 1,
+			'HOME' => getenv( 'HOME' ),
 		);
 		if ( $config_path = getenv( 'WP_CLI_CONFIG_PATH' ) ) {
 			$env['WP_CLI_CONFIG_PATH'] = $config_path;

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -73,7 +73,7 @@ class Runner {
 			$config_path = getenv( 'WP_CLI_CONFIG_PATH' );
 			$this->_global_config_path_debug = 'Using global config from WP_CLI_CONFIG_PATH env var: ' . $config_path;
 		} else {
-			$config_path = WP_CLI::get_home() . '/config.yml';
+			$config_path = WP_CLI::home_path( 'config.yml' );
 			$this->_global_config_path_debug = 'Using default global config: ' . $config_path;
 		}
 

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -73,7 +73,7 @@ class Runner {
 			$config_path = getenv( 'WP_CLI_CONFIG_PATH' );
 			$this->_global_config_path_debug = 'Using global config from WP_CLI_CONFIG_PATH env var: ' . $config_path;
 		} else {
-			$config_path = getenv( 'HOME' ) . '/.wp-cli/config.yml';
+			$config_path = WP_CLI::get_home() . '/config.yml';
 			$this->_global_config_path_debug = 'Using default global config: ' . $config_path;
 		}
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -83,15 +83,22 @@ class WP_CLI {
 	}
 
 	/**
+	 * Converts a path relative to ~/.wp-cli to an absolute path
+	 * @param  string $path
+	 * @return string
+	 */
+	public static function home_path( $path = '' ) {
+		return self::get_home() . '/' . $path;
+	}
+
+	/**
 	 * @return FileCache
 	 */
 	public static function get_cache() {
 		static $cache;
 
 		if ( !$cache ) {
-			$home = self::get_home();
-
-			$dir = getenv( 'WP_CLI_CACHE_DIR' ) ? : "$home/cache";
+			$dir = getenv( 'WP_CLI_CACHE_DIR' ) ? : self::home_path( 'cache' );
 
 			// 6 months, 300mb
 			$cache = new FileCache( $dir, 15552000, 314572800 );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -62,18 +62,36 @@ class WP_CLI {
 	}
 
 	/**
+	 * Returns the path to ~/.wp-cli and creates this directory if it doesn't exist
+	 *
+	 * @return string
+	 */
+	public static function get_home() {
+		$home = getenv( 'HOME' );
+		if ( !$home ) {
+			// sometime in windows $HOME is not defined
+			$home = getenv( 'HOMEDRIVE' ) . getenv( 'HOMEPATH' );
+		}
+
+		$dir = "$home/.wp-cli";
+
+		if ( ! file_exists( $dir . '/' ) ) {
+			mkdir( $dir, 0755 );
+		}
+
+		return $dir;
+	}
+
+	/**
 	 * @return FileCache
 	 */
 	public static function get_cache() {
 		static $cache;
 
 		if ( !$cache ) {
-			$home = getenv( 'HOME' );
-			if ( !$home ) {
-				// sometime in windows $HOME is not defined
-				$home = getenv( 'HOMEDRIVE' ) . getenv( 'HOMEPATH' );
-			}
-			$dir = getenv( 'WP_CLI_CACHE_DIR' ) ? : "$home/.wp-cli/cache";
+			$home = self::get_home();
+
+			$dir = getenv( 'WP_CLI_CACHE_DIR' ) ? : "$home/cache";
 
 			// 6 months, 300mb
 			$cache = new FileCache( $dir, 15552000, 314572800 );

--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -208,6 +208,14 @@ class CLI_Command extends WP_CLI_Command {
 		} else {
 			$updated_version = $newest['version'];
 		}
+
+		// clear the flag for available updates
+		$flag = WP_CLI::get_home() . "/has-new-version";
+
+		if ( file_exists( $flag ) ) {
+			unlink( $flag );
+		}
+
 		WP_CLI::success( sprintf( 'Updated WP-CLI to %s', $updated_version ) );
 	}
 
@@ -272,6 +280,12 @@ class CLI_Command extends WP_CLI_Command {
 				return ! empty( $updates[ $type ] ) ? array( $updates[ $type ] ) : false;
 			}
 		}
+
+		// if there are any updates, set a persistent flag which should only be cleared after a successful update
+		if ( count( $updates ) > 0 ) {
+			touch( WP_CLI::get_home() . '/has-new-version' );
+		}
+
 		return array_values( $updates );
 	}
 

--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -210,7 +210,7 @@ class CLI_Command extends WP_CLI_Command {
 		}
 
 		// clear the flag for available updates
-		$flag = WP_CLI::get_home() . "/has-new-version";
+		$flag = WP_CLI::home_path( 'has-new-version' );
 
 		if ( file_exists( $flag ) ) {
 			unlink( $flag );
@@ -244,7 +244,8 @@ class CLI_Command extends WP_CLI_Command {
 			'major'      => false,
 			'minor'      => false,
 			'patch'      => false,
-			);
+		);
+
 		foreach ( $release_data as $release ) {
 
 			// get rid of leading "v" if there is one set
@@ -281,9 +282,14 @@ class CLI_Command extends WP_CLI_Command {
 			}
 		}
 
-		// if there are any updates, set a persistent flag which should only be cleared after a successful update
-		if ( count( $updates ) > 0 ) {
-			touch( WP_CLI::get_home() . '/has-new-version' );
+		if ( is_writable( WP_CLI::home_path() ) ) {
+			// if there are any updates, set a persistent flag which should only be cleared after a successful update
+			if ( count( $updates ) > 0 ) {
+				touch( WP_CLI::home_path( 'has-new-version' ) );
+			}
+
+			// no automatic updates for the next 24 hours
+			file_put_contents( WP_CLI::home_path( 'next-update-check' ), time() + 24*60*60 );
 		}
 
 		return array_values( $updates );

--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -84,6 +84,9 @@ class CLI_Command extends WP_CLI_Command {
 	 * [--major]
 	 * : Only list major updates
 	 *
+	 * [--latest]
+	 * : Only show the latest version
+	 *
 	 * [--field=<field>]
 	 * : Prints the value of a single field for each update.
 	 *
@@ -103,6 +106,11 @@ class CLI_Command extends WP_CLI_Command {
 				$assoc_args,
 				array( 'version', 'update_type', 'package_url' )
 			);
+
+			if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'latest' ) ) {
+				$updates = array( $updates[0] );
+			}
+
 			$formatter->display_items( $updates );
 		} else if ( empty( $assoc_args['format'] ) || 'table' == $assoc_args['format'] ) {
 			$update_type = $this->get_update_type_str( $assoc_args );

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -36,7 +36,12 @@ class Help_Command extends WP_CLI_Command {
 
 			// new version notification
 			if ( file_exists( WP_CLI::home_path( 'has-new-version' ) ) ) {
-				\WP_CLI::error( 'Your wp-cli is outdated. Please run `wp cli check-update` for more information.' );
+				WP_CLI::line( 'Your wp-cli is outdated. Most recent version is:' );
+				WP_CLI::get_runner()->run_command( array( 'cli', 'check-update' ), array( 'latest' => true ) );
+
+				WP_CLI::confirm( 'Proceed with update?' );
+
+				WP_CLI::get_runner()->run_command( array( 'cli', 'update' ), array() );
 			}
 
 			exit;

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -35,7 +35,7 @@ class Help_Command extends WP_CLI_Command {
 			self::show_help( $command );
 
 			// new version notification
-			if ( file_exists( WP_CLI::get_home() . '/has-new-version' ) ) {
+			if ( file_exists( WP_CLI::home_path( 'has-new-version' ) ) ) {
 				\WP_CLI::error( 'Your wp-cli is outdated. Please run `wp cli check-update` for more information.' );
 			}
 

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -33,6 +33,12 @@ class Help_Command extends WP_CLI_Command {
 			}
 
 			self::show_help( $command );
+
+			// new version notification
+			if ( file_exists( WP_CLI::get_home() . '/has-new-version' ) ) {
+				\WP_CLI::error( 'Your wp-cli is outdated. Please run `wp cli check-update` for more information.' );
+			}
+
 			exit;
 		}
 

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -35,11 +35,22 @@ class Help_Command extends WP_CLI_Command {
 			self::show_help( $command );
 
 			// new version notification
-			if ( file_exists( WP_CLI::home_path( 'has-new-version' ) ) ) {
+
+			$update_flag = WP_CLI::home_path( 'has-new-version' );
+
+			if ( file_exists( $update_flag ) && file_get_contents( $update_flag ) !== 'skip' ) {
 				WP_CLI::line( 'Your wp-cli is outdated. Most recent version is:' );
 				WP_CLI::get_runner()->run_command( array( 'cli', 'check-update' ), array( 'latest' => true ) );
 
-				WP_CLI::confirm( 'Proceed with update?' );
+				// modified WP_CLI::confirm() which ignores the --yes CLI flag
+				fwrite( STDOUT, "Proceed with update? [y/n] " );
+
+				$answer = trim( fgets( STDIN ) );
+
+				if ( 'y' != $answer ) {
+					file_put_contents( $update_flag, 'skip' );
+					exit;
+				}
 
 				WP_CLI::get_runner()->run_command( array( 'cli', 'update' ), array() );
 			}

--- a/php/wp-cli.php
+++ b/php/wp-cli.php
@@ -18,4 +18,28 @@ include WP_CLI_ROOT . '/php/class-wp-cli-command.php';
 
 \WP_CLI\Utils\load_dependencies();
 
+// check for updates on shutdown with 1/50 probability
+// disabled for Behat as we are limited to 60 request per hour
+if ( getenv('BEHAT_RUN') && 0 === mt_rand( 0, 50 ) ) {
+	register_shutdown_function( function() {
+		// prevent unnecessary checks - we don't care what updates are available, only that there is an update
+		if ( file_exists( \WP_CLI::get_home() . "/has-new-version" ) ) {
+			return;
+		}
+
+		// prevent infinite loops
+		if ( ! isset( $GLOBALS['argv'][1] ) || 'cli' !== $GLOBALS['argv'][1] || ! isset( $GLOBALS['argv'][2] ) || 'check-update' !== $GLOBALS['argv'][1] ) {
+
+			// make sure that the HOME env variable is set
+			$home = getenv( 'HOME' ) ? : getenv( 'HOMEDRIVE' ) . getenv( 'HOMEPATH' );
+			$php_binary = \WP_CLI::get_php_binary();
+			$wp_cli_path = realpath( $_SERVER['argv'][0] );
+			$allow_root = \WP_CLI::get_runner()->config['allow-root'] ? '--allow-root' : '';
+
+			// output must be redirected to /dev/null, otherwise this will block
+			\WP_CLI\Process::create( "HOME=$home {$php_binary} {$wp_cli_path} cli check-update {$allow_root} > /dev/null 2>&1 &" )->run();
+		}
+	} );
+}
+
 WP_CLI::get_runner()->start();


### PR DESCRIPTION
I'm looking for comments on the general idea behind this. I'll add tests later.

Here is how it works:
1. Unless we already know that an update is available, run `wp cli check-update` on shutdown with 1/50 probability. It is a separate, non-blocking, process.
2. If `wp cli check-update` finds any updates, it will touch `~/.wp-cli/has-new-version`.
3. `wp help` will display an error message if `~/.wp-cli/has-new-version` exists, but only after exiting from the pager.
4. `wp cli update` will unlink `~/.wp-cli/has-new-version` if it exists.