### PR TITLE
Parameter sequence corrected for wp_create_user.

### DIFF
--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -289,7 +289,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 			if ( is_wp_error( $ret['errors'] ) && ! empty( $ret['errors']->errors ) ) {
 				WP_CLI::error( $ret['errors'] );
 			}
-			$user_id = wpmu_create_user( $user->user_login, $user->user_email, $user->user_login, $user->user_pass );
+			$user_id = wpmu_create_user( $user->user_login, $user->user_pass, $user->user_email );
 			if ( ! $user_id ) {
 				WP_CLI::error( "Unknown error creating new user" );
 			}
@@ -711,7 +711,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 						WP_CLI::warning( $ret['errors'] );
 						continue;
 					}
-					$user_id = wpmu_create_user( $new_user['user_login'], $new_user['user_email'], $new_user['user_pass'] );
+					$user_id = wpmu_create_user( $new_user['user_login'], $new_user['user_pass'], $new_user['user_email'] );
 					if ( ! $user_id ) {
 						WP_CLI::warning( "Unknown error creating new user" );
 						continue;


### PR DESCRIPTION
We have a plugin in application that listens to the Hook wpmu_new_user. Here we noticed that the new user at the time still has no email. The problem was that the parameters are passed in the wrong order on wpmu_create_user.