### PR TITLE
Ensure `wp_new_blog_notification()` isn't defined before we do so

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -539,7 +539,8 @@ class Core_Command extends WP_CLI_Command {
 			return false;
 		}
 
-		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-email' ) ) {
+		if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-email' )
+			&& ! function_exists( 'wp_new_blog_notification' ) ) {
 			function wp_new_blog_notification() {
 				// Silence is golden
 			}


### PR DESCRIPTION
While it wouldn't realistically ever be defined in this scope, a PHP
script calling `install()` twice would fatal on the second time. Better
safe than sorry.