### PR TITLE
Introduce `CompositeCommand->remove_subcommand()`

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -490,3 +490,24 @@ Feature: WP-CLI Commands
       shop: cha cha cha
       burrito:
       """
+
+  Scenario: Removing a subcommand should remove it from the index
+    Given an empty directory
+    And a remove-comment.php file:
+      """
+      <?php
+      $command = WP_CLI::get_root_command();
+      $command->remove_subcommand( 'comment' );
+      """
+
+    When I run `wp`
+    Then STDOUT should contain:
+      """
+      Manage comments.
+      """
+
+    When I run `wp --require=remove-comment.php`
+    Then STDOUT should not contain:
+      """
+      Manage comments.
+      """

--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -59,6 +59,19 @@ class CompositeCommand {
 	}
 
 	/**
+	 * Remove a named subcommand from this composite command's set of contained
+	 * subcommands
+	 *
+	 * @param string $name Represents how subcommand should be invoked
+	 */
+	public function remove_subcommand( $name ) {
+		if ( isset( $this->subcommands[ $name ] ) ) {
+			unset( $this->subcommands[ $name ] );
+		}
+	}
+
+
+	/**
 	 * Composite commands always contain subcommands.
 	 *
 	 * @return true

--- a/php/WP_CLI/Dispatcher/RootCommand.php
+++ b/php/WP_CLI/Dispatcher/RootCommand.php
@@ -53,8 +53,6 @@ class RootCommand extends CompositeCommand {
 	 * @return array
 	 */
 	public function get_subcommands() {
-		Utils\load_all_commands();
-
 		return parent::get_subcommands();
 	}
 }

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -626,7 +626,7 @@ class Runner {
 
 		// Load bundled commands early, so that they're forced to use the same
 		// APIs as non-bundled commands.
-		Utils\load_command( $this->arguments[0] );
+		Utils\load_all_commands();
 
 		$skip_packages = \WP_CLI::get_runner()->config['skip-packages'];
 		if ( true === $skip_packages ) {


### PR DESCRIPTION
This permits a subcommand to be de-registered from its parent.

Also modifies the bootstrap process to always register commands, instead
of lazyloading them based on command name. Packages and required
commands are always loaded, so we should follow similar behavior with
core commands.