### PR TITLE
Verify md5 hash when `wp core download`

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -42,6 +42,16 @@ Feature: Download WordPress
       Error: Release not found.
       """
 
+  Scenario: Verify release hash when downloading new version
+    Given an empty directory
+
+    When I run `wp core download --version=4.4.1`
+    Then STDOUT should contain:
+      """
+      md5 hash verified: 1907d1dbdac7a009d89224a516496b8d
+      Success: WordPress downloaded.
+      """
+
   Scenario: Core download to a directory specified by `--path` in custom command
     Given a WP install
     And a download-command.php file:

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -138,12 +138,12 @@ class Core_Command extends WP_CLI_Command {
 			$response = Utils\http_request( 'GET', $download_url, null, $headers, $options );
 			if ( 404 == $response->status_code ) {
 				WP_CLI::error( "Release not found. Double-check locale or version." );
-			} else if ( 20 !== substr( $response->status_code, 0, 2 ) ) {
+			} else if ( 20 != substr( $response->status_code, 0, 2 ) ) {
 				WP_CLI::error( "Couldn't access download URL (HTTP code {$response->status_code})" );
 			}
 
 			$md5_response = Utils\http_request( 'GET', $download_url . '.md5' );
-			if ( 20 !== substr( $md5_response->status_code, 0, 2 ) ) {
+			if ( 20 != substr( $md5_response->status_code, 0, 2 ) ) {
 				WP_CLI::error( "Couldn't access md5 hash for release (HTTP code {$response->status_code})" );
 			}
 

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -142,6 +142,18 @@ class Core_Command extends WP_CLI_Command {
 				WP_CLI::error( "Couldn't access download URL (HTTP code {$response->status_code})" );
 			}
 
+			$md5_response = Utils\http_request( 'GET', $download_url . '.md5' );
+			if ( 20 != substr( $md5_response->status_code, 0, 2 ) ) {
+				WP_CLI::error( "Couldn't access md5 hash for release (HTTP code {$response->status_code})" );
+			}
+
+			$md5_file = md5_file( $temp );
+			if ( $md5_file === $md5_response->body ) {
+				WP_CLI::log( 'md5 hash verified: ' . $md5_file );
+			} else {
+				WP_CLI::error( "md5 hash for download ({$md5_file}) is different than the release hash ({$md5_response->body})" );
+			}
+
 			try {
 				self::_extract( $temp, $download_dir );
 			} catch ( Exception $e ) {

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -138,12 +138,12 @@ class Core_Command extends WP_CLI_Command {
 			$response = Utils\http_request( 'GET', $download_url, null, $headers, $options );
 			if ( 404 == $response->status_code ) {
 				WP_CLI::error( "Release not found. Double-check locale or version." );
-			} else if ( 20 != substr( $response->status_code, 0, 2 ) ) {
+			} else if ( 20 !== substr( $response->status_code, 0, 2 ) ) {
 				WP_CLI::error( "Couldn't access download URL (HTTP code {$response->status_code})" );
 			}
 
 			$md5_response = Utils\http_request( 'GET', $download_url . '.md5' );
-			if ( 20 != substr( $md5_response->status_code, 0, 2 ) ) {
+			if ( 20 !== substr( $md5_response->status_code, 0, 2 ) ) {
 				WP_CLI::error( "Couldn't access md5 hash for release (HTTP code {$response->status_code})" );
 			}
 


### PR DESCRIPTION
To permit offline use of the download cache, verification only happens
when downloading a new copy of WordPress.

Fixes #1899