### PR TITLE
Recently active plugins list is not populated

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ WP-CLI's maintainers and project contributors do their best to respond to all ne
 - [Common issues and their fixes](https://wp-cli.org/docs/common-issues/)
 - [Best practices for submitting a bug report](https://wp-cli.org/docs/bug-reports/)
 - [Documentation portal](https://wp-cli.org/docs/)
+- [Open or closed issues on Github](https://github.com/wp-cli/wp-cli/issues?utf8=%E2%9C%93&q=is%3Aissue)
+- [WordPress StackExchange forums](http://wordpress.stackexchange.com/questions/tagged/wp-cli)
 
 If you have a WordPress.org account, you may also consider joining the `#cli` channel on the [WordPress.org Slack organization](https://make.wordpress.org/chat/).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ WP-CLI
 
 [WP-CLI](https://wp-cli.org/) is a set of command-line tools for managing [WordPress](https://wordpress.org/) installations. You can update plugins, configure multisite installs and much more, without using a web browser.
 
-For news and announcements, follow [@wpcli on Twitter](https://twitter.com/wpcli) or [sign up for our email newsletter](http://wp-cli.us13.list-manage.com/subscribe?u=0615e4d18f213891fc000adfd&id=8c61d7641e).
+To stay up to date, follow [@wpcli on Twitter](https://twitter.com/wpcli) or [sign up for our email newsletter](http://wp-cli.us13.list-manage.com/subscribe?u=0615e4d18f213891fc000adfd&id=8c61d7641e).
 
 [![Build Status](https://travis-ci.org/wp-cli/wp-cli.png?branch=master)](https://travis-ci.org/wp-cli/wp-cli) [![Dependency Status](https://gemnasium.com/badges/github.com/wp-cli/wp-cli.svg)](https://gemnasium.com/github.com/wp-cli/wp-cli)
 
@@ -22,9 +22,7 @@ Quick links: [Using](#using) &#124; [Installing](#installing) &#124; [Support](#
 
 ## Using
 
-WP-CLI's mission is to provide a command-line interface for any action you might want to perform in the WordPress dashboard. WP-CLI also includes commands for many things you can't do in the WordPress dashboard.
-
-For instance, `wp plugin install` ([doc](https://wp-cli.org/commands/plugin/install/)) lets you install and activate a WordPress plugin:
+WP-CLI's goal is to provide a command-line interface for any action you might want to perform in the WordPress admin. For instance, `wp plugin install` ([doc](https://wp-cli.org/commands/plugin/install/)) lets you install and activate a WordPress plugin:
 
 ```
 $ wp plugin install rest-api --activate
@@ -37,20 +35,20 @@ Activating 'rest-api'...
 Success: Plugin 'rest-api' activated.
 ```
 
-Similarly, `wp transient` ([doc](https://wp-cli.org/commands/transient/)) lets you delete one or all transients:
+WP-CLI also includes commands for many things you can't do in the WordPress admin. For example, `wp transient delete-all` ([doc](https://wp-cli.org/commands/transient/delete-all/)) lets you delete one or all transients:
 
 ```
 $ wp transient delete-all
 Success: 34 transients deleted from the database.
 ```
 
-For a complete introduction to WP-CLI, read the [Quick Start guide](https://wp-cli.org/docs/quick-start/).
+For a more complete introduction to using WP-CLI, read the [Quick Start guide](https://wp-cli.org/docs/quick-start/).
 
 Already feel comfortable with the basics? Jump into the [complete list of commands](https://wp-cli.org/commands/) for detailed information on managing themes and plugins, importing and exporting data, performing database search-replace operations and more.
 
 ## Installing
 
-We recommend installing WP-CLI through the Phar distribution mechanism: download the Phar build, mark it executable, and place it on your PATH. The complete instructions follow shortly. Should you need, see also our documentation on [alternative installation methods](https://wp-cli.org/docs/installing/).
+Downloading the Phar file is our recommended installation method. Should you need, see also our documentation on [alternative installation methods](https://wp-cli.org/docs/installing/).
 
 Before installing WP-CLI, please make sure your environment meets the minimum requirements:
 
@@ -58,7 +56,7 @@ Before installing WP-CLI, please make sure your environment meets the minimum re
 - PHP 5.3.29 or later
 - WordPress 3.7 or later
 
-Once you've verified requirements, download the [wp-cli.phar](https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar) file using `wget` or `curl`. For example:
+Once you've verified requirements, download the [wp-cli.phar](https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar) file using `wget` or `curl`:
 
 ```
 $ curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
@@ -70,14 +68,14 @@ Next, check if it is working:
 $ php wp-cli.phar --info
 ```
 
-To use it from the command line by typing `wp`, make the file executable and move it to somewhere in your PATH. For example:
+To use WP-CLI from the command line by typing `wp`, make the file executable and move it to somewhere in your PATH. For example:
 
 ```
 $ chmod +x wp-cli.phar
 $ sudo mv wp-cli.phar /usr/local/bin/wp
 ```
 
-If WP-CLI installed successfully, you should see something like this when you run `wp --info`:
+If WP-CLI was installed successfully, you should see something like this when you run `wp --info`:
 
 ```
 $ wp --info
@@ -90,6 +88,8 @@ WP-CLI global config:   /home/wp-cli/.wp-cli/config.yml
 WP-CLI project config:
 WP-CLI version: 0.23.0
 ```
+
+You can update WP-CLI with `wp cli update` ([doc](https://wp-cli.org/commands/cli/update/)), or by repeating the installation steps.
 
 ## Support
 
@@ -113,11 +113,11 @@ To get involved, please first read about [creating an issue](https://wp-cli.org/
 
 ### Leadership
 
-* [Andreas Creten](https://github.com/andreascreten) - founder
-* [Cristi Burcă](https://github.com/scribu) - previous maintainer
 * [Daniel Bachhuber](https://github.com/danielbachhuber/) - current maintainer
+* [Cristi Burcă](https://github.com/scribu) - previous maintainer
+* [Andreas Creten](https://github.com/andreascreten) - founder
 
-Read more about the project's [Governance](https://wp-cli.org/docs/governance/) and view a [complete list of contributors](https://github.com/wp-cli/wp-cli/contributors).
+Read more about the project's [governance](https://wp-cli.org/docs/governance/) and view a [complete list of contributors](https://github.com/wp-cli/wp-cli/contributors).
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ WP-CLI
 
 To stay up to date, follow [@wpcli on Twitter](https://twitter.com/wpcli) or [sign up for our email newsletter](http://wp-cli.us13.list-manage.com/subscribe?u=0615e4d18f213891fc000adfd&id=8c61d7641e).
 
-[![Build Status](https://travis-ci.org/wp-cli/wp-cli.png?branch=master)](https://travis-ci.org/wp-cli/wp-cli) [![Dependency Status](https://gemnasium.com/badges/github.com/wp-cli/wp-cli.svg)](https://gemnasium.com/github.com/wp-cli/wp-cli)
+[![Build Status](https://travis-ci.org/wp-cli/wp-cli.png?branch=master)](https://travis-ci.org/wp-cli/wp-cli) [![Dependency Status](https://gemnasium.com/badges/github.com/wp-cli/wp-cli.svg)](https://gemnasium.com/github.com/wp-cli/wp-cli) [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/wp-cli/wp-cli.svg)](http://isitmaintained.com/project/wp-cli/wp-cli "Average time to resolve an issue") [![Percentage of issues still open](http://isitmaintained.com/badge/open/wp-cli/wp-cli.svg)](http://isitmaintained.com/project/wp-cli/wp-cli "Percentage of issues still open")
 
 <div style="
 	border: 1px solid #7AD03A;

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -76,7 +76,7 @@ Feature: Manage WordPress plugins
     When I run `wp option get recently_activated`
     Then STDOUT should contain:
       """
-          Zombieland/Zombieland.php
+      Zombieland/Zombieland.php
       """
 
     When I run `wp plugin uninstall Zombieland`

--- a/features/plugin.feature
+++ b/features/plugin.feature
@@ -73,6 +73,12 @@ Feature: Manage WordPress plugins
     When I run `wp plugin deactivate Zombieland`
     Then STDOUT should not be empty
 
+    When I run `wp option get recently_activated`
+    Then STDOUT should contain:
+      """
+          Zombieland/Zombieland.php
+      """
+
     When I run `wp plugin uninstall Zombieland`
     Then STDOUT should contain:
       """


### PR DESCRIPTION
When deactivating a plugin via `wp plugin deactivate <plugin>`, the plugin doesn't get added to the "Recently Active" list.

Fixes #3069 