### PR TITLE
Define `DOING_CRON` before WordPress is loaded

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -747,6 +747,10 @@ class Runner {
 			define( 'WP_IMPORTING', true );
 		}
 
+		if ( $this->cmd_starts_with( array( 'cron', 'event', 'run' ) ) ) {
+			define( 'DOING_CRON', true );
+		}
+
 		if ( $this->cmd_starts_with( array( 'plugin' ) ) ) {
 			$GLOBALS['pagenow'] = 'plugins.php';
 		}


### PR DESCRIPTION
Some plugins make use of this constant to conditionally load code, which
is a valid use case we should do our best to accommodate.

Fixes #2679