### PR TITLE
Only display `$shortdesc` in man doc when present.

### DIFF
--- a/templates/man.mustache
+++ b/templates/man.mustache
@@ -2,10 +2,12 @@
 
 	{{name}}
 
+{{#shortdesc}}
 ## DESCRIPTION
 
 	{{shortdesc}}
 
+{{/shortdesc}}
 ## SYNOPSIS
 
 	{{synopsis}}


### PR DESCRIPTION
Sometimes there may not be a short description available.