### PR TITLE
Fix `wp server` when php binary contains spaces

### DIFF
--- a/php/commands/server.php
+++ b/php/commands/server.php
@@ -53,15 +53,21 @@ class Server_Command extends WP_CLI_Command {
 			}
 		}
 
-		$cmd = \WP_CLI\Utils\esc_cmd( PHP_BINARY . ' -S %s -t %s %s',
+		$cmd = \WP_CLI\Utils\esc_cmd( '%s -S %s -t %s %s',
+			PHP_BINARY,
 			$assoc_args['host'] . ':' . $assoc_args['port'],
 			$docroot,
 			\WP_CLI\Utils\extract_from_phar( WP_CLI_ROOT . '/php/router.php' )
 		);
 
 		$descriptors = array( STDIN, STDOUT, STDERR );
+		
+		// https://bugs.php.net/bug.php?id=60181
+		$options = array();
+		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
+			$options["bypass_shell"] = TRUE;
 
-		exit( proc_close( proc_open( $cmd, $descriptors, $pipes ) ) );
+		exit( proc_close( proc_open( $cmd, $descriptors, $pipes, NULL, NULL, $options ) ) );
 	}
 }
 


### PR DESCRIPTION
Ran this on windows:

```
B:\Archpaper>vendor\bin\wp server --port=4900 --path=build
'C:\Program' is not recognized as an internal or external command,
operable program or batch file.
```

While fixing, ran into a different [bug in PHP](https://bugs.php.net/bug.php?id=60181) (it seems to be windows-specific, but I can't confirm as all my linux php binaries reside in folders without spaces), so I added a workaround for that as well.

This is what I get after applying the fix:

```
B:\Archpaper>vendor\bin\wp server --port=4900 --path=build
PHP 7.0.1 Development Server started at Fri Jan 29 22:46:00 2016
Listening on http://localhost:4900
Document root is B:\Archpaper\build
Press Ctrl-C to quit.
```