### PR TITLE
Introduce `wp_version_compare()` for comparing WP versions

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -64,7 +64,7 @@ class Core_Command extends WP_CLI_Command {
 
 		foreach ( $release_versions as $release_version ) {
 			// don't list earliers versions
-			if ( version_compare( $release_version, $wp_version, '<=' ) )
+			if ( \WP_CLI\Utils\wp_version_compare( $release_version, '>=' ) )
 				continue;
 
 			$release_parts = explode( '.', $release_version );
@@ -385,7 +385,7 @@ class Core_Command extends WP_CLI_Command {
 				'https://api.wordpress.org/secret-key/1.1/salt/' );
 		}
 
-		if ( version_compare( $wp_version, '4.0', '<' ) ) {
+		if ( \WP_CLI\Utils\wp_version_compare( '4.0', '<' ) ) {
 			$assoc_args['add-wplang'] = true;
 		} else {
 			$assoc_args['add-wplang'] = false;
@@ -945,7 +945,7 @@ EOT;
 				list( $update ) = $from_api->updates;
 			}
 
-		} else if (	version_compare( $wp_version, $assoc_args['version'], '<' )
+		} else if (	\WP_CLI\Utils\wp_version_compare( $assoc_args['version'], '<' )
 					|| \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) ) {
 
 			$version = $assoc_args['version'];
@@ -1115,7 +1115,7 @@ class Core_Language_Command extends WP_CLI\CommandWithTranslation {
 
 WP_CLI::add_command( 'core language', 'Core_Language_Command', array(
 	'before_invoke' => function() {
-		if ( version_compare( $GLOBALS['wp_version'], '4.0', '<' ) ) {
+		if ( \WP_CLI\Utils\wp_version_compare( '4.0', '<' ) ) {
 			WP_CLI::error( "Requires WordPress 4.0 or greater." );
 		}
 	})

--- a/php/commands/cron.php
+++ b/php/commands/cron.php
@@ -509,9 +509,8 @@ class Cron_Command extends WP_CLI_Command {
 	 * @return WP_Error|array The response or WP_Error on failure.
 	 */
 	protected static function get_cron_spawn() {
-		global $wp_version;
 
-		$sslverify     = version_compare( $wp_version, 4.0, '<' );
+		$sslverify     = \WP_CLI\Utils\wp_version_compare( 4.0, '<' );
 		$doing_wp_cron = sprintf( '%.22F', microtime( true ) );
 
 		$cron_request = apply_filters( 'cron_request', array(

--- a/php/commands/taxonomy.php
+++ b/php/commands/taxonomy.php
@@ -17,9 +17,8 @@ class Taxonomy_Command extends WP_CLI_Command {
 	);
 
 	public function __construct() {
-		global $wp_version;
 
-		if ( version_compare( $wp_version, 3.7, '<' ) ) {
+		if ( \WP_CLI\Utils\wp_version_compare( 3.7, '<' ) ) {
 			// remove description for wp <= 3.7
 			$this->fields = array_values( array_diff( $this->fields, array( 'description' ) ) );
 		}

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -770,11 +770,9 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	 * @param string $password
 	 */
 	private static function wp_new_user_notification( $user_id, $password ) {
-		global $wp_version;
-		$version = str_replace( '-src', '', $wp_version );
-		if ( version_compare( $version, '4.3.1', '>=' ) ) {
+		if ( \WP_CLI\Utils\wp_version_compare( '4.3.1', '>=' ) ) {
 			wp_new_user_notification( $user_id, null, 'both' );
-		} else if ( version_compare( $version, '4.3', '>=' ) ) {
+		} else if ( \WP_CLI\Utils\wp_version_compare( '4.3', '>=' ) ) {
 			wp_new_user_notification( $user_id, 'both' );
 		} else {
 			wp_new_user_notification( $user_id, $password );

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -56,9 +56,13 @@ function wp_redirect_handler( $url ) {
 }
 
 function maybe_require( $since, $path ) {
-	if ( version_compare( str_replace( array( '-src' ), '', $GLOBALS['wp_version'] ), $since, '>=' ) ) {
+	if ( wp_version_compare( $since, '>=' ) ) {
 		require $path;
 	}
+}
+
+function wp_version_compare( $since, $operator ) {
+	return version_compare( str_replace( array( '-src' ), '', $GLOBALS['wp_version'] ), $since, $operator );
 }
 
 function get_upgrader( $class ) {

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -61,10 +61,6 @@ function maybe_require( $since, $path ) {
 	}
 }
 
-function wp_version_compare( $since, $operator ) {
-	return version_compare( str_replace( array( '-src' ), '', $GLOBALS['wp_version'] ), $since, $operator );
-}
-
 function get_upgrader( $class ) {
 	if ( !class_exists( '\WP_Upgrader' ) )
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';

--- a/php/utils.php
+++ b/php/utils.php
@@ -234,6 +234,10 @@ function locate_wp_config() {
 	return $path;
 }
 
+function wp_version_compare( $since, $operator ) {
+	return version_compare( str_replace( array( '-src' ), '', $GLOBALS['wp_version'] ), $since, $operator );
+}
+
 /**
  * Output items in a table, JSON, CSV, ids, or the total count
  *


### PR DESCRIPTION
Tagged WordPress releases include `-src` in `$wp_version`, which
`version_compare()` doesn't like. We need to make sure to strip it to
get an accurate result.

Fixes #2164