### PR TITLE
Fix greedy parsing of command args, part two

### DIFF
--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -120,7 +120,7 @@ class DocParser {
 	 * @return mixed|null
 	 */
 	public function get_arg_args( $name ) {
-		return $this->get_arg_or_param_args( "/\[?<{$name}>.*/" );
+		return $this->get_arg_or_param_args( "/^\[?<{$name}>.*/" );
 	}
 
 	/**
@@ -145,7 +145,7 @@ class DocParser {
 	 * @return mixed|null
 	 */
 	public function get_param_args( $key ) {
-		return $this->get_arg_or_param_args( "/\[?--{$key}=.*/" );
+		return $this->get_arg_or_param_args( "/^\[?--{$key}=.*/" );
 	}
 
 	/**

--- a/tests/test-doc-parser.php
+++ b/tests/test-doc-parser.php
@@ -97,6 +97,13 @@ EOB
 
 	public function test_desc_parses_yaml() {
 		$longdesc = <<<EOB
+Play some music loudly
+
+```
+# Here's an example of how you might run the command
+wp rock-on electronic --volume=11
+```
+
 ## OPTIONS
 
 <genre>...


### PR DESCRIPTION
When an example is included at the beginning of the command, we need to make sure we don't match on example usage.

From #2587