### PR TITLE
Provide more verbosity when `--ssh` fails

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -368,7 +368,9 @@ class Runner {
 		);
 
 		passthru( $escaped_command, $exit_code );
-		if ( 0 !== $exit_code ) {
+		if ( 255 === $exit_code ) {
+			WP_CLI::error( 'Cannot connect over SSH using provided configuration.', 255 );
+		} else {
 			exit( $exit_code );
 		}
 	}


### PR DESCRIPTION
```
$ wp --ssh=foo option get home
Error: Cannot connect over SSH using provided configuration.
```

Unfortunately, it doesn't seem possible to capture the SSH error itself.
`-o LogLevel=ERROR` still includes the "Connection closed" message.

Fixes #2765