### PR TITLE
Faster performance for `wp post list --format=count`

### DIFF
--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -312,6 +312,10 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 			$query_args['fields'] = 'ids';
 			$query = new WP_Query( $query_args );
 			echo implode( ' ', $query->posts );
+		} else if ( 'count' === $formatter->format ) {
+			$query_args['fields'] = 'ids';
+			$query = new WP_Query( $query_args );
+			$formatter->display_items( $query->posts );
 		} else {
 			$query = new WP_Query( $query_args );
 			$posts = array_map( function( $post ) {


### PR DESCRIPTION
When we only want the sum total, we don't need to fetch all data for
each post.