### PR TITLE
Clarify that `wp core verify-checksums` doesn't actually load WP

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -789,7 +789,9 @@ EOT;
 	/**
 	 * Verify WordPress files against WordPress.org's checksums.
 	 *
-	 * Specify version to verify checksums without loading WordPress.
+	 * For security, avoids loading WordPress when verifying checksums.
+	 *
+	 * ## OPTIONS
 	 *
 	 * [--version=<version>]
 	 * : Verify checksums against a specific version of WordPress.


### PR DESCRIPTION
This behavior changed in the last release