### PR TITLE
Hook wp_die handler in \WP_CLI\Runner instead of wp-settings-cli.php

### DIFF
--- a/features/db.feature
+++ b/features/db.feature
@@ -5,8 +5,18 @@ Feature: Perform database operations
     And WP files
     And wp-config.php
 
+    When I try `wp option get home`
+    Then STDOUT should be empty
+    And STDERR should be:
+      """
+      Error: Can’t select database
+      """
+
     When I run `wp db create`
-    Then STDOUT should not be empty
+    Then STDOUT should be:
+      """
+      Success: Database created.
+      """
 
     When I try the previous command again
     Then the return code should be 1

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -934,6 +934,8 @@ class Runner {
 			$this->add_wp_hook( 'setup_theme', array( $this, 'action_setup_theme_wp_cli_skip_themes' ), 999 );
 		}
 
+		$this->add_wp_hook( 'wp_die_handler', function() { return '\WP_CLI\Utils\wp_die_handler'; } );
+
 	}
 
 	/**

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -40,7 +40,7 @@ function wp_die_handler( $message ) {
 		$message = $matches[1];
 	}
 
-	$message = html_entity_decode( $message );
+	$message = html_entity_decode( $message, ENT_COMPAT, 'UTF-8' );
 
 	\WP_CLI::error( $message );
 }

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -70,7 +70,6 @@ require( ABSPATH . WPINC . '/class-wp-error.php' );
 require( ABSPATH . WPINC . '/pomo/mo.php' );
 
 // WP_CLI: Early hooks
-Utils\replace_wp_die_handler();
 add_filter( 'wp_redirect', 'WP_CLI\\Utils\\wp_redirect_handler' );
 if ( defined( 'WP_INSTALLING' ) && is_multisite() ) {
 	$values = array(


### PR DESCRIPTION
It's not necessary to add the callback as a part of the WP bootstrap
process, given the existing `\WP_CLI\Utils\replace_wp_die_handler()`
erroneously removes a callback that doesn't exist

See #2278
Originally #291