### PR TITLE
Support registering `default` and `options` for positional/assoc args

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -354,3 +354,118 @@ Feature: WP-CLI Commands
       [--meal=<meal>]
           A type of meal.
       """
+
+  Scenario: Register a command with default and accepted arguments.
+    Given an empty directory
+    And a test-cmd.php file:
+      """
+      <?php
+      /**
+       * An amazing command for managing burritos.
+       *
+       * [<bar>]
+       * : This is the bar argument.
+       * ---
+       * default: burrito
+       * ---
+       *
+       * [<shop>]
+       * : This is where you buy burritos.
+       * ---
+       * options:
+       *   - left_coast_siesta
+       *   - cha cha cha
+       * ---
+       *
+       * [--burrito=<burrito>]
+       * : This is the burrito argument.
+       * ---
+       * options:
+       *   - beans
+       *   - veggies
+       * ---
+       *
+       * @when before_wp_load
+       */
+      $foo = function( $args, $assoc_args ) {
+        $out = array(
+          'bar'     => isset( $args[0] ) ? $args[0] : '',
+          'shop'    => isset( $args[1] ) ? $args[1] : '',
+          'burrito' => isset( $assoc_args['burrito'] ) ? $assoc_args['burrito'] : '',
+        );
+        WP_CLI::print_value( $out, array( 'format' => 'yaml' ) );
+      };
+      WP_CLI::add_command( 'foo', $foo );
+      """
+
+    When I run `wp --require=test-cmd.php foo --help`
+    Then STDOUT should contain:
+      """
+      [<bar>]
+          This is the bar argument.
+          ---
+          default: burrito
+          ---
+      """
+    And STDOUT should contain:
+      """
+      [--burrito=<burrito>]
+          This is the burrito argument.
+          ---
+          options:
+            - beans
+            - veggies
+          ---
+      """
+
+    When I run `wp --require=test-cmd.php foo`
+    Then STDOUT should be YAML containing:
+      """
+      bar: burrito
+      shop:
+      burrito:
+      """
+
+    When I run `wp --require=test-cmd.php foo ''`
+    Then STDOUT should be YAML containing:
+      """
+      bar:
+      shop:
+      burrito:
+      """
+
+    When I run `wp --require=test-cmd.php foo apple --burrito=veggies`
+    Then STDOUT should be YAML containing:
+      """
+      bar: apple
+      shop:
+      burrito: veggies
+      """
+
+    When I try `wp --require=test-cmd.php foo apple --burrito=meat`
+    Then STDERR should contain:
+      """
+      Error: Parameter errors:
+       Invalid value specified for 'burrito' (This is the burrito argument.)
+      """
+
+    When I try `wp --require=test-cmd.php foo apple --burrito=''`
+    Then STDERR should contain:
+      """
+      Error: Parameter errors:
+       Invalid value specified for 'burrito' (This is the burrito argument.)
+      """
+
+    When I try `wp --require=test-cmd.php foo apple taco_del_mar`
+    Then STDERR should contain:
+      """
+      Error: Invalid value specified for positional arg.
+      """
+
+    When I run `wp --require=test-cmd.php foo apple 'cha cha cha'`
+    Then STDOUT should be YAML containing:
+      """
+      bar: apple
+      shop: cha cha cha
+      burrito:
+      """

--- a/features/command.feature
+++ b/features/command.feature
@@ -299,6 +299,7 @@ Feature: WP-CLI Commands
             'name'          => 'message',
             'description'   => 'An awesome message to display',
             'optional'      => false,
+            'options'       => array( 'hello', 'goodbye' ),
           ),
           array(
             'type'          => 'assoc',
@@ -311,6 +312,8 @@ Feature: WP-CLI Commands
             'name'          => 'meal',
             'description'   => 'A type of meal.',
             'optional'      => true,
+            'default'       => 'breakfast',
+            'options'       => array( 'breakfast', 'lunch', 'dinner' ),
           ),
         ),
       ) );
@@ -348,11 +351,23 @@ Feature: WP-CLI Commands
       """
       <message>
           An awesome message to display
+          ---
+          options:
+            - hello
+            - goodbye
+          ---
       """
     And STDOUT should contain:
       """
       [--meal=<meal>]
           A type of meal.
