### PR TITLE
Accommodate spaces in `ps -o ppid,pid,command` output

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -127,22 +127,24 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 		$master_pid = $status['pid'];
 
-		$output = `ps -o ppid,pid,command | grep ^$master_pid`;
+		$output = `ps -o ppid,pid,command | grep $master_pid`;
 
-		foreach ( explode( "\n", $output ) as $line ) {
-			if ( preg_match( '/^(\d+)\s+(\d+)/', $line, $matches ) ) {
+		foreach ( explode( PHP_EOL, $output ) as $line ) {
+			if ( preg_match( '/^\s+?(\d+)\s+(\d+)/', $line, $matches ) ) {
 				$parent = $matches[1];
 				$child = $matches[2];
 
 				if ( $parent == $master_pid ) {
-					if ( ! posix_kill( $child, 9 ) ) {
+					if ( ! posix_kill( (int) $child, 9 ) ) {
 						throw new RuntimeException( posix_strerror( posix_get_last_error() ) );
 					}
 				}
 			}
 		}
 
-		posix_kill( $master_pid, 9 );
+		if ( ! posix_kill( (int) $master_pid, 9 ) ) {
+			throw new RuntimeException( posix_strerror( posix_get_last_error() ) );
+		}
 	}
 
 	public static function create_cache_dir() {

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -130,7 +130,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		$output = `ps -o ppid,pid,command | grep $master_pid`;
 
 		foreach ( explode( PHP_EOL, $output ) as $line ) {
-			if ( preg_match( '/^\s+?(\d+)\s+(\d+)/', $line, $matches ) ) {
+			if ( preg_match( '/^\s*(\d+)\s+(\d+)/', $line, $matches ) ) {
 				$parent = $matches[1];
 				$child = $matches[2];
 


### PR DESCRIPTION
Some shells format output differently. We can easily accommodate minor
formatting changes, though.

See #2111