### PR TITLE
Ignore ambigious empty plugin and theme slugs when installing

### DIFF
--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -401,3 +401,16 @@ Feature: Manage WordPress plugins
     Then STDOUT should be a table containing rows:
       | name       | version   |
       | akismet    | 2.6.0     |
+
+  Scenario: Ignore empty slugs
+    Given a WP install
+
+    When I run `wp plugin install ''`
+    Then STDERR should contain:
+      """
+      Warning: Ignoring ambigious empty slug value.
+      """
+    And STDOUT should not contain:
+      """
+      Plugin installed successfully
+      """

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -2,6 +2,8 @@
 
 namespace WP_CLI;
 
+use WP_CLI;
+
 abstract class CommandWithUpgrade extends \WP_CLI_Command {
 
 	protected $item_type;
@@ -117,6 +119,12 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 	function install( $args, $assoc_args ) {
 
 		foreach ( $args as $slug ) {
+
+			if ( empty( $slug ) ) {
+				WP_CLI::warning( "Ignoring ambigious empty slug value." );
+				continue;
+			}
+
 			$local_or_remote_zip_file = false;
 			$result = false;
 


### PR DESCRIPTION
If a user supplies an empty slug, its likely a mistake. WP-CLI shouldn't
proceeed to install the first result from WordPress.org

Fixes #2708