### PR TITLE
Fix PHP notice when installing a child theme

### DIFF
--- a/php/WP_CLI/UpgraderSkin.php
+++ b/php/WP_CLI/UpgraderSkin.php
@@ -9,6 +9,8 @@ namespace WP_CLI;
  */
 class UpgraderSkin extends \WP_Upgrader_Skin {
 
+	public $api;
+
 	function header() {}
 	function footer() {}
 	function bulk_header() {}


### PR DESCRIPTION
`Plugin_Installer_Skin` and `Theme_Installer_Skin` both use a public
`$api` class variable. We can safely define this too to prevent the
error notice.

Fixes #2971