### PR TITLE
Support nightly builds with `wp cli check-update`

### DIFF
--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -276,25 +276,15 @@ class CLI_Command extends WP_CLI_Command {
 		}
 
 		if ( empty( $updates ) && preg_match( '#-alpha-(.+)$#', WP_CLI_VERSION, $matches ) ) {
-			$url = 'https://api.github.com/repos/wp-cli/wp-cli/git/refs/heads/master';
-
-			$response = Utils\http_request( 'GET', $url, $headers, $options );
-
+			$version_url = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/NIGHTLY_VERSION';
+			$response = Utils\http_request( 'GET', $version_url );
 			if ( ! $response->success || 200 !== $response->status_code ) {
-				WP_CLI::error( sprintf( "Failed to get master hash (HTTP code %d)", $response->status_code ) );
+				WP_CLI::error( sprintf( "Failed to get current nightly version (HTTP code %d)", $response->status_code ) );
 			}
-
-			$latest_hash_data = json_decode( $response->body );
-			$latest_short_hash = substr( $latest_hash_data->object->sha, 0, 7 );
-
-			if ( $latest_short_hash != $matches[1] ) {
-				$version_url = 'https://raw.githubusercontent.com/wp-cli/wp-cli/master/VERSION';
-				$response = Utils\http_request( 'GET', $version_url );
-				if ( ! $response->success || 200 !== $response->status_code ) {
-					WP_CLI::error( sprintf( "Failed to get current version (HTTP code %d)", $response->status_code ) );
-				}
+			$nightly_version = trim( $response->body );
+			if ( WP_CLI_VERSION != $nightly_version ) {
 				$updates['nightly'] = array(
-					'version'        => trim( $response->body ) . '-' . $latest_short_hash,
+					'version'        => $nightly_version,
 					'update_type'    => 'nightly',
 					'package_url'    => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar',
 				);


### PR DESCRIPTION
If there are no major, minor, or patch updates available, let's assume
the user is running a nightly build for the latest release. If they're
running a nightly build for the latest release, we can compare their
current hash to the latest nightly build hash. When they differ, we can
assume the latest nightly build is more recent than the local copy.

See #1011