### PR TITLE
Persist global WP-CLI config when using WP_CLI::launch_self()

### DIFF
--- a/features/rewrite.feature
+++ b/features/rewrite.feature
@@ -59,15 +59,24 @@ Feature: Manage WordPress rewrites
       Success: Rewrite rules flushed.
       """
 
-  Scenario: Generate .htaccess on hard flush
+  Scenario: Generate .htaccess on hard flush with a project config
     Given a WP install
     And a wp-cli.yml file:
       """
       apache_modules: [mod_rewrite]
       """
 
-    When I run `wp rewrite structure /%year%/%monthnum%/%day%/%postname%/`
-    And I run `wp rewrite flush --hard`
+    When I run `wp rewrite structure /%year%/%monthnum%/%day%/%postname%/ --hard`
+    Then the .htaccess file should exist
+
+  Scenario: Generate .htaccess on hard flush with a global config
+    Given a WP install
+    And a config.yml file:
+      """
+      apache_modules: [mod_rewrite]
+      """
+
+    When I run `WP_CLI_CONFIG_PATH=config.yml wp rewrite structure /%year%/%monthnum%/%day%/%postname%/ --hard`
     Then the .htaccess file should exist
 
   Scenario: Error when trying to generate .htaccess on a multisite install

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -758,10 +758,17 @@ class WP_CLI {
 
 		$script_path = $GLOBALS['argv'][0];
 
+		if ( getenv( 'WP_CLI_CONFIG_PATH' ) ) {
+			$config_path = getenv( 'WP_CLI_CONFIG_PATH' );
+		} else {
+			$config_path = getenv( 'HOME' ) . '/.wp-cli/config.yml';
+		}
+		$config_path = escapeshellarg( $config_path );
+
 		$args = implode( ' ', array_map( 'escapeshellarg', $args ) );
 		$assoc_args = \WP_CLI\Utils\assoc_args_to_str( $assoc_args );
 
-		$full_command = "{$php_bin} {$script_path} {$command} {$args} {$assoc_args}";
+		$full_command = "WP_CLI_CONFIG_PATH={$config_path} {$php_bin} {$script_path} {$command} {$args} {$assoc_args}";
 
 		return self::launch( $full_command, $exit_on_error, $return_detailed );
 	}


### PR DESCRIPTION
Use of this method has a reasonable expectation that the launched process will mirror the existing process as closely as possible. Including the global WP-CLI config is necessary for mirroring the existing process.

Fixes #1981