### PR TITLE
Don't ever prefix rewrite rules with `index.php`

### DIFF
--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -81,12 +81,8 @@ class Rewrite_Command extends WP_CLI_Command {
 		global $wp_rewrite;
 
 		// copypasta from /wp-admin/options-permalink.php
-		$home_path = get_home_path();
-		$iis7_permalinks = iis7_supports_permalinks();
 
 		$prefix = $blog_prefix = '';
-		if ( ! got_mod_rewrite() && ! $iis7_permalinks )
-			$prefix = '/index.php';
 		if ( is_multisite() && !is_subdomain_install() && is_main_site() )
 			$blog_prefix = '/blog';
 


### PR DESCRIPTION
Core does some fancy logic to determine whether `index.php` needs to be
prepended to rewrite rules. `got_url_rewrite()` returns true if mod
rewrite is available or `$GLOBALS['is_nginx']` is set. However, php-cli
doesn't easily have access to these values. Instead, let's assume the
developer knows the value they're passing, and that rewrites are
configured for the site.

Fixes #2184