### PR TITLE
Sort package lists alphabetically; provide breathing room between author names

### DIFF
--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -265,7 +265,7 @@ class Package_Command extends WP_CLI_Command {
 			$package_output = new stdClass;
 			$package_output->name = $package->getName();
 			$package_output->description = $package->getDescription();
-			$package_output->authors = implode( ',', array_column( (array) $package->getAuthors(), 'name' ) );
+			$package_output->authors = implode( ', ', array_column( (array) $package->getAuthors(), 'name' ) );
 			$package_output->version = $package->getPrettyVersion();
 			$list[$package_output->name] = $package_output;
 		}

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -270,6 +270,7 @@ class Package_Command extends WP_CLI_Command {
 			$list[$package_output->name] = $package_output;
 		}
 
+		ksort( $list );
 		WP_CLI\Utils\format_items( $assoc_args['format'], $list, $assoc_args['fields'] );
 	}
 


### PR DESCRIPTION
See #1564