### PR TITLE
Only prompt for the first command in the execution thread

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -124,6 +124,43 @@ Feature: WordPress code scaffolding
       node_modules/
       """
 
+  Scenario: Scaffold a plugin by prompting
+    Given a WP install
+    And a session file:
+      """
+      hello-world
+
+      Hello World
+      An awesome introductory plugin for WordPress
+      WP-CLI
+      http://wp-cli.org
+      http://wp-cli.org
+      n
+      Y
+      n
+      n
+      """
+
+    When I run `wp scaffold plugin --prompt < session`
+    Then STDOUT should not be empty
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+    And the wp-content/plugins/hello-world/readme.txt file should exist
+    And the wp-content/plugins/hello-world/tests directory should exist
+
+    When I run `wp plugin status hello-world`
+    Then STDOUT should contain:
+      """
+      Status: Active
+      """
+    And STDOUT should contain:
+      """
+      Name: Hello World
+      """
+    And STDOUT should contain:
+      """
+      Description: An awesome introductory plugin for WordPress
+      """
+
   Scenario: Scaffold a plugin and activate it
     Given a WP install
     When I run `wp scaffold plugin hello-world --activate`

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -288,8 +288,11 @@ class Subcommand extends CompositeCommand {
 	 * @param array $assoc_args
 	 */
 	public function invoke( $args, $assoc_args, $extra_args ) {
-		if ( \WP_CLI::get_config( 'prompt' ) )
+		static $prompted_once = false;
+		if ( \WP_CLI::get_config( 'prompt' ) && ! $prompted_once ) {
 			list( $args, $assoc_args ) = $this->prompt_args( $args, $assoc_args );
+			$prompted_once = true;
+		}
 
 		$to_unset = $this->validate_args( $args, $assoc_args, $extra_args );
 


### PR DESCRIPTION
Some WP-CLI commands call other WP-CLI commands, and can produce erroneous
results when they prompt a second time.