### PR TITLE
Persist object when using `WP_CLI::add_command()` with class method

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -132,6 +132,56 @@ Feature: WP-CLI Commands
       """
       <?php
       class Foo_Class extends WP_CLI_Command {
+
+        public function __construct( $prefix ) {
+          $this->prefix = $prefix;
+        }
+        /**
+         * My awesome class method command
+         *
+         * <message>
+         * : An awesome message to display
+         *
+         * @when before_wp_load
+         */
+        function foo( $args ) {
+          WP_CLI::success( $this->prefix . ':' . $args[0] );
+        }
+      }
+      $foo = new Foo_Class( 'boo' );
+      WP_CLI::add_command( 'foo', array( $foo, 'foo' ) );
+      """
+
+    When I run `wp --require=custom-cmd.php help`
+    Then STDOUT should contain:
+      """
+      foo
+      """
+
+    When I run `wp --require=custom-cmd.php help foo`
+    Then STDOUT should contain:
+      """
+      My awesome class method command
+      """
+
+    When I try `wp --require=custom-cmd.php foo bar --burrito`
+    Then STDERR should contain:
+      """
+      unknown --burrito parameter
+      """
+
+    When I run `wp --require=custom-cmd.php foo bar`
+    Then STDOUT should contain:
+      """
+      Success: boo:bar
+      """
+
+  Scenario: Use a class method as a command
+    Given an empty directory
+    And a custom-cmd.php file:
+      """
+      <?php
+      class Foo_Class extends WP_CLI_Command {
         /**
          * My awesome class method command
          *
@@ -144,8 +194,7 @@ Feature: WP-CLI Commands
           WP_CLI::success( $args[0] );
         }
       }
-      $foo = new Foo_Class;
-      WP_CLI::add_command( 'foo', array( $foo, 'foo' ) );
+      WP_CLI::add_command( 'foo', array( 'Foo_Class', 'foo' ) );
       """
 
     When I run `wp --require=custom-cmd.php help`

--- a/php/WP_CLI/Dispatcher/CommandFactory.php
+++ b/php/WP_CLI/Dispatcher/CommandFactory.php
@@ -24,7 +24,7 @@ class CommandFactory {
 			$command = self::create_subcommand( $parent, $name, $callable, $reflection );
 		} else if ( is_array( $callable ) && is_callable( $callable ) ) {
 			$reflection = new \ReflectionClass( $callable[0] );
-			$command = self::create_subcommand( $parent, $name, array( $reflection->name, $callable[1] ),
+			$command = self::create_subcommand( $parent, $name, array( $callable[0], $callable[1] ),
 					$reflection->getMethod( $callable[1] ) );
 		} else {
 			$reflection = new \ReflectionClass( $callable );
@@ -62,7 +62,8 @@ class CommandFactory {
 
 		$when_invoked = function ( $args, $assoc_args ) use ( $callable ) {
 			if ( is_array( $callable ) ) {
-				call_user_func( array( new $callable[0], $callable[1] ), $args, $assoc_args );
+				$callable[0] = is_object( $callable[0] ) ? $callable[0] : new $callable[0];
+				call_user_func( array( $callable[0], $callable[1] ), $args, $assoc_args );
 			} else {
 				call_user_func( $callable, $args, $assoc_args );
 			}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -188,7 +188,8 @@ class WP_CLI {
 		}
 		if ( ! $valid ) {
 			if ( is_array( $callable ) ) {
-				$callable = array( get_class( $callable[0] ), $callable[1] );
+				$callable[0] = is_object( $callable[0] ) ? get_class( $callable[0] ) : $callable[0];
+				$callable = array( $callable[0], $callable[1] );
 			}
 			WP_CLI::error( sprintf( "Callable %s does not exist, and cannot be registered as `wp %s`.", json_encode( $callable ), $name ) );
 		}


### PR DESCRIPTION
This permits an instance to be shared between commands, or be
instantiated with additional data.

See #2204