### PR TITLE
Explain exit codes for `wp (theme|plugin) is-installed`

### DIFF
--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -534,6 +534,8 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	/**
 	 * Check if the plugin is installed.
 	 *
+	 * Returns exit code 0 when installed, 1 when uninstalled.
+	 *
 	 * ## OPTIONS
 	 *
 	 * <plugin>
@@ -542,6 +544,7 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * ## EXAMPLES
 	 *
 	 *     wp plugin is-installed hello
+	 *     echo $? # displays 0 or 1
 	 *
 	 * @subcommand is-installed
 	 */

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -485,6 +485,8 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 	/**
 	 * Check if the theme is installed.
 	 *
+	 * Returns exit code 0 when installed, 1 when uninstalled.
+	 *
 	 * ## OPTIONS
 	 *
 	 * <theme>
@@ -493,6 +495,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 	 * ## EXAMPLES
 	 *
 	 *     wp theme is-installed twentytwelve
+	 *     echo $? # displays 0 or 1
 	 *
 	 * @subcommand is-installed
 	 */


### PR DESCRIPTION
See #2449