### PR TITLE
First pass at alias groups

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -701,7 +701,7 @@ class Runner {
 		$this->check_root();
 		if ( $this->alias ) {
 			if ( ! array_key_exists( $this->alias, $this->aliases ) ) {
-				WP_CLI::error( "Alias '{$alias}' not found." );
+				WP_CLI::error( "Alias '{$this->alias}' not found." );
 			}
 			// Numerically indexed means a group of aliases
 			if ( isset( $this->aliases[ $this->alias ][0] ) ) {


### PR DESCRIPTION
Given a `wp-cli.local.yml`:

```
@both:
  - @prod
  - @dev
@prod:
  ssh: rc~/webapps/production
@dev:
  ssh: v/srv/www/runcommand.dev
```

One can:

```
$ wp @both rewrite flush
Success: Rewrite rules flushed.
Success: Rewrite rules flushed.
```

See #2039