### PR TITLE
Remove `--config=<config>` as a runtime argument

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -68,10 +68,7 @@ class Runner {
 	 */
 	private function get_global_config_path() {
 
-		if ( isset( $runtime_config['config'] ) ) {
-			$config_path = $runtime_config['config'];
-			$this->_global_config_path_debug = 'Using global config from config runtime arg: ' . $config_path;
-		} else if ( getenv( 'WP_CLI_CONFIG_PATH' ) ) {
+		if ( getenv( 'WP_CLI_CONFIG_PATH' ) ) {
 			$config_path = getenv( 'WP_CLI_CONFIG_PATH' );
 			$this->_global_config_path_debug = 'Using global config from WP_CLI_CONFIG_PATH env var: ' . $config_path;
 		} else {

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -17,11 +17,6 @@ return array(
 		'runtime' => '=<url>',
 	),
 
-	'config' => array(
-		'deprecated' => 'Use the WP_CLI_CONFIG_PATH environment variable instead.',
-		'runtime' => '=<path>',
-	),
-
 	'user' => array(
 		'runtime' => '=<id|login|email>',
 		'file' => '<id|login|email>',


### PR DESCRIPTION
It's been broken since 7a1499e0a3683f9d51dc18d73d8b087685a9e318
(v0.13.0)

Fixes #2749