+          ---
+          default: breakfast
+          options:
+            - breakfast
+            - lunch
+            - dinner
+          ---
       """
 
   Scenario: Register a command with default and accepted arguments.

--- a/features/command.feature
+++ b/features/command.feature
@@ -369,7 +369,7 @@ Feature: WP-CLI Commands
        * default: burrito
        * ---
        *
-       * [<shop>]
+       * [<shop>...]
        * : This is where you buy burritos.
        * ---
        * options:
@@ -457,6 +457,12 @@ Feature: WP-CLI Commands
       """
 
     When I try `wp --require=test-cmd.php foo apple taco_del_mar`
+    Then STDERR should contain:
+      """
+      Error: Invalid value specified for positional arg.
+      """
+
+    When I try `wp --require=test-cmd.php foo apple 'cha cha cha' taco_del_mar`
     Then STDERR should contain:
       """
       Error: Invalid value specified for positional arg.

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -253,8 +253,7 @@ class Subcommand extends CompositeCommand {
 		}
 
 		$synopsis_spec = \WP_CLI\SynopsisParser::parse( $synopsis );
-		reset( $args );
-		$i = key( $args );
+		$i = 0;
 		$errors = array( 'fatal' => array(), 'warning' => array() );
 		foreach( $synopsis_spec as $spec ) {
 			if ( 'positional' === $spec['type'] ) {

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -253,7 +253,8 @@ class Subcommand extends CompositeCommand {
 		}
 
 		$synopsis_spec = \WP_CLI\SynopsisParser::parse( $synopsis );
-		$i = 0;
+		reset( $args );
+		$i = key( $args );
 		$errors = array( 'fatal' => array(), 'warning' => array() );
 		foreach( $synopsis_spec as $spec ) {
 			if ( 'positional' === $spec['type'] ) {

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -228,8 +228,9 @@ class Subcommand extends CompositeCommand {
 	 */
 	private function validate_args( $args, $assoc_args, $extra_args ) {
 		$synopsis = $this->get_synopsis();
-		if ( !$synopsis )
-			return array();
+		if ( !$synopsis ) {
+			return array( array(), $args, $assoc_args, $extra_args );
+		}
 
 		$validator = new \WP_CLI\SynopsisValidator( $synopsis );
 

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -256,9 +256,6 @@ class Subcommand extends CompositeCommand {
 		$i = 0;
 		$errors = array( 'fatal' => array(), 'warning' => array() );
 		foreach( $synopsis_spec as $spec ) {
-			if ( ! empty( $spec['repeating'] ) ) {
-				continue;
-			}
 			if ( 'positional' === $spec['type'] ) {
 				$spec_args = $this->docparser->get_arg_args( $spec['name'] );
 				if ( ! isset( $args[ $i ] ) ) {
@@ -266,9 +263,18 @@ class Subcommand extends CompositeCommand {
 						$args[ $i ] = $spec_args['default'];
 					}
 				}
-				if ( isset( $args[ $i ] ) && isset( $spec_args['options'] ) ) {
-					if ( ! in_array( $args[ $i ], $spec_args['options'] ) ) {
-						\WP_CLI::error( 'Invalid value specified for positional arg.' );
+				if ( isset( $spec_args['options'] ) ) {
+					if ( ! empty( $spec['repeating'] ) ) {
+						do {
+							if ( isset( $args[ $i ] ) && ! in_array( $args[ $i ], $spec_args['options'] ) ) {
+								\WP_CLI::error( 'Invalid value specified for positional arg.' );
+							}
+							$i++;
+						} while ( isset( $args[ $i ] ) );
+					} else {
+						if ( ! in_array( $args[ $i ], $spec_args['options'] ) ) {
+							\WP_CLI::error( 'Invalid value specified for positional arg.' );
+						}
 					}
 				}
 				$i++;

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -2,6 +2,8 @@
 
 namespace WP_CLI;
 
+use Spyc;
+
 /**
  * Parse command attributes from its PHPdoc.
  * Used to determine execution characteristics (arguments, etc.).
@@ -112,6 +114,19 @@ class DocParser {
 	}
 
 	/**
+	 * Get the arguments for a given argument.
+	 *
+	 * @param string $name Argument's doc name.
+	 * @return mixed|null
+	 */
+	public function get_arg_args( $name ) {
+		if ( preg_match( "/\[?<{$name}>.+(\n: (.+?)(\n|$))?\n---\n(.+)\n---/sU", $this->docComment, $matches ) ) {
+			return Spyc::YAMLLoadString( $matches[4] );
+		}
+		return null;
+	}
+
+	/**
 	 * Get the description for a given parameter.
 	 *
 	 * @param string $key Parameter's key.
@@ -124,6 +139,21 @@ class DocParser {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Get the arguments for a given parameter.
+	 *
+	 * @param string $key Parameter's key.
+	 * @return mixed|null
+	 */
+	public function get_param_args( $key ) {
+
+		if ( preg_match( "/\[?--{$key}=.+(\n: (.+?)(\n|$))?\n---\n(.+)\n---/sU", $this->docComment, $matches ) ) {
+			return Spyc::YAMLLoadString( $matches[4] );
+		}
+
+		return null;
 	}
 
 }

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -315,7 +315,7 @@ class WP_CLI {
 				foreach( $args['synopsis'] as $key => $arg ) {
 					$long_desc .= $bits[ $key ] . PHP_EOL . ': ' . $arg['description'] . PHP_EOL;
 					$yamlify = array();
-					foreach( array( 'options', 'default' ) as $key ) {
+					foreach( array( 'default', 'options' ) as $key ) {
 						if ( isset( $arg[ $key ] ) ) {
 							$yamlify[ $key ] = $arg[ $key ];
 						}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -313,7 +313,18 @@ class WP_CLI {
 				$long_desc = '';
 				$bits = explode( ' ', $synopsis );
 				foreach( $args['synopsis'] as $key => $arg ) {
-					$long_desc .= $bits[ $key ] . PHP_EOL . ': ' . $arg['description'] . PHP_EOL . PHP_EOL;
+					$long_desc .= $bits[ $key ] . PHP_EOL . ': ' . $arg['description'] . PHP_EOL;
+					$yamlify = array();
+					foreach( array( 'options', 'default' ) as $key ) {
+						if ( isset( $arg[ $key ] ) ) {
+							$yamlify[ $key ] = $arg[ $key ];
+						}
+					}
+					if ( ! empty( $yamlify ) ) {
+						$long_desc .= \Spyc::YAMLDump( $yamlify );
+						$long_desc .= '---' . PHP_EOL;
+					}
+					$long_desc .= PHP_EOL;
 				}
 				if ( ! empty( $long_desc ) ) {
 					$long_desc = rtrim( $long_desc, PHP_EOL );

--- a/tests/test-doc-parser.php
+++ b/tests/test-doc-parser.php
@@ -94,5 +94,46 @@ EOB
 		;
 		$this->assertEquals( $longdesc, $doc->get_longdesc() );
 	}
+
+	public function test_desc_parses_yaml() {
+		$longdesc = <<<EOB
+## OPTIONS
+
+<genre>...
+: Start with one or more genres.
+---
+options:
+  - rock
+  - electronic
+default: rock
+---
+
+--volume=<number>
+: Sets the volume.
+---
+default: 10
+---
+
+--artist=<artist-name>
+: Limit to a specific artist.
+
+## EXAMPLES
+
+wp rock-on electronic --volume=11
+
+EOB;
+		$doc = new DocParser( $longdesc );
+		$this->assertEquals( 'Start with one or more genres.', $doc->get_arg_desc( 'genre' ) );
+		$this->assertEquals( 'Sets the volume.', $doc->get_param_desc( 'volume' ) );
+		$this->assertEquals( array(
+			'options' => array( 'rock', 'electronic' ),
+			'default' => 'rock',
+		), $doc->get_arg_args( 'genre' ) );
+		$this->assertEquals( array(
+			'default' => 10,
+		), $doc->get_param_args( 'volume' ) );
+		$this->assertNull( $doc->get_param_args( 'artist' ) );
+	}
+
 }
 


### PR DESCRIPTION
`default` fills the value when it isn't set. `options` validates the
filled value against an enum of values.

YAML for the win:
```
--volume=<number>
: Sets the volume.
---
default: 10
---
```

Fixes #1293
Fixes #1294