### PR TITLE
Use `--network` flag for `wp transient *` to manage site transients

### DIFF
--- a/features/transient.feature
+++ b/features/transient.feature
@@ -1,0 +1,56 @@
+Feature: Manage WordPress transient cache
+
+  Scenario: Transient CRUD
+    Given a WP install
+
+    When I try `wp transient get foo`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo" is not set.
+      """
+
+    When I run `wp transient set foo bar`
+    Then STDOUT should be:
+      """
+      Success: Transient added.
+      """
+
+    When I run `wp transient get foo`
+    Then STDOUT should be:
+      """
+      bar
+      """
+
+    When I run `wp transient delete foo`
+    Then STDOUT should be:
+      """
+      Success: Transient deleted.
+      """
+
+  Scenario: Network transient CRUD
+    Given a WP multisite install
+    And I run `wp site create --slug=foo`
+
+    When I run `wp transient set foo bar --network`
+    Then STDOUT should be:
+      """
+      Success: Transient added.
+      """
+
+    When I run `wp --url=example.com/foo transient get foo --network`
+    Then STDOUT should be:
+      """
+      bar
+      """
+
+    When I try `wp transient get foo`
+    Then STDERR should be:
+      """
+      Warning: Transient with key "foo" is not set.
+      """
+
+    When I run `wp transient delete foo --network`
+    Then STDOUT should be:
+      """
+      Success: Transient deleted.
+      """

--- a/php/commands/transient.php
+++ b/php/commands/transient.php
@@ -17,11 +17,15 @@ class Transient_Command extends WP_CLI_Command {
 	 *
 	 * [--json]
 	 * : Format output as JSON.
+	 *
+	 * [--network]
+	 * : Get the value of the network transient, instead of the single site.
 	 */
 	public function get( $args, $assoc_args ) {
 		list( $key ) = $args;
 
-		$value = get_transient( $key );
+		$func = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' ) ? 'get_site_transient' : 'get_transient';
+		$value = $func( $key );
 
 		if ( false === $value ) {
 			WP_CLI::warning( 'Transient with key "' . $key . '" is not set.' );
@@ -42,16 +46,21 @@ class Transient_Command extends WP_CLI_Command {
 	 *
 	 * [<expiration>]
 	 * : Time until expiration, in seconds.
+	 *
+	 * [--network]
+	 * : Set the transient value on the network, instead of single site.
 	 */
-	public function set( $args ) {
+	public function set( $args, $assoc_args ) {
 		list( $key, $value ) = $args;
 
 		$expiration = \WP_CLI\Utils\get_flag_value( $args, 2, 0 );
 
-		if ( set_transient( $key, $value, $expiration ) )
+		$func = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' ) ? 'set_site_transient' : 'set_transient';
+		if ( $func( $key, $value, $expiration ) ) {
 			WP_CLI::success( 'Transient added.' );
-		else
+		} else {
 			WP_CLI::error( 'Transient could not be set.' );
+		}
 	}
 
 	/**
@@ -59,14 +68,19 @@ class Transient_Command extends WP_CLI_Command {
 	 *
 	 * <key>
 	 * : Key for the transient.
+	 *
+	 * [--network]
+	 * : Delete the value of a network transient, instead of that on a single site.
 	 */
-	public function delete( $args ) {
+	public function delete( $args, $assoc_args ) {
 		list( $key ) = $args;
 
-		if ( delete_transient( $key ) ) {
+		$func = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' ) ? 'delete_site_transient' : 'delete_transient';
+		if ( $func( $key ) ) {
 			WP_CLI::success( 'Transient deleted.' );
 		} else {
-			if ( get_transient( $key ) )
+			$func = \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' ) ? 'get_site_transient' : 'get_transient';
+			if ( $func( $key ) )
 				WP_CLI::error( 'Transient was not deleted even though the transient appears to exist.' );
 			else
 				WP_CLI::warning( 'Transient was not deleted; however, the transient does not appear to exist.' );


### PR DESCRIPTION
Fixes #1503