### PR TITLE
Make `wp package install` more verbose

### DIFF
--- a/php/WP_CLI/ComposerIO.php
+++ b/php/WP_CLI/ComposerIO.php
@@ -21,7 +21,19 @@ class ComposerIO extends NullIO {
      * {@inheritDoc}
      */
 	public function write( $messages, $newline = true ) {
-		WP_CLI::log( " - " . strip_tags( $messages ) );
+		self::output_clean_message( $messages );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function writeError( $messages, $newline = true ) {
+		self::output_clean_message( $messages );
+	}
+
+	private static function output_clean_message( $message ) {
+		$message = preg_replace( '#<(https?)([^>]+)>#', '$1$2', $message );
+		WP_CLI::log( strip_tags( trim( $message ) ) );
 	}
 
 }

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -108,17 +108,19 @@ class Package_Command extends WP_CLI_Command {
 
 		// Try running the installer, but revert composer.json if failed
 		WP_CLI::log( 'Using Composer to install the package...' );
+		WP_CLI::log( '---' );
 		try {
 			$res = $install->run();
 		} catch ( Exception $e ) {
 			WP_CLI::warning( $e->getMessage() );
 		}
+		WP_CLI::log( '---' );
 
 		if ( 0 === $res ) {
 			WP_CLI::success( "Package installed successfully." );
 		} else {
 			file_put_contents( $composer_json_obj->getPath(), $composer_backup );
-			WP_CLI::error( "Package installation failed. Reverted composer.json" );
+			WP_CLI::error( "Package installation failed (Composer return code {$res}). Reverted composer.json" );
 		}
 	}
 


### PR DESCRIPTION
* Update `WP_CLI\ComposerIO` to write error messages too.
* Display return code when Composer installer returns one.

See #1564