### PR TITLE
Magically globalize any new variables defined in wp-config.php

### DIFF
--- a/features/framework.feature
+++ b/features/framework.feature
@@ -83,3 +83,27 @@ Feature: Load WP-CLI
       """
       Error: This does not seem to be a WordPress install.
       """
+
+  Scenario: Globalize global variables in wp-config.php
+    Given an empty directory
+    And WP files
+    And a wp-config-extra.php file:
+      """
+      $redis_server = 'foo';
+      """
+
+    When I run `wp core config {CORE_CONFIG_SETTINGS} --extra-php < wp-config-extra.php`
+    Then the wp-config.php file should contain:
+      """
+      $redis_server = 'foo';
+      """
+
+    When I run `wp db create`
+    And I run `wp core install --url='localhost:8001' --title='Test' --admin_user=wpcli --admin_email=admin@example.com --admin_password=1`
+    Then STDOUT should not be empty
+
+    When I run `wp eval 'echo $GLOBALS["redis_server"];'`
+    Then STDOUT should be:
+      """
+      foo
+      """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -728,7 +728,14 @@ class Runner {
 		WP_CLI::debug( 'wp-config.php path: ' . $wp_config_path );
 
 		// Load wp-config.php code, in the global scope
+		$wp_cli_original_defined_vars = get_defined_vars();
 		eval( $this->get_wp_config_code() );
+		foreach( get_defined_vars() as $key => $var ) {
+			if ( array_key_exists( $key, $wp_cli_original_defined_vars ) || 'wp_cli_original_defined_vars' === $key ) {
+				continue;
+			}
+			$GLOBALS[ $key ] = $var;
+		}
 
 		$this->maybe_update_url_from_domain_constant();
 


### PR DESCRIPTION
They're expected to be global, so we should explicitly make it so.

From #2316