### PR TITLE
Display error if theme directory exists but is erred; permit force install

### DIFF
--- a/features/theme.feature
+++ b/features/theme.feature
@@ -131,16 +131,24 @@ Feature: Manage WordPress themes
 
   Scenario: Attempt to activate or fetch a broken theme
     Given a WP install
-    And I run `mkdir -pv wp-content/themes/just-test-theme`
 
-    When I try `wp theme activate just-test-theme`
+    When I run `mkdir -pv wp-content/themes/myth`
+    Then the wp-content/themes/myth directory should exist
+
+    When I try `wp theme activate myth`
     Then STDERR should contain:
       """
       Error: Stylesheet is missing.
       """
 
-    When I try `wp theme get just-test-theme`
+    When I try `wp theme get myth`
     Then STDERR should contain:
+      """
+      Error: Stylesheet is missing.
+      """
+
+    When I try `wp theme status myth`
+    Then STDERR should be:
       """
       Error: Stylesheet is missing.
       """

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -153,6 +153,12 @@ Feature: Manage WordPress themes
       Error: Stylesheet is missing.
       """
 
+    When I run `wp theme install myth --force`
+    Then STDOUT should contain:
+      """
+      Theme updated successfully.
+      """
+
   Scenario: Enabling and disabling a theme
   	Given a WP multisite install
     And I run `wp theme install jolene`

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -49,6 +49,13 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 	 *     		Author: the WordPress team
 	 */
 	function status( $args ) {
+		$theme = $this->fetcher->get_check( $args[0] );
+		$errors = $theme->errors();
+		if ( is_wp_error( $errors ) ) {
+			$message = $errors->get_error_message();
+			WP_CLI::error( $message );
+		}
+
 		parent::status( $args );
 	}
 


### PR DESCRIPTION
New behavior:

```
salty-wordpress ➜  wordpress-develop.dev  wp theme status myth
Error: Stylesheet is missing.
```

Previous behavior:

```
salty-wordpress ➜  wordpress-develop.dev  wp theme status myth
Theme myth details:
    Name: myth
    Status: Inactive
    Version:
    Author:
```

See #2790