### PR TITLE
Fix use of `--url` with multisite in WP < 3.9

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -13,6 +13,16 @@ Feature: Global flags
       }
       """
 
+  Scenario: Setting the URL on multisite
+    Given a WP multisite install
+    And I run `wp site create --slug=foo`
+
+    When I run `wp --url=example.com/foo option get home`
+    Then STDOUT should be:
+      """
+      http://example.com/foo
+      """
+
   @require-wp-3.9
   Scenario: Invalid URL
     Given a WP multisite install

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -730,7 +730,7 @@ class Runner {
 	public function load_wordpress() {
 		static $wp_cli_is_loaded;
 		// Globals not explicitly globalized in WordPress
-		global $site_id, $public, $current_site, $current_blog, $shortcode_tags;
+		global $site_id, $public, $current_site, $current_blog, $path, $shortcode_tags;
 
 		if ( ! empty( $wp_cli_is_loaded ) ) {
 			return;


### PR DESCRIPTION
Globalize `$path`, used until WP 3.9 for determining subsites in MS

Introduced in #2120 
