### PR TITLE
Adds support for PHP 5.5 Memcache extension

### DIFF
--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -152,7 +152,7 @@ function wp_get_cache_type() {
 		} elseif ( isset( $wp_object_cache->mc ) ) {
 			$is_memcache = true;
 			foreach ( $wp_object_cache->mc as $bucket ) {
-				if ( ! is_a( $bucket, 'Memcache' ) )
+				if ( ! is_a( $bucket, 'Memcache' ) && ! is_a( $bucket, 'Memcached' ) )
 					$is_memcache = false;
 			}
 


### PR DESCRIPTION
We've noticed that the `wp_get_cache_type()` utility method is returning with an empty `$message` due to a difference in the names of the cache bucket objects.