### PR TITLE
Use core's version check API for finding updates

### DIFF
--- a/features/core-check-update.feature
+++ b/features/core-check-update.feature
@@ -40,3 +40,22 @@ Feature: Check for more recent versions
       """
       1
       """
+
+  @less-than-php-7
+  Scenario: No minor updates for an unlocalized WordPress release
+    Given a WP install
+
+    When I run `wp core download --version=4.0 --locale=es_ES --force`
+    Then STDOUT should contain:
+      """
+      Success: WordPress downloaded.
+      """
+
+    When I run `wp core check-update --minor`
+    Then STDOUT should be a table containing rows:
+      | version | update_type | package_url                                        |
+      | 4.0.1   | minor       | https://es.wordpress.org/wordpress-4.0.1-es_ES.zip |
+    And STDERR should contain:
+      """
+      Warning: No release found for 4.0.10 (es_ES)
+      """

--- a/features/core-check-update.feature
+++ b/features/core-check-update.feature
@@ -9,9 +9,9 @@ Feature: Check for more recent versions
 
     When I run `wp core check-update`
     Then STDOUT should be a table containing rows:
-      | version | update_type | package_url                                |
-      | 4.4.2   | major       | https://wordpress.org/wordpress-4.4.2.zip  |
-      | 3.8.13  | minor       | https://wordpress.org/wordpress-3.8.13.zip |
+      | version | update_type | package_url                                                  |
+      | 4.4.2   | major       | https://downloads.wordpress.org/release/wordpress-4.4.2.zip  |
+      | 3.8.13  | minor       | https://downloads.wordpress.org/release/wordpress-3.8.13-partial-0.zip |
 
     When I run `wp core check-update --format=count`
     Then STDOUT should be:
@@ -21,8 +21,8 @@ Feature: Check for more recent versions
 
     When I run `wp core check-update --major`
     Then STDOUT should be a table containing rows:
-      | version | update_type | package_url                                |
-      | 4.4.2   | major       | https://wordpress.org/wordpress-4.4.2.zip  |
+      | version | update_type | package_url                                                  |
+      | 4.4.2   | major       | https://downloads.wordpress.org/release/wordpress-4.4.2.zip  |
 
     When I run `wp core check-update --major --format=count`
     Then STDOUT should be:
@@ -33,7 +33,7 @@ Feature: Check for more recent versions
     When I run `wp core check-update --minor`
     Then STDOUT should be a table containing rows:
       | version | update_type | package_url                                |
-      | 3.8.13  | minor       | https://wordpress.org/wordpress-3.8.13.zip |
+      | 3.8.13  | minor       | https://downloads.wordpress.org/release/wordpress-3.8.13-partial-0.zip |
 
     When I run `wp core check-update --minor --format=count`
     Then STDOUT should be:
@@ -54,8 +54,4 @@ Feature: Check for more recent versions
     When I run `wp core check-update --minor`
     Then STDOUT should be a table containing rows:
       | version | update_type | package_url                                        |
-      | 4.0.1   | minor       | https://es.wordpress.org/wordpress-4.0.1-es_ES.zip |
-    And STDERR should contain:
-      """
-      Warning: No release found for 4.0.10 (es_ES)
-      """
+      | 4.0.10  | minor       | https://downloads.wordpress.org/release/wordpress-4.0.10-partial-0.zip |

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -194,7 +194,7 @@ Feature: Update WordPress core
     When I run `wp post create --post_title='Test post' --porcelain`
     Then STDOUT should be a number
 
-  @less-than-php-7
+  @less-than-php-7 @require-wp-4.0
   Scenario: Minor update on an unlocalized WordPress release
     Given a WP install
     And an empty cache

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -197,6 +197,7 @@ Feature: Update WordPress core
   @less-than-php-7
   Scenario: Minor update on an unlocalized WordPress release
     Given a WP install
+    And an empty cache
 
     When I run `wp core download --version=4.0 --locale=es_ES --force`
     Then STDOUT should contain:
@@ -207,5 +208,10 @@ Feature: Update WordPress core
     When I run `wp core update --minor`
     Then STDOUT should contain:
       """
-      Success: WordPress updated successfully
+      Updating to version 4.0.10 (en_US)...
+      Descargando paquete de instalación desde https://downloads.wordpress.org/release/wordpress-4.0.10-partial-0.zip
+      """
+    And STDOUT should contain:
+      """
+      Success: WordPress updated successfully.
       """

--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -193,3 +193,19 @@ Feature: Update WordPress core
     Then STDOUT should not be empty
     When I run `wp post create --post_title='Test post' --porcelain`
     Then STDOUT should be a number
+
+  @less-than-php-7
+  Scenario: Minor update on an unlocalized WordPress release
+    Given a WP install
+
+    When I run `wp core download --version=4.0 --locale=es_ES --force`
+    Then STDOUT should contain:
+      """
+      Success: WordPress downloaded.
+      """
+
+    When I run `wp core update --minor`
+    Then STDOUT should contain:
+      """
+      Success: WordPress updated successfully
+      """


### PR DESCRIPTION
The version check API will give us exact URLs to upgrade packages. We shouldn't, imprecisely, build the download offers on our own.

Fixes #2468