### PR TITLE
Remove support for pseudotty

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -347,8 +347,6 @@ class Runner {
 		WP_CLI::debug( 'SSH host: ' . $host, 'bootstrap' );
 		WP_CLI::debug( 'SSH path: ' . $path, 'bootstrap' );
 
-		$is_tty = function_exists( 'posix_isatty' ) && posix_isatty( STDOUT );
-
 		$pre_cmd = getenv( 'WP_CLI_SSH_PRE_CMD' );
 		if ( $pre_cmd ) {
 			$pre_cmd = rtrim( $pre_cmd, ';' ) . '; ';

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -362,9 +362,8 @@ class Runner {
 			}
 		}
 		$command = sprintf(
-			'ssh -q %s %s %s',
+			'ssh -q %s %s',
 			escapeshellarg( $host ),
-			$is_tty ? '-t' : '-T',
 			escapeshellarg( $pre_cmd . $wp_binary . ' ' . $wp_path . ' ' . implode( ' ', $wp_args ) )
 		);
 


### PR DESCRIPTION
The original genesis is
https://github.com/xwp/wp-cli-ssh/commit/6e2d29bfc95a2d2fa6fd5a985042c6f1428dc5e6.
It doesn't seem necessary for us, and can cause problems on some hosts
where `-t` is blocked.

See #2754