### PR TITLE
A Behat test for menu item deleting bug

### DIFF
--- a/features/menu.feature
+++ b/features/menu.feature
@@ -111,3 +111,32 @@ Feature: Manage WordPress menus
     """
     0
     """
+
+  Scenario: Preserve grandparent item as ancestor of child item when parent item is removed.
+
+    When I run `wp menu create "Grandparent Test"`
+    Then STDOUT should not be empty
+
+    When I run `wp menu item add-custom grandparent-test Grandparent http://example.com/grandparent --porcelain`
+    Then save STDOUT as {GRANDPARENT_ID}
+
+    When I run `wp menu item add-custom grandparent-test  Parent   http://example.com/parent   --porcelain  --parent-id={GRANDPARENT_ID}`
+    Then save STDOUT as {PARENT_ID}
+
+    When I run `wp menu item add-custom grandparent-test  Child http://example.com/child   --porcelain  --parent-id={PARENT_ID}`
+    Then save STDOUT as {CHILD_ID}
+
+    When I run `wp menu item list grandparent-test --fields=title,db_id,menu_item_parent`
+    Then STDOUT should be a table containing rows:
+      | title       | db_id            | menu_item_parent |
+      | Grandparent | {GRANDPARENT_ID} | 0                |
+      | Parent      | {PARENT_ID}      | {GRANDPARENT_ID} |
+      | Child       | {CHILD_ID}       | {PARENT_ID}      |
+
+    When I run `wp menu item delete {PARENT_ID}`
+
+    When I run `wp menu item list grandparent-test --fields=title,db_id,menu_item_parent`
+    Then STDOUT should be a table containing rows:
+      | title       | db_id            | menu_item_parent |
+      | Grandparent | {GRANDPARENT_ID} | 0                |
+      | Child       | {CHILD_ID}       | {GRANDPARENT_ID} |


### PR DESCRIPTION
This PR is a Behat test to cover the bug mentioned in https://github.com/wp-cli/wp-cli/issues/2246. The behat test will fail because this bug is not fixed and the fix likely needs to be made in WordPress itself.

The issue being tested is the parent menu item of an item whose parent has been deleted. According to #2246 the value in the parent column should become the grandparent id.

