### PR TITLE
Add a timer to individual events in `wp cron event run`

### DIFF
--- a/features/cron.feature
+++ b/features/cron.feature
@@ -72,10 +72,16 @@ Feature: Manage WP-Cron events and schedules
       | wp_cli_test_event_5 | Non-repeating | {"foo":"bar"}       |
 
     When I run `wp cron event run wp_cli_test_event_5`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
-      Executed the cron event 'wp_cli_test_event_5'.
-      Executed the cron event 'wp_cli_test_event_5'.
+      Executed the cron event 'wp_cli_test_event_5'
+      """
+    And STDOUT should contain:
+      """
+      Executed the cron event 'wp_cli_test_event_5'
+      """
+    And STDOUT should contain:
+      """
       Success: Executed a total of 2 cron event(s).
       """
 
@@ -187,11 +193,11 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event run wp_version_check wp_update_plugins`
     Then STDOUT should contain:
       """
-      Executed the cron event 'wp_version_check'.
+      Executed the cron event 'wp_version_check'
       """
     And STDOUT should contain:
       """
-      Executed the cron event 'wp_update_plugins'.
+      Executed the cron event 'wp_update_plugins'
       """
     And STDOUT should contain:
       """
@@ -201,15 +207,15 @@ Feature: Manage WP-Cron events and schedules
     When I run `wp cron event run --all`
     Then STDOUT should contain:
       """
-      Executed the cron event 'wp_version_check'.
+      Executed the cron event 'wp_version_check'
       """
     And STDOUT should contain:
       """
-      Executed the cron event 'wp_update_plugins'.
+      Executed the cron event 'wp_update_plugins'
       """
     And STDOUT should contain:
       """
-      Executed the cron event 'wp_update_themes'.
+      Executed the cron event 'wp_update_themes'
       """
     And STDOUT should contain:
       """

--- a/php/commands/cron.php
+++ b/php/commands/cron.php
@@ -174,10 +174,12 @@ class Cron_Event_Command extends WP_CLI_Command {
 		$executed = 0;
 		foreach ( $events as $event ) {
 			if ( in_array( $event->hook, $args ) || \WP_CLI\Utils\get_flag_value( $assoc_args, 'all' ) ) {
+				$start = microtime( true );
 				$result = self::run_event( $event );
+				$total = round( microtime( true ) - $start, 3 );
 				if ( $result ) {
 					$executed++;
-					WP_CLI::log( sprintf( "Executed the cron event '%s'.", $event->hook ) );
+					WP_CLI::log( sprintf( "Executed the cron event '%s' in %ss.", $event->hook, $total ) );
 				} else {
 					WP_CLI::warning( sprintf( "Failed to the execute the cron event '%s'.", $event->hook ) );
 				}


### PR DESCRIPTION
When running multiple events at once, this makes it easier to see which
are taking a long time.

```
salty-wordpress ➜  wordpress-develop.dev  wp cron event run --all
Executed the cron event 'wp_update_plugins' in 0.421s.
Executed the cron event 'wp_update_themes' in 0.287s.
Executed the cron event 'wp_version_check' in 1.315s.
Executed the cron event 'update_network_counts' in 0.004s.
Executed the cron event 'wp_scheduled_auto_draft_delete' in 0.004s.
Success: Executed a total of 5 cron event(s).
```

Fixes #2434