### PR TITLE
Use 'wp-cli/wp-cli' for the Composer project name in our package dir

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -1,0 +1,20 @@
+Feature: Install WP-CLI packages
+
+  Scenario: Install a package with 'wp-cli/wp-cli' as a dependency
+    Given a WP install
+
+    When I run `wp package install sinebridge/wp-cli-about:v1.0.1`
+    Then STDOUT should contain:
+      """
+      Success: Package installed
+      """
+    And STDOUT should not contain:
+      """
+      requires wp-cli/wp-cli
+      """
+
+    When I run `wp about`
+    Then STDOUT should contain:
+      """
+      Site Information
+      """

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -91,6 +91,7 @@ class Package_Command extends WP_CLI_Command {
 		WP_CLI::log( sprintf( "Updating %s to require the package...", $composer_json_obj->getPath() ) );
 		$composer_backup = file_get_contents( $composer_json_obj->getPath() );
 		$json_manipulator = new JsonManipulator( $composer_backup );
+		$json_manipulator->addMainKey( 'name', 'wp-cli/wp-cli' );
 		$json_manipulator->addLink( 'require', $package_name, $version );
 		file_put_contents( $composer_json_obj->getPath(), $json_manipulator->getContents() );
 		try {
@@ -413,7 +414,7 @@ class Package_Command extends WP_CLI_Command {
 		);
 
 		$options = array(
-			'name' => 'wp-cli/wp-cli-community-packages',
+			'name' => 'wp-cli/wp-cli',
 			'description' => 'Installed community packages used by WP-CLI',
 			'authors' => array( $author ),
 			'homepage' => self::PACKAGE_INDEX_URL,


### PR DESCRIPTION
Apparently this causes Composer to skip 'wp-cli/wp-cli' as a dependency, which is exactly what we want.

Fixes #2493