### PR TITLE
A more helpful error message when a plugin or theme slug doesn't exist

### DIFF
--- a/features/upgradables.feature
+++ b/features/upgradables.feature
@@ -175,6 +175,12 @@ Feature: Manage WordPress themes and plugins
       Showing 2 of
       """
 
+    When I try `wp <type> install an-impossible-slug-because-abc3fr`
+    Then STDERR should contain:
+      """
+      Warning: Couldn't find 'an-impossible-slug-because-abc3fr' in the WordPress.org <type> directory.
+      """
+
     Examples:
       | type   | type_name | item                    | item_title              | version | zip_file                                                              | file_to_check                                                    |
       | theme  | Theme     | p2                      | P2                      | 1.0.1   | https://wordpress.org/themes/download/p2.1.0.1.zip                     | {CONTENT_DIR}/p2/style.css                                        |

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -141,7 +141,14 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 				$result = $this->install_from_repo( $slug, $assoc_args );
 
 				if ( is_wp_error( $result ) ) {
-					\WP_CLI::warning( "$slug: " . $result->get_error_message() );
+
+					$key = $result->get_error_code();
+					if ( in_array( $result->get_error_code(), array( 'plugins_api_failed', 'themes_api_failed' ) )
+						&& ! empty( $result->error_data[ $key ] ) && in_array( $result->error_data[ $key ], array( 'N;', 'b:0;' ) ) ) {
+						\WP_CLI::warning( "Couldn't find '$slug' in the WordPress.org {$this->item_type} directory." );
+					} else {
+						\WP_CLI::warning( "$slug: " . $result->get_error_message() );
+					}
 				}
 			}
 


### PR DESCRIPTION
We can, more or less, safely interpret this `WP_Error` response to mean
no matching plugins or themes.

Fixes #2181