### PR TITLE
Use `WP_CLI::warning()` when a theme is already active

### DIFF
--- a/features/theme.feature
+++ b/features/theme.feature
@@ -108,10 +108,10 @@ Feature: Manage WordPress themes
       Success: Switched to 'P2' theme.
       """
 
-    When I run `wp theme activate p2`
-    Then STDOUT should be:
+    When I try `wp theme activate p2`
+    Then STDERR should be:
       """
-      Success: The 'P2' theme is already active.
+      Warning: The 'P2' theme is already active.
       """
 
   Scenario: Install a theme when the theme directory doesn't yet exist

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -196,7 +196,7 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 		$name = $theme->get('Name');
 
 		if ( 'active' === $this->get_status( $theme ) ) {
-			WP_CLI::success( "The '$name' theme is already active." );
+			WP_CLI::warning( "The '$name' theme is already active." );
 			return;
 		}
 


### PR DESCRIPTION
This makes `wp theme activate` behave more consistently with `wp plugin
activate`

Originally #2920