### PR TITLE
Use `shortdesc`, `synopsis`, and `when` with `::add_subcommand()`

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -199,3 +199,56 @@ Feature: WP-CLI Commands
       """
       Error: Callable ["Foo_Class","bar"] does not exist, and cannot be registered as `wp bar`.
       """
+
+  Scenario: Register a synopsis for a given command
+    Given an empty directory
+    And a custom-cmd.php file:
+      """
+      <?php
+      function foo( $args ) {
+        $message = array_shift( $args );
+        WP_CLI::log( 'Message is: ' . $message );
+        WP_CLI::success( $args[0] );
+      }
+      WP_CLI::add_command( 'foo', 'foo', array(
+        'shortdesc'   => 'My awesome function command',
+        'when'        => 'before_wp_load',
+        'synopsis'    => array(
+          array(
+            'type'          => 'positional',
+            'name'          => 'message',
+            'description'   => 'An awesome message to display',
+            'optional'      => false,
+          ),
+          array(
+            'type'          => 'assoc',
+            'name'          => 'apple',
+            'description'   => 'A type of fruit.',
+            'optional'      => false,
+          ),
+          array(
+            'type'          => 'assoc',
+            'name'          => 'meal',
+            'description'   => 'A type of meal.',
+            'optional'      => true,
+          ),
+        ),
+      ) );
+      """
+    And a wp-cli.yml file:
+      """
+      require:
+        - custom-cmd.php
+      """
+
+    When I try `wp foo`
+    Then STDOUT should contain:
+      """
+      usage: wp foo <message> --apple=<apple> [--meal=<meal>]
+      """
+
+    When I run `wp help foo`
+    Then STDOUT should contain:
+      """
+      My awesome function command
+      """

