### PR TITLE
Switched confirm response to auto lower case

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -289,7 +289,7 @@ class WP_CLI {
 		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'yes' ) ) {
 			fwrite( STDOUT, $question . " [y/n] " );
 
-			$answer = trim( fgets( STDIN ) );
+			$answer = strtolower( trim( fgets( STDIN ) ) );
 
 			if ( 'y' != $answer )
 				exit;


### PR DESCRIPTION
Switching response to auto lower case allows us to use Y or y as yes