### PR TITLE
Mark `WP_CLI\Utils\make_progress_bar()` as a public internal API.

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -408,6 +408,34 @@ function mustache_render( $template_name, $data ) {
 	return $m->render( $template, $data );
 }
 
+/**
+ * Create a progress bar to display percent completion of a given operation.
+ *
+ * Progress bar is written to STDOUT, and disabled when command is piped. Progress
+ * advances with `$progress->tick()`, and completes with `$progress->finish()`.
+ * Process bar also indicates elapsed time and expected total time.
+ *
+ * ```
+ * # `wp user generate` ticks progress bar each time a new user is created.
+ * #
+ * # $ wp user generate --count=500
+ * # Generating users  22 % [=======>                             ] 0:05 / 0:23
+ *
+ * $progress = \WP_CLI\Utils\make_progress_bar( 'Generating users', $count );
+ * for ( $i = 0; $i < $count; $i++ ) {
+ *     // uses wp_insert_user() to insert the user
+ *     $progress->tick();
+ * }
+ * $progress->finish();
+ * ```
+ *
+ * @access public
+ * @category Output
+ *
+ * @param string  $message  Text to display before the progress bar.
+ * @param integer $count    Total number of ticks to be performed.
+ * @return cli\progress\Bar|WP_CLI\NoOp
+ */
 function make_progress_bar( $message, $count ) {
 	if ( \cli\Shell::isPiped() )
 		return new \WP_CLI\NoOp;


### PR DESCRIPTION
Fixes #2456