### PR TITLE
Fix typo in function synopsis

### DIFF
--- a/php/commands/transient.php
+++ b/php/commands/transient.php
@@ -40,7 +40,7 @@ class Transient_Command extends WP_CLI_Command {
 	 * <value>
 	 * : Value to be set for the transient.
 	 *
-	 * [<expiration]
+	 * [<expiration>]
 	 * : Time until expiration, in seconds.
 	 */
 	public function set( $args ) {


### PR DESCRIPTION
There's a typo in the synopsis for `set`. That typo is causing fatal errors in commands like
`wp transient set "51ecb1f884" "Cache rules everything around me." "2592001"`

Adding in the missing **>** fixes the problem.