### PR TITLE
Restore `advanced-cache.php` to `wp-settings-cli.php`

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -990,6 +990,11 @@ class Runner {
 			return true;
 		});
 
+		// Never load advanced-cache.php drop-in when WP-CLI is operating
+		$this->add_wp_hook( 'bypass_advanced_cache', function() {
+			return true;
+		});
+
 		// In a multisite install, die if unable to find site given in --url parameter
 		if ( $this->is_multisite() ) {
 			$this->add_wp_hook( 'ms_site_not_found', function( $current_site, $domain, $path ) {

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -65,6 +65,21 @@ timer_start();
 // Check if we're in WP_DEBUG mode.
 Utils\wp_debug_mode();
 
+/**
+ * Bypass the loading of advanced-cache.php
+ *
+ * This filter should *NOT* be used by plugins. It is designed for non-web
+ * runtimes. If true is returned, advance-cache.php will never be loaded.
+ *
+ * @since 4.6.0
+ *
+ * @param bool True to bypass advanced-cache.php
+ */
+if ( WP_CACHE && ! apply_filters( 'bypass_advanced_cache', false )  ) {
+	// For an advanced caching plugin to use. Uses a static drop-in because you would only want one.
+	WP_DEBUG ? include( WP_CONTENT_DIR . '/advanced-cache.php' ) : @include( WP_CONTENT_DIR . '/advanced-cache.php' );
+}
+
 // Define WP_LANG_DIR if not set.
 wp_set_lang_dir();
 


### PR DESCRIPTION
Even though this will never be called, this ensures
`wp-settings-cli.php` is in closer parity to `wp-settings.php`

See #2278