### PR TITLE
Load `utils-wp.php` right before `wp-settings-cli.php` is called

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -732,6 +732,9 @@ class Runner {
 
 		$this->maybe_update_url_from_domain_constant();
 
+		// Load WP-CLI utilities
+		require WP_CLI_ROOT . '/php/utils-wp.php';
+
 		// Load Core, mu-plugins, plugins, themes etc.
 		require WP_CLI_ROOT . '/php/wp-settings-cli.php';
 

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -55,9 +55,6 @@ wp_fix_server_vars();
 // Start loading timer.
 timer_start();
 
-// Load WP-CLI utilities
-require WP_CLI_ROOT . '/php/utils-wp.php';
-
 // Check if we're in WP_DEBUG mode.
 Utils\wp_debug_mode();
 


### PR DESCRIPTION
This helps to reduce the difference between `wp-settings-cli.php` and
`wp-settings.php`. It has no functional differences.

See #2278