### PR TITLE
Use `--skip-packages` to skip loading installed packages

### DIFF
--- a/features/package.feature
+++ b/features/package.feature
@@ -15,6 +15,16 @@ Feature: Manage WP-CLI packages
     When I run `wp help reset-post-date`
     Then STDERR should be empty
 
+    When I try `wp --skip-packages --debug help reset-post-date`
+    Then STDERR should contain:
+      """
+      Debug: Skipped loading packages.
+      """
+    And STDERR should contain:
+      """
+      Error: This does not seem to be a WordPress install.
+      """
+
     When I run `wp package list`
     Then STDOUT should contain:
       """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -629,13 +629,17 @@ class Runner {
 		// APIs as non-bundled commands.
 		Utils\load_command( $this->arguments[0] );
 
-		$package_autoload = $this->get_packages_dir_path() . 'vendor/autoload.php';
-
-		if ( file_exists( $package_autoload ) ) {
-			WP_CLI::debug( 'Loading packages from: ' . $package_autoload );
-			require_once $package_autoload;
+		$skip_packages = \WP_CLI::get_runner()->config['skip-packages'];
+		if ( true === $skip_packages ) {
+			WP_CLI::debug( 'Skipped loading packages.' );
 		} else {
-			WP_CLI::debug( 'No package autoload found to load.' );
+			$package_autoload = $this->get_packages_dir_path() . 'vendor/autoload.php';
+			if ( file_exists( $package_autoload ) ) {
+				WP_CLI::debug( 'Loading packages from: ' . $package_autoload );
+				require_once $package_autoload;
+			} else {
+				WP_CLI::debug( 'No package autoload found to load.' );
+			}
 		}
 
 		if ( isset( $this->config['require'] ) ) {

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -42,6 +42,13 @@ return array(
 		'default' => '',
 	),
 
+	'skip-packages' => array(
+		'runtime'   => '',
+		'file'      => '<bool>',
+		'desc'      => 'Skip loading all installed packages.',
+		'default'   => false,
+	),
+
 	'require' => array(
 		'runtime' => '=<path>',
 		'file' => '<path>',


### PR DESCRIPTION
A similar idea to `--skip-plugins`, if a package has gone awry, permit
normal usage of WP-CLI.

See #1564