### PR TITLE
Use `is_callable()` in `WP_CLI:add_command()`

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -249,15 +249,11 @@ class WP_CLI {
 	 */
 	public static function add_command( $name, $callable, $args = array() ) {
 		$valid = false;
-		if ( is_object( $callable ) && ( $callable instanceof \Closure ) ) {
-			$valid = true;
-		} else if ( is_string( $callable ) && function_exists( $callable ) ) {
+		if ( is_callable( $callable ) ) {
 			$valid = true;
 		} else if ( is_string( $callable ) && class_exists( (string) $callable ) ) {
 			$valid = true;
 		} else if ( is_object( $callable ) ) {
-			$valid = true;
-		} else if ( is_array( $callable ) && is_callable( $callable ) ) {
 			$valid = true;
 		}
 		if ( ! $valid ) {


### PR DESCRIPTION
This is much better than rolling our own equivalent logic