### PR TITLE
Add `parent` as a potential status in `wp theme status`

### DIFF
--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -372,12 +372,14 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			'active' => 'A',
 			'active-network' => 'N',
 			'must-use' => 'M',
+			'parent' => 'P',
 		),
 		'long' => array(
 			'inactive' => 'Inactive',
 			'active' => 'Active',
 			'active-network' => 'Network Active',
 			'must-use' => 'Must Use',
+			'parent' => 'Parent',
 		)
 	);
 
@@ -391,6 +393,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 			'active' => '%g',
 			'active-network' => '%g',
 			'must-use' => '%c',
+			'parent' => '%p',
 		);
 
 		return $colors[ $status ];


### PR DESCRIPTION
Fixes error notices when we're rendering the special case `parent`
status.

See https://github.com/wp-cli/wp-cli/pull/2034#issuecomment-198430899