### PR TITLE
Ignore `wp-cli.local.yml` in plugin scaffold `.gitignore`

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -155,6 +155,7 @@ Feature: WordPress code scaffolding
     And the {PLUGIN_DIR}/hello-world/.gitignore file should contain:
       """
       .DS_Store
+      wp-cli.local.yml
       node_modules/
       """
     And the {PLUGIN_DIR}/hello-world/.distignore file should contain:

--- a/templates/plugin-distignore.mustache
+++ b/templates/plugin-distignore.mustache
@@ -12,6 +12,7 @@ package.json
 phpunit.xml
 phpunit.xml.dist
 README.md
+wp-cli.local.yml
 tests
 vendor
 node_modules

--- a/templates/plugin-gitignore.mustache
+++ b/templates/plugin-gitignore.mustache
@@ -1,2 +1,3 @@
 .DS_Store
+wp-cli.local.yml
 node_modules/


### PR DESCRIPTION
This file is only ever meant for local development.