### PR TITLE
Fix listing user meta associated with a given username

### DIFF
--- a/features/user-meta.feature
+++ b/features/user-meta.feature
@@ -69,3 +69,9 @@ Feature: Manage user custom fields
       | user_id | meta_key | meta_value     |
       | 1       | nickname | admin          |
       | 1       | foo      | ["1","2"]      |
+
+    When I run `wp user meta list admin --keys=nickname,foo`
+    Then STDOUT should be a table containing rows:
+      | user_id | meta_key | meta_value     |
+      | 1       | nickname | admin          |
+      | 1       | foo      | ["1","2"]      |

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -831,6 +831,30 @@ class User_Meta_Command extends \WP_CLI\CommandWithMeta {
 	}
 
 	/**
+	 * List all metadata associated with a user.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id>
+	 * : ID for the object.
+	 *
+	 * [--keys=<keys>]
+	 * : Limit output to metadata of specific keys.
+	 *
+	 * [--fields=<fields>]
+	 * : Limit the output to specific row fields. Defaults to id,meta_key,meta_value.
+	 *
+	 * [--format=<format>]
+	 * : Accepted values: table, csv, json, count. Default: table
+	 *
+	 * @subcommand list
+	 */
+	public function list_( $args, $assoc_args ) {
+		$args = $this->replace_login_with_user_id( $args );
+		parent::list_( $args, $assoc_args );
+	}
+
+	/**
 	 * Get meta field value.
 	 *
 	 * ## OPTIONS


### PR DESCRIPTION
All methods on this class need to replace a provided username / email
address with the user id, which this method wasn't doing.