### PR TITLE
Introduce `wp package` for managing WP-CLI community commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 config.yml
 /cache
+/packages
 /vendor
 /*.phar
 /phpunit.xml.dist

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
 		"symfony/dependency-injection": "2.7.*",
 		"symfony/event-dispatcher": "2.7.*",
 		"symfony/translation": "2.7.*",
-		"nb/oxymel": "0.1.0"
+		"nb/oxymel": "0.1.0",
+		"composer/composer": "1.0.0-alpha11"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "3.7.*",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
 		"symfony/console": "2.7.*",
 		"symfony/dependency-injection": "2.7.*",
 		"symfony/event-dispatcher": "2.7.*",
+		"symfony/process": "~2.1",
 		"symfony/translation": "2.7.*",
 		"nb/oxymel": "0.1.0",
 		"composer/composer": "1.0.0-alpha11"

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,83 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7359993f535213af66c2148ea27369b3",
-    "content-hash": "da7f9e8dee2ffe0f76e5ed64233ecda9",
+    "hash": "73c38df6a0ba5a0690655b528fadb0f3",
+    "content-hash": "c201c938374a2ff19d8f0388a49475ff",
     "packages": [
+        {
+            "name": "composer/composer",
+            "version": "1.0.0-alpha11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/composer.git",
+                "reference": "cd9054ce2abd1d06ed0eb1244eba1b2c2af633b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/composer/zipball/cd9054ce2abd1d06ed0eb1244eba1b2c2af633b6",
+                "reference": "cd9054ce2abd1d06ed0eb1244eba1b2c2af633b6",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^1.0",
+                "composer/spdx-licenses": "^1.0",
+                "justinrainbow/json-schema": "^1.4.4",
+                "php": "^5.3.2 || ^7.0",
+                "seld/cli-prompt": "^1.0",
+                "seld/jsonlint": "^1.0",
+                "seld/phar-utils": "^1.0",
+                "symfony/console": "^2.5 || ^3.0",
+                "symfony/filesystem": "^2.5 || ^3.0",
+                "symfony/finder": "^2.2 || ^3.0",
+                "symfony/process": "^2.1 || ^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5",
+                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",
+                "ext-zip": "Enabling the zip extension allows you to unzip archives, and allows gzip compression of all internet traffic"
+            },
+            "bin": [
+                "bin/composer"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\": "src/Composer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Composer helps you declare, manage and install dependencies of PHP projects, ensuring you have the right stack everywhere.",
+            "homepage": "https://getcomposer.org/",
+            "keywords": [
+                "autoload",
+                "dependency",
+                "package"
+            ],
+            "time": "2015-11-14 16:21:07"
+        },
         {
             "name": "composer/semver",
             "version": "1.0.0",
@@ -67,6 +141,133 @@
                 "versioning"
             ],
             "time": "2015-09-21 09:42:36"
+        },
+        {
+            "name": "composer/spdx-licenses",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/spdx-licenses.git",
+                "reference": "9e1c3926bb0842812967213d7c92827bc5883671"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/9e1c3926bb0842812967213d7c92827bc5883671",
+                "reference": "9e1c3926bb0842812967213d7c92827bc5883671",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5",
+                "phpunit/phpunit-mock-objects": "~2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Spdx\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "SPDX licenses list and validation library.",
+            "keywords": [
+                "license",
+                "spdx",
+                "validator"
+            ],
+            "time": "2015-10-05 11:27:42"
+        },
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "cc84765fb7317f6b07bd8ac78364747f95b86341"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/cc84765fb7317f6b07bd8ac78364747f95b86341",
+                "reference": "cc84765fb7317f6b07bd8ac78364747f95b86341",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.29"
+            },
+            "require-dev": {
+                "json-schema/json-schema-test-suite": "1.1.0",
+                "phpdocumentor/phpdocumentor": "~2",
+                "phpunit/phpunit": "~3.7"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "time": "2016-01-25 15:43:01"
         },
         {
             "name": "mustache/mustache",
@@ -297,17 +498,155 @@
             "time": "2014-05-18 04:59:02"
         },
         {
-            "name": "symfony/config",
-            "version": "v2.7.7",
+            "name": "seld/cli-prompt",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/config.git",
-                "reference": "61973327bfb054f6f470de7be033a28b76c1dc20"
+                "url": "https://github.com/Seldaek/cli-prompt.git",
+                "reference": "b27db1514f7d7bb7a366ad95d4eb2b17140a0691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/61973327bfb054f6f470de7be033a28b76c1dc20",
-                "reference": "61973327bfb054f6f470de7be033a28b76c1dc20",
+                "url": "https://api.github.com/repos/Seldaek/cli-prompt/zipball/b27db1514f7d7bb7a366ad95d4eb2b17140a0691",
+                "reference": "b27db1514f7d7bb7a366ad95d4eb2b17140a0691",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Seld\\CliPrompt\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Allows you to prompt for user input on the command line, and optionally hide the characters they type",
+            "keywords": [
+                "cli",
+                "console",
+                "hidden",
+                "input",
+                "prompt"
+            ],
+            "time": "2016-01-09 17:55:27"
+        },
+        {
+            "name": "seld/jsonlint",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "66834d3e3566bb5798db7294619388786ae99394"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/66834d3e3566bb5798db7294619388786ae99394",
+                "reference": "66834d3e3566bb5798db7294619388786ae99394",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "time": "2015-11-21 02:21:41"
+        },
+        {
+            "name": "seld/phar-utils",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/phar-utils.git",
+                "reference": "7009b5139491975ef6486545a39f3e6dad5ac30a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/phar-utils/zipball/7009b5139491975ef6486545a39f3e6dad5ac30a",
+                "reference": "7009b5139491975ef6486545a39f3e6dad5ac30a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Seld\\PharUtils\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "PHAR file format utilities, for when PHP phars you up",
+            "keywords": [
+                "phra"
+            ],
+            "time": "2015-10-13 18:44:15"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v2.7.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "fbd0083cd9dac06556bd1096deaa0295c18a7584"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/fbd0083cd9dac06556bd1096deaa0295c18a7584",
+                "reference": "fbd0083cd9dac06556bd1096deaa0295c18a7584",
                 "shasum": ""
             },
             "require": {
@@ -344,20 +683,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-02 20:20:53"
+            "time": "2016-01-03 15:32:00"
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.7",
+            "version": "v2.7.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "16bb1cb86df43c90931df65f529e7ebd79636750"
+                "reference": "d3fc138b6ed8f8074591821d3416d8f9c04d6ca6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/16bb1cb86df43c90931df65f529e7ebd79636750",
-                "reference": "16bb1cb86df43c90931df65f529e7ebd79636750",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d3fc138b6ed8f8074591821d3416d8f9c04d6ca6",
+                "reference": "d3fc138b6ed8f8074591821d3416d8f9c04d6ca6",
                 "shasum": ""
             },
             "require": {
@@ -403,20 +742,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-18 09:54:26"
+            "time": "2016-01-14 08:26:43"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.7.7",
+            "version": "v2.7.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "7a201bf08c29e47075047cbb378724ad46dfe217"
+                "reference": "37dfddbf3791d79b46b11f610b39e90d622e7183"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/7a201bf08c29e47075047cbb378724ad46dfe217",
-                "reference": "7a201bf08c29e47075047cbb378724ad46dfe217",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/37dfddbf3791d79b46b11f610b39e90d622e7183",
+                "reference": "37dfddbf3791d79b46b11f610b39e90d622e7183",
                 "shasum": ""
             },
             "require": {
@@ -465,20 +804,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-23 10:17:36"
+            "time": "2016-01-12 17:44:11"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.7",
+            "version": "v2.7.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "7e2f9c31645680026c2372edf66f863fc7757af5"
+                "reference": "79493b6421786e5a0fc2d161410aa86f400bcaea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7e2f9c31645680026c2372edf66f863fc7757af5",
-                "reference": "7e2f9c31645680026c2372edf66f863fc7757af5",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/79493b6421786e5a0fc2d161410aa86f400bcaea",
+                "reference": "79493b6421786e5a0fc2d161410aa86f400bcaea",
                 "shasum": ""
             },
             "require": {
@@ -525,20 +864,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-30 20:10:21"
+            "time": "2016-01-13 10:26:43"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.7.7",
+            "version": "v2.7.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "8e173509d7fdbbba3cf34d6d072f2073c0210c1d"
+                "reference": "78188c6971053ff8eaa00fa180c0747c296152f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/8e173509d7fdbbba3cf34d6d072f2073c0210c1d",
-                "reference": "8e173509d7fdbbba3cf34d6d072f2073c0210c1d",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/78188c6971053ff8eaa00fa180c0747c296152f6",
+                "reference": "78188c6971053ff8eaa00fa180c0747c296152f6",
                 "shasum": ""
             },
             "require": {
@@ -574,20 +913,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-18 13:41:01"
+            "time": "2016-01-13 07:57:33"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.7.7",
+            "version": "v2.7.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "a06a0c0ff7db3736a50d530c908cca547bf13da9"
+                "reference": "d20ac81c81a67ab898b0c0afa435f3e9a7d460cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/a06a0c0ff7db3736a50d530c908cca547bf13da9",
-                "reference": "a06a0c0ff7db3736a50d530c908cca547bf13da9",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/d20ac81c81a67ab898b0c0afa435f3e9a7d460cf",
+                "reference": "d20ac81c81a67ab898b0c0afa435f3e9a7d460cf",
                 "shasum": ""
             },
             "require": {
@@ -623,20 +962,69 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-30 20:10:21"
+            "time": "2016-01-14 08:26:43"
         },
         {
-            "name": "symfony/translation",
-            "version": "v2.7.7",
+            "name": "symfony/process",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/translation.git",
-                "reference": "e4ecb9c3ba1304eaf24de15c2d7a428101c1982f"
+                "url": "https://github.com/symfony/process.git",
+                "reference": "dfecef47506179db2501430e732adbf3793099c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/e4ecb9c3ba1304eaf24de15c2d7a428101c1982f",
-                "reference": "e4ecb9c3ba1304eaf24de15c2d7a428101c1982f",
+                "url": "https://api.github.com/repos/symfony/process/zipball/dfecef47506179db2501430e732adbf3793099c8",
+                "reference": "dfecef47506179db2501430e732adbf3793099c8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-02-02 13:44:19"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v2.7.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "8cbab8445ad4269427077ba02fff8718cb397e22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/8cbab8445ad4269427077ba02fff8718cb397e22",
+                "reference": "8cbab8445ad4269427077ba02fff8718cb397e22",
                 "shasum": ""
             },
             "require": {
@@ -686,20 +1074,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-18 13:41:01"
+            "time": "2016-01-03 15:32:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.7",
+            "version": "v2.7.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "4cfcd7a9fceba662b3c036b7d9a91f6197af046c"
+                "reference": "a91e8af3dcde226e00be2e1c068764eef7b4c153"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/4cfcd7a9fceba662b3c036b7d9a91f6197af046c",
-                "reference": "4cfcd7a9fceba662b3c036b7d9a91f6197af046c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a91e8af3dcde226e00be2e1c068764eef7b4c153",
+                "reference": "a91e8af3dcde226e00be2e1c068764eef7b4c153",
                 "shasum": ""
             },
             "require": {
@@ -735,7 +1123,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-18 13:41:01"
+            "time": "2016-01-13 10:26:43"
         },
         {
             "name": "wp-cli/php-cli-tools",
@@ -1278,7 +1666,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "wp-cli/php-cli-tools": 20
+        "composer/composer": 15
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "73c38df6a0ba5a0690655b528fadb0f3",
-    "content-hash": "c201c938374a2ff19d8f0388a49475ff",
+    "hash": "be16eacf74b49e94af4974a9c8c2460e",
+    "content-hash": "5045f45078e9ea1cfb8087b858d377ac",
     "packages": [
         {
             "name": "composer/composer",
@@ -966,25 +966,25 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.0.2",
+            "version": "v2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "dfecef47506179db2501430e732adbf3793099c8"
+                "reference": "6f1979c3b0f4c22c77a8a8971afaa7dd07f082ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/dfecef47506179db2501430e732adbf3793099c8",
-                "reference": "dfecef47506179db2501430e732adbf3793099c8",
+                "url": "https://api.github.com/repos/symfony/process/zipball/6f1979c3b0f4c22c77a8a8971afaa7dd07f082ac",
+                "reference": "6f1979c3b0f4c22c77a8a8971afaa7dd07f082ac",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": ">=5.3.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1011,7 +1011,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-02 13:44:19"
+            "time": "2016-01-06 09:59:23"
         },
         {
             "name": "symfony/translation",

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -45,7 +45,8 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		$bin_dir = getenv( 'WP_CLI_BIN_DIR' ) ?: realpath( __DIR__ . "/../../bin" );
 		$env = array(
 			'PATH' =>  $bin_dir . ':' . getenv( 'PATH' ),
-			'BEHAT_RUN' => 1
+			'BEHAT_RUN' => 1,
+			'HOME' => '/tmp/wp-cli-home',
 		);
 		if ( $config_path = getenv( 'WP_CLI_CONFIG_PATH' ) ) {
 			$env['WP_CLI_CONFIG_PATH'] = $config_path;

--- a/features/package.feature
+++ b/features/package.feature
@@ -1,0 +1,31 @@
+Feature: Manage WP-CLI packages
+
+  Scenario: Package CRUD
+    Given an empty directory
+
+    When I run `wp package browse`
+    Then STDOUT should contain:
+      """
+      danielbachhuber/wp-cli-reset-post-date-command
+      """
+
+    When I run `wp package install danielbachhuber/wp-cli-reset-post-date-command`
+    Then STDERR should be empty
+
+    When I run `wp help reset-post-date`
+    Then STDERR should be empty
+
+    When I run `wp package list`
+    Then STDOUT should contain:
+      """
+      danielbachhuber/wp-cli-reset-post-date-command
+      """
+
+    When I run `wp package uninstall danielbachhuber/wp-cli-reset-post-date-command`
+    Then STDERR should be empty
+
+    When I run `wp package list`
+    Then STDOUT should not contain:
+      """
+      danielbachhuber/wp-cli-reset-post-date-command
+      """

--- a/php/WP_CLI/ComposerIO.php
+++ b/php/WP_CLI/ComposerIO.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace WP_CLI;
+
+use \Composer\IO\NullIO;
+use \WP_CLI;
+
+/**
+ * A Composer IO class so we can provide some level of interactivity from WP-CLI
+ */
+class ComposerIO extends NullIO {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isVerbose() {
+		return true;
+	}
+
+	/**
+     * {@inheritDoc}
+     */
+	public function write( $messages, $newline = true ) {
+		WP_CLI::log( " - " . strip_tags( $messages ) );
+	}
+
+}

