### PR TITLE
Ensure `upload_space_check_disabled=>1` when installing multisite

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -242,6 +242,12 @@ Feature: Manage WordPress installation
     When I try `wp core install-network --title='test network'`
     Then the return code should be 1
 
+    When I run `wp network meta get 1 upload_space_check_disabled`
+    Then STDOUT should be:
+      """
+      1
+      """
+
   Scenario: Install multisite from scratch
     Given an empty directory
     And WP files
@@ -260,6 +266,12 @@ Feature: Manage WordPress installation
     # Can complain that it's already installed, but don't exit with an error code
     When I try `wp core multisite-install --url=foobar.org --title=Test --admin_user=wpcli --admin_email=admin@example.com --admin_password=1`
     Then the return code should be 0
+
+    When I run `wp network meta get 1 upload_space_check_disabled`
+    Then STDOUT should be:
+      """
+      1
+      """
 
   Scenario: Install multisite from scratch, with MULTISITE already set in wp-config.php
     Given a WP multisite install

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -663,6 +663,10 @@ class Core_Command extends WP_CLI_Command {
 			}
 		}
 
+		// delete_site_option() cleans the alloptions cache to prevent dupe option
+		delete_site_option( 'upload_space_check_disabled' );
+		update_site_option( 'upload_space_check_disabled', 1 );
+
 		if ( !is_multisite() ) {
 			$subdomain_export = Utils\get_flag_value( $assoc_args, 'subdomains' ) ? 'true' : 'false';
 			$ms_config = <<<EOT


### PR DESCRIPTION
Because of how core executes `populate_network()`, this option is
erroneously set to an empty value when WP-CLI installs multisite.

The correct behavior is to disable multisite quotas by default on new
installs. See https://core.trac.wordpress.org/ticket/21513

Fixes #1371