### PR TITLE
Use `--debug=<group>` to limit debug output to a particular group

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -228,6 +228,58 @@ Feature: Have a config file
       Running command: option get
       """
 
+    When I run `wp option get home --debug=bootstrap`
+    Then STDERR should contain:
+      """
+      No readable global config found
+      """
+    Then STDERR should contain:
+      """
+      No project config found
+      """
+    And STDERR should contain:
+      """
+      Begin WordPress load
+      """
+    And STDERR should contain:
+      """
+      wp-config.php path:
+      """
+    And STDERR should contain:
+      """
+      Loaded WordPress
+      """
+    And STDERR should contain:
+      """
+      Running command: option get
+      """
+
+    When I run `wp option get home --debug=foo`
+    Then STDERR should not contain:
+      """
+      No readable global config found
+      """
+    Then STDERR should not contain:
+      """
+      No project config found
+      """
+    And STDERR should not contain:
+      """
+      Begin WordPress load
+      """
+    And STDERR should not contain:
+      """
+      wp-config.php path:
+      """
+    And STDERR should not contain:
+      """
+      Loaded WordPress
+      """
+    And STDERR should not contain:
+      """
+      Running command: option get
+      """
+
   Scenario: Missing required files should not fatal WP-CLI
     Given an empty directory
     And a wp-cli.yml file:

--- a/features/package.feature
+++ b/features/package.feature
@@ -18,7 +18,7 @@ Feature: Manage WP-CLI packages
     When I try `wp --skip-packages --debug help reset-post-date`
     Then STDERR should contain:
       """
-      Debug: Skipped loading packages.
+      Debug (bootstrap): Skipped loading packages.
       """
     And STDERR should contain:
       """

