### PR TITLE
Fix registering instantiated object with `__invoke()` method

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -221,6 +221,36 @@ Feature: WP-CLI Commands
       Success: bar
       """
 
+  Scenario: Use class with __invoke() passed as object
+    Given an empty directory
+    And a custom-cmd.php file:
+      """
+      <?php
+      class Foo_Class {
+
+        public function __construct( $message ) {
+          $this->message = $message;
+        }
+
+        /**
+         * My awesome class method command
+         *
+         * @when before_wp_load
+         */
+        function __invoke( $args ) {
+          WP_CLI::success( $this->message );
+        }
+      }
+      $foo = new Foo_Class( 'bar' );
+      WP_CLI::add_command( 'instantiated-command', $foo );
+      """
+
+    When I run `wp --require=custom-cmd.php instantiated-command`
+    Then STDOUT should contain:
+      """
+      bar
+      """
+
   Scenario: Use an invalid class method as a command
     Given an empty directory
     And a custom-cmd.php file:

--- a/features/command.feature
+++ b/features/command.feature
@@ -250,6 +250,7 @@ Feature: WP-CLI Commands
       """
       bar
       """
+    And STDERR should be empty
 
   Scenario: Use an invalid class method as a command
     Given an empty directory

--- a/php/WP_CLI/Dispatcher/CommandFactory.php
+++ b/php/WP_CLI/Dispatcher/CommandFactory.php
@@ -29,7 +29,8 @@ class CommandFactory {
 		} else {
 			$reflection = new \ReflectionClass( $callable );
 			if ( $reflection->hasMethod( '__invoke' ) ) {
-				$command = self::create_subcommand( $parent, $name, array( $reflection->name, '__invoke' ),
+				$class = is_object( $callable ) ? $callable : $reflection->name;
+				$command = self::create_subcommand( $parent, $name, array( $class, '__invoke' ),
 					$reflection->getMethod( '__invoke' ) );
 			} else {
 				$command = self::create_composite_command( $parent, $name, $reflection );


### PR DESCRIPTION
It should use the instantiated object, not try to instantiate it again.

From #2373