### PR TITLE
Refactor adding newline to shell prompt

### DIFF
--- a/php/WP_CLI/REPL.php
+++ b/php/WP_CLI/REPL.php
@@ -34,9 +34,14 @@ class REPL {
 
 				// Write directly to STDOUT, to sidestep any output buffers created by plugins
 				ob_start();
-				var_dump( eval( $line ) );
-				$out = rtrim( ob_get_clean(), "\n" ) . "\n";
-				fwrite( STDOUT, $out );
+				$evl  = eval( $line );
+				$out = ob_get_clean();
+				if ( 0 < strlen ( $out ) ) {
+					echo rtrim( $out, "\n" ) . "\n";
+				}
+				echo "=> ";
+				var_dump( $evl );
+				fwrite( STDOUT, ob_get_clean() );
 			}
 		}
 	}

--- a/php/WP_CLI/REPL.php
+++ b/php/WP_CLI/REPL.php
@@ -21,7 +21,13 @@ class REPL {
 			$line = rtrim( $line, ';' ) . ';';
 
 			if ( self::starts_with( self::non_expressions(), $line ) ) {
+				ob_start();
 				eval( $line );
+				$out = ob_get_clean();
+				if ( 0 < strlen ( $out ) ) {
+					$out = rtrim( $out, "\n" ) . "\n";
+				}
+				fwrite( STDOUT, $out );
 			} else {
 				if ( !self::starts_with( 'return', $line ) )
 					$line = 'return ' . $line;
@@ -29,7 +35,8 @@ class REPL {
 				// Write directly to STDOUT, to sidestep any output buffers created by plugins
 				ob_start();
 				var_dump( eval( $line ) );
-				fwrite( STDOUT, ob_get_clean() );
+				$out = rtrim( ob_get_clean(), "\n" ) . "\n";
+				fwrite( STDOUT, $out );
 			}
 		}
 	}

--- a/php/commands/shell.php
+++ b/php/commands/shell.php
@@ -35,7 +35,7 @@ class Shell_Command extends \WP_CLI_Command {
 		if ( '\\Psy\\Shell' == $class ) {
 			\Psy\Shell::debug();
 		} else {
-			$repl = new $class(  "\nwp> " );
+			$repl = new $class(  "wp> " );
 			$repl->start();
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/wp-cli/wp-cli/pull/2601#discussion_r59474161

@danielbachhuber: This adds newlines to output when needed, rather than every time the prompt is printed.

I've also taken a cue from other REPL implementations and added a `=> ` before the `var_dump` for expression returns to differentiate expression return values from output that occurs during expressions.

examples:
```
wp> echo "foo";
foo
wp> date ( 'ymd' );
=> string(6) "160414"
wp> echo date( 'ymd' );
160414
wp> print_r( [1,2,3,4] );
Array
(
    [0] => 1
    [1] => 2
    [2] => 3
    [3] => 4
)
=> bool(true)
wp> print_r( [1,2,3,4], 1 );
=> string(62) "Array
(
    [0] => 1
    [1] => 2
    [2] => 3
    [3] => 4
)
"
wp>
```

Same as above but on 0.23.0 release:
```
wp> echo "foo";
foowp> date ( 'ymd' );
string(6) "160414"
wp> echo date( 'ymd' );
160414wp> print_r( [1,2,3,4] );
Array
(
    [0] => 1
    [1] => 2
    [2] => 3
    [3] => 4
)
bool(true)
wp> print_r( [1,2,3,4], 1 );
string(62) "Array
(
    [0] => 1
    [1] => 2
    [2] => 3
    [3] => 4
)
"
wp>
```