### PR TITLE
Differentiate output when moving comments to trash from output when deleting comments

### DIFF
--- a/features/comment.feature
+++ b/features/comment.feature
@@ -28,7 +28,25 @@ Feature: Manage WordPress comments
       """
 	  Success: Deleted comment {COMMENT_ID}.
       """
-      
+
+    When I run `wp comment get {COMMENT_ID} --field=comment_approved`
+    Then STDOUT should be:
+      """
+      trash
+      """
+
+    When I run `wp comment delete {COMMENT_ID} --force`
+    Then STDOUT should be:
+      """
+      Success: Deleted comment {COMMENT_ID}.
+      """
+
+    When I try `wp comment get {COMMENT_ID}`
+    Then STDERR should be:
+      """
+      Error: Invalid comment ID.
+      """
+
     When I run `wp comment create --comment_post_ID=1`
     And I run `wp comment create --comment_post_ID=1`
     And I run `wp comment delete 3 4`

--- a/features/comment.feature
+++ b/features/comment.feature
@@ -55,7 +55,7 @@ Feature: Manage WordPress comments
       Success: Deleted comment 3.
       Success: Deleted comment 4.
       """
-  
+
   Scenario: Get details about an existing comment
     When I run `wp comment get 1`
     Then STDOUT should be a table containing rows:
@@ -91,7 +91,7 @@ Feature: Manage WordPress comments
       #comment-1
       """
 
-  Scenario: Count  comments
+  Scenario: Count comments
     When I run `wp comment count 1`
     Then STDOUT should contain:
       """

--- a/features/comment.feature
+++ b/features/comment.feature
@@ -26,7 +26,7 @@ Feature: Manage WordPress comments
     When I run `wp comment delete {COMMENT_ID}`
     Then STDOUT should be:
       """
-	  Success: Deleted comment {COMMENT_ID}.
+	  Success: Trashed comment {COMMENT_ID}.
       """
 
     When I run `wp comment get {COMMENT_ID} --field=comment_approved`
@@ -52,8 +52,8 @@ Feature: Manage WordPress comments
     And I run `wp comment delete 3 4`
     Then STDOUT should be:
       """
-      Success: Deleted comment 3.
-      Success: Deleted comment 4.
+      Success: Trashed comment 3.
+      Success: Trashed comment 4.
       """
 
   Scenario: Get details about an existing comment

--- a/php/commands/comment.php
+++ b/php/commands/comment.php
@@ -247,10 +247,16 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 */
 	public function delete( $args, $assoc_args ) {
 		parent::_delete( $args, $assoc_args, function ( $comment_id, $assoc_args ) {
-			$r = wp_delete_comment( $comment_id, \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) );
+			$force = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' );
+
+			$r = wp_delete_comment( $comment_id, $force );
 
 			if ( $r ) {
-				return array( 'success', "Deleted comment $comment_id." );
+				if ( $force ) {
+					return array( 'success', "Deleted comment $comment_id." );
+				} else {
+					return array( 'success', "Trashed comment $comment_id." );
+				}
 			} else {
 				return array( 'error', "Failed deleting comment $comment_id" );
 			}


### PR DESCRIPTION
Change the output of `wp comment delete` from:

`Success: Deleted comment {COMMENT_ID}.`

To:

`Success: Trashed comment {COMMENT_ID}.`

To differentiate it from the output of `wp comment delete --force` and to make it clear that `wp comment delete` trashes the comment.