### PR TITLE
Support for cleaning up files when ZIP is provided to `core update`

### DIFF
--- a/features/core-check-update.feature
+++ b/features/core-check-update.feature
@@ -10,8 +10,8 @@ Feature: Check for more recent versions
     When I run `wp core check-update`
     Then STDOUT should be a table containing rows:
       | version | update_type | package_url                                |
-      | 4.4.1   | major       | https://wordpress.org/wordpress-4.4.1.zip  |
-      | 3.8.12  | minor       | https://wordpress.org/wordpress-3.8.12.zip |
+      | 4.4.2   | major       | https://wordpress.org/wordpress-4.4.2.zip  |
+      | 3.8.13  | minor       | https://wordpress.org/wordpress-3.8.13.zip |
 
     When I run `wp core check-update --format=count`
     Then STDOUT should be:
@@ -22,7 +22,7 @@ Feature: Check for more recent versions
     When I run `wp core check-update --major`
     Then STDOUT should be a table containing rows:
       | version | update_type | package_url                                |
-      | 4.4.1   | major       | https://wordpress.org/wordpress-4.4.1.zip  |
+      | 4.4.2   | major       | https://wordpress.org/wordpress-4.4.2.zip  |
 
     When I run `wp core check-update --major --format=count`
     Then STDOUT should be:
@@ -33,7 +33,7 @@ Feature: Check for more recent versions
     When I run `wp core check-update --minor`
     Then STDOUT should be a table containing rows:
       | version | update_type | package_url                                |
-      | 3.8.12  | minor       | https://wordpress.org/wordpress-3.8.12.zip |
+      | 3.8.13  | minor       | https://wordpress.org/wordpress-3.8.13.zip |
 
     When I run `wp core check-update --minor --format=count`
     Then STDOUT should be:

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -19,6 +19,8 @@ Feature: Update WordPress core
       """
       Starting update...
       Unpacking the update...
+      Cleaning up files...
+      No files found that need cleaned up
       Success: WordPress updated successfully.
       """
 
@@ -38,7 +40,7 @@ Feature: Update WordPress core
     When I run `wp core update --minor`
     Then STDOUT should contain:
       """
-      Updating to version 3.7.12
+      Updating to version 3.7.13
       """
 
     When I run `wp core update --minor`
@@ -50,7 +52,7 @@ Feature: Update WordPress core
     When I run `wp core version`
     Then STDOUT should be:
       """
-      3.7.12
+      3.7.13
       """
 
   @less-than-php-7

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -982,9 +982,6 @@ EOT;
 			$result = Utils\get_upgrader( $upgrader )->upgrade( $update );
 			unset( $GLOBALS['wp_cli_update_obj'] );
 
-			$locale = \WP_CLI\Utils\get_flag_value( $assoc_args, 'locale', get_locale() );
-			$this->cleanup_extra_files( $from_version, $update->version, $locale );
-
 			if ( is_wp_error($result) ) {
 				$msg = WP_CLI::error_to_string( $result );
 				if ( 'up_to_date' != $result->get_error_code() ) {
@@ -993,6 +990,15 @@ EOT;
 					WP_CLI::success( $msg );
 				}
 			} else {
+
+				if ( file_exists( ABSPATH . 'wp-includes/version.php' ) ) {
+					include( ABSPATH . 'wp-includes/version.php' );
+					$to_version = $wp_version;
+				}
+
+				$locale = \WP_CLI\Utils\get_flag_value( $assoc_args, 'locale', get_locale() );
+				$this->cleanup_extra_files( $from_version, $to_version, $locale );
+
 				WP_CLI::success( 'WordPress updated successfully.' );
 			}
 


### PR DESCRIPTION
Also bumps WP version in tests for latest release.

From #2382