### PR TITLE
Don't colorize `format=table` by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	],
 	"require": {
 		"php": ">=5.3.2",
-		"wp-cli/php-cli-tools": "0.11.0",
+		"wp-cli/php-cli-tools": "dev-master",
 		"mustache/mustache": "~2.4",
 		"mustangostang/spyc": "0.5.1",
 		"composer/semver": "1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "be16eacf74b49e94af4974a9c8c2460e",
-    "content-hash": "5045f45078e9ea1cfb8087b858d377ac",
+    "hash": "78165aafa4140e764d4f1dc828752cce",
+    "content-hash": "7b6ae0fa1f96555e592ce2f48493a535",
     "packages": [
         {
             "name": "composer/composer",
@@ -1127,16 +1127,16 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "0.11.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "d0564da283585c7289e18877ed2f9c35c1b67013"
+                "reference": "5311a4b99103c0505db015a334be4952654d6e21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/d0564da283585c7289e18877ed2f9c35c1b67013",
-                "reference": "d0564da283585c7289e18877ed2f9c35c1b67013",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/5311a4b99103c0505db015a334be4952654d6e21",
+                "reference": "5311a4b99103c0505db015a334be4952654d6e21",
                 "shasum": ""
             },
             "require": {
@@ -1173,7 +1173,7 @@
                 "cli",
                 "console"
             ],
-            "time": "2015-08-10 12:46:19"
+            "time": "2016-02-08 14:34:01"
         }
     ],
     "packages-dev": [
@@ -1666,6 +1666,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "wp-cli/php-cli-tools": 20,
         "composer/composer": 15
     },
     "prefer-stable": false,

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -263,13 +263,24 @@ class Formatter {
 	private static function show_table( $items, $fields ) {
 		$table = new \cli\Table();
 
+		$enabled = \cli\Colors::shouldColorize();
+		if ( $enabled ) {
+			\cli\Colors::disable( true );
+		}
+
 		$table->setHeaders( $fields );
 
 		foreach ( $items as $item ) {
 			$table->addRow( array_values( \WP_CLI\Utils\pick_fields( $item, $fields ) ) );
 		}
 
-		$table->display();
+		foreach( $table->getDisplayLines() as $line ) {
+			\WP_CLI::line( $line );
+		}
+
+		if ( $enabled ) {
+			\cli\Colors::enable( true );
+		}
 	}
 
 	/**


### PR DESCRIPTION
More often than not, strings are accidentally colorized because they
contain colorization tokens. Developers can still colorize their strings
in advance, and include the colorized strings in their table.

Fixes #2455