### PR TITLE
Add WP REST API registration args to `scaffold (post-type|taxonomy)`

### DIFF
--- a/templates/post_type.mustache
+++ b/templates/post_type.mustache
@@ -23,4 +23,7 @@
 		'rewrite'           => true,
 		'query_var'         => true,
 		'menu_icon'         => 'dashicons-{{dashicon}}',
+		'show_in_rest'      => true,
+		'rest_base'         => '{{slug}}',
+		'rest_controller_class' => 'WP_REST_Posts_Controller',
 	) );

--- a/templates/taxonomy.mustache
+++ b/templates/taxonomy.mustache
@@ -30,4 +30,7 @@
 			'not_found'                  => __( 'No {{label_plural}} found.', '{{textdomain}}' ),
 			'menu_name'                  => __( '{{label_plural_ucfirst}}', '{{textdomain}}' ),
 		),
+		'show_in_rest'      => true,
+		'rest_base'         => '{{slug}}',
+		'rest_controller_class' => 'WP_REST_Terms_Controller',
 	) );


### PR DESCRIPTION
These are pretty well-established now.

Fixes #2158