### PR TITLE
Fix exception in menu list command if the format is ids #3074

### DIFF
--- a/features/menu.feature
+++ b/features/menu.feature
@@ -33,6 +33,13 @@ Feature: Manage WordPress menus
     0
     """
 
+    When I run `wp menu create "First Menu"`
+    And I run `wp menu list --format=ids`
+    Then STDOUT should be:
+    """
+    5
+    """
+
   Scenario: Assign / remove location from a menu
 
     When I run `wp theme install p2 --activate`

--- a/php/commands/menu.php
+++ b/php/commands/menu.php
@@ -177,14 +177,19 @@ class Menu_Command extends WP_CLI_Command {
 			}
 
 			// Normalize the data for some output formats.
-			if ( ! isset( $assoc_args['format'] ) || in_array( $assoc_args['format'], array( 'csv', 'table' ) ) ) {
+			if ( ! isset( $assoc_args['format'] ) || in_array( $assoc_args['format'], array( 'csv', 'table') ) ) {
 				$menu->locations = implode( ',', $menu->locations );
 			}
 		}
 
 		$formatter = $this->get_formatter( $assoc_args );
-		$formatter->display_items( $menus );
 
+		if ( 'ids' == $formatter->format ) {
+			$ids = array_column( $menus, 'term_id' );
+			$formatter->display_items( $ids );
+		} else {
+			$formatter->display_items( $menus );
+		}
 	}
 
 	protected function get_formatter( &$assoc_args ) {

--- a/php/commands/menu.php
+++ b/php/commands/menu.php
@@ -177,7 +177,7 @@ class Menu_Command extends WP_CLI_Command {
 			}
 
 			// Normalize the data for some output formats.
-			if ( ! isset( $assoc_args['format'] ) || in_array( $assoc_args['format'], array( 'csv', 'table') ) ) {
+			if ( ! isset( $assoc_args['format'] ) || in_array( $assoc_args['format'], array( 'csv', 'table' ) ) ) {
 				$menu->locations = implode( ',', $menu->locations );
 			}
 		}

--- a/php/commands/menu.php
+++ b/php/commands/menu.php
@@ -185,7 +185,11 @@ class Menu_Command extends WP_CLI_Command {
 		$formatter = $this->get_formatter( $assoc_args );
 
 		if ( 'ids' == $formatter->format ) {
-			$ids = array_column( $menus, 'term_id' );
+			$ids = array_map(
+				function($o) {
+					return $o->term_id;
+				}, $menus
+			);
 			$formatter->display_items( $ids );
 		} else {
 			$formatter->display_items( $menus );


### PR DESCRIPTION
Fixes #3074 

---

# 🐛 Bug

Command: `wp menu list --format=ids`

If the format was ids, the whole menu array with wp_terms object got passed to the display_items() method. However the formatter could not convert the wp_terms object to a string.

# 🚑  Fix
Checked before passing the whole menu object array to the display_items method, if the format is ids. 
If yes, grabbed out the term_ids and passed only an array of ids to the display_items() method. 

---

Don't really know whats best practice here. You could also implode the `$ids` array directly, without passing it to display_items(). I checked other commands that have the `--format=ids` option, but they are a bit inconsistent. On some the ids get directly imploded and echo'ed out, on some they are passed to display_items(). But I think passing them to display_items() is better, if the display style get changed at some point. 
