### PR TITLE
Improve plugin vs. theme detection for the error generated when the requested version of a plugin or theme does not exist

### DIFF
--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -173,10 +173,12 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 		list( $link ) = explode( $response->slug, $response->download_link );
 
-		if ( false !== strpos( $response->download_link, 'theme' ) )
+		if ( false !== strpos( $response->download_link, '/theme/' ) )
 			$download_type = 'theme';
-		else
+		else if ( false !== strpos( $response->download_link, '/plugin/' ) )
 			$download_type = 'plugin';
+		else
+			$download_type = 'plugin/theme';
 
 		if ( 'dev' == $version ) {
 			$response->download_link = $link . $response->slug . '.zip';


### PR DESCRIPTION
When requesting a non-existant version of a plugin such as Easy Updates Manager (which has the slug 'stops-core-theme-and-plugin-updates'), the `alter_api_response` function incorrectly reports that the requested version of the _theme_ could not be found.

This happens because that function checks for the substring 'theme' in the URL returned by the WordPress repository API to determine whether the requested resource is a theme or a plugin.

This change makes the substring test stricter, by expecting the URL to contain the string '/theme/' for themes. It also performs a similar check for plugins ('/plugin/'), and if both checks fail, it will produce a more generic response (e.g. Can't find the requested plugin/theme's version...)