### PR TITLE
Fix `wp core update --minor`

### DIFF
--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -32,19 +32,25 @@ Feature: Update WordPress core
   Scenario: Update to the latest minor release
     Given a WP install
 
-    When I run `wp core download --version=3.8 --force`
+    When I run `wp core download --version=3.7.9 --force`
     Then STDOUT should not be empty
 
     When I run `wp core update --minor`
     Then STDOUT should contain:
       """
-      Downloading update
+      Updating to version 3.7.11
       """
 
     When I run `wp core update --minor`
     Then STDOUT should be:
       """
       Success: WordPress is at the latest minor release.
+      """
+
+    When I run `wp core version`
+    Then STDOUT should be:
+      """
+      3.7.11
       """
 
   @less-than-php-7

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -882,7 +882,7 @@ EOT;
 		if ( empty( $args[0] ) && empty( $assoc_args['version'] ) && \WP_CLI\Utils\get_flag_value( $assoc_args, 'minor' ) ) {
 			$updates = $this->get_updates( array( 'minor' => true ) );
 			if ( ! empty( $updates ) ) {
-				$assoc_args['version'] = $updates['version'];
+				$assoc_args['version'] = $updates[0]['version'];
 			} else {
 				WP_CLI::success( 'WordPress is at the latest minor release.' );
 				return;


### PR DESCRIPTION
It updates to the latest major release, which it shouldn't

Introduced in #2256