### PR TITLE
Abuse the `nocache_headers` filter to run our `Utils\wp_not_installed()`

### DIFF
--- a/features/core-config.feature
+++ b/features/core-config.feature
@@ -41,6 +41,15 @@ Feature: Manage wp-config
     Then the return code should be 1
     And STDERR should not be empty
 
+    When I run `wp db create`
+    Then STDOUT should not be empty
+
+    When I try `wp option get option home`
+    Then STDERR should contain:
+      """
+      Error: The site you have requested is not installed
+      """
+
   Scenario: Configure with existing salts
     Given an empty directory
     And WP files

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -965,6 +965,11 @@ class Runner {
 		// Prevent code from performing a redirect
 		$this->add_wp_hook( 'wp_redirect', 'WP_CLI\\Utils\\wp_redirect_handler' );
 
+		$this->add_wp_hook( 'nocache_headers', function( $headers ){
+			Utils\wp_not_installed();
+			return $headers;
+		});
+
 		// Get rid of warnings when converting single site to multisite
 		if ( defined( 'WP_INSTALLING' ) && $this->is_multisite() ) {
 			$values = array(

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -120,7 +120,7 @@ if ( SHORTINIT )
 require_once( ABSPATH . WPINC . '/l10n.php' );
 
 // Run the installer if WordPress is not installed.
-Utils\wp_not_installed();
+wp_not_installed();
 
 // Load most of WordPress.
 require( ABSPATH . WPINC . '/class-wp-walker.php' );

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -119,6 +119,9 @@ if ( SHORTINIT )
 // Load the L10n library.
 require_once( ABSPATH . WPINC . '/l10n.php' );
 
+// WP-CLI: Permit Utils\wp_not_installed() to run on < WP 4.0
+apply_filters( 'nocache_headers', array() );
+
 // Run the installer if WordPress is not installed.
 wp_not_installed();
 


### PR DESCRIPTION
If `wp_not_installed()` identifies that WordPress isn't installed, it
will call `nocache_headers()` before trying to redirect. Hijacking this
particular filter lets WP-CLI exit with its own message before the
redirect is called, and avoid having to maintain a forked
`wp-settings-cli.php`

See #2278