### PR TITLE
Ensure `default` and `options` are used when supplied as arg args

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -285,10 +285,10 @@ Feature: WP-CLI Commands
     And a custom-cmd.php file:
       """
       <?php
-      function foo( $args ) {
+      function foo( $args, $assoc_args ) {
         $message = array_shift( $args );
         WP_CLI::log( 'Message is: ' . $message );
-        WP_CLI::success( $args[0] );
+        WP_CLI::success( $assoc_args['meal'] );
       }
       WP_CLI::add_command( 'foo', 'foo', array(
         'shortdesc'   => 'My awesome function command',
@@ -368,6 +368,32 @@ Feature: WP-CLI Commands
             - lunch
             - dinner
           ---
+      """
+
+    When I try `wp foo nana --apple=fuji`
+    Then STDERR should contain:
+      """
+      Error: Invalid value specified for positional arg.
+      """
+
+    When I try `wp foo hello --apple=fuji --meal=snack`
+    Then STDERR should contain:
+      """
+      Invalid value specified for 'meal' (A type of meal.)
+      """
+
+    When I run `wp foo hello --apple=fuji`
+    Then STDOUT should be:
+      """
+      Message is: hello
+      Success: breakfast
+      """
+
+    When I run `wp foo hello --apple=fuji --meal=dinner`
+    Then STDOUT should be:
+      """
+      Message is: hello
+      Success: dinner
       """
 
   Scenario: Register a command with default and accepted arguments.

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -258,9 +258,13 @@ class Subcommand extends CompositeCommand {
 		$synopsis_spec = \WP_CLI\SynopsisParser::parse( $synopsis );
 		$i = 0;
 		$errors = array( 'fatal' => array(), 'warning' => array() );
+		$mock_doc = array( $this->get_shortdesc(), '' );
+		$mock_doc = array_merge( $mock_doc, explode( PHP_EOL, $this->get_longdesc() ) );
+		$mock_doc = '/**' . PHP_EOL . '* ' . implode( PHP_EOL . '* ', $mock_doc ) . PHP_EOL . '*/';
+		$docparser = new \WP_CLI\DocParser( $mock_doc );
 		foreach( $synopsis_spec as $spec ) {
 			if ( 'positional' === $spec['type'] ) {
-				$spec_args = $this->docparser->get_arg_args( $spec['name'] );
+				$spec_args = $docparser->get_arg_args( $spec['name'] );
 				if ( ! isset( $args[ $i ] ) ) {
 					if ( isset( $spec_args['default'] ) ) {
 						$args[ $i ] = $spec_args['default'];
@@ -282,7 +286,7 @@ class Subcommand extends CompositeCommand {
 				}
 				$i++;
 			} else if ( 'assoc' === $spec['type'] ) {
-				$spec_args = $this->docparser->get_param_args( $spec['name'] );
+				$spec_args = $docparser->get_param_args( $spec['name'] );
 				if ( ! isset( $assoc_args[ $spec['name'] ] ) ) {
 					if ( isset( $spec_args['default'] ) ) {
 						$assoc_args[ $spec['name'] ] = $spec_args['default'];
@@ -313,7 +317,7 @@ class Subcommand extends CompositeCommand {
 			$out = 'Parameter errors:';
 			foreach ( $errors['fatal'] as $key => $error ) {
 				$out .= "\n {$error}";
-				if ( $desc = $this->docparser->get_param_desc( $key ) ) {
+				if ( $desc = $docparser->get_param_desc( $key ) ) {
 					$out .= " ({$desc})";
 				}
 			}


### PR DESCRIPTION
I should've written these tests cases originally. Because I didn't, the functionality has been broken since it was originally introduced in #2556