### PR TITLE
Run `before_invoke` and `after_invoke` callbacks on subcommands

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -511,3 +511,28 @@ Feature: WP-CLI Commands
       """
       Manage comments.
       """
+
+  Scenario: before_invoke should call subcommands
+    Given an empty directory
+    And a call-invoke.php file:
+      """
+      <?php
+      /**
+       * @when before_wp_load
+       */
+      WP_CLI::add_command( 'before invoke', function() {
+        WP_CLI::success( 'Invoked' );
+      }, array( 'before_invoke' => function() {
+        WP_CLI::success( 'before invoke' );
+      }, 'after_invoke' => function() {
+        WP_CLI::success( 'after invoke' );
+      }));
+      """
+
+    When I run `wp --require=call-invoke.php before invoke`
+    Then STDOUT should contain:
+      """
+      Success: before invoke
+      Success: Invoked
+      Success: after invoke
+      """

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -2,6 +2,8 @@
 
 namespace WP_CLI\Dispatcher;
 
+use WP_CLI;
+
 /**
  * A leaf node in the command tree.
  *
@@ -346,11 +348,15 @@ class Subcommand extends CompositeCommand {
 		}
 
 		$path = get_path( $this->get_parent() );
-		\WP_CLI::do_hook( 'before_invoke:' . implode( ' ', array_slice( $path, 1 ) ) );
+		$parent = implode( ' ', array_slice( $path, 1 ) );
+		$cmd = $parent . ' ' . $this->name;
+		WP_CLI::do_hook( "before_invoke:{$parent}" );
+		WP_CLI::do_hook( "before_invoke:{$cmd}" );
 
 		call_user_func( $this->when_invoked, $args, array_merge( $extra_args, $assoc_args ) );
 
-		\WP_CLI::do_hook( 'after_invoke:' . implode( ' ', array_slice( $path, 1 ) ) );
+		WP_CLI::do_hook( "after_invoke:{$parent}" );
+		WP_CLI::do_hook( "after_invoke:{$cmd}" );
 	}
 }
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -294,6 +294,7 @@ class WP_CLI {
 	 * @param array $args {
 	 *      Optional An associative array with additional registration parameters.
 	 *      'before_invoke' => callback to execute before invoking the command,
+	 *      'after_invoke' => callback to execute after invoking the command,
 	 *      'shortdesc' => short description (80 char or less) for the command,
 	 *      'synopsis' => the synopsis for the command (string or array),
 	 *      'when' => execute callback on a named WP-CLI hook (e.g. before_wp_load),
@@ -317,8 +318,10 @@ class WP_CLI {
 			WP_CLI::error( sprintf( "Callable %s does not exist, and cannot be registered as `wp %s`.", json_encode( $callable ), $name ) );
 		}
 
-		if ( isset( $args['before_invoke'] ) ) {
-			self::add_hook( "before_invoke:$name", $args['before_invoke'] );
+		foreach( array( 'before_invoke', 'after_invoke' ) as $when ) {
+			if ( isset( $args[ $when ] ) ) {
+				self::add_hook( "{$when}:{$name}", $args[ $when ] );
+			}
 		}
 
 		$path = preg_split( '/\s+/', $name );


### PR DESCRIPTION
This appears to be an oversight from
6ae19150fe3263b5b19e1237c58b92f73d9eab15 that no one has noticed since.

Keep calling the parent too, for backwards compat purposes.