### PR TITLE
Move `--skip-themes` feature to a filter, instead of wp-settings hack

### DIFF
--- a/features/skip-themes.feature
+++ b/features/skip-themes.feature
@@ -46,6 +46,60 @@ Feature: Skipping themes
       false
       """
 
+  Scenario: Skip parent and child themes
+    Given a WP install
+    And I run `wp theme install jolene biker`
+
+    When I run `wp theme activate jolene`
+    When I run `wp eval 'var_export( function_exists( "jolene_setup" ) );'`
+    Then STDOUT should be:
+      """
+      true
+      """
+
+    When I run `wp --skip-themes=jolene eval 'var_export( function_exists( "jolene_setup" ) );'`
+    Then STDOUT should be:
+      """
+      false
+      """
+
+    When I run `wp theme activate biker`
+    When I run `wp eval 'var_export( function_exists( "jolene_setup" ) );'`
+    Then STDOUT should be:
+      """
+      true
+      """
+
+    When I run `wp eval 'var_export( function_exists( "biker_setup" ) );'`
+    Then STDOUT should be:
+      """
+      true
+      """
+
+    When I run `wp --skip-themes=biker eval 'var_export( function_exists( "jolene_setup" ) );'`
+    Then STDOUT should be:
+      """
+      false
+      """
+
+    When I run `wp --skip-themes=biker eval 'var_export( function_exists( "biker_setup" ) );'`
+    Then STDOUT should be:
+      """
+      false
+      """
+
+    When I run `wp --skip-themes=biker eval 'echo get_template_directory();'`
+    Then STDOUT should contain:
+      """
+      wp-content/themes/jolene
+      """
+
+    When I run `wp --skip-themes=biker eval 'echo get_stylesheet_directory();'`
+    Then STDOUT should contain:
+      """
+      wp-content/themes/biker
+      """
+
   Scenario: Skipping multiple themes via config file
     Given a WP install
     And a wp-cli.yml file:

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -383,12 +383,10 @@ $GLOBALS['wp_locale'] = new WP_Locale();
 // Load the functions for the active theme, for both parent and child theme if applicable.
 global $pagenow;
 if ( ! defined( 'WP_INSTALLING' ) || 'wp-activate.php' === $pagenow ) {
-	if ( !Utils\is_theme_skipped( TEMPLATEPATH ) ) {
-		if ( TEMPLATEPATH !== STYLESHEETPATH && file_exists( STYLESHEETPATH . '/functions.php' ) )
-			include( STYLESHEETPATH . '/functions.php' );
-		if ( file_exists( TEMPLATEPATH . '/functions.php' ) )
-			include( TEMPLATEPATH . '/functions.php' );
-	}
+	if ( TEMPLATEPATH !== STYLESHEETPATH && file_exists( STYLESHEETPATH . '/functions.php' ) )
+		include( STYLESHEETPATH . '/functions.php' );
+	if ( file_exists( TEMPLATEPATH . '/functions.php' ) )
+		include( TEMPLATEPATH . '/functions.php' );
 }
 
 do_action( 'after_setup_theme' );


### PR DESCRIPTION
Introduces `Runner->add_wp_hook()` and `Runner->remove_wp_hook()` for
adding actions and filters before `add_filter()` is defined.

To ensure child themes can be skipped from loading, the `stylesheet`
value is always checked.

Filter is added late on `setup_theme` hook to noop TEMPLATEPATH and
`STYLESHEETPATH`, and then removed early on `after_setup_theme` to
ensure use of `get_template_directory()` still works as expected. Unfortunately,
the downside is that the constants are defined incorrectly in this request,
but hopefully this is an acceptable cost to the value of `--skip-themes`.

See #2278