### PR TITLE
Check update file response status

### DIFF
--- a/php/WP_CLI/CoreUpgrader.php
+++ b/php/WP_CLI/CoreUpgrader.php
@@ -59,7 +59,11 @@ class CoreUpgrader extends \Core_Upgrader {
 
 			$this->skin->feedback( 'downloading_package', $package );
 
-			Utils\http_request( 'GET', $package, null, $headers, $options );
+			/** @var \Requests_Response|null $req */
+			$req = Utils\http_request( 'GET', $package, null, $headers, $options );
+			if ( ! is_null( $req ) && $req->status_code !== 200 ) {
+				return new \WP_Error( 'download_failed', $this->strings['download_failed'] );
+			}
 			$cache->import( $cache_key, $temp );
 			return $temp;
 		}
@@ -67,4 +71,3 @@ class CoreUpgrader extends \Core_Upgrader {
 	}
 
 }
-


### PR DESCRIPTION
Check update file download response status.

Now, when I try to update version which not already exist like 4.4.1-ja (that is it now), that return 404 and no content, but wp-cli try to unzip null file, and throw `PCLZIP_ERR_BAD_FORMAT (-10) : Unable to find End of Central Dir Record signature`.
It should check is response succeed.