### PR TITLE
fix incorrect parameter in post-type list command doc

### DIFF
--- a/php/commands/post-type.php
+++ b/php/commands/post-type.php
@@ -49,7 +49,7 @@ class Post_Type_Command extends WP_CLI_Command {
 	 *
 	 *     wp post-type list --format=csv
 	 *
-	 *     wp post-type list --object-type=post --fields=name,public
+	 *     wp post-type list --capability_type=post --fields=name,public
 	 *
 	 * @subcommand list
 	 */


### PR DESCRIPTION
In the example `object-type` parameter is changed to `capability_type`

Fixes #2733