### PR TITLE
Catch `WP_Error` from `translations_api()`

### DIFF
--- a/php/WP_CLI/CommandWithTranslation.php
+++ b/php/WP_CLI/CommandWithTranslation.php
@@ -342,6 +342,9 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 		require_once ABSPATH . '/wp-admin/includes/translation-install.php';
 
 		$response = translations_api( $this->obj_type );
+		if ( is_wp_error( $response ) ) {
+			WP_CLI::error( $response );
+		}
 		$translations = ! empty( $response['translations'] ) ? $response['translations'] : array();
 
 		$en_us = array(


### PR DESCRIPTION
See #2670