--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -100,6 +100,15 @@ class CompositeCommand {
 	}
 
 	/**
+	 * Set the short description for this composite command.
+	 *
+	 * @param string
+	 */
+	public function set_shortdesc( $shortdesc ) {
+		$this->shortdesc = $shortdesc;
+	}
+
+	/**
 	 * Get the long description for this composite
 	 * command.
 	 *

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -59,6 +59,15 @@ class Subcommand extends CompositeCommand {
 	}
 
 	/**
+	 * Set the synopsis string for this subcommand.
+	 *
+	 * @param string
+	 */
+	public function set_synopsis( $synopsis ) {
+		$this->synopsis = $synopsis;
+	}
+
+	/**
 	 * If an alias is set, grant access to it.
 	 * Aliases permit subcommands to be instantiated
 	 * with a secondary identity.

--- a/php/WP_CLI/SynopsisParser.php
+++ b/php/WP_CLI/SynopsisParser.php
@@ -35,6 +35,47 @@ class SynopsisParser {
 	}
 
 	/**
+	 * @param array A structured synopsis
+	 * @return string Rendered synopsis
+	 */
+	public static function render( $synopsis ) {
+		if ( ! is_array( $synopsis ) ) {
+			return '';
+		}
+		$bits = array( 'positional' => '', 'assoc' => '', 'flag' => '' );
+		foreach( $bits as $key => &$value ) {
+			foreach( $synopsis as $arg ) {
+				if ( empty( $arg['type'] )
+					|| empty( $arg['name'] )
+					|| $key !== $arg['type'] ) {
+					continue;
+				}
+				if ( 'positional' === $key ) {
+					$rendered_arg = "<{$arg['name']}>";
+				} else if ( 'assoc' === $key ) {
+					$rendered_arg = "--{$arg['name']}=<{$arg['name']}>";
+				} else if ( 'flag' === $key ) {
+					$rendered_arg = "--{$arg['name']}";
+				}
+				if ( ! empty( $arg['repeating'] ) ) {
+					$rendered_arg = "{$rendered_arg}...";
+				}
+				if ( ! empty( $arg['optional'] ) ) {
+					$rendered_arg = "[{$rendered_arg}]";
+				}
+				$value .= "{$rendered_arg} ";
+			}
+		}
+		$rendered = '';
+		foreach( $bits as $v ) {
+			if ( ! empty( $v ) ) {
+				$rendered .= $v;
+			}
+		}
+		return rtrim( $rendered, ' ' );
+	}
+
+	/**
 	 * Classify argument attributes based on its syntax.
 	 *
 	 * @param string $token

--- a/php/WP_CLI/SynopsisParser.php
+++ b/php/WP_CLI/SynopsisParser.php
@@ -42,18 +42,24 @@ class SynopsisParser {
 		if ( ! is_array( $synopsis ) ) {
 			return '';
 		}
-		$bits = array( 'positional' => '', 'assoc' => '', 'flag' => '' );
+		$bits = array( 'positional' => '', 'assoc' => '', 'generic' => '', 'flag' => '' );
 		foreach( $bits as $key => &$value ) {
 			foreach( $synopsis as $arg ) {
 				if ( empty( $arg['type'] )
-					|| empty( $arg['name'] )
 					|| $key !== $arg['type'] ) {
 					continue;
 				}
+
+				if ( empty( $arg['name'] ) && 'generic' !== $arg['type'] ) {
+					continue;
+				}
+
 				if ( 'positional' === $key ) {
 					$rendered_arg = "<{$arg['name']}>";
 				} else if ( 'assoc' === $key ) {
 					$rendered_arg = "--{$arg['name']}=<{$arg['name']}>";
+				} else if ( 'generic' === $key ) {
+					$rendered_arg = "--<field>=<value>";
 				} else if ( 'flag' === $key ) {
 					$rendered_arg = "--{$arg['name']}";
 				}
@@ -149,4 +155,3 @@ class SynopsisParser {
 		}
 	}
 }
-

--- a/tests/test-synopsis.php
+++ b/tests/test-synopsis.php
@@ -135,5 +135,41 @@ class SynopsisParserTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals( 'unknown', $r[3]['type'] );
 	}
-}
 
+	function testRender() {
+		$a = array(
+			array(
+				'name'        => 'message',
+				'type'        => 'positional',
+				'description' => 'A short message to display to the user.',
+			),
+			array(
+				'name'        => 'secrets',
+				'type'        => 'positional',
+				'description' => 'You may tell secrets, or you may not',
+				'optional'    => true,
+				'repeating'   => true,
+			),
+			array(
+				'name'        => 'meal',
+				'type'        => 'assoc',
+				'description' => 'A meal during the day or night.',
+			),
+			array(
+				'name'        => 'snack',
+				'type'        => 'assoc',
+				'description' => 'If you are hungry between meals, you should snack.',
+				'optional'    => true,
+			)
+		);
+		$this->assertEquals( '<message> [<secrets>...] --meal=<meal> [--snack=<snack>]', SynopsisParser::render( $a ) );
+	}
+
+	function testParseThenRender() {
+		$o = '<positional> --assoc=<assoc> --<field>=<value> [--flag]';
+		$a = SynopsisParser::parse( $o );
+		$r = SynopsisParser::render( $a );
+		$this->assertEquals( $o, $r );
+	}
+
+}


### PR DESCRIPTION
Permits registration of these command attributes through variable,
instead of PHPDoc. For instance:

```
WP_CLI::add_command( 'foo', 'foo', array(
  'shortdesc'   => 'My awesome function command',
  'when'        => 'before_wp_load',
  'synopsis'    => array(
    array(
      'type'          => 'positional',
      'name'          => 'message',
      'description'   => 'An awesome message to display',
      'optional'      => false,
    ),
    array(
      'type'          => 'assoc',
      'name'          => 'apple',
      'description'   => 'A type of fruit.',
      'optional'      => false,
    ),
    array(
      'type'          => 'assoc',
      'name'          => 'meal',
      'description'   => 'A type of meal.',
      'optional'      => true,
    ),
  ),
) );
```

See #2374