### PR TITLE
get wp version when scaffolding plugin

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -109,6 +109,8 @@ Feature: WordPress code scaffolding
     Given a WP install
     Given I run `wp plugin path`
     And save STDOUT as {PLUGIN_DIR}
+    Given I run `wp core version`
+    And save STDOUT as {WP_VERSION}
 
     When I run `wp scaffold plugin hello-world --plugin_author="Hello World Author"`
     Then STDOUT should not be empty
@@ -139,6 +141,14 @@ Feature: WordPress code scaffolding
     And the {PLUGIN_DIR}/hello-world/hello-world.php file should contain:
       """
       * @package         Hello_World
+      """
+    And the {PLUGIN_DIR}/hello-world/readme.txt file should contain:
+      """
+      Stable tag: 0.1.0
+      """
+    And the {PLUGIN_DIR}/hello-world/readme.txt file should contain:
+      """
+      Tested up to: {WP_VERSION}
       """
 
     When I run `cat {PLUGIN_DIR}/hello-world/package.json`
@@ -332,6 +342,8 @@ Feature: WordPress code scaffolding
 
   Scenario: Scaffold tests parses plugin readme.txt
     Given a WP install
+    When I run `wp core version`
+    Then save STDOUT as {WP_VERSION}
     When I run `wp plugin path`
     Then save STDOUT as {PLUGIN_DIR}
 
@@ -343,8 +355,8 @@ Feature: WordPress code scaffolding
       """
       env:
         - WP_VERSION=latest WP_MULTISITE=0
-        - WP_VERSION=3.0.1 WP_MULTISITE=0
-        - WP_VERSION=3.4 WP_MULTISITE=0
+        - WP_VERSION=3.7 WP_MULTISITE=0
+        - WP_VERSION={WP_VERSION} WP_MULTISITE=0
       """
 
   Scenario: Scaffold starter code for a theme and network enable it

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -415,13 +415,14 @@ class Scaffold_Command extends WP_CLI_Command {
 		$plugin_package = str_replace( ' ', '_', $plugin_name );
 
 		$data = wp_parse_args( $assoc_args, array(
-			'plugin_slug'        => $plugin_slug,
-			'plugin_name'        => $plugin_name,
-			'plugin_package'     => $plugin_package,
-			'plugin_description' => 'PLUGIN DESCRIPTION HERE',
-			'plugin_author'      => 'YOUR NAME HERE',
-			'plugin_author_uri'  => 'YOUR SITE HERE',
-			'plugin_uri'         => 'PLUGIN SITE HERE',
+			'plugin_slug'         => $plugin_slug,
+			'plugin_name'         => $plugin_name,
+			'plugin_package'      => $plugin_package,
+			'plugin_description'  => 'PLUGIN DESCRIPTION HERE',
+			'plugin_author'       => 'YOUR NAME HERE',
+			'plugin_author_uri'   => 'YOUR SITE HERE',
+			'plugin_uri'          => 'PLUGIN SITE HERE',
+			'plugin_tested_up_to' => get_bloginfo('version'),
 		) );
 
 		$data['textdomain'] = $plugin_slug;

--- a/templates/plugin-readme.mustache
+++ b/templates/plugin-readme.mustache
@@ -2,9 +2,9 @@
 Contributors: (this should be a list of wordpress.org userid's)
 Donate link: http://example.com/
 Tags: comments, spam
-Requires at least: 3.0.1
-Tested up to: 3.4
-Stable tag: 4.3
+Requires at least: 3.7
+Tested up to: {{plugin_tested_up_to}}
+Stable tag: 0.1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
* Set latest version number to plugin's `readme.txt` and `.travis.yml`.
* Update minimum WP version in `.travis.yml` to 3.7 (WP-CLI's minimum require).
* `Stable tag` in `readme.txt` should has same value with `Version` in `templates/plugin.mustache`.

Thanks!