### PR TITLE
Handle multi-column keys in search and replace

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -232,6 +232,18 @@ Feature: Do global search/replace
       """
     And STDOUT should be empty
 
+  Scenario: Search and replace a table that has a multi-column primary key
+    Given a WP install
+    And I run `wp db query "CREATE TABLE wp_multicol ( "id" bigint(20) NOT NULL AUTO_INCREMENT,"name" varchar(60) NOT NULL,"value" text NOT NULL,PRIMARY KEY ("id","name"),UNIQUE KEY "name" ("name") ) ENGINE=InnoDB DEFAULT CHARSET=utf8 "`
+    And I run `wp db query "INSERT INTO wp_multicol VALUES (1, 'foo',  'bar')"`
+    And I run `wp db query "INSERT INTO wp_multicol VALUES (2, 'bar',  'foo')"`
+
+    When I run `wp search-replace bar replaced wp_multicol`
+    Then STDOUT should be a table containing rows:
+      | Table       | Column | Replacements | Type |
+      | wp_multicol | name   | 1            | SQL  |
+      | wp_multicol | value  | 1            | SQL  |
+
   Scenario Outline: Large guid search/replace where replacement contains search (or not)
     Given a WP install
     And I run `wp option get siteurl`

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -288,7 +288,8 @@ class Search_Replace_Command extends WP_CLI_Command {
 		foreach ( $rows as $keys ) {
 			$where_sql = '';
 			foreach( (array) $keys as $k => $v ) {
-				$where_sql .= "{$k}={$v}";
+				if (strlen($where_sql)) $where_sql .= ' AND ';
+				$where_sql .= "{$k}='{$v}'";
 			}
 			$col_value = $wpdb->get_var( "SELECT {$col_sql} FROM {$table_sql} WHERE {$where_sql}" );
 			if ( '' === $col_value )


### PR DESCRIPTION
The where clause was constructed without regard to handling multiple
column keys nor quoting character values.

The example table that the previous technique doesn't work with is
wp_wp_super_edit_options which has a primary key on id and name.

Adding single quotes around integer values has no negative effect.

CREATE TABLE "wp_wp_super_edit_options" (
  "id" bigint(20) NOT NULL AUTO_INCREMENT,
  "name" varchar(60) NOT NULL,
  "value" text NOT NULL,
  PRIMARY KEY ("id","name"),
  UNIQUE KEY "name" ("name")
) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 
