### PR TITLE
Fix fatal error when a dependency needs to be installed

### DIFF
--- a/php/WP_CLI/PackageManagerEventSubscriber.php
+++ b/php/WP_CLI/PackageManagerEventSubscriber.php
@@ -37,7 +37,7 @@ class PackageManagerEventSubscriber implements EventSubscriberInterface {
 				case Rule::RULE_PACKAGE_CONFLICT;
 				case Rule::RULE_PACKAGE_SAME_NAME:
 				case Rule::RULE_PACKAGE_REQUIRES:
-					$composer_error = $reason->getPrettyString();
+					$composer_error = $reason->getPrettyString( $event->getPool() );
 					break;
 
 			}


### PR DESCRIPTION
```
PHP Catchable fatal error:  Argument 1 passed to
Composer\DependencyResolver\Rule::getPrettyString() must be an instance
of Composer\DependencyResolver\Pool, none given, called in
/home/vagrant/.wp-cli/php/WP_CLI/PackageManagerEventSubscriber.php on
line 40 and defined in
/home/vagrant/.wp-cli/vendor/composer/composer/src/Composer/DependencyResolver/Rule.php
on line 161
```

See #2482
Related #1564