### PR TITLE
Assume db errors during `wp_install()` to be installation failure

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -562,6 +562,10 @@ class Core_Command extends WP_CLI_Command {
 		}
 		// @codingStandardsIgnoreEnd
 
+		if ( ! empty( $GLOBALS['wpdb']->last_error ) ) {
+			WP_CLI::error( 'Installation produced database errors, and may have partially or completely failed.' );
+		}
+
 		// Confirm the uploads directory exists
 		$upload_dir = wp_upload_dir();
 		if ( ! empty( $upload_dir['error'] ) ) {


### PR DESCRIPTION
If database errors occur, let the user know with:

```
Error: Installation produced database errors, and may have partially or
completely failed.
```

We should only show a success message when there aren't database errors.

Fixes #1075