### PR TITLE
Use `--format=ids` with `wp (*) generate` output generated ids

### DIFF
--- a/features/comment-generate.feature
+++ b/features/comment-generate.feature
@@ -1,8 +1,9 @@
 Feature: Generate comments
 
-  Scenario: Generate a specific number of comments
-    Given a WP install 
+  Background:
+    Given a WP install
 
+  Scenario: Generate a specific number of comments
     When I run `wp comment generate --count=20`
     And I run `wp comment list --format=count`
     Then STDOUT should be:
@@ -11,8 +12,6 @@ Feature: Generate comments
       """
 
   Scenario: Generate comments assigned to a specific post
-    Given a WP install
-
     When I run `wp comment generate --count=4 --post_id=2`
     And I run `wp comment list --post_id=2 --format=count`
     Then STDOUT should be:
@@ -24,4 +23,14 @@ Feature: Generate comments
     Then STDOUT should be:
       """
       1
+      """
+
+  Scenario: Generating comments and outputting ids
+    When I run `wp comment generate --count=1 --format=ids`
+    Then save STDOUT as {COMMENT_ID}
+
+    When I run `wp comment update {COMMENT_ID} --comment_content="foo"`
+    Then STDOUT should contain:
+      """
+      Success:
       """

--- a/features/post-generate.feature
+++ b/features/post-generate.feature
@@ -31,3 +31,14 @@ Feature: Generate new WordPress posts
       """
       1
       """
+
+  Scenario: Generating posts and outputting ids
+    When I run `wp post generate --count=1 --format=ids`
+    Then save STDOUT as {POST_ID}
+
+    When I run `wp post update {POST_ID} --post_title="foo"`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+

--- a/features/term-generate.feature
+++ b/features/term-generate.feature
@@ -3,6 +3,23 @@ Feature: Generate WP terms
   Background:
     Given a WP install
 
+  Scenario: Generating terms
+    When I run `wp term generate category --count=10`
+    And I run `wp term list category --format=count`
+    Then STDOUT should be:
+      """
+      11
+      """
+
+  Scenario: Generating terms when terms already exist
+    When I run `wp term generate category --count=10`
+    And I run `wp term generate category --count=10`
+    And I run `wp term list category --format=count`
+    Then STDOUT should be:
+      """
+      21
+      """
+
   Scenario: Generating terms and outputting ids
     When I run `wp term generate category --count=1 --format=ids`
     Then save STDOUT as {TERM_ID}

--- a/features/term-generate.feature
+++ b/features/term-generate.feature
@@ -1,0 +1,14 @@
+Feature: Generate WP terms
+
+  Background:
+    Given a WP install
+
+  Scenario: Generating terms and outputting ids
+    When I run `wp term generate category --count=1 --format=ids`
+    Then save STDOUT as {TERM_ID}
+
+    When I run `wp term update category {TERM_ID} --name="foo"`
+    Then STDOUT should contain:
+      """
+      Success:
+      """

--- a/features/term.feature
+++ b/features/term.feature
@@ -75,23 +75,6 @@ Feature: Manage WordPress terms
     When I try the previous command again
     Then STDERR should not be empty
 
-  Scenario: Generating terms
-    When I run `wp term generate category --count=10`
-    And I run `wp term list category --format=count`
-    Then STDOUT should be:
-      """
-      11
-      """
-
-  Scenario: Generating terms when terms already exist
-    When I run `wp term generate category --count=10`
-    And I run `wp term generate category --count=10`
-    And I run `wp term list category --format=count`
-    Then STDOUT should be:
-      """
-      21
-      """
-
   Scenario: Term with a non-existent parent
     When I try `wp term create category Apple --parent=99 --porcelain`
     Then STDERR should be:

--- a/features/user-generate.feature
+++ b/features/user-generate.feature
@@ -3,6 +3,27 @@ Feature: Generate WP users
   Background:
     Given a WP install
 
+  Scenario: Generating and deleting users
+    When I run `wp user list --role=editor --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp user generate --count=10 --role=editor`
+    And I run `wp user list --role=editor --format=count`
+    Then STDOUT should be:
+      """
+      10
+      """
+
+    When I try `wp user list --field=ID | xargs wp user delete invalid-user --yes`
+    And I run `wp user list --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
   Scenario: Generating users and outputting ids
     When I run `wp user generate --count=1 --format=ids`
     Then save STDOUT as {USER_ID}

--- a/features/user-generate.feature
+++ b/features/user-generate.feature
@@ -1,0 +1,14 @@
+Feature: Generate WP users
+
+  Background:
+    Given a WP install
+
+  Scenario: Generating users and outputting ids
+    When I run `wp user generate --count=1 --format=ids`
+    Then save STDOUT as {USER_ID}
+
+    When I run `wp user update {USER_ID} --display_name="foo"`
+    Then STDOUT should contain:
+      """
+      Success:
+      """

--- a/features/user.feature
+++ b/features/user.feature
@@ -102,29 +102,6 @@ Feature: Manage WordPress users
     When I try `wp user get bobjones`
     Then STDERR should not be empty
 
-  Scenario: Generating and deleting users
-    Given a WP install
-
-    When I run `wp user list --role=editor --format=count`
-    Then STDOUT should be:
-      """
-      0
-      """
-
-    When I run `wp user generate --count=10 --role=editor`
-    And I run `wp user list --role=editor --format=count`
-    Then STDOUT should be:
-      """
-      10
-      """
-
-    When I try `wp user list --field=ID | xargs wp user delete invalid-user --yes`
-    And I run `wp user list --format=count`
-    Then STDOUT should be:
-      """
-      0
-      """
-
   Scenario: Create new users on multisite
     Given a WP multisite install
 

--- a/php/commands/comment.php
+++ b/php/commands/comment.php
@@ -99,6 +99,14 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	 *
 	 * [--post_id=<post-id>]
 	 * : Assign comments to a specific post.
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: progress, ids. Default: ids.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Add meta to every generated comment
+	 *     wp comment generate --format=ids | xargs -0 -d ' ' -I % wp comment meta add % foo bar
 	 */
 	public function generate( $args, $assoc_args ) {
 
@@ -108,20 +116,37 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 		);
 		$assoc_args = array_merge( $defaults, $assoc_args );
 
-		$notify = \WP_CLI\Utils\make_progress_bar( 'Generating comments', $assoc_args['count'] );
+		$format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'progress' );
+
+		$notify = false;
+		if ( 'progress' === $format ) {
+			$notify = \WP_CLI\Utils\make_progress_bar( 'Generating comments', $assoc_args['count'] );
+		}
+
 		$comment_count = wp_count_comments();
 		$total = (int )$comment_count->total_comments;
 		$limit = $total + $assoc_args['count'];
 
 		for ( $i = $total; $i < $limit; $i++ ) {
-			wp_insert_comment( array(
+			$comment_id = wp_insert_comment( array(
 				'comment_content'       => "Comment {$i}",
 				'comment_post_ID'       => $assoc_args['post_id'],
 				) );
-			$notify->tick();
+			if ( 'progress' === $format ) {
+				$notify->tick();
+			} else if ( 'ids' === $format ) {
+				if ( 'ids' === $format ) {
+					echo $comment_id;
+					if ( $i < $limit - 1 ) {
+						echo ' ';
+					}
+				}
+			}
 		}
 
-		$notify->finish();
+		if ( 'progress' === $format ) {
+			$notify->finish();
+		}
 
 	}
 

--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -352,10 +352,16 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 	 * [--max_depth=<number>]
 	 * : For hierarchical post types, generate child posts down to a certain depth. Default: 1
 	 *
+	 * [--format=<format>]
+	 * : Accepted values: progress, ids. Default: ids.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp post generate --count=10 --post_type=page --post_date=1999-01-04
 	 *     curl http://loripsum.net/api/5 | wp post generate --post_content --count=10
+	 *
+	 *     # Add meta to every generated post
+	 *     wp post generate --format=ids | xargs -0 -d ' ' -I % wp post meta add % foo bar
 	 */
 	public function generate( $args, $assoc_args ) {
 		global $wpdb;
@@ -394,7 +400,12 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 
 		$limit = $count + $total;
 
-		$notify = \WP_CLI\Utils\make_progress_bar( 'Generating posts', $count );
+		$format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'progress' );
+
+		$notify = false;
+		if ( 'progress' === $format ) {
+			$notify = \WP_CLI\Utils\make_progress_bar( 'Generating posts', $count );
+		}
 
 		$previous_post_id = 0;
 		$current_depth = 1;
@@ -433,11 +444,21 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 				WP_CLI::warning( $post_id );
 			} else {
 				$previous_post_id = $post_id;
+				if ( 'ids' === $format ) {
+					echo $post_id;
+					if ( $i < $limit - 1 ) {
+						echo ' ';
+					}
+				}
 			}
 
-			$notify->tick();
+			if ( 'progress' === $format ) {
+				$notify->tick();
+			}
 		}
-		$notify->finish();
+		if ( 'progress' === $format ) {
+			$notify->finish();
+		}
 		// @codingStandardsIgnoreEnd
 	}
 

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -366,6 +366,14 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	 *
 	 * [--role=<role>]
 	 * : The role of the generated users. Default: default role from WP
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: progress, ids. Default: ids.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Add meta to every generated user
+	 *     wp user generate --format=ids | xargs -0 -d ' ' -I % wp user meta add % foo bar
 	 */
 	public function generate( $args, $assoc_args ) {
 		global $blog_id;
@@ -386,7 +394,12 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 		$total = $user_count['total_users'];
 		$limit = $assoc_args['count'] + $total;
 
-		$notify = \WP_CLI\Utils\make_progress_bar( 'Generating users', $assoc_args['count'] );
+		$format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'progress' );
+
+		$notify = false;
+		if ( 'progress' === $format ) {
+			$notify = \WP_CLI\Utils\make_progress_bar( 'Generating users', $assoc_args['count'] );
+		}
 
 		for ( $i = $total; $i < $limit; $i++ ) {
 			$login = sprintf( 'user_%d_%d', $blog_id, $i );
@@ -405,10 +418,19 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 				delete_user_option( $user_id, 'user_level' );
 			}
 
-			$notify->tick();
+			if ( 'progress' === $format ) {
+				$notify->tick();
+			} else if ( 'ids' === $format ) {
+				echo $user_id;
+				if ( $i < $limit - 1 ) {
+					echo ' ';
+				}
+			}
 		}
 
-		$notify->finish();
+		if ( 'progress' === $format ) {
+			$notify->finish();
+		}
 	}
 
 	/**


### PR DESCRIPTION
More helpful than a progress bar for chaining commands together:

```
wp user generate --format=ids | xargs -0 -d ' ' -I % wp user meta add %
foo bar
```

Fixes #2224