### PR TITLE
Introduce `WP_CLI\Utils\get_temp_dir()` for safer temp directories

### DIFF
--- a/php/WP_CLI/CoreUpgrader.php
+++ b/php/WP_CLI/CoreUpgrader.php
@@ -35,7 +35,7 @@ class CoreUpgrader extends \Core_Upgrader {
 		$filename = pathinfo( $package, PATHINFO_FILENAME );
 		$ext = pathinfo( $package, PATHINFO_EXTENSION );
 
-		$temp = sys_get_temp_dir() . '/' . uniqid('wp_') . '.' . $ext;
+		$temp = \WP_CLI\Utils\get_temp_dir() . uniqid('wp_') . '.' . $ext;
 
 		$cache = WP_CLI::get_cache();
 		$update = $GLOBALS['wp_cli_update_obj'];

--- a/php/WP_CLI/REPL.php
+++ b/php/WP_CLI/REPL.php
@@ -99,7 +99,7 @@ BASH;
 	private function set_history_file() {
 		$data = getcwd() . get_current_user();
 
-		$this->history_file = sys_get_temp_dir() . '/wp-cli-history-' . md5( $data );
+		$this->history_file = \WP_CLI\Utils\get_temp_dir() . 'wp-cli-history-' . md5( $data );
 	}
 
 	private static function starts_with( $tokens, $line ) {

--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -169,7 +169,7 @@ class CLI_Command extends WP_CLI_Command {
 
 		WP_CLI::log( sprintf( 'Downloading from %s...', $download_url ) );
 
-		$temp = sys_get_temp_dir() . '/' . uniqid('wp_') . '.phar';
+		$temp = \WP_CLI\Utils\get_temp_dir() . uniqid('wp_') . '.phar';
 
 		$headers = array();
 		$options = array(

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -119,7 +119,7 @@ class Core_Command extends WP_CLI_Command {
 		if ( ! $cache_file || $bad_cache ) {
 			// We need to use a temporary file because piping from cURL to tar is flaky
 			// on MinGW (and probably in other environments too).
-			$temp = sys_get_temp_dir() . '/' . uniqid('wp_') . '.tar.gz';
+			$temp = \WP_CLI\Utils\get_temp_dir() . uniqid('wp_') . '.tar.gz';
 
 			$headers = array('Accept' => 'application/json');
 			$options = array(

--- a/php/utils.php
+++ b/php/utils.php
@@ -21,7 +21,7 @@ function extract_from_phar( $path ) {
 
 	$fname = basename( $path );
 
-	$tmp_path = sys_get_temp_dir() . "/wp-cli-$fname";
+	$tmp_path = get_temp_dir() . "wp-cli-$fname";
 
 	copy( $path, $tmp_path );
 
@@ -576,4 +576,34 @@ function get_named_sem_ver( $new_version, $original_version ) {
  */
 function get_flag_value( $args, $flag, $default = null ) {
 	return isset( $args[ $flag ] ) ? $args[ $flag ] : $default;
+}
+
+/**
+ * Get the temp directory, and let the user know if it isn't writable.
+ *
+ * @return string
+ */
+function get_temp_dir() {
+	static $temp = '';
+
+	$trailingslashit = function( $path ) {
+		return rtrim( $path ) . '/';
+	};
+
+	if ( $temp )
+		return $trailingslashit( $temp );
+
+	if ( function_exists( 'sys_get_temp_dir' ) ) {
+		$temp = sys_get_temp_dir();
+	} else if ( ini_get( 'upload_tmp_dir' ) ) {
+		$temp = ini_get( 'upload_tmp_dir' );
+	} else {
+		$temp = '/tmp/';
+	}
+
+	if ( ! @is_writable( $temp ) ) {
+		WP_CLI::warning( "Temp directory isn't writable: {$temp}" );
+	}
+
+	return $trailingslashit( $temp );
 }


### PR DESCRIPTION
Also warns end user when the temp directory isn't writable.

Fixes #1118