### PR TITLE
Check if taxonomy exists before listing its terms

### DIFF
--- a/features/term.feature
+++ b/features/term.feature
@@ -49,6 +49,12 @@ Feature: Manage WordPress terms
       | name      | Test term  |
       | taxonomy  | post_tag   |
 
+    When I try `wp term list nonexistent_taxonomy`
+    Then STDERR should be:
+      """
+      Error: Taxonomy nonexistent_taxonomy doesn't exist.
+      """
+
   Scenario: Creating/deleting a term
     When I run `wp term create post_tag 'Test delete term' --slug=test-delete --description='This is a test term to be deleted' --porcelain`
     Then STDOUT should be a number

--- a/php/commands/term.php
+++ b/php/commands/term.php
@@ -59,6 +59,12 @@ class Term_Command extends WP_CLI_Command {
 	 * @subcommand list
 	 */
 	public function list_( $args, $assoc_args ) {
+		foreach ( $args as $taxonomy ) {
+			if ( ! taxonomy_exists( $taxonomy ) ) {
+				WP_CLI::error( "Taxonomy $taxonomy doesn't exist." );
+			}
+		}
+
 		$formatter = $this->get_formatter( $assoc_args );
 
 		$defaults = array(


### PR DESCRIPTION
Check if taxonomy exists before listing its terms to differentiate between a taxonomy with no terms and a nonexistent taxonomy,