### PR TITLE
Normalize plugin / theme version numbers and header formatting

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -42,7 +42,7 @@ Feature: Manage WordPress plugins
       Plugin Zombieland details:
           Name: Zombieland
           Status: Inactive
-          Version: 0.1-alpha
+          Version: 0.1.0
           Author: YOUR NAME HERE
           Description: PLUGIN DESCRIPTION HERE
       """
@@ -61,8 +61,8 @@ Feature: Manage WordPress plugins
 
     When I run `wp plugin list`
     Then STDOUT should be a table containing rows:
-      | name       | status | update | version   |
-      | Zombieland | active | none   | 0.1-alpha |
+      | name       | status | update | version |
+      | Zombieland | active | none   | 0.1.0   |
 
     When I try `wp plugin uninstall Zombieland`
     Then STDERR should contain:

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -125,17 +125,25 @@ Feature: WordPress code scaffolding
       """
     And the {PLUGIN_DIR}/hello-world/hello-world.php file should contain:
       """
-      * Plugin Name: Hello World
+      * Plugin Name:     Hello World
       """
     And the {PLUGIN_DIR}/hello-world/hello-world.php file should contain:
       """
-      * @package Hello_World
+      * Version:         0.1.0
+      """
+    And the {PLUGIN_DIR}/hello-world/hello-world.php file should contain:
+      """
+      * @package         Hello_World
       """
 
     When I run `cat {PLUGIN_DIR}/hello-world/package.json`
     Then STDOUT should be JSON containing:
       """
       {"author":"Hello World Author"}
+      """
+    And STDOUT should be JSON containing:
+      """
+      {"version":"0.1.0"}
       """
 
   Scenario: Scaffold a plugin by prompting

--- a/templates/plugin-packages.mustache
+++ b/templates/plugin-packages.mustache
@@ -1,7 +1,7 @@
 
 {
   "name": "{{plugin_slug}}",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "main": "Gruntfile.js",
   "author": "{{plugin_author}}",
   "devDependencies": {

--- a/templates/plugin.mustache
+++ b/templates/plugin.mustache
@@ -1,12 +1,13 @@
 <?php
 /**
- * Plugin Name: {{plugin_name}}
- * Version: 0.1-alpha
- * Description: {{plugin_description}}
- * Author: {{plugin_author}}
- * Author URI: {{plugin_author_uri}}
- * Plugin URI: {{plugin_uri}}
- * Text Domain: {{textdomain}}
- * Domain Path: /languages
- * @package {{plugin_package}}
+ * Plugin Name:     {{plugin_name}}
+ * Plugin URI:      {{plugin_uri}}
+ * Description:     {{plugin_description}}
+ * Author:          {{plugin_author}}
+ * Author URI:      {{plugin_author_uri}}
+ * Text Domain:     {{textdomain}}
+ * Domain Path:     /languages
+ * Version:         0.1.0
+ *
+ * @package         {{plugin_package}}
  */


### PR DESCRIPTION
Currently if you scaffold a child theme and a plugin, the theme uses `0.1.0` for the version number, while the plugin uses `0.1-alpha`, which is itself different than the version used in the plugin's `package.json` (`0.0.0`). The plugin headers are also formatted differently than the child theme headers. This pull request normalizes the version numbers and header formatting and updates related functional tests.