### PR TITLE
Only clean up `wp core download` when WP was already present

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -73,9 +73,9 @@ Feature: Download WordPress
     When I run `wp core download --version=4.4`
     Then the wp-includes/rest-api.php file should exist
     Then the wp-includes/class-wp-comment.php file should exist
-    And STDOUT should not contain:
+    And STDERR should not contain:
       """
-      File removed: wp-content
+      Warning: Failed to find WordPress version. Please cleanup files manually.
       """
 
     When I run `wp core download --version=4.3.2 --force`

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -75,8 +75,9 @@ class Core_Command extends WP_CLI_Command {
 	public function download( $args, $assoc_args ) {
 
 		$download_dir = ! empty( $assoc_args['path'] ) ? $assoc_args['path'] : ABSPATH;
+		$wordpress_present = is_readable( $download_dir . 'wp-load.php' );
 
-		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) && is_readable( $download_dir . 'wp-load.php' ) )
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) && $wordpress_present )
 			WP_CLI::error( 'WordPress files seem to already be present here.' );
 
 		if ( !is_dir( $download_dir ) ) {
@@ -150,7 +151,9 @@ class Core_Command extends WP_CLI_Command {
 			unlink($temp);
 		}
 
-		$this->cleanup_extra_files( $from_version, $assoc_args['version'], $locale );
+		if ( $wordpress_present ) {
+			$this->cleanup_extra_files( $from_version, $version, $locale );
+		}
 
 		WP_CLI::success( 'WordPress downloaded.' );
 	}


### PR DESCRIPTION
If we're downloading to an empty directory, skip the operation.

Bug introduced in #2382