### PR TITLE
Use `--export=<file>` to `search-replace` to a saved file

### DIFF
--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -144,3 +144,37 @@ Feature: Search / replace with file export
       """
       Error: Unable to open "foo/bar.sql" for writing.
       """
+
+  Scenario: Search / replace specific table
+    Given a WP install
+
+    When I run `wp post create --post_title=foo --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp option update bar foo`
+    Then STDOUT should not be empty
+
+    When I run `wp search-replace foo burrito wp_posts --export=wordpress.sql --verbose`
+    Then STDOUT should contain:
+      """
+      Checking: wp_posts
+      """
+    And STDOUT should contain:
+      """
+      Success: Made 1 replacements and exported to wordpress.sql.
+      """
+
+    When I run `wp db import wordpress.sql`
+    Then STDOUT should not be empty
+
+    When I run `wp post get {POST_ID} --field=title`
+    Then STDOUT should be:
+      """
+      burrito
+      """
+
+    When I run `wp option get bar`
+    Then STDOUT should be:
+      """
+      foo
+      """

--- a/features/search-replace-export.feature
+++ b/features/search-replace-export.feature
@@ -1,0 +1,146 @@
+Feature: Search / replace with file export
+
+  Scenario: Search / replace export to STDOUT
+    Given a WP install
+
+    When I run `wp search-replace example.com example.net --export`
+    Then STDOUT should contain:
+      """
+      DROP TABLE IF EXISTS `wp_commentmeta`;
+      CREATE TABLE `wp_commentmeta`
+      """
+    And STDOUT should contain:
+      """
+      INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES ('1', 'siteurl', 'http://example.net', 'yes');
+      """
+
+    When I run `wp option get home`
+    Then STDOUT should be:
+      """
+      http://example.com
+      """
+
+    When I run `wp search-replace example.com example.net --skip-columns=option_value --export`
+    Then STDOUT should contain:
+      """
+      INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES ('1', 'siteurl', 'http://example.com', 'yes');
+      """
+
+    When I run `wp search-replace foo bar --export | tail -n 1`
+    Then STDOUT should not contain:
+      """
+      Success: Made
+      """
+
+    When I run `wp search-replace example.com example.net --export > wordpress.sql`
+    And I run `wp db import wordpress.sql`
+    Then STDOUT should not be empty
+
+    When I run `wp option get home`
+    Then STDOUT should be:
+      """
+      http://example.net
+      """
+
+  Scenario: Search / replace export to file
+    Given a WP install
+    And I run `wp post generate --count=30`
+
+    When I run `wp search-replace example.com example.net --export=wordpress.sql`
+    Then STDOUT should contain:
+      """
+      Success: Made 39 replacements and exported to wordpress.sql
+      """
+    And STDOUT should be a table containing rows:
+      | Table         | Column       | Replacements | Type |
+      | wp_options    | option_value | 5            | PHP  |
+
+    When I run `wp option get home`
+    Then STDOUT should be:
+      """
+      http://example.com
+      """
+
+    When I run `wp site empty --yes`
+    And I run `wp post list --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp db import wordpress.sql`
+    Then STDOUT should not be empty
+
+    When I run `wp option get home`
+    Then STDOUT should be:
+      """
+      http://example.net
+      """
+
+    When I run `wp post list --format=count`
+    Then STDOUT should be:
+      """
+      31
+      """
+
+  Scenario: Search / replace export to file with verbosity
+    Given a WP install
+
+    When I run `wp search-replace example.com example.net --export=wordpress.sql --verbose`
+    Then STDOUT should contain:
+      """
+      Checking: wp_posts
+      """
+    And STDOUT should contain:
+      """
+      Checking: wp_options
+      """
+
+  Scenario: Search / replace export with dry-run
+    Given a WP install
+
+    When I try `wp search-replace example.com example.net --export --dry-run`
+    Then STDERR should be:
+      """
+      Error: You cannot supply --dry-run and --export at the same time.
+      """
+
+  Scenario: Search / replace shouldn't affect primary key
+    Given a WP install
+    And I run `wp post create --post_title=foo --porcelain`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp option update {POST_ID} foo`
+    And I run `wp option get {POST_ID}`
+    Then STDOUT should be:
+      """
+      foo
+      """
+
+    When I run `wp search-replace {POST_ID} 99999999 --export=wordpress.sql`
+    And I run `wp db import wordpress.sql`
+    Then STDOUT should not be empty
+
+    When I run `wp post get {POST_ID} --field=title`
+    Then STDOUT should be:
+      """
+      foo
+      """
+
+    When I try `wp option get {POST_ID}`
+    Then STDOUT should be empty
+
+    When I run `wp option get 99999999`
+    Then STDOUT should be:
+      """
+      foo
+      """
+
+  Scenario: Search / replace export invalid file
+    Given a WP install
+
+    When I try `wp search-replace example.com example.net --export=foo/bar.sql`
+    Then STDERR should contain:
+      """
+      Error: Unable to open "foo/bar.sql" for writing.
+      """

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -15,32 +15,6 @@ Feature: Do global search/replace
       guid
       """
 
-  Scenario: Search/replace with export
-    Given a WP install
-
-    When I run `wp search-replace example.com example.net --export`
-    Then STDOUT should contain:
-      """
-      DROP TABLE IF EXISTS `wp_commentmeta`;
-      CREATE TABLE `wp_commentmeta`
-      """
-    And STDOUT should contain:
-      """
-      INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES ('1', 'siteurl', 'http://example.org', 'yes');
-      """
-
-    When I run `wp search-replace example.com example.org --skip-columns=option_value --export`
-    Then STDOUT should contain:
-      """
-      INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES ('1', 'siteurl', 'http://example.com', 'yes');
-      """
-
-    When I run `wp search-replace foo bar --export | tail -n 1`
-    Then STDOUT should not contain:
-      """
-      Success: Made
-      """
-
   Scenario: Multisite search/replace
     Given a WP multisite install
     And I run `wp site create --slug="foo" --title="foo" --email="foo@example.com"`

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -15,6 +15,31 @@ Feature: Do global search/replace
       guid
       """
 
+  Scenario: Search/replace with export
+    Given a WP install
+
+    When I run `wp search-replace example.com example.net --export`
+    Then STDOUT should contain:
+      """
+      DROP TABLE IF EXISTS `wp_commentmeta`;
+      CREATE TABLE `wp_commentmeta`
+      """
+    And STDOUT should contain:
+      """
+      INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES ('1', 'siteurl', 'http://example.org', 'yes');
+      """
+
+    When I run `wp search-replace example.com example.org --skip-columns=option_value --export`
+    Then STDOUT should contain:
+      """
+      INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES ('1', 'siteurl', 'http://example.com', 'yes');
+      """
+
+    When I run `wp search-replace foo bar --export | tail -n 1`
+    Then STDOUT should not contain:
+      """
+      Success: Made
+      """
 
   Scenario: Multisite search/replace
     Given a WP multisite install

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -183,9 +183,13 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$table->display();
 
 		if ( ! $this->dry_run ) {
-			$success_message = ! empty( $assoc_args['export'] ) ? "Made {$total} replacements and exported to {$assoc_args['export']}." : "Made $total replacements.";
-			if ( $total && 'Default' !== WP_CLI\Utils\wp_get_cache_type() ) {
-				$success_message .= ' Please remember to flush your persistent object cache with `wp cache flush`.';
+			if ( ! empty( $assoc_args['export'] ) ) {
+				$success_message = "Made {$total} replacements and exported to {$assoc_args['export']}.";
+			} else {
+				$success_message = "Made $total replacements.";
+				if ( $total && 'Default' !== WP_CLI\Utils\wp_get_cache_type() ) {
+					$success_message .= ' Please remember to flush your persistent object cache with `wp cache flush`.';
+				}
 			}
 			WP_CLI::success( $success_message );
 		}

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -74,6 +74,9 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 *
 	 *     # Turn your production database into a local database
 	 *     wp search-replace --url=example.com example.com example.dev wp_\*_options
+	 *
+	 *     # Search/replace to a SQL file without transforming the database
+	 *     wp search-replace foo bar --export=database.sql
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		global $wpdb;

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -160,21 +160,22 @@ class Search_Replace_Command extends WP_CLI_Command {
 			fclose( $this->export_handle );
 		}
 
-		if ( ! WP_CLI::get_config( 'quiet' ) && STDOUT !== $this->export_handle ) {
+		// Only informational output after this point
+		if ( WP_CLI::get_config( 'quiet' ) || STDOUT === $this->export_handle ) {
+			return;
+		}
 
-			$table = new \cli\Table();
-			$table->setHeaders( array( 'Table', 'Column', 'Replacements', 'Type' ) );
-			$table->setRows( $report );
-			$table->display();
+		$table = new \cli\Table();
+		$table->setHeaders( array( 'Table', 'Column', 'Replacements', 'Type' ) );
+		$table->setRows( $report );
+		$table->display();
 
-			if ( ! $dry_run ) {
-				$success_message = "Made $total replacements.";
-				if ( $total && 'Default' !== WP_CLI\Utils\wp_get_cache_type() ) {
-					$success_message .= ' Please remember to flush your persistent object cache with `wp cache flush`.';
-				}
-				WP_CLI::success( $success_message );
+		if ( ! $dry_run ) {
+			$success_message = "Made $total replacements.";
+			if ( $total && 'Default' !== WP_CLI\Utils\wp_get_cache_type() ) {
+				$success_message .= ' Please remember to flush your persistent object cache with `wp cache flush`.';
 			}
-
+			WP_CLI::success( $success_message );
 		}
 	}
 


### PR DESCRIPTION
For instance, to replace instances of "foo" with "bar" without transforming the database:

```
wp search-replace foo bar --export=database.sql
```

Also begins to abstract arguments to class-level variables for easier reuse between methods.

Props @westonruter for much of the original code

Fixes #709