--- a/php/WP_CLI/PackageManagerEventSubscriber.php
+++ b/php/WP_CLI/PackageManagerEventSubscriber.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace WP_CLI;
+
+use \Composer\DependencyResolver\Rule;
+use \Composer\EventDispatcher\Event;
+use \Composer\EventDispatcher\EventSubscriberInterface;
+use \Composer\Script\PackageEvent;
+use \Composer\Script\ScriptEvents;
+use \WP_CLI;
+
+/**
+ * A Composer Event subscriber so we can keep track of what's happening inside Composer
+ */
+class PackageManagerEventSubscriber implements EventSubscriberInterface {
+
+	public static function getSubscribedEvents() {
+
+		return array(
+			ScriptEvents::PRE_PACKAGE_INSTALL => 'pre_install',
+			ScriptEvents::POST_PACKAGE_INSTALL => 'post_install',
+			);
+	}
+
+	public static function pre_install( PackageEvent $event ) {
+		WP_CLI::log( ' - Installing package' );
+	}
+
+	public static function post_install( PackageEvent $event ) {
+
+		$operation = $event->getOperation();
+		$reason = $operation->getReason();
+		if ( $reason instanceof Rule ) {
+
+			switch ( $reason->getReason() ) {
+
+				case Rule::RULE_PACKAGE_CONFLICT;
+				case Rule::RULE_PACKAGE_SAME_NAME:
+				case Rule::RULE_PACKAGE_REQUIRES:
+					$composer_error = $reason->getPrettyString();
+					break;
+
+			}
+
+			if ( ! empty( $composer_error ) ) {
+				WP_CLI::log( sprintf( " - Error: %s", $composer_error ) );
+			}
+		}
+
+	}
+
+}

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -609,6 +609,16 @@ class Runner {
 		// APIs as non-bundled commands.
 		Utils\load_command( $this->arguments[0] );
 
+		if ( getenv( 'WP_CLI_PACKAGES_DIR' ) ) {
+			$package_autoload = rtrim( getenv( 'WP_CLI_PACKAGES_DIR' ), '/' ) . '/vendor/autoload.php';
+		} else {
+			$package_autoload = getenv( 'HOME' ) . '/.wp-cli/packages/vendor/autoload.php';
+		}
+
+		if ( file_exists( $package_autoload ) ) {
+			require_once $package_autoload;
+		}
+
 		if ( isset( $this->config['require'] ) ) {
 			foreach ( $this->config['require'] as $path ) {
 				if ( ! file_exists( $path ) ) {

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -1,0 +1,416 @@
+<?php
+use \Composer\Config;
+use \Composer\Config\JsonConfigSource;
+use \Composer\EventDispatcher\Event;
+use \Composer\Factory;
+use \Composer\IO\NullIO;
+use \Composer\Installer;
+use \Composer\Json\JsonFile;
+use \Composer\Json\JsonManipulator;
+use \Composer\Package;
+use \Composer\Package\Version\VersionParser;
+use \Composer\Repository;
+use \Composer\Repository\CompositeRepository;
+use \Composer\Repository\ComposerRepository;
+use \Composer\Repository\RepositoryManager;
+use \Composer\Util\Filesystem;
+use \WP_CLI\ComposerIO;
+
+/**
+ * Manage WP-CLI community packages.
+ *
+ * @package WP-CLI
+ *
+ * @when before_wp_load
+ */
+class Package_Command extends WP_CLI_Command {
+
+	// TODO: read from composer.json
+	const PACKAGE_INDEX_URL = 'http://wp-cli.org/package-index/';
+
+	private $fields = array(
+		'name',
+		'description',
+		'authors',
+		'version',
+	);
+
+	/**
+	 * Browse available WP-CLI community packages.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, json. Default: table
+	 */
+	public function browse( $_, $assoc_args ) {
+		$this->show_packages( $this->get_community_packages(), $assoc_args );
+	}
+
+	/**
+	 * Install a WP-CLI community package.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <package>
+	 * : The name of the package to install. Can optionally contain a version constraint.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # install the latest development version
+	 *     wp package install wp-cli/server-command
+	 *
+	 *     # install the latest stable version
+	 *     wp package install wp-cli/server-command:@stable
+	 */
+	public function install( $args, $assoc_args ) {
+		list( $package_name ) = $args;
+
+		if ( false !== strpos( $package_name, ':' ) ) {
+			list( $package_name, $version ) = explode( ':', $package_name );
+		} else {
+			$version = 'dev-master';
+		}
+
+		$package = $this->get_community_package_by_name( $package_name );
+		if ( ! $package ) {
+			WP_CLI::error( "Invalid package." );
+		} else {
+			WP_CLI::log( sprintf( "Installing %s (%s)", $package_name, $version ) );
+		}
+
+		$composer = $this->get_composer();
+		$composer_json_obj = $this->get_composer_json();
+
+		// Add the 'require' to composer.json
+		WP_CLI::log( sprintf( "Updating %s to require the package...", $composer_json_obj->getPath() ) );
+		$composer_backup = file_get_contents( $composer_json_obj->getPath() );
+		$json_manipulator = new JsonManipulator( $composer_backup );
+		$json_manipulator->addLink( 'require', $package_name, $version );
+		file_put_contents( $composer_json_obj->getPath(), $json_manipulator->getContents() );
+		$composer = $this->get_composer();
+
+		// Set up the EventSubscriber
+		$event_subscriber = new \WP_CLI\PackageManagerEventSubscriber;
+		$composer->getEventDispatcher()->addSubscriber( $event_subscriber );
+
+		// Set up the installer
+		$install = Installer::create( new ComposerIO, $composer );
+		$install->setUpdate( true ); // Installer class will only override composer.lock with this flag
+
+		// Try running the installer, but revert composer.json if failed
+		WP_CLI::log( 'Using Composer to install the package...' );
+		try {
+			$res = $install->run();
+		} catch ( Exception $e ) {
+			WP_CLI::error( $e->getMessage() );
+		}
+
+		if ( 0 === $res ) {
+			WP_CLI::success( "Package installed successfully." );
+		} else {
+			file_put_contents( $composer_json_obj->getPath(), $composer_backup );
+			WP_CLI::error( "Package installation failed. Reverted composer.json" );
+		}
+	}
+
+	/**
+	 * List installed WP-CLI community packages.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, json. Default: table
+	 *
+	 * @subcommand list
+	 */
+	public function list_( $args, $assoc_args ) {
+		$this->show_packages( $this->get_installed_packages(), $assoc_args );
+	}
+
+	/**
+	 * Uninstall a WP-CLI community package.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <package>
+	 * : The name of the package to uninstall.
+	 */
+	public function uninstall( $args ) {
+		list( $package_name ) = $args;
+
+		$composer = $this->get_composer();
+		if ( false === ( $package = $this->get_installed_package_by_name( $package_name ) ) ) {
+			WP_CLI::error( "Package not installed." );
+		}
+
+		$composer_json_obj = $this->get_composer_json();
+
+		// Remove the 'require' from composer.json
+		$json_path = $composer_json_obj->getPath();
+		WP_CLI::log( sprintf( 'Removing require statement from %s', $json_path ) );
+		$contents = file_get_contents( $json_path );
+		$manipulator = new JsonManipulator( $contents );
+		$manipulator->removeSubNode( 'require', $package_name );
+		file_put_contents( $composer_json_obj->getPath(), $manipulator->getContents() );
+
+		// Delete the directory
+		$package_path = $composer->getConfig()->get( 'vendor-dir' ) . '/' . $package->getName();
+		WP_CLI::log( sprintf( 'Deleting package directory %s', $package_path ) );
+		$filesystem = new Filesystem;
+		$filesystem->removeDirectory( $package_path );
+
+		// Reset Composer and regenerate the auto-loader
+		$composer = $this->get_composer();
+		WP_CLI::log( 'Regenerating Composer autoload.' );
+		$this->regenerate_autoloader();
+
+		WP_CLI::success( "Uninstalled package." );
+	}
+
+	/**
+	 * Check whether a package is a WP-CLI community package based
+	 * on membership in our package index.
+	 *
+	 * @param object      $package     A package object
+	 * @return bool
+	 */
+	private function is_community_package( $package ) {
+		return $this->package_index()->hasPackage( $package );
+	}
+
+	/**
+	 * Get a Composer instance.
+	 */
+	private function get_composer() {
+		$composer_path = $this->get_composer_json_path();
+
+		// Composer's auto-load generating code makes some assumptions about where
+		// the 'vendor-dir' is, and where Composer is running from.
+		// Best to just pretend we're installing a package from ~/.wp-cli or similar
+		chdir( pathinfo( $composer_path, PATHINFO_DIRNAME ) );
+
+		try {
+			$composer = Factory::create( new NullIO, $composer_path );
+		} catch( Exception $e ) {
+			WP_CLI::error( $e->getMessage() );
+		}
+
+		$this->composer = $composer;
+		return $this->composer;
+	}
+
+	/**
+	 * Get all of the community packages.
+	 *
+	 * @return array
+	 */
+	private function get_community_packages() {
+		static $community_packages;
+
+		if ( null === $community_packages ) {
+			$community_packages = $this->package_index()->getPackages();
+		}
+
+		return $community_packages;
+	}
+
+	/**
+	 * Get the package index instance
+	 *
+	 * We need to construct the instance manually, because there's no way to select
+	 * a particular instance using $composer->getRepositoryManager()
+	 *
+	 * @return ComposerRepository
+	 */
+	private function package_index() {
+		static $package_index;
+
+		if ( !$package_index ) {
+			$config = new Config();
+			$config->merge(array('config' => array(
+				'home' => dirname( $this->get_composer_json_path() ),
+				/* 'cache-dir' => $cacheDir */
+			)));
+			$config->setConfigSource( new JsonConfigSource( $this->get_composer_json() ) );
+
+			$package_index = new ComposerRepository( array( 'url' => self::PACKAGE_INDEX_URL ), new NullIO, $config );
+		}
+
+		return $package_index;
+	}
+
+	/**
+	 * Display a set of packages
+	 *
+	 * @param array
+	 * @param array
+	 */
+	private function show_packages( $packages, $assoc_args ) {
+		$defaults = array(
+			'fields' => implode( ',', $this->fields ),
+			'format' => 'table'
+		);
+		$assoc_args = array_merge( $defaults, $assoc_args );
+
+		$list = array();
+		foreach ( $packages as $package ) {
+			$package_output = new stdClass;
+			$package_output->name = $package->getName();
+			$package_output->description = $package->getDescription();
+			$package_output->authors = implode( ',', array_column( (array) $package->getAuthors(), 'name' ) );
+			$package_output->version = $package->getPrettyVersion();
+			$list[$package_output->name] = $package_output;
+		}
+
+		WP_CLI\Utils\format_items( $assoc_args['format'], $list, $assoc_args['fields'] );
+	}
+
+	/**
+	 * Get a community package by its name.
+	 */
+	private function get_community_package_by_name( $package_name ) {
+		foreach( $this->get_community_packages() as $package ) {
+			if ( $package_name == $package->getName() )
+				return $package;
+		}
+		return false;
+	}
+
+	/**
+	 * Get the installed community packages.
+	 */
+	private function get_installed_packages() {
+		$composer = $this->get_composer();
+		$repo = $composer->getRepositoryManager()->getLocalRepository();
+
+		$installed_packages = array();
+		foreach( $repo->getPackages() as $package ) {
+
+			if ( ! $this->is_community_package( $package ) )
+				continue;
+
+			$installed_packages[] = $package;
+		}
+
+		return $installed_packages;
+	}
+
+	/**
+	 * Get an installed package by its name.
+	 */
+	private function get_installed_package_by_name( $package_name ) {
+		foreach( $this->get_installed_packages() as $package ) {
+			if ( $package_name == $package->getName() )
+				return $package;
+		}
+		return false;
+	}
+
+	/**
+	 * Check if the package name provided is already installed.
+	 */
+	private function is_package_installed( $package_name ) {
+		if ( $this->get_installed_package_by_name( $package_name ) )
+			return true;
+		else
+			return false;
+	}
+
+	/**
+	 * Get the composer.json object
+	 */
+	private function get_composer_json() {
+		return new JsonFile( $this->get_composer_json_path() );
+	}
+
+	/**
+	 * Get the path to composer.json
+	 */
+	private function get_composer_json_path() {
+		static $composer_path;
+
+		if ( null === $composer_path ) {
+
+			if ( getenv( 'WP_CLI_PACKAGES_DIR' ) ) {
+				$composer_path = rtrim( getenv( 'WP_CLI_PACKAGES_DIR' ), '/' ) . '/composer.json';
+			} else {
+				$composer_path = getenv( 'HOME' ) . '/.wp-cli/packages/composer.json';
+			}
+
+			// `composer.json` and its directory might need to be created
+			if ( ! file_exists( $composer_path ) ) {
+				$this->create_default_composer_json( $composer_path );
+			}
+		}
+
+		return $composer_path;
+	}
+
+	/**
+	 * Create a default composer.json, should one not already exist
+	 *
+	 * @param string $composer_path Where the composer.json should be created
+	 * @return true|WP_Error
+	 */
+	private function create_default_composer_json( $composer_path ) {
+
+		$composer_dir = pathinfo( $composer_path, PATHINFO_DIRNAME );
+		if ( ! is_dir( $composer_dir ) ) {
+			\WP_CLI\Process::create( WP_CLI\Utils\esc_cmd( 'mkdir -p %s', $composer_dir ) )->run();
+		}
+
+		if ( ! is_dir( $composer_dir ) ) {
+			WP_CLI::error( "Composer directory for packages couldn't be created." );
+		}
+
+		$json_file = new JsonFile( $composer_path );
+
+		$author = (object)array(
+			'name'   => 'WP-CLI',
+			'email'  => 'noreply@wpcli.org'
+		);
+
+		$repositories = (object)array(
+			'wp-cli'     => (object)array(
+				'type'      => 'composer',
+				'url'       => self::PACKAGE_INDEX_URL,
+			),
+		);
+
+		$options = array(
+			'name' => 'wp-cli/wp-cli-community-packages',
+			'description' => 'Installed community packages used by WP-CLI',
+			'authors' => array( $author ),
+			'homepage' => self::PACKAGE_INDEX_URL,
+			'require' => new stdClass,
+			'require-dev' => new stdClass,
+			'minimum-stability' => 'dev',
+			'license' => 'MIT',
+			'repositories' => $repositories,
+		);
+
+		try {
+			$json_file->write( $options );
+		} catch( Exception $e ) {
+			WP_CLI::error( $e->getMessage() );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Regenerate the Composer autoloader
+	 */
+	private function regenerate_autoloader() {
+		$this->composer->getAutoloadGenerator()->dump(
+			$this->composer->getConfig(),
+			$this->composer->getRepositoryManager()->getLocalRepository(),
+			$this->composer->getPackage(),
+			$this->composer->getInstallationManager(),
+			'composer'
+		);
+	}
+}
+
+WP_CLI::add_command( 'package', 'Package_Command' );

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -162,7 +162,7 @@ class Package_Command extends WP_CLI_Command {
 		// Reset Composer and regenerate the auto-loader
 		$composer = $this->get_composer();
 		WP_CLI::log( 'Regenerating Composer autoload.' );
-		$this->regenerate_autoloader();
+		$this->regenerate_autoloader( $composer );
 
 		WP_CLI::success( "Uninstalled package." );
 	}
@@ -195,8 +195,7 @@ class Package_Command extends WP_CLI_Command {
 			WP_CLI::error( $e->getMessage() );
 		}
 
-		$this->composer = $composer;
-		return $this->composer;
+		return $composer;
 	}
 
 	/**
@@ -285,8 +284,9 @@ class Package_Command extends WP_CLI_Command {
 		$installed_packages = array();
 		foreach( $repo->getPackages() as $package ) {
 
-			if ( ! $this->is_community_package( $package ) )
+			if ( ! $this->is_community_package( $package ) ) {
 				continue;
+			}
 
 			$installed_packages[] = $package;
 		}
@@ -299,8 +299,9 @@ class Package_Command extends WP_CLI_Command {
 	 */
 	private function get_installed_package_by_name( $package_name ) {
 		foreach( $this->get_installed_packages() as $package ) {
-			if ( $package_name == $package->getName() )
+			if ( $package_name == $package->getName() ) {
 				return $package;
+			}
 		}
 		return false;
 	}
@@ -309,10 +310,11 @@ class Package_Command extends WP_CLI_Command {
 	 * Check if the package name provided is already installed.
 	 */
 	private function is_package_installed( $package_name ) {
-		if ( $this->get_installed_package_by_name( $package_name ) )
+		if ( $this->get_installed_package_by_name( $package_name ) ) {
 			return true;
-		else
+		} else {
 			return false;
+		}
 	}
 
 	/**
@@ -400,12 +402,12 @@ class Package_Command extends WP_CLI_Command {
 	/**
 	 * Regenerate the Composer autoloader
 	 */
-	private function regenerate_autoloader() {
-		$this->composer->getAutoloadGenerator()->dump(
-			$this->composer->getConfig(),
-			$this->composer->getRepositoryManager()->getLocalRepository(),
-			$this->composer->getPackage(),
-			$this->composer->getInstallationManager(),
+	private function regenerate_autoloader( $composer ) {
+		$composer->getAutoloadGenerator()->dump(
+			$composer->getConfig(),
+			$composer->getRepositoryManager()->getLocalRepository(),
+			$composer->getPackage(),
+			$composer->getInstallationManager(),
 			'composer'
 		);
 	}

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -25,7 +25,6 @@ use \WP_CLI\ComposerIO;
  */
 class Package_Command extends WP_CLI_Command {
 
-	// TODO: read from composer.json
 	const PACKAGE_INDEX_URL = 'http://wp-cli.org/package-index/';
 
 	private $fields = array(
@@ -230,7 +229,6 @@ class Package_Command extends WP_CLI_Command {
 			$config = new Config();
 			$config->merge(array('config' => array(
 				'home' => dirname( $this->get_composer_json_path() ),
-				/* 'cache-dir' => $cacheDir */
 			)));
 			$config->setConfigSource( new JsonConfigSource( $this->get_composer_json() ) );
 

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -102,7 +102,7 @@ class Package_Command extends WP_CLI_Command {
 		try {
 			$res = $install->run();
 		} catch ( Exception $e ) {
-			WP_CLI::error( $e->getMessage() );
+			WP_CLI::warning( $e->getMessage() );
 		}
 
 		if ( 0 === $res ) {

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -78,7 +78,11 @@ class Package_Command extends WP_CLI_Command {
 			WP_CLI::log( sprintf( "Installing %s (%s)", $package_name, $version ) );
 		}
 
-		$composer = $this->get_composer();
+		try {
+			$composer = $this->get_composer();
+		} catch( Exception $e ) {
+			WP_CLI::error( $e->getMessage() );
+		}
 		$composer_json_obj = $this->get_composer_json();
 
 		// Add the 'require' to composer.json
@@ -87,7 +91,11 @@ class Package_Command extends WP_CLI_Command {
 		$json_manipulator = new JsonManipulator( $composer_backup );
 		$json_manipulator->addLink( 'require', $package_name, $version );
 		file_put_contents( $composer_json_obj->getPath(), $json_manipulator->getContents() );
-		$composer = $this->get_composer();
+		try {
+			$composer = $this->get_composer();
+		} catch( Exception $e ) {
+			WP_CLI::error( $e->getMessage() );
+		}
 
 		// Set up the EventSubscriber
 		$event_subscriber = new \WP_CLI\PackageManagerEventSubscriber;
@@ -138,7 +146,11 @@ class Package_Command extends WP_CLI_Command {
 	public function uninstall( $args ) {
 		list( $package_name ) = $args;
 
-		$composer = $this->get_composer();
+		try {
+			$composer = $this->get_composer();
+		} catch( Exception $e ) {
+			WP_CLI::error( $e->getMessage() );
+		}
 		if ( false === ( $package = $this->get_installed_package_by_name( $package_name ) ) ) {
 			WP_CLI::error( "Package not installed." );
 		}
@@ -160,8 +172,13 @@ class Package_Command extends WP_CLI_Command {
 		$filesystem->removeDirectory( $package_path );
 
 		// Reset Composer and regenerate the auto-loader
-		$composer = $this->get_composer();
 		WP_CLI::log( 'Regenerating Composer autoload.' );
+		try {
+			$composer = $this->get_composer();
+		} catch( Exception $e ) {
+			WP_CLI::warning( $e->getMessage() );
+			WP_CLI::error( 'Composer autoload will need to be manually regenerated.' );
+		}
 		$this->regenerate_autoloader( $composer );
 
 		WP_CLI::success( "Uninstalled package." );
@@ -188,14 +205,7 @@ class Package_Command extends WP_CLI_Command {
 		// the 'vendor-dir' is, and where Composer is running from.
 		// Best to just pretend we're installing a package from ~/.wp-cli or similar
 		chdir( pathinfo( $composer_path, PATHINFO_DIRNAME ) );
-
-		try {
-			$composer = Factory::create( new NullIO, $composer_path );
-		} catch( Exception $e ) {
-			WP_CLI::error( $e->getMessage() );
-		}
-
-		return $composer;
+		return Factory::create( new NullIO, $composer_path );
 	}
 
 	/**
@@ -279,7 +289,11 @@ class Package_Command extends WP_CLI_Command {
 	 * Get the installed community packages.
 	 */
 	private function get_installed_packages() {
-		$composer = $this->get_composer();
+		try {
+			$composer = $this->get_composer();
+		} catch( Exception $e ) {
+			WP_CLI::error( $e->getMessage() );
+		}
 		$repo = $composer->getRepositoryManager()->getLocalRepository();
 
 		$installed_packages = array();

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -268,8 +268,9 @@ class Package_Command extends WP_CLI_Command {
 	 */
 	private function get_community_package_by_name( $package_name ) {
 		foreach( $this->get_community_packages() as $package ) {
-			if ( $package_name == $package->getName() )
+			if ( $package_name == $package->getName() ) {
 				return $package;
+			}
 		}
 		return false;
 	}

--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -69,11 +69,11 @@ $finder
 	->in(WP_CLI_ROOT . '/vendor/mustache')
 	->in(WP_CLI_ROOT . '/vendor/rmccue/requests')
 	->in(WP_CLI_ROOT . '/vendor/composer')
-	->in(WP_CLI_ROOT . '/vendor/symfony/finder')
+	->in(WP_CLI_ROOT . '/vendor/symfony')
 	->in(WP_CLI_ROOT . '/vendor/nb/oxymel')
 	->in(WP_CLI_ROOT . '/vendor/ramsey/array_column')
-	->in(WP_CLI_ROOT . '/vendor/composer/semver')
 	->in(WP_CLI_ROOT . '/vendor/mustangostang')
+	->in(WP_CLI_ROOT . '/vendor/justinrainbow/json-schema')
 	->exclude('test')
 	->exclude('tests')
 	->exclude('Tests')
@@ -99,6 +99,8 @@ foreach ( $finder as $file ) {
 
 add_file( $phar, WP_CLI_ROOT . '/vendor/autoload.php' );
 add_file( $phar, WP_CLI_ROOT . '/ci/behat-tags.php' );
+add_file( $phar, WP_CLI_ROOT . '/vendor/composer/composer/LICENSE' );
+add_file( $phar, WP_CLI_ROOT . '/vendor/composer/composer/res/composer-schema.json' );
 add_file( $phar, WP_CLI_ROOT . '/utils/get-package-require-from-composer.php' );
 add_file( $phar, WP_CLI_ROOT . '/vendor/rmccue/requests/library/Requests/Transport/cacert.pem' );
 


### PR DESCRIPTION
Use `wp package browse` to view all available community commands.
Install a specific command with `wp package install
<namespace/package-name>`. List all installed packages with `wp
package list`. Or, uninstall a package with `wp package uninstall`

Packages are installed to their own Composer project in `~/.wp-cli/packages`.
This can be changed by setting a `WP_CLI_PACKAGES_DIR` environment variable.

See #1564
Previously #936