### PR TITLE
Move `--skip-plugins` feature to a filter, instead of wp-settings hack

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -944,7 +944,7 @@ class Runner {
 	 * Set up the filters to skip the loaded plugins
 	 */
 	private function setup_skip_plugins_filters() {
-		$wp_cli_filter_active_plugins = function( $plugins ) use( $skip_plugins ) {
+		$wp_cli_filter_active_plugins = function( $plugins ) {
 			$skipped_plugins = WP_CLI::get_runner()->config['skip-plugins'];
 			if ( true === $skipped_plugins ) {
 				return array();

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -247,11 +247,9 @@ unset( $mu_plugin );
 // Load network activated plugins.
 if ( is_multisite() ) {
 	foreach( wp_get_active_network_plugins() as $network_plugin ) {
-		if ( !Utils\is_plugin_skipped( $network_plugin ) ) {
-			if ( $symlinked_plugins_supported )
-				wp_register_plugin_realpath( $network_plugin );
-			include_once( $network_plugin );
-		}
+		if ( $symlinked_plugins_supported )
+			wp_register_plugin_realpath( $network_plugin );
+		include_once( $network_plugin );
 	}
 	unset( $network_plugin );
 }
@@ -284,11 +282,9 @@ register_theme_directory( get_theme_root() );
 
 // Load active plugins.
 foreach ( wp_get_active_and_valid_plugins() as $plugin ) {
-	if ( !Utils\is_plugin_skipped( $plugin ) ) {
-		if ( $symlinked_plugins_supported )
-			wp_register_plugin_realpath( $plugin );
-		include_once( $plugin );
-	}
+	if ( $symlinked_plugins_supported )
+		wp_register_plugin_realpath( $plugin );
+	include_once( $plugin );
 }
 unset( $plugin, $symlinked_plugins_supported );
 


### PR DESCRIPTION
Filters are added before the bootstrap process, to noop
`wp_get_active_network_plugins()` and
`wp_get_active_and_valid_plugins()`, and then removed early on
`plugins_loaded` to ensure later use of `get_option( 'active_plugins'
);` works as expected.

Unfortunately, `get_options( 'active_plugins' );` will be inaccurate on
the `muplugins_loaded` hook. Hopefully this will be an acceptable cost
to being able to continue using `--skip-plugins`.

See #2278