### PR TITLE
Officially support PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,7 @@ matrix:
     - php: 5.6
       env: WP_VERSION=trunk
     - php: 7.0
-      env: WP_VERSION=trunk
-  allow_failures:
-    - php: 7.0
+      env: WP_VERSION=latest
 
 before_script: ./ci/prepare.sh
 

--- a/ci/behat-tags.php
+++ b/ci/behat-tags.php
@@ -4,7 +4,7 @@ function php_version_tags() {
 	exec( 'grep "@require-php-[0-9\.]*" -h -o features/*.feature | uniq', $existing_tags );
 }
 
-function version_tags( $prefix, $current ) {
+function version_tags( $prefix, $current, $operator = '<' ) {
 	if ( ! $current )
 		return;
 
@@ -13,8 +13,8 @@ function version_tags( $prefix, $current ) {
 	$skip_tags = array();
 
 	foreach ( $existing_tags as $tag ) {
-		$required = str_replace( "@{$prefix}-", '', $tag );
-		if ( version_compare( $current, $required, '<' ) ) {
+		$compare = str_replace( "@{$prefix}-", '', $tag );
+		if ( version_compare( $current, $compare, $operator ) ) {
 			$skip_tags[] = $tag;
 		}
 	}
@@ -23,8 +23,9 @@ function version_tags( $prefix, $current ) {
 }
 
 $skip_tags = array_merge(
-	version_tags( 'require-wp', getenv( 'WP_VERSION' ) ),
-	version_tags( 'require-php', PHP_VERSION )
+	version_tags( 'require-wp', getenv( 'WP_VERSION' ), '<' ),
+	version_tags( 'require-php', PHP_VERSION, '<' ),
+	version_tags( 'less-than-php', PHP_VERSION, '>' )
 );
 
 # Skip Github API tests by default because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612

--- a/features/core-check-update.feature
+++ b/features/core-check-update.feature
@@ -1,5 +1,6 @@
 Feature: Check for more recent versions
 
+  @less-than-php-7
   Scenario: Check for update via Version Check API
     Given a WP install
 

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -1,5 +1,6 @@
 Feature: Update WordPress core
 
+  @less-than-php-7
   Scenario: Update from a ZIP file
     Given a WP install
 
@@ -27,6 +28,7 @@ Feature: Update WordPress core
       3.9
       """
 
+  @less-than-php-7
   Scenario: Update to the latest minor release
     Given a WP install
 
@@ -45,6 +47,7 @@ Feature: Update WordPress core
       Success: WordPress is at the latest minor release.
       """
 
+  @less-than-php-7
   Scenario: Core update from cache
     Given a WP install
     And an empty cache

--- a/features/eval.feature
+++ b/features/eval.feature
@@ -4,7 +4,7 @@ Feature: Evaluating PHP code and files.
     Given a WP install
 
     When I run `wp eval 'var_dump(defined("WP_CONTENT_DIR"));'`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       bool(true)
       """
@@ -16,7 +16,7 @@ Feature: Evaluating PHP code and files.
       """
 
     When I run `wp eval-file script.php foo bar`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       foo bar
       """
@@ -31,7 +31,7 @@ Feature: Evaluating PHP code and files.
       """
 
     When I run `wp eval 'var_dump(defined("WP_CONTENT_DIR"));' --skip-wordpress`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       bool(false)
       """
@@ -51,7 +51,7 @@ Feature: Evaluating PHP code and files.
       """
 
     When I run `wp eval-file script.php --skip-wordpress`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       bool(false)
       """

--- a/features/menu.feature
+++ b/features/menu.feature
@@ -77,7 +77,10 @@ Feature: Manage WordPress menus
     Then save STDOUT as {POST_ITEM_ID}
 
     When I run `wp menu item update {POST_ITEM_ID} --description="Washington Apples"`
-    Then STDERR should be empty
+    Then STDOUT should be:
+      """
+      Success: Menu item updated.
+      """
 
     When I run `wp menu item add-term sidebar-menu post_tag {TERM_ID} --porcelain`
     Then save STDOUT as {TERM_ITEM_ID}
@@ -86,7 +89,16 @@ Feature: Manage WordPress menus
     Then save STDOUT as {CUSTOM_ITEM_ID}
 
     When I run `wp menu item update {CUSTOM_ITEM_ID} --title=WordPress --link='http://wordpress.org' --target=_blank --position=2`
-    Then STDERR should be empty
+    Then STDOUT should be:
+      """
+      Success: Menu item updated.
+      """
+
+    When I run `wp menu item update {TERM_ITEM_ID} --position=3`
+    Then STDOUT should be:
+      """
+      Success: Menu item updated.
+      """
 
     When I run `wp menu item list sidebar-menu --fields=type,title,description,position,link,menu_item_parent`
     Then STDOUT should be a table containing rows:

--- a/features/shell.feature
+++ b/features/shell.feature
@@ -35,7 +35,7 @@ Feature: WordPress REPL
       """
 
     When I run `wp shell --basic < session`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       bool(true)
       """


### PR DESCRIPTION
Skip tests which download versions of WordPress earlier than 4.4, as
they throw error notices in PHP 7.

Fixes #1842