### PR TITLE
Update WP versions number

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -343,8 +343,8 @@ Feature: WordPress code scaffolding
       """
       env:
         - WP_VERSION=latest WP_MULTISITE=0
-        - WP_VERSION=3.0.1 WP_MULTISITE=0
-        - WP_VERSION=3.4 WP_MULTISITE=0
+        - WP_VERSION=3.5.1 WP_MULTISITE=0
+        - WP_VERSION=4.5.2 WP_MULTISITE=0
       """
 
   Scenario: Scaffold starter code for a theme and network enable it

--- a/templates/plugin-readme.mustache
+++ b/templates/plugin-readme.mustache
@@ -2,8 +2,8 @@
 Contributors: (this should be a list of wordpress.org userid's)
 Donate link: http://example.com/
 Tags: comments, spam
-Requires at least: 3.0.1
-Tested up to: 3.4
+Requires at least: 3.5.1
+Tested up to: 4.5
 Stable tag: 4.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/templates/plugin-readme.mustache
+++ b/templates/plugin-readme.mustache
@@ -3,7 +3,7 @@ Contributors: (this should be a list of wordpress.org userid's)
 Donate link: http://example.com/
 Tags: comments, spam
 Requires at least: 3.5.1
-Tested up to: 4.5
+Tested up to: 4.5.2
 Stable tag: 4.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
The .travis.yml uses the versions defined in the readme when generating a the plugin scaffold. WP 3.4 was released in 2012 and 3.5 in 2013 so it would be good to test with the latest versions. https://wordpress.org/news/category/releases/