### PR TITLE
Validate parameters when using `--help`

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -27,6 +27,20 @@ Feature: Get help about WP-CLI commands
       wp post list
       """
 
+  Scenario: Validate parameters with help, but warn instead of error
+    Given a WP install
+
+    When I run `wp option get home --url-foo.com --help`
+    Then STDOUT should contain:
+      """
+      wp option get
+      """
+    And STDERR should contain:
+      """
+      Warning: Parameter errors:
+       unknown --url-foo.com parameter
+      """
+
   Scenario: Help when WordPress is downloaded but not installed
     Given an empty directory
 

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -248,10 +248,8 @@ class Subcommand extends CompositeCommand {
 			array_merge( \WP_CLI::get_config(), $extra_args, $assoc_args )
 		);
 
-		if ( $this->name != 'help' ) {
-			foreach ( $validator->unknown_assoc( $assoc_args ) as $key ) {
-				$errors['fatal'][] = "unknown --$key parameter";
-			}
+		foreach ( $validator->unknown_assoc( $assoc_args ) as $key ) {
+			$errors['fatal'][] = "unknown --$key parameter";
 		}
 
 		if ( !empty( $errors['fatal'] ) ) {
@@ -263,7 +261,11 @@ class Subcommand extends CompositeCommand {
 				}
 			}
 
-			\WP_CLI::error( $out );
+			if ( 'help' === $this->name ) {
+				\WP_CLI::warning( $out );
+			} else {
+				\WP_CLI::error( $out );
+			}
 		}
 
 		array_map( '\\WP_CLI::warning', $errors['warning'] );


### PR DESCRIPTION
Instead of blocking script execution, just send a warning to STDOUT

Fixes #2043