### PR TITLE
Error messages explain what files failed.

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -510,6 +510,7 @@ class Runner {
 		if ( !$this->wp_exists() ) {
 			WP_CLI::error(
 				"This does not seem to be a WordPress install.\n" .
+				"(".ABSPATH."wp-includes/version.php is not readable).\n" .
 				"Pass --path=`path/to/wordpress` or run `wp core download`." );
 		}
 

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -871,6 +871,7 @@ EOT;
 		if ( ! is_readable( $versions_path ) ) {
 			WP_CLI::error(
 				"This does not seem to be a WordPress install.\n" .
+				"(".ABSPATH."wp-includes/version.php is not readable).\n" .
 				"Pass --path=`path/to/wordpress` or run `wp core download`." );
 		}
 


### PR DESCRIPTION
Saying "This" does not seem to be a WP install is not helpful because
it doesn't attempt to answer what the program was considering "This"
to be

Including exactly what was attempted to be accessed can help with
debugging.