### PR TITLE
Don't `exit` on premature success for `wp theme activate`

### DIFF
--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -131,7 +131,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 
 		if ( 'active' === $this->get_status( $theme ) ) {
 			WP_CLI::success( "The '$name' theme is already active." );
-			exit;
+			return;
 		}
 
 		if ( $theme->get_stylesheet() != $theme->get_template() && ! $this->fetcher->get( $theme->get_template() ) ) {


### PR DESCRIPTION
This can kill other scripts calling the method directly. `return` is
fine for our needs to stop command execution.

Fixes #2411