### PR TITLE
Persist IPTC data in `wp media import` when missing title/caption

### DIFF
--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -60,6 +60,20 @@ Feature: Manage WordPress attachments
       My fabulous caption
       """
 
+  Scenario: Import a file and use its filename as the title
+    Given download:
+      | path                        | url                                              |
+      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
+
+    When I run `wp media import {CACHE_DIR}/large-image.jpg --porcelain`
+    Then save STDOUT as {ATTACHMENT_ID}
+
+    When I run `wp post get {ATTACHMENT_ID} --field=title`
+    Then STDOUT should be:
+      """
+      large-image.jpg
+      """
+
   Scenario: Import a file and persist its original metadata
     Given download:
       | path                         | url                                              |

--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -45,11 +45,37 @@ Feature: Manage WordPress attachments
       | path                        | url                                              |
       | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
 
-    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported attachment" --porcelain`
+    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported attachment" --caption="My fabulous caption" --porcelain`
     Then save STDOUT as {ATTACHMENT_ID}
 
     When I run `wp post get {ATTACHMENT_ID} --field=title`
     Then STDOUT should be:
       """
       My imported attachment
+      """
+
+    When I run `wp post get {ATTACHMENT_ID} --field=excerpt`
+    Then STDOUT should be:
+      """
+      My fabulous caption
+      """
+
+  Scenario: Import a file and persist its original metadata
+    Given download:
+      | path                         | url                                              |
+      | {CACHE_DIR}/canola.jpg       | http://wp-cli.org/behat-data/canola.jpg          |
+
+    When I run `wp media import {CACHE_DIR}/canola.jpg --porcelain`
+    Then save STDOUT as {ATTACHMENT_ID}
+
+    When I run `wp post get {ATTACHMENT_ID} --field=title`
+    Then STDOUT should be:
+      """
+      A field of amazing canola
+      """
+
+    When I run `wp post get {ATTACHMENT_ID} --field=excerpt`
+    Then STDOUT should be:
+      """
+      The description for the image
       """

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -169,7 +169,6 @@ class Media_Command extends WP_CLI_Command {
 			if ( empty( $post_array['post_title'] ) || empty( $post_array['post_excerpt'] ) ) {
 				// @codingStandardsIgnoreStart
 				$image_meta = @wp_read_image_metadata( $tempfile );
-				error_log( var_export( $image_meta, true ) );
 				// @codingStandardsIgnoreEnd
 				if ( ! empty( $image_meta ) ) {
 					if ( empty( $post_array['post_title'] ) && trim( $image_meta['title'] ) && ! is_numeric( sanitize_title( $image_meta['title'] ) ) ) {

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -181,6 +181,10 @@ class Media_Command extends WP_CLI_Command {
 				}
 			}
 
+			if ( empty( $post_array['post_title'] ) ) {
+				$post_array['post_title'] = $file_array['name'];
+			}
+
 			// Deletes the temporary file.
 			$success = media_handle_sideload( $file_array, $assoc_args['post_id'], $assoc_args['title'], $post_array );
 			if ( is_wp_error( $success ) ) {

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -165,6 +165,23 @@ class Media_Command extends WP_CLI_Command {
 				'post_content' => $assoc_args['desc']
 			);
 
+			// use image exif/iptc data for title and caption defaults if possible
+			if ( empty( $post_array['post_title'] ) || empty( $post_array['post_excerpt'] ) ) {
+				// @codingStandardsIgnoreStart
+				$image_meta = @wp_read_image_metadata( $tempfile );
+				error_log( var_export( $image_meta, true ) );
+				// @codingStandardsIgnoreEnd
+				if ( ! empty( $image_meta ) ) {
+					if ( empty( $post_array['post_title'] ) && trim( $image_meta['title'] ) && ! is_numeric( sanitize_title( $image_meta['title'] ) ) ) {
+						$post_array['post_title'] = $image_meta['title'];
+					}
+
+					if ( empty( $post_array['post_excerpt'] ) && trim( $image_meta['caption'] ) ) {
+						$post_array['post_excerpt'] = $image_meta['caption'];
+					}
+				}
+			}
+
 			// Deletes the temporary file.
 			$success = media_handle_sideload( $file_array, $assoc_args['post_id'], $assoc_args['title'], $post_array );
 			if ( is_wp_error( $success ) ) {


### PR DESCRIPTION
If no IPTC data is present, use the filename as the attachment title.

Fixes #2416