### PR TITLE
#2760 readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # WP-CLI
 
-Command-line tools for managing WordPress installations.
+Command-line tools for managing WordPress installations. [http://wp-cli.org/](http://wp-cli.org/).
 
 [![Build Status](https://travis-ci.org/wp-cli/wp-cli.png?branch=master)](https://travis-ci.org/wp-cli/wp-cli)
-
-[Documentation](http://wp-cli.org/)
 
 Quick links: [Using](#using) | [Installing](#installing) | [Support](#support) | [Extending](#extending) | [Contributing](#contributing)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ wp transient delete-all
 Success: 34 transients deleted from the database.
 ```
 
-For a complete introduction, the [Quick Start guide](http://wp-cli.org/docs/quick-start/). If you already feel comfortable with the basics, jump into the [complete list of commands](http://wp-cli.org/commands/) for managing themes and plugins, importing and exporting data, performing database search-replace operations and more.
+For a complete introduction, read the [Quick Start guide](http://wp-cli.org/docs/quick-start/). If you already feel comfortable with the basics, jump into the [complete list of commands](http://wp-cli.org/commands/) for managing themes and plugins, importing and exporting data, performing database search-replace operations and more.
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ View the [Quick Start](http://wp-cli.org/docs/quick-start/) guide or jump to the
 
 The recommended way to install WP-CLI is to download the Phar build, mark it executable and place it in your PATH.
 
-Download the `[wp-cli.phar](https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar)` using `wget` or `curl`. For example:
+Download the [wp-cli.phar](https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar) using `wget` or `curl`. For example:
 
 `$ curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar`
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,89 @@
-WP-CLI
-======
+# WP-CLI
+
+Command-line tools for managing WordPress installations.
 
 [![Build Status](https://travis-ci.org/wp-cli/wp-cli.png?branch=master)](https://travis-ci.org/wp-cli/wp-cli)
 
-WP-CLI is a set of command-line tools for managing WordPress installations.
+[Documentation](http://wp-cli.org/)
 
-Installing
-------------
-If you just want to use WP-CLI, see <http://wp-cli.org/#install>.
+Quick links: [Using](#using) | [Installing](#installing) | [Support](#support) | [Extending](#extending) | [Contributing](#contributing)
 
-If you want to hack on WP-CLI, see [CONTRIBUTING.md](CONTRIBUTING.md).
+## Using
 
-Where can I get more info?
---------------------------
-For documentation and examples, check out [wp-cli.org](http://wp-cli.org/) and the [documentation portal](http://wp-cli.org/docs/).
+This project aims to provide command-line support for any action you can perform in the WordPress admin and many you can't. So you can [install a plugin](http://wp-cli.org/commands/plugin/install/):
 
-Also, WordPress Answers has a growing list of [WP-CLI related questions](http://wordpress.stackexchange.com/questions/tagged/wp-cli).
+`
+$ wp plugin install rest-api
+`
 
-If you want to receive an email for every single commit, you can subscribe to the [wp-cli-commits](https://groups.google.com/forum/?fromgroups=#!forum/wp-cli-commits) mailing list.
+And [activate it](http://wp-cli.org/commands/plugin/activate/):
 
-I'm running into troubles, what can I do?
------------------------------------------
-To suggest a feature, report a bug, or general discussion, visit the [issues section](https://github.com/wp-cli/wp-cli/issues).
+`
+$ wp plugin activate rest-api
+`
 
-If you're reporting a bug, please include the output from `wp --info` and do your best to follow [bug reporting best practices](http://wp-cli.org/docs/bug-reports/).
+View the [Quick Start](http://wp-cli.org/docs/quick-start/) guide or jump to the [complete list of commands](http://wp-cli.org/commands/) for managing themes and plugins, importing and exporting data, performing database search-replace operations and more.
 
-Credits
--------
+## Installing
+
+The recommended way to install WP-CLI is to download the Phar build, mark it executable and place it in your PATH.
+
+Download the `[wp-cli.phar](https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar)` using `wget` or `curl`. For example:
+
+`$ curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar`
+
+Check if it is working:
+
+`$ php wp-cli.phar --info`
+
+To use it from the command line by typing `wp`, make the file executable and move it to somewhere in your PATH. For example:
+
+`
+$ chmod +x wp-cli.phar
+$ sudo mv wp-cli.phar /usr/local/bin/wp
+`
+
+If WP-CLI installed successfully, you should see something like this when you run `wp --info`:
+
+`
+$ wp --info
+PHP binary:    /usr/bin/php5
+PHP version:    5.5.9-1ubuntu4.14
+php.ini used:   /etc/php5/cli/php.ini
+WP-CLI root dir:        /home/wp-cli/.wp-cli
+WP-CLI packages dir:    /home/wp-cli/.wp-cli/packages/
+WP-CLI global config:   /home/wp-cli/.wp-cli/config.yml
+WP-CLI project config:
+WP-CLI version: 0.23.0
+`
+
+Now that you've got WP-CLI, read the [Quick Start](http://wp-cli.org/docs/quick-start/) guide. Or view the [full installation guide](http://wp-cli.org/docs/installing/) with alternative installation methods.
+
+## Support
+
+WP-CLI is a volunteer-led project and can't support every user individually. If you run into trouble, here are some places to look for help:
+
+- [Common issues and their fixes](http://wp-cli.org/docs/common-issues/)
+- [Bug reports](http://wp-cli.org/docs/bug-reports/)
+- [External resources](http://wp-cli.org/docs/external-resources/)
+
+## Extending
+
+Creating a custom WP-CLI command can be easier than it looks. Read the [commands cookbook](http://wp-cli.org/docs/commands-cookbook/).
+
+## Contributing
+
+Thanks for helping to improve WP-CLI. Please read about [creating an issue](http://wp-cli.org/docs/bug-reports/) or [submitting a pull request](http://wp-cli.org/docs/pull-requests/).
+
+### Contributors
+* [Andreas Creten](https://github.com/andreascreten) - founder
+* [Cristi Burcă](https://github.com/scribu) - previous maintainer
+* [Daniel Bachhuber](https://github.com/danielbachhuber/) - current maintainer
+
+Read more about the project's [Governance](http://wp-cli.org/docs/governance/) and view a [complete list of contributors](https://github.com/wp-cli/wp-cli/contributors).
+
+## Credits
+
 Besides the libraries defined in [composer.json](composer.json), we have used code or ideas from the following projects:
 
 * [Drush](http://drush.ws/) for... a lot of things
@@ -36,13 +93,3 @@ Besides the libraries defined in [composer.json](composer.json), we have used co
 * [WordPress-CLI-Exporter](https://github.com/Automattic/WordPress-CLI-Exporter) for `wp export`
 * [WordPress-CLI-Importer](https://github.com/Automattic/WordPress-CLI-Importer) for `wp import`
 * [wordpress-plugin-tests](https://github.com/benbalter/wordpress-plugin-tests/) for `wp scaffold plugin-tests`
-
-Who's behind this thing?
-------------------------
-* [Andreas Creten](https://github.com/andreascreten) - founder
-* [Cristi Burcă](https://github.com/scribu) - previous maintainer
-* [Daniel Bachhuber](https://github.com/danielbachhuber/) - current maintainer
-
-For more info, see [Governance](http://wp-cli.org/docs/governance/).
-
-A complete list of contributors can be found [here](https://github.com/wp-cli/wp-cli/contributors).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# WP-CLI
+WP-CLI
+======
 
-Command-line tools for managing WordPress installations. [http://wp-cli.org/](http://wp-cli.org/).
+[WP-CLI](http://wp-cli.org/) is a set of command-line tools for managing WordPress installations. You can update plugins, set up multisite installs and much more, without using a web browser.
 
 [![Build Status](https://travis-ci.org/wp-cli/wp-cli.png?branch=master)](https://travis-ci.org/wp-cli/wp-cli)
 
@@ -8,23 +9,39 @@ Quick links: [Using](#using) | [Installing](#installing) | [Support](#support) |
 
 ## Using
 
-This project aims to provide command-line support for any action you can perform in the WordPress admin and many you can't. So you can [install a plugin](http://wp-cli.org/commands/plugin/install/):
+The goal of WP-CLI is to provide a command-line interface for any action you can perform in the WordPress admin. The project also includes commands for many actions you can't perform in the WordPress admin.
+
+For instance, `wp plugin install` ([doc](http://wp-cli.org/commands/plugin/install/)) lets you install and activate a WordPress plugin:
 
 ```
-$ wp plugin install rest-api
+$ wp plugin install rest-api --activate
+Installing WordPress REST API (Version 2) (2.0-beta13)
+Downloading install package from https://downloads.wordpress.org/plugin/rest-api.2.0-beta13.zip...
+Unpacking the package...
+Installing the plugin...
+Plugin installed successfully.
+Activating 'rest-api'...
+Success: Plugin 'rest-api' activated.
 ```
 
-And [activate it](http://wp-cli.org/commands/plugin/activate/):
+`wp transient` ([doc](http://wp-cli.org/commands/transient/)) lets you delete one or all transients:
 
 ```
-$ wp plugin activate rest-api
+$ wp transient delete-all
+Success: 34 transients deleted from the database.
 ```
 
-View the [Quick Start](http://wp-cli.org/docs/quick-start/) guide or jump to the [complete list of commands](http://wp-cli.org/commands/) for managing themes and plugins, importing and exporting data, performing database search-replace operations and more.
+For a complete introduction, the [Quick Start guide](http://wp-cli.org/docs/quick-start/). If you already feel comfortable with the basics, jump into the [complete list of commands](http://wp-cli.org/commands/) for managing themes and plugins, importing and exporting data, performing database search-replace operations and more.
 
 ## Installing
 
 The recommended way to install WP-CLI is to download the Phar build, mark it executable and place it in your PATH.
+
+Before you install though, please make sure your environment meets the minimum requirements:
+
+- UNIX-like environment (OS X, Linux, FreeBSD, Cygwin); limited support in Windows environment
+- PHP 5.3.29 or later
+- WordPress 3.7 or later
 
 Download the [wp-cli.phar](https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar) using `wget` or `curl`. For example:
 
@@ -63,21 +80,23 @@ Now that you've got WP-CLI, read the [Quick Start](http://wp-cli.org/docs/quick-
 
 ## Support
 
-WP-CLI is a volunteer-led project and can't support every user individually. If you run into trouble, here are some places to look for help:
+WP-CLI's project maintainers do their best to respond to all bug reports and configuration errors within reason and the constraints on their time. Before requesting help, please read to find a solution to your problem in the following resources:
 
 - [Common issues and their fixes](http://wp-cli.org/docs/common-issues/)
-- [Bug reports](http://wp-cli.org/docs/bug-reports/)
+- [Submit a bug report](http://wp-cli.org/docs/bug-reports/)
 - [External resources](http://wp-cli.org/docs/external-resources/)
 
 ## Extending
 
-Creating a custom WP-CLI command can be easier than it looks. Read the [commands cookbook](http://wp-cli.org/docs/commands-cookbook/).
+A **command** is an atomic unit of WP-CLI functionality. `wp plugin install` ([doc](http://wp-cli.org/commands/plugin/install/)) is one command. `wp plugin activate` ([doc](http://wp-cli.org/commands/plugin/activate/)) is another.
+
+WP-CLI comes with dozens of commands. But it's easier than it looks to create a custom WP-CLI command. Read the [commands cookbook](http://wp-cli.org/docs/commands-cookbook/) to learn more.
 
 ## Contributing
 
 Thanks for helping to improve WP-CLI. Please read about [creating an issue](http://wp-cli.org/docs/bug-reports/) or [submitting a pull request](http://wp-cli.org/docs/pull-requests/).
 
-### Contributors
+### Leadership
 * [Andreas Creten](https://github.com/andreascreten) - founder
 * [Cristi Burcă](https://github.com/scribu) - previous maintainer
 * [Daniel Bachhuber](https://github.com/danielbachhuber/) - current maintainer

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Command-line tools for managing WordPress installations. [http://wp-cli.org/](ht
 
 [![Build Status](https://travis-ci.org/wp-cli/wp-cli.png?branch=master)](https://travis-ci.org/wp-cli/wp-cli)
 
-Quick links: [Using](#using) | [Installing](#installing) | [Support](#support) | [Extending](#extending) | [Contributing](#contributing)
+Quick links: [Using](#using) | [Installing](#installing) | [Support](#support) | [Extending](#extending) | [Contributing](#contributing) | [Credits](#credits)
 
 ## Using
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Quick links: [Using](#using) | [Installing](#installing) | [Support](#support) |
 
 This project aims to provide command-line support for any action you can perform in the WordPress admin and many you can't. So you can [install a plugin](http://wp-cli.org/commands/plugin/install/):
 
-`
+```
 $ wp plugin install rest-api
-`
+```
 
 And [activate it](http://wp-cli.org/commands/plugin/activate/):
 
-`
+```
 $ wp plugin activate rest-api
-`
+```
 
 View the [Quick Start](http://wp-cli.org/docs/quick-start/) guide or jump to the [complete list of commands](http://wp-cli.org/commands/) for managing themes and plugins, importing and exporting data, performing database search-replace operations and more.
 
@@ -28,22 +28,26 @@ The recommended way to install WP-CLI is to download the Phar build, mark it exe
 
 Download the [wp-cli.phar](https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar) using `wget` or `curl`. For example:
 
-`$ curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar`
+```
+$ curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+```
 
 Check if it is working:
 
-`$ php wp-cli.phar --info`
+```
+$ php wp-cli.phar --info
+```
 
 To use it from the command line by typing `wp`, make the file executable and move it to somewhere in your PATH. For example:
 
-`
+```
 $ chmod +x wp-cli.phar
 $ sudo mv wp-cli.phar /usr/local/bin/wp
-`
+```
 
 If WP-CLI installed successfully, you should see something like this when you run `wp --info`:
 
-`
+```
 $ wp --info
 PHP binary:    /usr/bin/php5
 PHP version:    5.5.9-1ubuntu4.14
@@ -53,7 +57,7 @@ WP-CLI packages dir:    /home/wp-cli/.wp-cli/packages/
 WP-CLI global config:   /home/wp-cli/.wp-cli/config.yml
 WP-CLI project config:
 WP-CLI version: 0.23.0
-`
+```
 
 Now that you've got WP-CLI, read the [Quick Start](http://wp-cli.org/docs/quick-start/) guide. Or view the [full installation guide](http://wp-cli.org/docs/installing/) with alternative installation methods.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Activating 'rest-api'...
 Success: Plugin 'rest-api' activated.
 ```
 
-`wp transient` ([doc](http://wp-cli.org/commands/transient/)) lets you delete one or all transients:
+Similarly, `wp transient` ([doc](http://wp-cli.org/commands/transient/)) lets you delete one or all transients:
 
 ```
 $ wp transient delete-all
@@ -35,7 +35,7 @@ For a complete introduction, read the [Quick Start guide](http://wp-cli.org/docs
 
 ## Installing
 
-The recommended way to install WP-CLI is to download the Phar build, mark it executable and place it in your PATH.
+The recommended way to install WP-CLI is to download the Phar build, mark it executable and place it in your PATH. See also our documentation on [alternative installation methods](http://wp-cli.org/docs/installing/).
 
 Before you install though, please make sure your environment meets the minimum requirements:
 
@@ -76,11 +76,9 @@ WP-CLI project config:
 WP-CLI version: 0.23.0
 ```
 
-Now that you've got WP-CLI, read the [Quick Start](http://wp-cli.org/docs/quick-start/) guide. Or view the [full installation guide](http://wp-cli.org/docs/installing/) with alternative installation methods.
-
 ## Support
 
-WP-CLI's project maintainers do their best to respond to all bug reports and configuration errors within reason and the constraints on their time. Before requesting help, please read to find a solution to your problem in the following resources:
+WP-CLI's project maintainers do their best to respond to all bug reports and configuration errors within reason and the constraints on their volunteered time. Before requesting help, please read to find a solution to your problem in the following resources:
 
 - [Common issues and their fixes](http://wp-cli.org/docs/common-issues/)
 - [Submit a bug report](http://wp-cli.org/docs/bug-reports/)
@@ -90,11 +88,11 @@ WP-CLI's project maintainers do their best to respond to all bug reports and con
 
 A **command** is an atomic unit of WP-CLI functionality. `wp plugin install` ([doc](http://wp-cli.org/commands/plugin/install/)) is one command. `wp plugin activate` ([doc](http://wp-cli.org/commands/plugin/activate/)) is another.
 
-WP-CLI comes with dozens of commands. But it's easier than it looks to create a custom WP-CLI command. Read the [commands cookbook](http://wp-cli.org/docs/commands-cookbook/) to learn more.
+WP-CLI comes with dozens of commands. It's easier than it looks to create a custom WP-CLI command. Read the [commands cookbook](http://wp-cli.org/docs/commands-cookbook/) to learn more.
 
 ## Contributing
 
-Thanks for helping to improve WP-CLI. Please read about [creating an issue](http://wp-cli.org/docs/bug-reports/) or [submitting a pull request](http://wp-cli.org/docs/pull-requests/).
+To get involved, please first read about [creating an issue](http://wp-cli.org/docs/bug-reports/) or [submitting a pull request](http://wp-cli.org/docs/pull-requests/).
 
 ### Leadership
 * [Andreas Creten](https://github.com/andreascreten) - founder


### PR DESCRIPTION
Probably easiest to see this in action on my fork: https://github.com/NateWr/wp-cli/tree/i2760_readme_update

Should tick all the boxes in #2760 except for installation requirements (see https://github.com/wp-cli/wp-cli/issues/2760#issuecomment-220031625).

Happy to go in a different direction with anything you don't like the look of.