### PR TITLE
Treat `@[A-Za-z0-9-_]+` defined in yml config as an alias

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -26,3 +26,27 @@ Feature: Create shortcuts to specific WordPress installs
       """
       Error: Alias '@test' not found.
       """
+
+  Scenario: Treat global params as local when alias is used
+    Given a WP install in 'testdir'
+    And a wp-cli.yml file:
+      """
+      @testdir:
+        path: testdir
+      """
+
+    When I run `wp @testdir option get home`
+    Then STDOUT should be:
+      """
+      http://example.com
+      """
+
+    When I try `wp @testdir option get home --path=testdir`
+    Then STDERR should contain:
+      """
+      Parameter errors:
+      """
+    And STDERR should contain:
+      """
+      unknown --path parameter
+      """

--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -1,0 +1,28 @@
+Feature: Create shortcuts to specific WordPress installs
+
+  Scenario: Alias for a path to a specific WP install
+    Given a WP install in 'testdir'
+    And a wp-cli.yml file:
+      """
+      @testdir:
+        path: testdir
+      """
+
+    When I try `wp core is-installed`
+    Then STDERR should contain:
+      """
+      Error: This does not seem to be a WordPress install.
+      """
+    And the return code should be 1
+
+    When I run `wp @testdir core is-installed`
+    Then the return code should be 0
+
+  Scenario: Error when invalid alias provided
+    Given an empty directory
+
+    When I try `wp @test option get home`
+    Then STDERR should be:
+      """
+      Error: Alias '@test' not found.
+      """

--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -27,7 +27,7 @@ Feature: Create shortcuts to specific WordPress installs
       Error: Alias '@test' not found.
       """
 
-  Scenario: Treat global params as local when alias is used
+  Scenario: Treat global params as local when included in alias
     Given a WP install in 'testdir'
     And a wp-cli.yml file:
       """
@@ -49,6 +49,35 @@ Feature: Create shortcuts to specific WordPress installs
     And STDERR should contain:
       """
       unknown --path parameter
+      """
+
+    When I run `wp @testdir eval 'echo get_current_user_id();' --user=admin`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    Given a wp-cli.yml file:
+      """
+      @testdir:
+        path: testdir
+        user: admin
+      """
+
+    When I run `wp @testdir eval 'echo get_current_user_id();'`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I try `wp @testdir eval 'echo get_current_user_id();' --user=admin`
+    Then STDERR should contain:
+      """
+      Parameter errors:
+      """
+    And STDERR should contain:
+      """
+      unknown --user parameter
       """
 
   Scenario: Support global params specific to the WordPress install, not WP-CLI generally

--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -50,3 +50,19 @@ Feature: Create shortcuts to specific WordPress installs
       """
       unknown --path parameter
       """
+
+  Scenario: Support global params specific to the WordPress install, not WP-CLI generally
+    Given a WP install in 'testdir'
+    And a wp-cli.yml file:
+      """
+      @testdir:
+        path: testdir
+        debug: true
+      """
+
+    When I run `wp @testdir option get home`
+    Then STDOUT should be:
+      """
+      http://example.com
+      """
+    And STDERR should be empty

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -25,6 +25,11 @@ class Configurator {
 	private $extra_config = array();
 
 	/**
+	 * @var array $aliases Any aliases defined in config files.
+	 */
+	private $aliases = array();
+
+	/**
 	 * @param string $path Path to config spec file.
 	 */
 	function __construct( $path ) {
@@ -61,6 +66,15 @@ class Configurator {
 	 */
 	function get_spec() {
 		return $this->spec;
+	}
+
+	/**
+	 * Get any aliases defined in config files.
+	 *
+	 * @return array
+	 */
+	function get_aliases() {
+		return $this->aliases;
 	}
 
 	/**
@@ -142,7 +156,9 @@ class Configurator {
 			$this->merge_yml( $yaml['_']['inherit'] );
 		}
 		foreach ( $yaml as $key => $value ) {
-			if ( !isset( $this->spec[ $key ] ) || false === $this->spec[ $key ]['file'] ) {
+			if ( preg_match( '#@[A-Za-z0-9-_]+#', $key ) ) {
+				$this->aliases[ $key ] = $value;
+			} elseif ( !isset( $this->spec[ $key ] ) || false === $this->spec[ $key ]['file'] ) {
 				if ( isset( $this->extra_config[ $key ] )
 					&& ! empty( $yaml['_']['merge'] )
 					&& is_array( $this->extra_config[ $key ] )

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -157,7 +157,17 @@ class Configurator {
 		}
 		foreach ( $yaml as $key => $value ) {
 			if ( preg_match( '#@[A-Za-z0-9-_]+#', $key ) ) {
-				$this->aliases[ $key ] = $value;
+				$this->aliases[ $key ] = array();
+				foreach( array(
+					'user',
+					'url',
+					'path',
+					'ssh',
+				) as $i ) {
+					if ( isset( $value[ $i ] ) ) {
+						$this->aliases[ $key ][ $i ] = $value[ $i ];
+					}
+				}
 			} elseif ( !isset( $this->spec[ $key ] ) || false === $this->spec[ $key ]['file'] ) {
 				if ( isset( $this->extra_config[ $key ] )
 					&& ! empty( $yaml['_']['merge'] )

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -658,7 +658,14 @@ class Runner {
 		if ( ! array_key_exists( $alias, $this->aliases ) ) {
 			WP_CLI::error( "Alias '{$alias}' not found." );
 		}
-		$this->config = array_merge( $this->config, $this->aliases[ $this->alias ] );
+		$orig_config = $this->config;
+		$alias_config = $this->aliases[ $this->alias ];
+		$this->config = array_merge( $orig_config, $alias_config );
+		foreach( $alias_config as $key => $_ ) {
+			if ( isset( $orig_config[ $key ] ) && ! is_null( $orig_config[ $key ] ) ) {
+				$this->assoc_args[ $key ] = $orig_config[ $key ];
+			}
+		}
 	}
 
 	public function start() {


### PR DESCRIPTION
Aliases are a way of defining a shorthand reference to a WordPress install.

One or more aliases can be defined in `config.yml` or `wp-cli.yml`:

```
@wpdev:
  path: /srv/www/wordpress-develop.dev/src
```

An alias is called as the first argument to the `wp` executable:

```
salty-wordpress ➜  .wp-cli  wp @wpdev option get home
http://wordpress-develop.dev
```

The matching alias will overload the global parameters it defines. When an alias is used, any passed arguments will be treated as local parameters:

```
salty-wordpress ➜  .wp-cli  wp @wpdev option get home --path=/srv/www/wordpress-develop.dev/src
Error: Parameter errors:
 unknown --path parameter
```

This last implementation detail provides a path forward for solving #1222 without breaking backwards compat.

See #2039