### PR TITLE
Include pem file that is occasionally needed by Composer

### DIFF
--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -101,6 +101,7 @@ foreach ( $finder as $file ) {
 add_file( $phar, WP_CLI_ROOT . '/vendor/autoload.php' );
 add_file( $phar, WP_CLI_ROOT . '/ci/behat-tags.php' );
 add_file( $phar, WP_CLI_ROOT . '/vendor/composer/composer/LICENSE' );
+add_file( $phar, WP_CLI_ROOT . '/vendor/composer/composer/res/cacert.pem' );
 add_file( $phar, WP_CLI_ROOT . '/vendor/composer/composer/res/composer-schema.json' );
 add_file( $phar, WP_CLI_ROOT . '/vendor/rmccue/requests/library/Requests/Transport/cacert.pem' );
 


### PR DESCRIPTION
Without it, `wp package list` and `wp package browse` can fatal. I'm not sure how long this has been broken in the Phar build.