### PR TITLE
Restore `defined( 'WP_INSTALLING' )` check in legacy wp-settings-cli.php

### DIFF
--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -400,7 +400,8 @@ $GLOBALS['wp']->init();
 do_action( 'init' );
 
 // Check site status
-if ( is_multisite() ) {
+# if ( is_multisite() ) {  // WP-CLI
+if ( is_multisite() && !defined('WP_INSTALLING') ) {
 	if ( true !== ( $file = ms_site_check() ) ) {
 		require( $file );
 		die();


### PR DESCRIPTION
This will prevent error notices when using WP-CLI against <WP 4.6

See https://github.com/wp-cli/wp-cli/issues/2278#issuecomment-226634504