### PR TITLE
Always permit CLI operations against sites, regardless of status

### DIFF
--- a/features/site.feature
+++ b/features/site.feature
@@ -257,3 +257,20 @@ Feature: Manage sites in a multisite installation
       """
       Warning: You are not allowed to change the main site.
       """
+
+  Scenario: Permit CLI operations against archived and suspended sites
+    Given a WP multisite install
+    And I run `wp site create --slug=first --porcelain`
+    And save STDOUT as {FIRST_SITE}
+
+    When I run `wp site archive {FIRST_SITE}`
+    Then STDOUT should be:
+      """
+      Success: Site {FIRST_SITE} archived.
+      """
+
+    When I run `wp --url=example.com/first option get home`
+    Then STDOUT should be:
+      """
+      http://example.com/first
+      """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -965,9 +965,8 @@ class Runner {
 			}
 		}
 
-		if ( defined( 'WP_INSTALLING' ) ) {
-			$this->add_wp_hook( 'ms_site_check', '__return_true' );
-		}
+		// Always permit operations against sites, regardless of status
+		$this->add_wp_hook( 'ms_site_check', '__return_true' );
 
 		// In a multisite install, die if unable to find site given in --url parameter
 		if ( $this->is_multisite() ) {


### PR DESCRIPTION
When using WP-CLI without the `--user=<user>` argument, the expectation
is that you can perform any operation, and those operations aren't run
as any user. Even when the `--user=<user>` argument is provided, there's
a reasonable assumption the CLI operation isn't meant to run into a
capability check.

Fixes #2970