### PR TITLE
Ignore the current alias when handling `--ssh`

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -345,6 +345,11 @@ class Runner {
 		$wp_binary = 'wp';
 		$wp_args = array_slice( $GLOBALS['argv'], 1 );
 		$wp_path = $path ? sprintf( '--path=%s', str_replace( '~', '$HOME', $path ) ) : '';
+
+		if ( $this->alias && ! empty( $wp_args[0] ) && $this->alias === $wp_args[0] ) {
+			array_shift( $wp_args );
+		}
+
 		foreach( $wp_args as $k => $v ) {
 			if ( preg_match( '#--ssh=#', $v ) ) {
 				unset( $wp_args[ $k ] );


### PR DESCRIPTION
The current alias isn't meant to be passed through to the remote server.

See #2754, #2039