### PR TITLE
Include a `.svnignore` when scaffolding a new plugin

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -123,6 +123,11 @@ Feature: WordPress code scaffolding
       .DS_Store
       node_modules/
       """
+    And the {PLUGIN_DIR}/hello-world/.svnignore file should contain:
+      """
+      .git
+      .gitignore
+      """
     And the {PLUGIN_DIR}/hello-world/hello-world.php file should contain:
       """
       * Plugin Name:     Hello World

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -446,6 +446,7 @@ class Scaffold_Command extends WP_CLI_Command {
 			"$plugin_dir/package.json" => Utils\mustache_render( 'plugin-packages.mustache', $data ),
 			"$plugin_dir/Gruntfile.js" => Utils\mustache_render( 'plugin-gruntfile.mustache', $data ),
 			"$plugin_dir/.gitignore" => Utils\mustache_render( 'plugin-gitignore.mustache', $data ),
+			"$plugin_dir/.svnignore" => Utils\mustache_render( 'plugin-svnignore.mustache', $data ),
 			"$plugin_dir/.editorconfig" => file_get_contents( WP_CLI_ROOT . "/templates/.editorconfig" ),
 		), $force );
 

--- a/templates/plugin-svnignore.mustache
+++ b/templates/plugin-svnignore.mustache
@@ -1,0 +1,12 @@
+# A set of files you probably don't want in your WordPress.org distribution
+.editorconfig
+.git
+.gitignore
+.travis.yml
+bin
+composer.json
+composer.lock
+phpunit.xml
+tests
+vendor
+node_modules

--- a/templates/plugin-svnignore.mustache
+++ b/templates/plugin-svnignore.mustache
@@ -1,4 +1,5 @@
 # A set of files you probably don't want in your WordPress.org distribution
+.svnignore
 .editorconfig
 .git
 .gitignore
@@ -6,7 +7,11 @@
 bin
 composer.json
 composer.lock
+Gruntfile.js
+package.json
 phpunit.xml
+phpunit.xml.dist
+README.md
 tests
 vendor
 node_modules


### PR DESCRIPTION
For authors intending to distribute to WordPress.org, this is a helpful
starter template of exclusions.