### PR TITLE
Clarify behavior of `wp plugin delete`

### DIFF
--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -556,7 +556,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	}
 
 	/**
-	 * Delete plugin files.
+	 * Delete plugin files without deactivating or uninstalling.
 	 *
 	 * ## OPTIONS
 	 *


### PR DESCRIPTION
It's different than deactivating + uninstalling.

See #2315