### PR TITLE
Use `wp-settings.php` instead of `wp-settings-cli.php` for >=WP4.6

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -996,20 +996,13 @@ class Runner {
 		$this->add_wp_hook( 'ms_site_check', '__return_true' );
 
 		// Always permit operations against WordPress, regardless of maintenance mode
-		$this->add_wp_hook( 'bypass_maintenance_mode', function() {
-			return true;
+		$this->add_wp_hook( 'enable_maintenance_mode', function() {
+			return false;
 		});
 
 		// Use our own debug mode handling instead of WP core
-		$this->add_wp_hook( 'bypass_debug_mode', function( $ret ) {
-			static $did_once;
-
-			// Sometimes called a second time in >= WP 4.6, prevent loop
-			if ( ! empty( $did_once ) ) {
-				return $ret;
-			}
+		$this->add_wp_hook( 'enable_wp_debug_mode_checks', function( $ret ) {
 			Utils\wp_debug_mode();
-			$did_once = true;
 
 			// Check to see of wpdb is errored, instead of waiting for dead_db()
 			require_wp_db();
@@ -1018,12 +1011,12 @@ class Runner {
 				Utils\wp_die_handler( $wpdb->error );
 			}
 
-			return true;
+			return false;
 		});
 
 		// Never load advanced-cache.php drop-in when WP-CLI is operating
-		$this->add_wp_hook( 'bypass_advanced_cache', function() {
-			return true;
+		$this->add_wp_hook( 'enable_loading_advanced_cache_dropin', function() {
+			return false;
 		});
 
 		// In a multisite install, die if unable to find site given in --url parameter

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -843,7 +843,7 @@ class Runner {
 	public function load_wordpress() {
 		static $wp_cli_is_loaded;
 		// Globals not explicitly globalized in WordPress
-		global $site_id, $public, $current_site, $current_blog, $path, $shortcode_tags;
+		global $site_id, $wpdb, $public, $current_site, $current_blog, $path, $shortcode_tags;
 
 		if ( ! empty( $wp_cli_is_loaded ) ) {
 			return;

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -575,6 +575,7 @@ class Runner {
 				"Pass --path=`path/to/wordpress` or run `wp core download`." );
 		}
 
+		global $wp_version;
 		include ABSPATH . 'wp-includes/version.php';
 
 		$minimum_version = '3.7';
@@ -885,7 +886,11 @@ class Runner {
 		$this->setup_bootstrap_hooks();
 
 		// Load Core, mu-plugins, plugins, themes etc.
-		require WP_CLI_ROOT . '/php/wp-settings-cli.php';
+		if ( Utils\wp_version_compare( '4.6-alpha-37575', '>=' ) ) {
+			require ABSPATH . 'wp-settings.php';
+		} else {
+			require WP_CLI_ROOT . '/php/wp-settings-cli.php';
+		}
 
 		// Fix memory limit. See http://core.trac.wordpress.org/ticket/14889
 		@ini_set( 'memory_limit', -1 );

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -19,7 +19,25 @@ function wp_debug_mode() {
 
 		error_reporting( E_ALL & ~E_DEPRECATED & ~E_STRICT );
 	} else {
-		\wp_debug_mode();
+		if ( WP_DEBUG ) {
+			error_reporting( E_ALL );
+
+			if ( WP_DEBUG_DISPLAY )
+				ini_set( 'display_errors', 1 );
+			elseif ( null !== WP_DEBUG_DISPLAY )
+				ini_set( 'display_errors', 0 );
+
+			if ( WP_DEBUG_LOG ) {
+				ini_set( 'log_errors', 1 );
+				ini_set( 'error_log', WP_CONTENT_DIR . '/debug.log' );
+			}
+		} else {
+			error_reporting( E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_ERROR | E_WARNING | E_PARSE | E_USER_ERROR | E_USER_WARNING | E_RECOVERABLE_ERROR );
+		}
+
+		if ( defined( 'XMLRPC_REQUEST' ) || defined( 'REST_REQUEST' ) || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
+			@ini_set( 'display_errors', 0 );
+		}
 	}
 
 	// XDebug already sends errors to STDERR

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -54,7 +54,20 @@ wp_unregister_GLOBALS();
 wp_fix_server_vars();
 
 // Check if we're in maintenance mode.
-// WP-CLI: run bypass_maintenance_mode filter early for compat with < WP 4.6
+// WP-CLI: run enable_maintenance_mode filter early for compat with < WP 4.6
+/**
+ * Filters whether to enable maintenance mode.
+ *
+ * This filter runs before it can be used by plugins. It is designed for
+ * non-web runtimes. If this filter returns true, maintenance mode will be
+ * active and the request will end. If false, the request will be allowed to
+ * continue processing even if maintenance mode should be active.
+ *
+ * @since 4.6.0
+ *
+ * @param bool $enable_checks Whether to enable maintenance mode. Default true.
+ * @param int  $upgrading     The timestamp set in the .maintenance file.
+ */
 if ( apply_filters( 'enable_maintenance_mode', true ) ) {
 	wp_maintenance();
 }
@@ -62,31 +75,33 @@ if ( apply_filters( 'enable_maintenance_mode', true ) ) {
 // Start loading timer.
 timer_start();
 
+// WP-CLI: run enable_wp_debug_mode_checks filter early for compat with < WP 4.6
 /**
- * Bypass the debug mode check
+ * Filters whether to allow the debug mode check to occur.
  *
- * This filter should *NOT* be used by plugins. It is designed for non-web
- * runtimes. Returning true causes the WP_DEBUG and related constants to
- * not be checked and the default php values for errors will be used unless
- * you take care to update them yourself.
+ * This filter runs before it can be used by plugins. It is designed for
+ * non-web run-times. Returning false causes the `WP_DEBUG` and related
+ * constants to not be checked and the default php values for errors
+ * will be used unless you take care to update them yourself.
  *
  * @since 4.6.0
  *
- * @param bool True to bypass debug mode
+ * @param bool $enable_debug_mode Whether to enable debug mode checks to occur. Default true.
  */
 if ( apply_filters( 'enable_wp_debug_mode_checks', true ) ){
 	wp_debug_mode();
 }
 
 /**
- * Bypass the loading of advanced-cache.php
+ * Filters whether to enable loading of the advanced-cache.php drop-in.
  *
- * This filter should *NOT* be used by plugins. It is designed for non-web
- * runtimes. If true is returned, advance-cache.php will never be loaded.
+ * This filter runs before it can be used by plugins. It is designed for non-web
+ * run-times. If false is returned, advance-cache.php will never be loaded.
  *
  * @since 4.6.0
  *
- * @param bool True to bypass advanced-cache.php
+ * @param bool $enable_advanced_cache Whether to enable loading advanced-cache.php (if present).
+ *                                    Default true.
  */
 if ( WP_CACHE && apply_filters( 'enable_loading_advanced_cache_dropin', true )  ) {
 	// For an advanced caching plugin to use. Uses a static drop-in because you would only want one.

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -55,7 +55,7 @@ wp_fix_server_vars();
 
 // Check if we're in maintenance mode.
 // WP-CLI: run bypass_maintenance_mode filter early for compat with < WP 4.6
-if ( ! apply_filters( 'bypass_maintenance_mode', false ) ) {
+if ( apply_filters( 'enable_maintenance_mode', true ) ) {
 	wp_maintenance();
 }
 
@@ -74,7 +74,7 @@ timer_start();
  *
  * @param bool True to bypass debug mode
  */
-if ( ! apply_filters( 'bypass_debug_mode', false ) ){
+if ( apply_filters( 'enable_wp_debug_mode_checks', true ) ){
 	wp_debug_mode();
 }
 
@@ -88,7 +88,7 @@ if ( ! apply_filters( 'bypass_debug_mode', false ) ){
  *
  * @param bool True to bypass advanced-cache.php
  */
-if ( WP_CACHE && ! apply_filters( 'bypass_advanced_cache', false )  ) {
+if ( WP_CACHE && apply_filters( 'enable_loading_advanced_cache_dropin', true )  ) {
 	// For an advanced caching plugin to use. Uses a static drop-in because you would only want one.
 	WP_DEBUG ? include( WP_CONTENT_DIR . '/advanced-cache.php' ) : @include( WP_CONTENT_DIR . '/advanced-cache.php' );
 }


### PR DESCRIPTION
Maintaining a fork isn't a ton of fun.

Fixes #2278