### PR TITLE
Quote example in `wp search-replace` instead of escaping

### DIFF
--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -87,7 +87,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 *     wp search-replace 'foo' 'bar' wp_posts wp_postmeta wp_terms --dry-run
 	 *
 	 *     # Turn your production database into a local database
-	 *     wp search-replace --url=example.com example.com example.dev wp_\*_options
+	 *     wp search-replace --url=example.com example.com example.dev 'wp_*_options'
 	 *
 	 *     # Search/replace to a SQL file without transforming the database
 	 *     wp search-replace foo bar --export=database.sql


### PR DESCRIPTION
Quotes are more friendly and understandable to end users.

From https://twitter.com/wpcli/status/706906502892654592