### PR TITLE
Use `--minor` flag with `wp core update` to update to latest minor

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -339,31 +339,23 @@ Feature: Manage WordPress installation
     Then STDOUT should be a table containing rows:
       | version | update_type | package_url                                |
       | 4.3.1   | major       | https://wordpress.org/wordpress-4.3.1.zip  |
-      | 4.2.5   | major       | https://wordpress.org/wordpress-4.2.5.zip  |
-      | 4.1.8   | major       | https://wordpress.org/wordpress-4.1.8.zip  |
-      | 4.0.8   | major       | https://wordpress.org/wordpress-4.0.8.zip  |
-      | 3.9.9   | major       | https://wordpress.org/wordpress-3.9.9.zip  |
       | 3.8.11  | minor       | https://wordpress.org/wordpress-3.8.11.zip |
 
     When I run `wp core check-update --format=count`
     Then STDOUT should be:
       """
-      6
+      2
       """
 
     When I run `wp core check-update --major`
     Then STDOUT should be a table containing rows:
       | version | update_type | package_url                                |
       | 4.3.1   | major       | https://wordpress.org/wordpress-4.3.1.zip  |
-      | 4.2.5   | major       | https://wordpress.org/wordpress-4.2.5.zip  |
-      | 4.1.8   | major       | https://wordpress.org/wordpress-4.1.8.zip  |
-      | 4.0.8   | major       | https://wordpress.org/wordpress-4.0.8.zip  |
-      | 3.9.9   | major       | https://wordpress.org/wordpress-3.9.9.zip  |
 
     When I run `wp core check-update --major --format=count`
     Then STDOUT should be:
       """
-      5
+      1
       """
 
     When I run `wp core check-update --minor`

--- a/features/core.feature
+++ b/features/core.feature
@@ -369,6 +369,25 @@ Feature: Manage WordPress installation
       1
       """
 
+  @download
+  Scenario: Update to the latest minor release
+    Given a WP install
+
+    When I run `wp core download --version=3.8 --force`
+    Then STDOUT should not be empty
+
+    When I run `wp core update --minor`
+    Then STDOUT should contain:
+      """
+      Downloading update
+      """
+
+    When I run `wp core update --minor`
+    Then STDOUT should be:
+      """
+      Success: WordPress is at the latest minor release.
+      """
+
   Scenario: Custom wp-content directory
     Given a WP install
     And a custom wp-content directory

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -847,8 +847,11 @@ EOT;
 	 * [<zip>]
 	 * : Path to zip file to use, instead of downloading from wordpress.org.
 	 *
+	 * [--minor]
+	 * : Only perform updates for minor releases.
+	 *
 	 * [--version=<version>]
-	 * : Update to this version, instead of to the latest version.
+	 * : Update to a specific version, instead of to the latest version.
 	 *
 	 * [--force]
 	 * : Update even when installed WP version is greater than the requested version.
@@ -871,6 +874,16 @@ EOT;
 
 		$update = $from_api = null;
 		$upgrader = 'WP_CLI\\CoreUpgrader';
+
+		if ( empty( $args[0] ) && empty( $assoc_args['version'] ) && \WP_CLI\Utils\get_flag_value( $assoc_args, 'minor' ) ) {
+			$updates = $this->get_updates( array( 'minor' => true ) );
+			if ( ! empty( $updates ) ) {
+				$assoc_args['version'] = $updates['version'];
+			} else {
+				WP_CLI::success( 'WordPress is at the latest minor release.' );
+				return;
+			}
+		}
 
 		if ( ! empty( $args[0] ) ) {
 


### PR DESCRIPTION
This changes the behavior of `wp core check-upate` to only list one major
update. Users should be updating to the latest major release, not an
intermediate one.

Fixes #1850