### PR TITLE
Display success message in dry run in search-replace

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -216,6 +216,12 @@ Feature: Do global search/replace
       | Table      | Column       | Replacements | Type       |
       | wp_posts   | post_content | 1            | SQL        |
 
+    When I run `wp search-replace '<a href="http://google.com">Google</a>' '<a href="http://apple.com">Apple</a>' --dry-run`
+    Then STDOUT should contain:
+      """
+      1 replacement(s) to be made.
+      """
+
     When I run `wp post get {POST_ID} --field=content`
     Then STDOUT should be:
       """

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -207,6 +207,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 			}
 			WP_CLI::success( $success_message );
 		}
+		else {
+			$success_message = "$total replacement(s) to be made.";
+			WP_CLI::success( $success_message );
+		}
 	}
 
 	private function php_export_table( $table, $old, $new ) {


### PR DESCRIPTION
Display success message in dry run in search-replace. Fix #2739 