### PR TITLE
Perform dead db check earlier, by loading wpdb ourselves

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1000,6 +1000,14 @@ class Runner {
 			}
 			Utils\wp_debug_mode();
 			$did_once = true;
+
+			// Check to see of wpdb is errored, instead of waiting for dead_db()
+			require_wp_db();
+			global $wpdb;
+			if ( ! empty( $wpdb->error ) ) {
+				Utils\wp_die_handler( $wpdb->error );
+			}
+
 			return true;
 		});
 

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -32,7 +32,7 @@ function replace_wp_die_handler() {
 }
 
 function wp_die_handler( $message ) {
-	if ( is_wp_error( $message ) ) {
+	if ( $message instanceof \WP_Error ) {
 		$message = $message->get_error_message();
 	}
 

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -106,6 +106,11 @@ require( ABSPATH . WPINC . '/pomo/mo.php' );
 // Include the wpdb class and, if present, a db.php database drop-in.
 require_wp_db();
 
+// WP-CLI: Handle db error ourselves, instead of waiting for dead_db()
+global $wpdb;
+if ( !empty( $wpdb->error ) )
+	wp_die( $wpdb->error );
+
 // Set the database table prefix and the format specifiers for database table columns.
 // @codingStandardsIgnoreStart
 $GLOBALS['table_prefix'] = $table_prefix;

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -106,11 +106,6 @@ require( ABSPATH . WPINC . '/pomo/mo.php' );
 // Include the wpdb class and, if present, a db.php database drop-in.
 require_wp_db();
 
-// WP-CLI: Handle db error ourselves, instead of waiting for dead_db()
-global $wpdb;
-if ( !empty( $wpdb->error ) )
-	wp_die( $wpdb->error );
-
 // Set the database table prefix and the format specifiers for database table columns.
 // @codingStandardsIgnoreStart
 $GLOBALS['table_prefix'] = $table_prefix;


### PR DESCRIPTION
In doing so, we're causing wpdb to be loaded slightly earlier in the
bootstrap process.

See #2278