### PR TITLE
Default title for `wp media import` images shouldn't include extension

### DIFF
--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -71,7 +71,7 @@ Feature: Manage WordPress attachments
     When I run `wp post get {ATTACHMENT_ID} --field=title`
     Then STDOUT should be:
       """
-      large-image.jpg
+      large-image
       """
 
   Scenario: Import a file and persist its original metadata

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -182,7 +182,7 @@ class Media_Command extends WP_CLI_Command {
 			}
 
 			if ( empty( $post_array['post_title'] ) ) {
-				$post_array['post_title'] = $file_array['name'];
+				$post_array['post_title'] = preg_replace( '/\.[^.]+$/', '', basename( $file ) );
 			}
 
 			// Deletes the temporary file.


### PR DESCRIPTION
This better mirrors core's behavior.

From #2438