### PR TITLE
if theme active, warning instead of success

### DIFF
--- a/features/theme.feature
+++ b/features/theme.feature
@@ -111,7 +111,7 @@ Feature: Manage WordPress themes
     When I run `wp theme activate p2`
     Then STDOUT should be:
       """
-      Success: The 'P2' theme is already active.
+      Warning: The 'P2' theme is already active.
       """
 
   Scenario: Install a theme when the theme directory doesn't yet exist

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -166,7 +166,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 		$name = $theme->get('Name');
 
 		if ( 'active' === $this->get_status( $theme ) ) {
-			WP_CLI::success( "The '$name' theme is already active." );
+			WP_CLI::warning( "The '$name' theme is already active." );
 			return;
 		}
 


### PR DESCRIPTION
compare `plugins`, e.g. `@ Warning: Plugin 'wp-mail-smtp' is already active.`