### PR TITLE
Increase minimum supported version to PHP 5.3.29

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"bin/wp.bat", "bin/wp"
 	],
 	"require": {
-		"php": ">=5.3.2",
+		"php": ">=5.3.29",
 		"wp-cli/php-cli-tools": "~0.11.1",
 		"mustache/mustache": "~2.4",
 		"mustangostang/spyc": "~0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -1735,7 +1735,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.29"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
While WP-CLI may work with earlier versions, this is the minimum version
we can support because 5.3.29 is the version available in Travis.

Fixes #2669