### PR TITLE
In `WP_CLI::error_to_string()`, `json_encode()` `WP_Error` data

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -401,10 +401,11 @@ class WP_CLI {
 
 		if ( is_object( $errors ) && is_a( $errors, 'WP_Error' ) ) {
 			foreach ( $errors->get_error_messages() as $message ) {
-				if ( $errors->get_error_data() )
-					return $message . ' ' . $errors->get_error_data();
-				else
+				if ( $errors->get_error_data() ) {
+					return $message . ' ' . json_encode( $errors->get_error_data() );
+				} else {
 					return $message;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Data is typically an array. Giving us a flattened array is more helpful
than indicating "Array"