### PR TITLE
In `wp import`, use `WP_CLI::log()` instead of `WP_CLI::line()`

### DIFF
--- a/php/commands/import.php
+++ b/php/commands/import.php
@@ -57,7 +57,7 @@ class Import_Command extends WP_CLI_Command {
 			if ( is_wp_error( $ret ) ) {
 				WP_CLI::error( $ret );
 			} else {
-				WP_CLI::line(); // WXR import ends with HTML, so make sure message is on next line
+				WP_CLI::log(''); // WXR import ends with HTML, so make sure message is on next line
 				WP_CLI::success( "Finished importing from $file file." );
 			}
 		}
@@ -170,11 +170,11 @@ class Import_Command extends WP_CLI_Command {
 			global $wpcli_import_counts;
 
 			$wpcli_import_counts['current_post']++;
-			WP_CLI::line();
-			WP_CLI::line();
-			WP_CLI::line( sprintf( 'Processing post #%d ("%s") (post_type: %s)', $post['post_id'], $post['post_title'], $post['post_type'] ) );
-			WP_CLI::line( sprintf( '-- %s of %s', number_format( $wpcli_import_counts['current_post'] ), number_format( $wpcli_import_counts['total_posts'] ) ) );
-			WP_CLI::line( '-- ' . date( 'r' ) );
+			WP_CLI::log('');
+			WP_CLI::log('');
+			WP_CLI::log( sprintf( 'Processing post #%d ("%s") (post_type: %s)', $post['post_id'], $post['post_title'], $post['post_type'] ) );
+			WP_CLI::log( sprintf( '-- %s of %s', number_format( $wpcli_import_counts['current_post'] ), number_format( $wpcli_import_counts['total_posts'] ) ) );
+			WP_CLI::log( '-- ' . date( 'r' ) );
 
 			return $post;
 		} );
@@ -184,32 +184,32 @@ class Import_Command extends WP_CLI_Command {
 			if ( is_wp_error( $post_id ) ) {
 				WP_CLI::warning( "-- Error importing post: " . $post_id->get_error_code() );
 			} else {
-				WP_CLI::line( "-- Imported post as post_id #{$post_id}" );
+				WP_CLI::log( "-- Imported post as post_id #{$post_id}" );
 			}
 
 			if ( $wpcli_import_counts['current_post'] % 500 === 0 ) {
 				WP_CLI\Utils\wp_clear_object_cache();
-				WP_CLI::line( "-- Cleared object cache." );
+				WP_CLI::log( "-- Cleared object cache." );
 			}
 
 		}, 10, 4 );
 
 		add_action( 'wp_import_insert_term', function( $t, $import_term, $post_id, $post ) {
-			WP_CLI::line( "-- Created term \"{$import_term['name']}\"" );
+			WP_CLI::log( "-- Created term \"{$import_term['name']}\"" );
 		}, 10, 4 );
 
 		add_action( 'wp_import_set_post_terms', function( $tt_ids, $term_ids, $taxonomy, $post_id, $post ) {
-			WP_CLI::line( "-- Added terms (" . implode( ',', $term_ids ) .") for taxonomy \"{$taxonomy}\"" );
+			WP_CLI::log( "-- Added terms (" . implode( ',', $term_ids ) .") for taxonomy \"{$taxonomy}\"" );
 		}, 10, 5 );
 
 		add_action( 'wp_import_insert_comment', function( $comment_id, $comment, $comment_post_ID, $post ) {
 			global $wpcli_import_counts;
 			$wpcli_import_counts['current_comment']++;
-			WP_CLI::line( sprintf( '-- Added comment #%d (%s of %s)', $comment_id, number_format( $wpcli_import_counts['current_comment'] ), number_format( $wpcli_import_counts['total_comments'] ) ) );
+			WP_CLI::log( sprintf( '-- Added comment #%d (%s of %s)', $comment_id, number_format( $wpcli_import_counts['current_comment'] ), number_format( $wpcli_import_counts['total_comments'] ) ) );
 		}, 10, 4 );
 
 		add_action( 'import_post_meta', function( $post_id, $key, $value ) {
-			WP_CLI::line( "-- Added post_meta $key" );
+			WP_CLI::log( "-- Added post_meta $key" );
 		}, 10, 3 );
 
 	}


### PR DESCRIPTION
The former gives us more control over verbosity.

See #1159