### PR TITLE
Squash `wp export` notice about `skip_comments`

### DIFF
--- a/php/export/class-wp-export-query.php
+++ b/php/export/class-wp-export-query.php
@@ -356,7 +356,7 @@ class WP_Export_Query {
 	private function get_comments_for_post( $post ) {
 		global $wpdb;
 
-		if ( $this->filters['skip_comments'] ) {
+		if ( isset( $this->filters['skip_comments'] ) ) {
 			return array();
 		}
 


### PR DESCRIPTION
2ad7b8e21fa introduced a PHP notice because `$this->filters['skip_comments']` is checked, but it won't exist if the flag isn't set.