### PR TITLE
Load wp-includes/vars.php in wp-settings-cli.php

### DIFF
--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -267,12 +267,8 @@ wp_cookie_constants( );
 // Define and enforce our SSL constants
 wp_ssl_constants( );
 
-// Don't create common globals, but we still need wp_is_mobile() and $pagenow
-// require( ABSPATH . WPINC . '/vars.php' );
-$GLOBALS['pagenow'] = null;
-function wp_is_mobile() {
-	return false;
-}
+// Create common globals.
+require( ABSPATH . WPINC . '/vars.php' );
 
 // Make taxonomies and posts available to plugins and themes.
 // @plugin authors: warning: these get registered again on the init hook.


### PR DESCRIPTION
It doesn't appear there is an actual reason not to.

Originally #917
See #2278 