### PR TITLE
Set default `indent_size=4` when scaffolding `.editorconfig`

### DIFF
--- a/templates/.editorconfig
+++ b/templates/.editorconfig
@@ -12,6 +12,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
+indent_size = 4
 
 [{.jshintrc,*.json,*.yml}]
 indent_style = space


### PR DESCRIPTION
This makes indentation more readable in editors.