### PR TITLE
Genuinely run test suite against built Phar file; including missing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: false
 
 language: php
 
+env:
+  global:
+    - WP_CLI_BIN_DIR=/tmp/wp-cli-phar
+
 matrix:
   include:
     - php: 5.3
@@ -11,7 +15,7 @@ matrix:
     - php: 5.6
       env: WP_VERSION=latest
     - php: 5.6
-      env: WP_VERSION=latest BUILD=git
+      env: WP_VERSION=latest BUILD=git WP_CLI_BIN_DIR=''
     - php: 5.6
       env: WP_VERSION=trunk
     - php: 7.0

--- a/ci/prepare.sh
+++ b/ci/prepare.sh
@@ -17,10 +17,8 @@ fi
 # the Behat test suite will pick up the executable found in $WP_CLI_BIN_DIR
 if [[ $BUILD == 'git' ]]
 then
-	export WP_CLI_BIN_DIR=bin/wp
 	echo $CLI_VERSION > VERSION
 else
-	export WP_CLI_BIN_DIR=/tmp/wp-cli-phar
 	mkdir -p $WP_CLI_BIN_DIR
 	php -dphar.readonly=0 utils/make-phar.php wp-cli.phar --quiet --version=$CLI_VERSION
 	mv wp-cli.phar $WP_CLI_BIN_DIR/wp

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+export WP_CLI_BIN_DIR=/tmp/wp-cli-phar
+
 # Run the unit tests
 vendor/bin/phpunit
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-export WP_CLI_BIN_DIR=/tmp/wp-cli-phar
+$WP_CLI_BIN_DIR/wp --info
 
 # Run the unit tests
 vendor/bin/phpunit

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,8 +2,6 @@
 
 set -ex
 
-$WP_CLI_BIN_DIR/wp --info
-
 # Run the unit tests
 vendor/bin/phpunit
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -85,6 +85,10 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	 * @BeforeSuite
 	 */
 	public static function prepare( SuiteEvent $event ) {
+		$result = Process::create( 'wp cli info', null, self::get_process_env_variables() )->run_check();
+		echo PHP_EOL;
+		echo $result->stdout;
+		echo PHP_EOL;
 		self::cache_wp_files();
 	}
 

--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -69,6 +69,7 @@ $finder
 	->in(WP_CLI_ROOT . '/vendor/mustache')
 	->in(WP_CLI_ROOT . '/vendor/rmccue/requests')
 	->in(WP_CLI_ROOT . '/vendor/composer')
+	->in(WP_CLI_ROOT . '/vendor/seld')
 	->in(WP_CLI_ROOT . '/vendor/symfony')
 	->in(WP_CLI_ROOT . '/vendor/nb/oxymel')
 	->in(WP_CLI_ROOT . '/vendor/ramsey/array_column')


### PR DESCRIPTION
Broken since 326c3bb2b86ea2639c38d1585fc09dc8d1c06d35, because you can't set an environment variable from a shell script.

I don't know at what point we started producing a broken build, but the latest stable release is confirmed working.