### PR TITLE
Don't cd in WP_TESTS_DIR before dowloading and setting up wp-tests-config.php

### DIFF
--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -81,8 +81,6 @@ install_test_suite() {
 		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
 	fi
 
-	cd $WP_TESTS_DIR
-
 	if [ ! -f wp-tests-config.php ]; then
 		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php


### PR DESCRIPTION
The paths in the remaining of the function are relative to the main directory, so the script shouldn't cd in WP_TESTS_DIR.