### PR TITLE
Wrap wp-config.php file name with quotes in command messages

### DIFF
--- a/features/core-config.feature
+++ b/features/core-config.feature
@@ -15,7 +15,7 @@ Feature: Manage wp-config
     Then the return code should be 1
     And STDERR should be:
       """
-      Error: wp-config.php not found.
+      Error: 'wp-config.php' not found.
       Either create one manually or use `wp core config`.
       """
 

--- a/features/core.feature
+++ b/features/core.feature
@@ -135,7 +135,7 @@ Feature: Manage WordPress installation
     Then STDOUT should be:
       """
       Set up multisite database tables.
-      Added multisite constants to wp-config.php.
+      Added multisite constants to 'wp-config.php'.
       Success: Network installed. Don't forget to set up rewrite rules.
       """
     And STDERR should be empty
@@ -169,7 +169,7 @@ Feature: Manage WordPress installation
       """
       Created single site database tables.
       Set up multisite database tables.
-      Added multisite constants to wp-config.php.
+      Added multisite constants to 'wp-config.php'.
       Success: Network installed. Don't forget to set up rewrite rules.
       """
     And STDERR should be empty

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -784,7 +784,7 @@ class Runner {
 
 		if ( !Utils\locate_wp_config() ) {
 			WP_CLI::error(
-				"wp-config.php not found.\n" .
+				"'wp-config.php' not found.\n" .
 				"Either create one manually or use `wp core config`." );
 		}
 
@@ -859,7 +859,7 @@ class Runner {
 		$wp_config_path = Utils\locate_wp_config();
 		if ( ! $wp_config_path ) {
 			WP_CLI::error(
-				"wp-config.php not found.\n" .
+				"'wp-config.php' not found.\n" .
 				"Either create one manually or use `wp core config`." );
 		}
 

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -763,9 +763,9 @@ EOT;
 			$wp_config_path = Utils\locate_wp_config();
 			if ( is_writable( $wp_config_path ) ) {
 				self::modify_wp_config( $ms_config );
-				WP_CLI::log( 'Added multisite constants to wp-config.php.' );
+				WP_CLI::log( "Added multisite constants to 'wp-config.php'." );
 			} else {
-				WP_CLI::warning( 'Multisite constants could not be written to wp-config.php. You may need to add them manually:' );
+				WP_CLI::warning( "Multisite constants could not be written to 'wp-config.php'. You may need to add them manually:" );
 				WP_CLI::log( $ms_config );
 			}
 		}


### PR DESCRIPTION
Wrap wp-config.php file name with quotes in command messages.