### PR TITLE
Run `wp package` commands before any packages are loaded

### DIFF
--- a/features/package.feature
+++ b/features/package.feature
@@ -29,3 +29,20 @@ Feature: Manage WP-CLI packages
       """
       danielbachhuber/wp-cli-reset-post-date-command
       """
+
+  Scenario: Run package commands early, before any bad code can break them
+    Given an empty directory
+    And a bad-command.php file:
+      """
+      <?php
+      WP_CLI::error( "Doing it wrong." );
+      """
+
+    When I try `wp --require=bad-command.php option`
+    Then STDERR should contain:
+      """
+      Error: Doing it wrong.
+      """
+
+    When I run `wp --require=bad-command.php package list`
+    Then STDERR should be empty

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -619,6 +619,12 @@ class Runner {
 			exit;
 		}
 
+		// Protect 'package' commands from most of the runtime too
+		if ( 'package' === $this->arguments[0] ) {
+			$this->_run_command();
+			exit;
+		}
+
 		// Load bundled commands early, so that they're forced to use the same
 		// APIs as non-bundled commands.
 		Utils\load_command( $this->arguments[0] );


### PR DESCRIPTION
If a user installs a bad package, we want them to be able to back out of it.

See https://github.com/wp-cli/wp-cli/issues/2548#issuecomment-194870695
See #1564