### PR TITLE
Set current user on `init` early, instead of after wp-settings.php load

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -205,21 +205,6 @@ class Runner {
 	}
 
 	/**
-	 * Set a specific user context for WordPress.
-	 *
-	 * @param array $assoc_args
-	 */
-	private static function set_user( $assoc_args ) {
-		if ( isset( $assoc_args['user'] ) ) {
-			$fetcher = new \WP_CLI\Fetchers\User;
-			$user = $fetcher->get_check( $assoc_args['user'] );
-			wp_set_current_user( $user->ID );
-		} else {
-			kses_remove_filters();
-		}
-	}
-
-	/**
 	 * Guess which URL context WP-CLI has been invoked under.
 	 *
 	 * @param array $assoc_args
@@ -864,11 +849,6 @@ class Runner {
 
 		add_filter( 'filesystem_method', function() { return 'direct'; }, 99 );
 
-		// Handle --user parameter
-		if ( ! defined( 'WP_INSTALLING' ) ) {
-			self::set_user( $this->config );
-		}
-
 		WP_CLI::debug( 'Loaded WordPress', 'bootstrap' );
 		WP_CLI::do_hook( 'after_wp_load' );
 
@@ -965,6 +945,20 @@ class Runner {
 			$this->add_wp_hook( 'ms_site_not_found', function( $current_site, $domain, $path ) {
 				WP_CLI::error( "Site {$domain}{$path} not found." );
 			}, 10, 3 );
+		}
+
+		// Handle --user parameter
+		if ( ! defined( 'WP_INSTALLING' ) ) {
+			$config = $this->config;
+			$this->add_wp_hook( 'init', function() use ( $config ) {
+				if ( isset( $config['user'] ) ) {
+					$fetcher = new \WP_CLI\Fetchers\User;
+					$user = $fetcher->get_check( $config['user']  );
+					wp_set_current_user( $user->ID );
+				} else {
+					kses_remove_filters();
+				}
+			}, 0 );
 		}
 
 	}

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -956,7 +956,7 @@ class Runner {
 					$user = $fetcher->get_check( $config['user']  );
 					wp_set_current_user( $user->ID );
 				} else {
-					kses_remove_filters();
+					add_action( 'init', 'kses_remove_filters', 11 );
 				}
 			}, 0 );
 		}


### PR DESCRIPTION
This more closely mirrors WordPress' behavior, allowing the rest of
`wp-settings.php` to operate under the expected user context.

See #2970