### PR TITLE
Add compatibility with WP 4.5 by loading `WP_Metadata_Lazyloader`

### DIFF
--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -160,6 +160,7 @@ Utils\maybe_require( '4.4-beta4-35719', ABSPATH . WPINC . '/class-wp-user-query.
 Utils\maybe_require( '4.0', ABSPATH . WPINC . '/session.php' );
 require( ABSPATH . WPINC . '/meta.php' );
 Utils\maybe_require( '4.4-beta4-35719', ABSPATH . WPINC . '/class-wp-meta-query.php' );
+Utils\maybe_require( '4.5-alpha-35776', ABSPATH . WPINC . '/class-wp-metadata-lazyloader.php' );
 require( ABSPATH . WPINC . '/general-template.php' );
 require( ABSPATH . WPINC . '/link-template.php' );
 require( ABSPATH . WPINC . '/author-template.php' );


### PR DESCRIPTION
Introduced in https://core.trac.wordpress.org/changeset/36566/

Build began failing in #2485