### PR TITLE
Run help early for `wp core` commands used when core isn't yet installed

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -37,6 +37,13 @@ Feature: Get help about WP-CLI commands
       wp core config
       """
 
+    When I run `wp core config {CORE_CONFIG_SETTINGS}`
+    And I run `wp help core install`
+    Then STDOUT should contain:
+      """
+      wp core install
+      """
+
   Scenario: Help for nonexistent commands
     Given a WP install
     

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -664,7 +664,7 @@ class Runner {
 		self::set_wp_root( $this->find_wp_root() );
 
 		// First try at showing man page
-		if ( 'help' === $this->arguments[0] && ( ! $this->wp_exists() || ! Utils\locate_wp_config() ) ) {
+		if ( 'help' === $this->arguments[0] && ( ! $this->wp_exists() || ! Utils\locate_wp_config() || 'core' === $this->arguments[1] && in_array( $this->arguments[2], array( 'config', 'install', 'multisite-install', 'verify-checksums', 'version' ) ) ) ) {
 			$this->_run_command();
 		}
 


### PR DESCRIPTION
While it would be more ideal to run help early _always_ when core isn't
installed, we are unable to easily inspect the database for blog tables.

This change permits `wp help core install` to be run when
`wp-config.php` is created, but the database isn't yet configured.
Previously, the user would see a "Database not created" error.

Fixes #2191