### PR TITLE
Move more filters into `WP_CLI\Runner` instead of wp-settings-cli.php

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -132,7 +132,13 @@ Feature: Manage WordPress installation
     Then the return code should be 1
 
     When I run `wp core install-network --title='test network'`
-    Then STDOUT should not be empty
+    Then STDOUT should be:
+      """
+      Set up multisite database tables.
+      Added multisite constants to wp-config.php.
+      Success: Network installed. Don't forget to set up rewrite rules.
+      """
+    And STDERR should be empty
 
     When I run `wp eval 'var_export( is_multisite() );'`
     Then STDOUT should be:
@@ -159,7 +165,14 @@ Feature: Manage WordPress installation
     And a database
 
     When I run `wp core multisite-install --url=foobar.org --title=Test --admin_user=wpcli --admin_email=admin@example.com --admin_password=1`
-    Then STDOUT should not be empty
+    Then STDOUT should be:
+      """
+      Created single site database tables.
+      Set up multisite database tables.
+      Added multisite constants to wp-config.php.
+      Success: Network installed. Don't forget to set up rewrite rules.
+      """
+    And STDERR should be empty
 
     When I run `wp eval 'echo $GLOBALS["current_site"]->domain;'`
     Then STDOUT should be:

--- a/features/framework.feature
+++ b/features/framework.feature
@@ -148,3 +148,19 @@ Feature: Load WP-CLI
       Error: This has no exit.
       Error: So I can use multiple lines.
       """
+
+  Scenario: A plugin calling wp_redirect() shouldn't redirect
+    Given a WP install
+    And a wp-content/mu-plugins/redirect.php file:
+      """
+      <?php
+      add_action( 'init', function(){
+          wp_redirect( 'http://apple.com' );
+      });
+      """
+
+    When I try `wp option get home`
+    Then STDERR should contain:
+      """
+      Warning: Some code is trying to do a URL redirect.
+      """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -956,6 +956,10 @@ class Runner {
 			}
 		}
 
+		if ( defined( 'WP_INSTALLING' ) ) {
+			$this->add_wp_hook( 'ms_site_check', '__return_true' );
+		}
+
 		// In a multisite install, die if unable to find site given in --url parameter
 		if ( $this->is_multisite() ) {
 			$this->add_wp_hook( 'ms_site_not_found', function( $current_site, $domain, $path ) {

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -936,6 +936,13 @@ class Runner {
 
 		$this->add_wp_hook( 'wp_die_handler', function() { return '\WP_CLI\Utils\wp_die_handler'; } );
 
+		// In a multisite install, die if unable to find site given in --url parameter
+		if ( $this->is_multisite() ) {
+			$this->add_wp_hook( 'ms_site_not_found', function( $current_site, $domain, $path ) {
+				WP_CLI::error( "Site {$domain}{$path} not found." );
+			}, 10, 3 );
+		}
+
 	}
 
 	/**
@@ -1093,6 +1100,24 @@ class Runner {
 			// Static Calling
 			return $function[0] . '::' . $function[1];
 		}
+	}
+
+	/**
+	 * Whether or not this WordPress install is multisite.
+	 *
+	 * For use after wp-config.php has loaded, but before the rest of WordPress
+	 * is loaded.
+	 */
+	private function is_multisite() {
+		if ( defined( 'MULTISITE' ) ) {
+			return MULTISITE;
+		}
+
+		if ( defined( 'SUBDOMAIN_INSTALL' ) || defined( 'VHOST' ) || defined( 'SUNRISE' ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -936,6 +936,9 @@ class Runner {
 
 		$this->add_wp_hook( 'wp_die_handler', function() { return '\WP_CLI\Utils\wp_die_handler'; } );
 
+		// Prevent code from performing a redirect
+		$this->add_wp_hook( 'wp_redirect', 'WP_CLI\\Utils\\wp_redirect_handler' );
+
 		// In a multisite install, die if unable to find site given in --url parameter
 		if ( $this->is_multisite() ) {
 			$this->add_wp_hook( 'ms_site_not_found', function( $current_site, $domain, $path ) {

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -939,6 +939,23 @@ class Runner {
 		// Prevent code from performing a redirect
 		$this->add_wp_hook( 'wp_redirect', 'WP_CLI\\Utils\\wp_redirect_handler' );
 
+		// Get rid of warnings when converting single site to multisite
+		if ( defined( 'WP_INSTALLING' ) && $this->is_multisite() ) {
+			$values = array(
+				'ms_files_rewriting' => null,
+				'active_sitewide_plugins' => array(),
+				'_site_transient_update_core' => null,
+				'_site_transient_update_themes' => null,
+				'_site_transient_update_plugins' => null,
+				'WPLANG' => '',
+			);
+			foreach ( $values as $key => $value ) {
+				$this->add_wp_hook( "pre_site_option_$key", function () use ( $values, $key ) {
+					return $values[ $key ];
+				} );
+			}
+		}
+
 		// In a multisite install, die if unable to find site given in --url parameter
 		if ( $this->is_multisite() ) {
 			$this->add_wp_hook( 'ms_site_not_found', function( $current_site, $domain, $path ) {

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -70,7 +70,6 @@ require( ABSPATH . WPINC . '/class-wp-error.php' );
 require( ABSPATH . WPINC . '/pomo/mo.php' );
 
 // WP_CLI: Early hooks
-add_filter( 'wp_redirect', 'WP_CLI\\Utils\\wp_redirect_handler' );
 if ( defined( 'WP_INSTALLING' ) && is_multisite() ) {
 	$values = array(
 		'ms_files_rewriting' => null,

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -369,8 +369,7 @@ $GLOBALS['wp']->init();
 do_action( 'init' );
 
 // Check site status
-# if ( is_multisite() ) {  // WP-CLI
-if ( is_multisite() && !defined('WP_INSTALLING') ) {
+if ( is_multisite() ) {
 	if ( true !== ( $file = ms_site_check() ) ) {
 		require( $file );
 		die();

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -88,13 +88,6 @@ if ( defined( 'WP_INSTALLING' ) && is_multisite() ) {
 	unset( $values, $key, $value );
 }
 
-// In a multisite install, die if unable to find site given in --url parameter
-if ( is_multisite() ) {
-	add_action( 'ms_site_not_found', function( $current_site, $domain, $path ) {
-		WP_CLI::error( "Site {$domain}{$path} not found." );
-	}, 10, 3 );
-}
-
 // Include the wpdb class and, if present, a db.php database drop-in.
 require_wp_db();
 

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -69,24 +69,6 @@ require( ABSPATH . WPINC . '/class-wp.php' );
 require( ABSPATH . WPINC . '/class-wp-error.php' );
 require( ABSPATH . WPINC . '/pomo/mo.php' );
 
-// WP_CLI: Early hooks
-if ( defined( 'WP_INSTALLING' ) && is_multisite() ) {
-	$values = array(
-		'ms_files_rewriting' => null,
-		'active_sitewide_plugins' => array(),
-		'_site_transient_update_core' => null,
-		'_site_transient_update_themes' => null,
-		'_site_transient_update_plugins' => null,
-		'WPLANG' => '',
-	);
-	foreach ( $values as $key => $value ) {
-		add_filter( "pre_site_option_$key", function () use ( $values, $key ) {
-			return $values[ $key ];
-		} );
-	}
-	unset( $values, $key, $value );
-}
-
 // Include the wpdb class and, if present, a db.php database drop-in.
 require_wp_db();
 


### PR DESCRIPTION
* Move `ms_site_not_found` action inside of `WP_CLI\Runner`. From #1909
* Move `wp_redirect` handler to Runner from wp-settings-cli.php. From #521
* Move filters for suppressing multisite installation warnings. From #598
* Skip `ms_site_check` when installing. From #598

See #2278