--- a/php/WP_CLI/Loggers/Base.php
+++ b/php/WP_CLI/Loggers/Base.php
@@ -29,12 +29,22 @@ abstract class Base {
 	 * Write a message to STDERR, prefixed with "Debug: ".
 	 *
 	 * @param string $message Message to write.
+	 * @param string $group Organize debug message to a specific group.
 	 */
-	public function debug( $message ) {
-		if ( $this->get_runner()->config['debug'] ) {
-			$time = round( microtime( true ) - WP_CLI_START_MICROTIME, 3 );
-			$this->_line( "$message ({$time}s)", 'Debug', '%B', STDERR );
+	public function debug( $message, $group = false ) {
+		$debug = $this->get_runner()->config['debug'];
+		if ( ! $debug ) {
+			return;
 		}
+		if ( true !== $debug && $group !== $debug ) {
+			return;
+		}
+		$time = round( microtime( true ) - WP_CLI_START_MICROTIME, 3 );
+		$prefix = 'Debug';
+		if ( $group && true === $debug ) {
+			$prefix = 'Debug (' . $group . ')';
+		}
+		$this->_line( "$message ({$time}s)", $prefix, '%B', STDERR );
 	}
 
 	/**

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -202,7 +202,7 @@ class Runner {
 	 */
 	private static function set_wp_root( $path ) {
 		define( 'ABSPATH', rtrim( $path, '/' ) . '/' );
-		WP_CLI::debug( 'ABSPATH defined: ' . ABSPATH );
+		WP_CLI::debug( 'ABSPATH defined: ' . ABSPATH, 'bootstrap' );
 
 		$_SERVER['DOCUMENT_ROOT'] = realpath( $path );
 	}
@@ -321,7 +321,7 @@ class Runner {
 			$extra_args = array();
 		}
 
-		WP_CLI::debug( 'Running command: ' . $name );
+		WP_CLI::debug( 'Running command: ' . $name, 'bootstrap' );
 		try {
 			$command->invoke( $final_args, $assoc_args, $extra_args );
 		} catch ( WP_CLI\Iterators\Exception $e ) {
@@ -604,8 +604,8 @@ class Runner {
 		$this->init_colorization();
 		$this->init_logger();
 
-		WP_CLI::debug( $this->_global_config_path_debug );
-		WP_CLI::debug( $this->_project_config_path_debug );
+		WP_CLI::debug( $this->_global_config_path_debug, 'bootstrap' );
+		WP_CLI::debug( $this->_project_config_path_debug, 'bootstrap' );
 
 		$this->check_root();
 
@@ -630,14 +630,14 @@ class Runner {
 
 		$skip_packages = \WP_CLI::get_runner()->config['skip-packages'];
 		if ( true === $skip_packages ) {
-			WP_CLI::debug( 'Skipped loading packages.' );
+			WP_CLI::debug( 'Skipped loading packages.', 'bootstrap' );
 		} else {
 			$package_autoload = $this->get_packages_dir_path() . 'vendor/autoload.php';
 			if ( file_exists( $package_autoload ) ) {
-				WP_CLI::debug( 'Loading packages from: ' . $package_autoload );
+				WP_CLI::debug( 'Loading packages from: ' . $package_autoload, 'bootstrap' );
 				require_once $package_autoload;
 			} else {
-				WP_CLI::debug( 'No package autoload found to load.' );
+				WP_CLI::debug( 'No package autoload found to load.', 'bootstrap' );
 			}
 		}
 
@@ -664,7 +664,7 @@ class Runner {
 					WP_CLI::error( sprintf( "Required file '%s' doesn't exist%s.", basename( $path ), $context ) );
 				}
 				Utils\load_file( $path );
-				WP_CLI::debug( 'Required file from config: ' . $path );
+				WP_CLI::debug( 'Required file from config: ' . $path, 'bootstrap' );
 			}
 		}
 
@@ -771,7 +771,7 @@ class Runner {
 
 		$wp_cli_is_loaded = true;
 
-		WP_CLI::debug( 'Begin WordPress load' );
+		WP_CLI::debug( 'Begin WordPress load', 'bootstrap' );
 		WP_CLI::do_hook( 'before_wp_load' );
 
 		$this->check_wp_version();
@@ -783,7 +783,7 @@ class Runner {
 				"Either create one manually or use `wp core config`." );
 		}
 
-		WP_CLI::debug( 'wp-config.php path: ' . $wp_config_path );
+		WP_CLI::debug( 'wp-config.php path: ' . $wp_config_path, 'bootstrap' );
 		WP_CLI::do_hook( 'before_wp_config_load' );
 
 		// Load wp-config.php code, in the global scope
@@ -818,7 +818,7 @@ class Runner {
 			self::set_user( $this->config );
 		}
 
-		WP_CLI::debug( 'Loaded WordPress' );
+		WP_CLI::debug( 'Loaded WordPress', 'bootstrap' );
 		WP_CLI::do_hook( 'after_wp_load' );
 
 	}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -93,7 +93,7 @@ class WP_CLI {
 	 * Set the context in which WP-CLI should be run
 	 */
 	public static function set_url( $url ) {
-		WP_CLI::debug( 'Set URL: ' . $url );
+		WP_CLI::debug( 'Set URL: ' . $url, 'bootstrap' );
 		$url_parts = Utils\parse_url( $url );
 		self::set_url_params( $url_parts );
 	}
@@ -482,10 +482,11 @@ class WP_CLI {
 	 * @category Output
 	 *
 	 * @param string $message Message to write to STDERR.
+	 * @param string $group Organize debug message to a specific group.
 	 * @return null
 	 */
-	public static function debug( $message ) {
-		self::$logger->debug( self::error_to_string( $message ) );
+	public static function debug( $message, $group = false ) {
+		self::$logger->debug( self::error_to_string( $message ), $group );
 	}
 
 	/**

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -71,8 +71,8 @@ return array(
 	),
 
 	'debug' => array(
-		'runtime' => '',
-		'file' => '<bool>',
+		'runtime' => '[=<group>]',
+		'file' => '<group>',
 		'default' => false,
 		'desc' => 'Show all PHP errors; add verbosity to WP-CLI bootstrap.',
 	),


### PR DESCRIPTION
When `--debug` is used as a flag, the group is included in the prefix:

```
salty-wordpress ➜  wordpress-develop.dev  wp option get home --debug
Debug (bootstrap): Using default global config: /home/vagrant/.wp-cli/config.yml (0.051s)
Debug (bootstrap): Using project config: /srv/www/wordpress-develop.dev/wp-cli.yml (0.054s)
Debug (bootstrap): Loading packages from: /home/vagrant/.wp-cli/packages/vendor/autoload.php (0.287s)
Debug (bootstrap): Required file from config: /srv/www/wp-hook-command/command.php (0.428s)
Debug (bootstrap): ABSPATH defined: /srv/www/wordpress-develop.dev/src/
(0.428s)
Debug (bootstrap): Begin WordPress load (0.433s)
Debug (bootstrap): wp-config.php path: /srv/www/wordpress-develop.dev/wp-config.php (0.436s)
Debug (bootstrap): Loaded WordPress (1.307s)
Debug: No schema title found for /, skipping REST command registration.(1.487s)
Debug: No schema title found for /wp/v2, skipping REST command registration. (1.487s)
Debug: No schema title found for /wp/v2/users/me, skipping REST command registration. (1.507s)
Debug: No schema title found for /oembed/1.0, skipping REST command registration. (1.51s)
Debug: No schema title found for /oembed/1.0/embed, skipping REST command registration. (1.51s)
Debug: No schema title found for /wpx/v1, skipping REST command registration. (1.51s)
Debug: No schema title found for /wpx/v1/page-templates, skipping REST command registration. (1.51s)
Debug (bootstrap): Running command: option get (1.511s) http://wordpress-develop.dev
```

Using `--debug=bootstrap` limits output to debug from that particular group:

```
salty-wordpress ➜  wordpress-develop.dev  wp option get home --debug=bootstrap
Debug: Using default global config: /home/vagrant/.wp-cli/config.yml (0.05s)
Debug: Using project config: /srv/www/wordpress-develop.dev/wp-cli.yml (0.053s)
Debug: Loading packages from: /home/vagrant/.wp-cli/packages/vendor/autoload.php (0.209s)
Debug: Required file from config: /srv/www/wp-hook-command/command.php (0.298s)
Debug: ABSPATH defined: /srv/www/wordpress-develop.dev/src/ (0.299s)
Debug: Begin WordPress load (0.303s)
Debug: wp-config.php path: /srv/www/wordpress-develop.dev/wp-config.php (0.306s)
Debug: Loaded WordPress (1.105s)
Debug: Running command: option get (1.304s)
http://wordpress-develop.dev
```

Fixes #2611