### PR TITLE
Only register `description` for a command when present

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -313,7 +313,10 @@ class WP_CLI {
 				$long_desc = '';
 				$bits = explode( ' ', $synopsis );
 				foreach( $args['synopsis'] as $key => $arg ) {
-					$long_desc .= $bits[ $key ] . PHP_EOL . ': ' . $arg['description'] . PHP_EOL;
+					$long_desc .= $bits[ $key ] . PHP_EOL;
+					if ( ! empty( $arg['description'] ) ) {
+						$long_desc .= ': ' . $arg['description'] . PHP_EOL;
+					}
 					$yamlify = array();
 					foreach( array( 'default', 'options' ) as $key ) {
 						if ( isset( $arg[ $key ] ) ) {


### PR DESCRIPTION
Doing so prevents wonky formatting when `description` isn't set.

Bug introduced in #2512