### PR TITLE
Added support for page parameter.

### DIFF
--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -407,6 +407,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 		$defaults = array(
 			'per-page' => 10,
+			'page' => 1,
 			'fields' => implode( ',', array( 'name', 'slug', 'rating' ) ),
 		);
 		$assoc_args = array_merge( $defaults, $assoc_args );
@@ -419,6 +420,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 		$api_args = array(
 			'per_page' => (int) $assoc_args['per-page'],
+			'page' => (int) $assoc_args['page'],
 			'search' => $term,
 			'fields' => $fields,
 		);

--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -53,6 +53,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 * <search>
 	 * : The string to search for.
 	 *
+	 * [--page=<page>]
+	 * : Optional page to display.  Defaults to 1.
+	 *
 	 * [--per-page=<per-page>]
 	 * : Optional number of results to display. Defaults to 10.
 	 *


### PR DESCRIPTION
There didn't appear to be a way to add the page parameter, and some searches are too large
to pull down the full answer set.

Now it is possible to write queries like:

wp plugin search <SOMETHING> --page=2