### PR TITLE
`wp core download` should check for permission before attempting to create directory and download WP

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -240,3 +240,23 @@ Feature: Manage WordPress installation
       """
       Hello world!
       """
+
+  Scenario: Download WordPress
+    Given an empty directory
+
+    When I run `wp core download`
+    Then STDOUT should contain:
+     """
+     Success: WordPress downloaded.
+     """
+    And the wp-settings.php file should exist
+
+  Scenario: Don't download WordPress when files are already present
+    Given an empty directory
+    And WP files
+
+    When I try `wp core download`
+    Then STDERR should be:
+      """
+      Error: WordPress files seem to already be present here.
+      """

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -86,6 +86,10 @@ class Core_Command extends WP_CLI_Command {
 			WP_CLI::launch( Utils\esc_cmd( $mkdir, $download_dir ) );
 		}
 
+		if ( ! is_writable( $download_dir ) ) {
+			WP_CLI::error( sprintf( "%s is not writable by current user", $download_dir ) );
+		}
+
 		$locale = \WP_CLI\Utils\get_flag_value( $assoc_args, 'locale', 'en_US' );
 
 		if ( isset( $assoc_args['version'] ) ) {

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -80,7 +80,11 @@ class Core_Command extends WP_CLI_Command {
 		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) && $wordpress_present )
 			WP_CLI::error( 'WordPress files seem to already be present here.' );
 
-		if ( !is_dir( $download_dir ) ) {
+		if ( ! is_dir( $download_dir ) ) {
+			if ( ! is_writable( dirname( $download_dir ) ) ) {
+				WP_CLI::error( sprintf( "Insufficient permission to create directory %s", $download_dir ) );
+			}
+
 			WP_CLI::log( sprintf( 'Creating directory %s', $download_dir ) );
 			$mkdir = \WP_CLI\Utils\is_windows() ? 'mkdir %s' : 'mkdir -p %s';
 			WP_CLI::launch( Utils\esc_cmd( $mkdir, $download_dir ) );


### PR DESCRIPTION
This PR adds two checks to verify if PHP has write permission before attempting to create a directory and extract WordPress file when running `wp core download`.

I've also added two basic tests for `wp core download` but I was unable to find a way to test the two error messages I've added. Any suggestion?