### PR TITLE
Avoid PHP Notice about undefined index

### DIFF
--- a/php/export/class-wp-export-query.php
+++ b/php/export/class-wp-export-query.php
@@ -173,7 +173,7 @@ class WP_Export_Query {
 		}
 
 		// Multiple post types
-		if ( is_array( $post_types_filters['name'] ) ) {
+		if ( isset( $post_types_filters['name'] ) && is_array( $post_types_filters['name'] ) ) {
 			$post_types = array();
 			foreach ( $post_types_filters['name'] as $post_type ) {
 				if ( post_type_exists( $post_type ) ) {


### PR DESCRIPTION
Was getting this:

> Notice: Undefined index: name in `/Users/mark/.composer/vendor/wp-cli/wp-cli/php/export/class-wp-export-query.php` on line `176`