### PR TITLE
Consider image sizes missing when `sizes` doesn't have registered sizes

### DIFF
--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -315,7 +315,11 @@ class Media_Command extends WP_CLI_Command {
 		$original_path = $dir_path . basename( $metadata['file'] );
 
 		if ( empty( $metadata['sizes'] ) ) {
-			return false;
+			return true;
+		}
+
+		if ( array_diff( get_intermediate_image_sizes(), array_keys( $metadata['sizes'] ) ) ) {
+			return true;
 		}
 
 		foreach( $metadata['sizes'] as $size_info ) {


### PR DESCRIPTION
Also considers image needing regeneration if `sizes` is empty (which means its missing all sizes).

Fixes #2608