### PR TITLE
Don't ever clean up wp-content with `wp core update` or `wp core download`

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -73,7 +73,15 @@ Feature: Download WordPress
     When I run `wp core download --version=4.4`
     Then the wp-includes/rest-api.php file should exist
     Then the wp-includes/class-wp-comment.php file should exist
+    And STDOUT should not contain:
+      """
+      File removed: wp-content
+      """
 
     When I run `wp core download --version=4.3.2 --force`
     Then the wp-includes/rest-api.php file should not exist
     Then the wp-includes/class-wp-comment.php file should not exist
+    And STDOUT should not contain:
+      """
+      File removed: wp-content
+      """

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -164,6 +164,10 @@ Feature: Update WordPress core
     When I run `wp core update --version=4.4 --force`
     Then the wp-includes/rest-api.php file should exist
     Then the wp-includes/class-wp-comment.php file should exist
+    And STDOUT should not contain:
+      """
+      File removed: wp-content
+      """
 
     When I run `wp core update --version=4.3.2 --force`
     Then the wp-includes/rest-api.php file should not exist
@@ -177,6 +181,10 @@ Feature: Update WordPress core
       File removed: wp-includes/class-wp-http-response.php
       File removed: wp-includes/class-walker-category-dropdown.php
       File removed: wp-includes/rest-api.php
+      """
+    And STDOUT should not contain:
+      """
+      File removed: wp-content
       """
 
     When I run `wp option add str_opt 'bar'`

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -1185,6 +1185,12 @@ EOT;
 
 			$count = 0;
 			foreach ( $files_to_remove as $file ) {
+
+				// wp-content should be considered user data
+				if ( 0 === stripos( $file, 'wp-content' ) ) {
+					continue;
+				}
+
 				if ( file_exists( ABSPATH . $file ) ) {
 					unlink( ABSPATH . $file );
 					WP_CLI::log( 'File removed: ' . $file );


### PR DESCRIPTION
Everything in wp-content should be considered user data

cc @gilbitron

Inroduced in #2382