### PR TITLE
Properly add `wp plugin search` fields to plugins_api() request

### DIFF
--- a/features/plugin-search.feature
+++ b/features/plugin-search.feature
@@ -1,0 +1,14 @@
+Feature: Search WordPress.org plugins
+
+  Scenario: Search for plugins with active_installs field
+    Given a WP install
+
+    When I run `wp plugin search foo --fields=name,slug,active_installs --format=csv`
+    Then STDOUT should contain:
+      """
+      Success: Showing
+      """
+    And STDOUT should contain:
+      """
+      name,slug,active_installs
+      """

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -407,15 +407,20 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 		$defaults = array(
 			'per-page' => 10,
-			'fields' => array( 'name', 'slug', 'rating' )
+			'fields' => implode( ',', array( 'name', 'slug', 'rating' ) ),
 		);
 		$assoc_args = array_merge( $defaults, $assoc_args );
+		$fields = array();
+		foreach( explode( ',', $assoc_args['fields'] ) as $field ) {
+			$fields[ $field ] = true;
+		}
 
 		$formatter = $this->get_formatter( $assoc_args );
 
 		$api_args = array(
 			'per_page' => (int) $assoc_args['per-page'],
 			'search' => $term,
+			'fields' => $fields,
 		);
 
 		if ( 'plugin' == $this->item_type ) {

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -407,6 +407,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 		$defaults = array(
 			'per-page' => 10,
+			'page' => 1,
 			'fields' => implode( ',', array( 'name', 'slug', 'rating' ) ),
 		);
 		$assoc_args = array_merge( $defaults, $assoc_args );
@@ -419,6 +420,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 		$api_args = array(
 			'per_page' => (int) $assoc_args['per-page'],
+			'page' => (int) $assoc_args['page'],
 			'search' => $term,
 			'fields' => $fields,
 		);

--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -53,6 +53,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * <search>
 	 * : The string to search for.
 	 *
+	 * [--page=<page>]
+	 * : Optional page to display.  Defaults to 1.
+	 *
 	 * [--per-page=<per-page>]
 	 * : Optional number of results to display. Defaults to 10.
 	 *


### PR DESCRIPTION
They need to be supplied in the first place, and passed in a
non-standard format.

Fixes #2568