### PR TITLE
Explain nuances of `wp core update --minor`

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -877,7 +877,7 @@ EOT;
 	 * : Path to zip file to use, instead of downloading from wordpress.org.
 	 *
 	 * [--minor]
-	 * : Only perform updates for minor releases.
+	 * : Only perform updates for minor releases (e.g. update from WP 4.3 to 4.3.3 instead of 4.4.2).
 	 *
 	 * [--version=<version>]
 	 * : Update to a specific version, instead of to the latest version.


### PR DESCRIPTION
WordPress doesn't follow semver, so `--minor` would take you from WP 4.3
to WP 4.3.3 instead of WP 4.4.2

From https://github.com/wp-cli/wp-cli/issues/2441#issuecomment-179308541