### PR TITLE
Use more robust failed download checking in `wp cli update`

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -32,6 +32,16 @@ Feature: `wp cli` tasks
     Given an empty directory
     And a new Phar with version "0.0.0"
 
+    When I run `{PHAR_PATH} --info`
+    Then STDOUT should contain:
+      """
+      WP-CLI version
+      """
+    And STDOUT should contain:
+      """
+      0.0.0
+      """
+
     When I run `{PHAR_PATH} cli update --yes`
     Then STDOUT should contain:
     """
@@ -40,10 +50,26 @@ Feature: `wp cli` tasks
     And STDERR should be empty
     And the return code should be 0
 
+    When I run `{PHAR_PATH} --info`
+    Then STDOUT should contain:
+      """
+      WP-CLI version
+      """
+    And STDOUT should not contain:
+      """
+      0.0.0
+      """
+
   @github-api
   Scenario: Patch update from 0.14.0 to 0.14.1
     Given an empty directory
     And a new Phar with version "0.14.0"
+
+    When I run `{PHAR_PATH} --version`
+    Then STDOUT should be:
+      """
+      WP-CLI 0.14.0
+      """
 
     When I run `{PHAR_PATH} cli update --patch --yes`
     Then STDOUT should contain:
@@ -52,6 +78,12 @@ Feature: `wp cli` tasks
     """
     And STDERR should be empty
     And the return code should be 0
+
+    When I run `{PHAR_PATH} --version`
+    Then STDOUT should be:
+      """
+      WP-CLI 0.14.1
+      """
 
   @github-api
   Scenario: Not a patch update from 0.14.0

--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -181,9 +181,9 @@ class CLI_Command extends WP_CLI_Command {
 
 		$allow_root = WP_CLI::get_runner()->config['allow-root'] ? '--allow-root' : '';
 		$php_binary = WP_CLI::get_php_binary();
-		$process = WP_CLI\Process::create( "{$php_binary} $temp --version {$allow_root}" );
+		$process = WP_CLI\Process::create( "{$php_binary} $temp --info {$allow_root}" );
 		$result = $process->run();
-		if ( 0 !== $result->return_code ) {
+		if ( 0 !== $result->return_code || false === stripos( $result->stdout, 'WP-CLI version:' ) ) {
 			$multi_line = explode( PHP_EOL, $result->stderr );
 			WP_CLI::error_multi_line( $multi_line );
 			WP_CLI::error( 'The downloaded PHAR is broken, try running wp cli update again.' );


### PR DESCRIPTION
Because `php file.xml` returns exit code `0`, we need to run a command
where only WP-CLI will return the string we expect.

Fixes #2483