### PR TITLE
Move the APC cache check to `muplugins_loaded`

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -997,6 +997,14 @@ class Runner {
 			}, 10, 3 );
 		}
 
+		// The APC cache is not available on the command-line, so bail, to prevent cache poisoning
+		$this->add_wp_hook( 'muplugins_loaded', function() {
+			if ( $GLOBALS['_wp_using_ext_object_cache'] && class_exists( 'APC_Object_Cache' ) ) {
+				WP_CLI::warning( 'Running WP-CLI while the APC object cache is activated can result in cache corruption.' );
+				WP_CLI::confirm( 'Given the consequences, do you wish to continue?' );
+			}
+		}, 0 );
+
 		// Handle --user parameter
 		if ( ! defined( 'WP_INSTALLING' ) ) {
 			$config = $this->config;

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -92,12 +92,6 @@ wp_set_wpdb_vars();
 // Start the WordPress object cache, or an external object cache if the drop-in is present.
 wp_start_object_cache();
 
-// WP-CLI: the APC cache is not available on the command-line, so bail, to prevent cache poisoning
-if ( $GLOBALS['_wp_using_ext_object_cache'] && class_exists( 'APC_Object_Cache' ) ) {
-	WP_CLI::warning( 'Running WP-CLI while the APC object cache is activated can result in cache corruption.' );
-	WP_CLI::confirm( 'Given the consequences, do you wish to continue?' );
-}
-
 // Attach the default filters.
 require( ABSPATH . WPINC . '/default-filters.php' );
 


### PR DESCRIPTION
Doing so mitigates our need to include it in a forked
wp-settings-cli.php. There is minimal risk in performing the AYS check
later in the bootstrap process.

See #2278