### PR TITLE
Defer to `$PAGER` environment variable when set

### DIFF
--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -91,7 +91,9 @@ class Help_Command extends WP_CLI_Command {
 
 	private static function pass_through_pager( $out ) {
 
-		$pager = Utils\is_windows() ? 'more' : 'less -r';
+		if ( false === ( $pager = getenv( 'PAGER' ) ) ) {
+			$pager = Utils\is_windows() ? 'more' : 'less -r';
+		}
 
 		// convert string to file handle
 		$fd = fopen( "php://temp", "r+" );


### PR DESCRIPTION
Doing so gives more control to the end user on how their output will be
presented.

Fixes #2110