### PR TITLE
Avoid loading WordPress in `wp core verify-checksums`

### DIFF
--- a/features/core-verify-checksums.feature
+++ b/features/core-verify-checksums.feature
@@ -36,7 +36,7 @@ Feature: Validate checksums for WordPress install
     Given an empty directory
     And I run `wp core download --version=4.3`
 
-    When I try `wp core verify-checksums`
+    When I run `wp core verify-checksums`
     Then STDOUT should be:
       """
       Success: WordPress install verifies against checksums.

--- a/features/core-verify-checksums.feature
+++ b/features/core-verify-checksums.feature
@@ -37,9 +37,9 @@ Feature: Validate checksums for WordPress install
     And I run `wp core download --version=4.3`
 
     When I try `wp core verify-checksums`
-    Then STDERR should contain:
+    Then STDOUT should be:
       """
-      Error: wp-config.php not found.
+      Success: WordPress install verifies against checksums.
       """
 
     When I run `wp core verify-checksums --version=4.3 --locale=en_US`

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -889,7 +889,7 @@ EOT;
 			}
 		}
 
-		$checksums = self::get_core_checksums( $wp_version, isset( $wp_local_package ) ? $wp_local_package : 'en_US' );
+		$checksums = self::get_core_checksums( $wp_version, ! empty( $wp_local_package ) ? $wp_local_package : 'en_US' );
 
 		if ( ! is_array( $checksums ) ) {
 			WP_CLI::error( "Couldn't get checksums from WordPress.org." );

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -789,7 +789,8 @@ EOT;
 		return array(
 			'wp' => $wp_version,
 			'db' => $wp_db_version,
-			'tinymce' => $tinymce_version
+			'tinymce' => $tinymce_version,
+			'local_package' => $wp_local_package
 		);
 	}
 
@@ -853,6 +854,7 @@ EOT;
 		if ( empty( $wp_version ) ) {
 			$version = self::get_version();
 			$wp_version = $version['wp'];
+			$wp_local_package = $version['local_package'];
 		}
 
 		$checksums = self::get_core_checksums( $wp_version, isset( $wp_local_package ) ? $wp_local_package : 'en_US' );

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -742,7 +742,7 @@ EOT;
 	 * @when before_wp_load
 	 */
 	public function version( $args = array(), $assoc_args = array() ) {
-		$version = self::get_version();
+		$version = self::get_wp_details();
 
 		// @codingStandardsIgnoreStart
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'extra' ) ) {
@@ -775,7 +775,7 @@ EOT;
 	 *     @type string $tinymce The TinyMCE version.
 	 * }
 	 */
-	private static function get_version() {
+	private static function get_wp_details() {
 		$versions_path = ABSPATH . 'wp-includes/version.php';
 
 		if ( !is_readable( $versions_path ) ) {
@@ -852,9 +852,12 @@ EOT;
 		}
 
 		if ( empty( $wp_version ) ) {
-			$version = self::get_version();
-			$wp_version = $version['wp'];
-			$wp_local_package = $version['local_package'];
+			$details = self::get_wp_details();
+			$wp_version = $details['wp'];
+
+			if ( empty( $wp_local_package ) ) {
+				$wp_local_package = $details['local_package'];
+			}
 		}
 
 		$checksums = self::get_core_checksums( $wp_version, isset( $wp_local_package ) ? $wp_local_package : 'en_US' );

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -785,7 +785,7 @@ EOT;
 				"Pass --path=`path/to/wordpress` or run `wp core download`." );
 		}
 
-		$version_content = file_get_contents($versions_path, null, null, 6, 2048);
+		$version_content = file_get_contents( $versions_path, null, null, 6, 2048 );
 
 		$vars = array(
 			'wp' => 'wp_version',
@@ -796,30 +796,30 @@ EOT;
 
 		$result = array();
 
-		foreach($vars as $key => $var) {
-			$result[$key] = self::find_var($var, $version_content);
+		foreach( $vars as $key => $var ) {
+			$result[$key] = self::find_var( $var, $version_content );
 		}
 
 		return $result;
 	}
 
-	private static function find_var($key, $content) {
-		$start = strpos ($content, '$' . $key . ' = ');
+	private static function find_var( $key, $content ) {
+		$start = strpos( $content, '$' . $key . ' = ' );
 
 		if( ! $start ) {
 			return '';
 		}
 
-		$start =  $start + strlen($key) + 3;
-		$end   = strpos($content, "\n", $start);
+		$start =  $start + strlen( $key ) + 3;
+		$end   = strpos( $content, "\n", $start );
 
-		$value = substr($content, $start, $end - $start);
-		$value = rtrim($value, ";");
+		$value = substr( $content, $start, $end - $start );
+		$value = rtrim( $value, ";" );
 
-		if ($value[0] = "'" ) {
-			return trim($value, "'");
+		if ( $value[0] = "'" ) {
+			return trim( $value, "'" );
 		} else {
-			return intval($value);
+			return intval( $value );
 		}
 	}
 

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -773,6 +773,7 @@ EOT;
 	 *     @type string $wp The WordPress version.
 	 *     @type int $db The WordPress DB revision.
 	 *     @type string $tinymce The TinyMCE version.
+	 *     @type string $local_package The TinyMCE version.
 	 * }
 	 */
 	private static function get_wp_details() {

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -851,7 +851,8 @@ EOT;
 		}
 
 		if ( empty( $wp_version ) ) {
-			$wp_version = self::get_version()['wp'];
+			$version = self::get_version();
+			$wp_version = $version['wp'];
 		}
 
 		$checksums = self::get_core_checksums( $wp_version, isset( $wp_local_package ) ? $wp_local_package : 'en_US' );

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -785,14 +785,42 @@ EOT;
 				"Pass --path=`path/to/wordpress` or run `wp core download`." );
 		}
 
-		include $versions_path;
+		$version_content = file_get_contents($versions_path, null, null, 6, 2048);
 
-		return array(
-			'wp' => $wp_version,
-			'db' => $wp_db_version,
-			'tinymce' => $tinymce_version,
-			'local_package' => $wp_local_package
+		$vars = array(
+			'wp' => 'wp_version',
+			'db' => 'wp_db_version',
+			'tinymce' => 'tinymce_version',
+			'local_package' => 'wp_local_package'
 		);
+
+		$result = array();
+
+		foreach($vars as $key => $var) {
+			$result[$key] = self::find_var($var, $version_content);
+		}
+
+		return $result;
+	}
+
+	private static function find_var($key, $content) {
+		$start = strpos ($content, '$' . $key . ' = ');
+
+		if( ! $start ) {
+			return '';
+		}
+
+		$start =  $start + strlen($key) + 3;
+		$end   = strpos($content, "\n", $start);
+
+		$value = substr($content, $start, $end - $start);
+		$value = rtrim($value, ";");
+
+		if ($value[0] = "'" ) {
+			return trim($value, "'");
+		} else {
+			return intval($value);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Hi,

I thought it would be nice not to load WordPress in `wp core verify-checksums`.

With this change, you can do:

	wp core download
	wp core verify-checksums

Before, you had to either specify version with `--version` or install and load WordPress before calling `wp core verify-checksums`.