### PR TITLE
DEP-6882 WP-CLI: wp-cli-package missing fix merged into wp-cli master

### DIFF
--- a/php/wp-cli.php
+++ b/php/wp-cli.php
@@ -2,7 +2,7 @@
 
 // Can be used by plugins/themes to check if WP-CLI is running or not
 define( 'WP_CLI', true );
-define( 'WP_CLI_VERSION', trim( file_get_contents( WP_CLI_ROOT . '/VERSION' ) ) );
+define( 'WP_CLI_VERSION', '0.21.3' );
 define( 'WP_CLI_START_MICROTIME', microtime( true ) );
 
 // Set common headers, to prevent warnings from plugins


### PR DESCRIPTION
### Reviewers

- [x] @ryanshoover 
- [ ] 

cc: 
### High level summary
Reverted how the WP_CLI version is defined to the way it was in 0.17.X.
This can be put back once we determine how to correclty map the VERSION
in the box package


### Automated tests
Type | Automated?
------------ | -------------
 Unit | 
 Functional | 
 Integration | 
 Smoke | 

### Manual smoke test instructions

#### Reason for manual tests

### Extra deploy steps

### Dependencies

