### PR TITLE
Restore `wp_debug_mode()` call in `wp-settings-cli.php`

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -990,6 +990,19 @@ class Runner {
 			return true;
 		});
 
+		// Use our own debug mode handling instead of WP core
+		$this->add_wp_hook( 'bypass_debug_mode', function( $ret ) {
+			static $did_once;
+
+			// Sometimes called a second time in >= WP 4.6, prevent loop
+			if ( ! empty( $did_once ) ) {
+				return $ret;
+			}
+			Utils\wp_debug_mode();
+			$did_once = true;
+			return true;
+		});
+
 		// Never load advanced-cache.php drop-in when WP-CLI is operating
 		$this->add_wp_hook( 'bypass_advanced_cache', function() {
 			return true;

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -62,8 +62,21 @@ if ( ! apply_filters( 'bypass_maintenance_mode', false ) ) {
 // Start loading timer.
 timer_start();
 
-// Check if we're in WP_DEBUG mode.
-Utils\wp_debug_mode();
+/**
+ * Bypass the debug mode check
+ *
+ * This filter should *NOT* be used by plugins. It is designed for non-web
+ * runtimes. Returning true causes the WP_DEBUG and related constants to
+ * not be checked and the default php values for errors will be used unless
+ * you take care to update them yourself.
+ *
+ * @since 4.6.0
+ *
+ * @param bool True to bypass debug mode
+ */
+if ( ! apply_filters( 'bypass_debug_mode', false ) ){
+	wp_debug_mode();
+}
 
 /**
  * Bypass the loading of advanced-cache.php


### PR DESCRIPTION
We can use the new `bypass_debug_mode` filter to hook in our existing
`WP_CLI\Utils\wp_debug_mode()` call, and make sure it just runs once

See #2278