### PR TITLE
Prevent unnecessary calls to `$wpdb->update()` when no replacements

### DIFF
--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -285,6 +285,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 
 			$value = $replacer->run( $row->$col );
 
+			if ( $value === $row->$col ) {
+				continue;
+			}
+
 			if ( $dry_run ) {
 				if ( $value != $row->$col )
 					$count++;


### PR DESCRIPTION
If the replacement value is the same as the original value, we don't
need to perform an update