### PR TITLE
Remove dead error handling code in `Cron_Event_Command->run()`

### DIFF
--- a/php/commands/cron.php
+++ b/php/commands/cron.php
@@ -177,12 +177,8 @@ class Cron_Event_Command extends WP_CLI_Command {
 				$start = microtime( true );
 				$result = self::run_event( $event );
 				$total = round( microtime( true ) - $start, 3 );
-				if ( $result ) {
-					$executed++;
-					WP_CLI::log( sprintf( "Executed the cron event '%s' in %ss.", $event->hook, $total ) );
-				} else {
-					WP_CLI::warning( sprintf( "Failed to the execute the cron event '%s'.", $event->hook ) );
-				}
+				$executed++;
+				WP_CLI::log( sprintf( "Executed the cron event '%s' in %ss.", $event->hook, $total ) );
 			}
 		}
 


### PR DESCRIPTION
`Cron_Event_Command::run_event()` always returns true

See #2445