### PR TITLE
Support config deep merging and inheritance

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -290,7 +290,7 @@ Feature: Have a config file
       """
     And a wp-cli.yml file:
       """
-      cli config:
+      _:
         merge: true
       test-cmd:
         bar: burrito
@@ -311,7 +311,7 @@ Feature: Have a config file
 
     Given a wp-cli.yml file:
       """
-      cli config:
+      _:
         merge: false
       test-cmd:
         bar: burrito
@@ -350,7 +350,7 @@ Feature: Have a config file
 
     Given a wp-cli.local.yml file:
       """
-      cli config:
+      _:
         inherit: wp-cli.yml
         merge: true
       test-cmd:

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -138,6 +138,9 @@ class Configurator {
 	 */
 	public function merge_yml( $path ) {
 		$yaml = self::load_yml( $path );
+		if ( ! empty( $yaml['cli config']['inherit'] ) ) {
+			$this->merge_yml( $yaml['cli config']['inherit'] );
+		}
 		foreach ( $yaml as $key => $value ) {
 			if ( !isset( $this->spec[ $key ] ) || false === $this->spec[ $key ]['file'] ) {
 				if ( isset( $this->extra_config[ $key ] )

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -138,13 +138,13 @@ class Configurator {
 	 */
 	public function merge_yml( $path ) {
 		$yaml = self::load_yml( $path );
-		if ( ! empty( $yaml['cli config']['inherit'] ) ) {
-			$this->merge_yml( $yaml['cli config']['inherit'] );
+		if ( ! empty( $yaml['_']['inherit'] ) ) {
+			$this->merge_yml( $yaml['_']['inherit'] );
 		}
 		foreach ( $yaml as $key => $value ) {
 			if ( !isset( $this->spec[ $key ] ) || false === $this->spec[ $key ]['file'] ) {
 				if ( isset( $this->extra_config[ $key ] )
-					&& ! empty( $yaml['cli config']['merge'] )
+					&& ! empty( $yaml['_']['merge'] )
 					&& is_array( $this->extra_config[ $key ] )
 					&& is_array( $value ) ) {
 					$this->extra_config[ $key ] = array_merge( $this->extra_config[ $key ], $value );

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -137,9 +137,17 @@ class Configurator {
 	 * @param string $path Path to YAML file.
 	 */
 	public function merge_yml( $path ) {
-		foreach ( self::load_yml( $path ) as $key => $value ) {
+		$yaml = self::load_yml( $path );
+		foreach ( $yaml as $key => $value ) {
 			if ( !isset( $this->spec[ $key ] ) || false === $this->spec[ $key ]['file'] ) {
-				$this->extra_config[ $key ] = $value;
+				if ( isset( $this->extra_config[ $key ] )
+					&& ! empty( $yaml['cli config']['merge'] )
+					&& is_array( $this->extra_config[ $key ] )
+					&& is_array( $value ) ) {
+					$this->extra_config[ $key ] = array_merge( $this->extra_config[ $key ], $value );
+				} else {
+					$this->extra_config[ $key ] = $value;
+				}
 			} elseif ( $this->spec[ $key ]['multiple'] ) {
 				self::arrayify( $value );
 				$this->config[ $key ] = array_merge( $this->config[ $key ], $value );


### PR DESCRIPTION
A `config.yml`, `wp-cli.yml` or `wp-cli.local.yml` configuration file now supports two configuration parameters:

```
_:
  merge: true
  inherit: <file>.yml
```

`merge` will merge any argument definition, fixing #2069.

`inherit` supports inheriting an arbitrary YAML file, fixing #1063