### PR TITLE
Fix formatting of GLOBAL PARAMETERS when command has subcommands

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -174,3 +174,36 @@ Feature: Get help about WP-CLI commands
       """
       test-extra
       """
+
+  Scenario: Help renders global parameters correctly
+    Given a WP install
+
+    When I run `wp help import get`
+    Then STDOUT should contain:
+      """
+      GLOBAL PARAMETERS
+      """
+    And STDOUT should not contain:
+      """
+      ## GLOBAL PARAMETERS
+      """
+
+    When I run `wp help option get`
+    Then STDOUT should contain:
+      """
+      GLOBAL PARAMETERS
+      """
+    And STDOUT should not contain:
+      """
+      ## GLOBAL PARAMETERS
+      """
+
+    When I run `wp help option`
+    Then STDOUT should contain:
+      """
+      GLOBAL PARAMETERS
+      """
+    And STDOUT should not contain:
+      """
+      ## GLOBAL PARAMETERS
+      """

--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -30,7 +30,6 @@ class CompositeCommand {
 
 		$this->shortdesc = $docparser->get_shortdesc();
 		$this->longdesc = $docparser->get_longdesc();
-		$this->longdesc .= $this->get_global_params();
 		$this->docparser = $docparser;
 
 		$when_to_invoke = $docparser->get_tag( 'when' );
@@ -115,7 +114,7 @@ class CompositeCommand {
 	 * @return string
 	 */
 	public function get_longdesc() {
-		return $this->longdesc;
+		return $this->longdesc . $this->get_global_params();
 	}
 
 	/**
@@ -276,6 +275,10 @@ class CompositeCommand {
 				'synopsis' => $synopsis,
 				'desc' => $details['desc']
 			);
+		}
+
+		if ( $this->get_subcommands() ) {
+			$binding['has_subcommands'] = true;
 		}
 
 		return Utils\mustache_render( 'man-params.mustache', $binding );

--- a/templates/man-params.mustache
+++ b/templates/man-params.mustache
@@ -2,6 +2,10 @@
 
 
 {{/is_subcommand}}
+{{#has_subcommands}}
+
+
+{{/has_subcommands}}
 ## GLOBAL PARAMETERS
 
 {{#parameters}}


### PR DESCRIPTION
Also ensures GLOBAL PARAMETERS are added to commands with synopsis passed as `$args`

Previously:

![image](https://cloud.githubusercontent.com/assets/36432/13356138/c5d13526-dc58-11e5-98e1-927abcea679b.png)
