### PR TITLE
Remove `$pagenow` definition in `\WP_CLI\Runner`

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -799,10 +799,6 @@ class Runner {
 			define( 'DOING_CRON', true );
 		}
 
-		if ( $this->cmd_starts_with( array( 'plugin' ) ) ) {
-			$GLOBALS['pagenow'] = 'plugins.php';
-		}
-
 		$this->load_wordpress();
 
 		$this->_run_command();


### PR DESCRIPTION
Originally introduced in 58ea052de3090dc5738ef933fde2120ac39fe64e, it
hasn't worked since dc8502de2d5fb39fe2430b4447633a171628adbb. The
original issue this hack solved should just be addressed in the plugin.

See #2278