### PR TITLE
issue of taking only first digit from Comment ID

### DIFF
--- a/features/comment.feature
+++ b/features/comment.feature
@@ -171,7 +171,7 @@ Feature: Manage WordPress comments
       Unapproved comment {COMMENT_ID}
       """
 
-    When I run `wp comment get --field=comment_approved {COMMENT_ID}`
+    When I run `wp comment list --format=count --status=approve`
     Then STDOUT should be:
       """
       10
@@ -183,7 +183,7 @@ Feature: Manage WordPress comments
       Approved comment {COMMENT_ID}
       """
 
-    When I run `wp comment get --field=comment_approved {COMMENT_ID}`
+    When I run `wp comment list --format=count --status=approve`
     Then STDOUT should be:
       """
       11

--- a/features/comment.feature
+++ b/features/comment.feature
@@ -161,7 +161,8 @@ Feature: Manage WordPress comments
       """
 
   Scenario: Approving/unapproving comments with multidigit comment ID
-    Given I run `wp comment generate --count=10 --quiet`
+    Given I run `wp comment delete $(wp comment list --field=ID)`
+    And I run `wp comment generate --count=10 --quiet`
     And I run `wp comment create --porcelain`
     And save STDOUT as {COMMENT_ID}
 

--- a/features/comment.feature
+++ b/features/comment.feature
@@ -159,3 +159,33 @@ Feature: Manage WordPress comments
       """
       0
       """
+
+  Scenario: Approving/unapproving comments with multidigit comment ID
+    Given I run `wp comment generate --count=10 --quiet`
+    And I run `wp comment create --porcelain`
+    And save STDOUT as {COMMENT_ID}
+
+    When I run `wp comment unapprove {COMMENT_ID}`
+    Then STDOUT should contain:
+      """
+      Unapproved comment {COMMENT_ID}
+      """
+
+    When I run `wp comment get --field=comment_approved {COMMENT_ID}`
+    Then STDOUT should be:
+      """
+      10
+      """
+
+    When I run `wp comment approve {COMMENT_ID}`
+    Then STDOUT should contain:
+      """
+      Approved comment {COMMENT_ID}
+      """
+
+    When I run `wp comment get --field=comment_approved {COMMENT_ID}`
+    Then STDOUT should be:
+      """
+      11
+      """
+

--- a/php/commands/comment.php
+++ b/php/commands/comment.php
@@ -302,7 +302,7 @@ class Comment_Command extends \WP_CLI\CommandWithDBObject {
 	}
 
 	private function set_status( $args, $status, $success ) {
-		$comment = $this->fetcher->get_check( $args[0] );
+		$comment = $this->fetcher->get_check( $args );
 
 		$r = wp_set_comment_status( $comment->comment_ID, $status, true );
 


### PR DESCRIPTION
Resolve issue of taking only first digit from Comment ID in `comment` command.

Fixes #2710 