### PR TITLE
Introduce reset subcommand for widget

### DIFF
--- a/features/widget-reset.feature
+++ b/features/widget-reset.feature
@@ -3,7 +3,7 @@ Feature: Reset WordPress sidebars
   Scenario: Reset sidebar
     Given a WP install
 
-    When I run `wp theme install twentysixteen --activate`
+    When I run `wp theme install twentytwelve --activate`
     Then STDOUT should not be empty
 
     When I run `wp widget list sidebar-1 --format=count`
@@ -68,7 +68,7 @@ Feature: Reset WordPress sidebars
   Scenario: Reset all sidebars
     Given a WP install
 
-    When I run `wp theme install twentysixteen --activate`
+    When I run `wp theme install twentytwelve --activate`
     Then STDOUT should not be empty
 
     When I run `wp widget add calendar sidebar-1 --title="Calendar"`
@@ -103,7 +103,7 @@ Feature: Reset WordPress sidebars
   Scenario: Testing movement of widgets while reset
     Given a WP install
 
-    When I run `wp theme install twentysixteen --activate`
+    When I run `wp theme install twentytwelve --activate`
     Then STDOUT should not be empty
 
     When I run `wp widget add calendar sidebar-2 --title="Calendar"`

--- a/features/widget-reset.feature
+++ b/features/widget-reset.feature
@@ -1,0 +1,96 @@
+Feature: Reset widgets in WordPress sidebar
+
+  Scenario: Reset sidebar
+    Given a WP install
+
+    When I run `wp theme install twentysixteen --activate`
+    Then STDOUT should not be empty
+
+    When I run `wp widget list sidebar-1 --format=count`
+    Then STDOUT should be:
+      """
+      6
+      """
+
+    When I run `wp widget reset sidebar-1`
+    And I run `wp widget list sidebar-1 --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I try `wp widget reset`
+    Then STDERR should be:
+      """
+      Error: Please specify one or more sidebars, or use --all.
+      """
+
+    When I try `wp widget reset sidebar-1`
+    Then STDERR should be:
+      """
+      Warning: 'sidebar-1' is already empty.
+      """
+
+    When I try `wp widget reset non-existing-sidebar-id`
+    Then STDERR should be:
+      """
+      Warning: Invalid sidebar: non-existing-sidebar-id
+      """
+
+    When I run `wp widget add calendar sidebar-1 --title="Calendar"`
+    Then STDOUT should not be empty
+    And I run `wp widget list sidebar-1 --format=count`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp widget add search sidebar-2 --title="Quick Search"`
+    Then STDOUT should not be empty
+    And I run `wp widget list sidebar-2 --format=count`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp widget reset sidebar-1 sidebar-2`
+    And I run `wp widget list sidebar-1 --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+    And I run `wp widget list sidebar-2 --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+  Scenario: Reset all sidebars
+    Given a WP install
+
+    When I run `wp theme install twentysixteen --activate`
+    Then STDOUT should not be empty
+
+    When I run `wp widget add calendar sidebar-1 --title="Calendar"`
+    Then STDOUT should not be empty
+    When I run `wp widget add search sidebar-2 --title="Quick Search"`
+    Then STDOUT should not be empty
+    When I run `wp widget add text sidebar-3 --title="Text"`
+    Then STDOUT should not be empty
+
+    When I run `wp widget reset --all`
+    And I run `wp widget list sidebar-1 --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+    And I run `wp widget list sidebar-2 --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+    And I run `wp widget list sidebar-3 --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """

--- a/features/widget-reset.feature
+++ b/features/widget-reset.feature
@@ -28,7 +28,7 @@ Feature: Reset WordPress sidebars
     When I try `wp widget reset sidebar-1`
     Then STDERR should be:
       """
-      Warning: 'sidebar-1' is already empty.
+      Warning: Sidebar 'sidebar-1' is already empty.
       """
 
     When I try `wp widget reset non-existing-sidebar-id`
@@ -93,6 +93,11 @@ Feature: Reset WordPress sidebars
     Then STDOUT should be:
       """
       0
+      """
+    When I run `wp widget list wp_inactive_widgets --format=ids`
+    Then STDOUT should be:
+      """
+      text-1 search-3 meta-2 categories-2 archives-2 recent-comments-2 recent-posts-2 search-2 calendar-1
       """
 
   Scenario: Testing movement of widgets while reset

--- a/features/widget-reset.feature
+++ b/features/widget-reset.feature
@@ -1,4 +1,4 @@
-Feature: Reset widgets in WordPress sidebar
+Feature: Reset WordPress sidebars
 
   Scenario: Reset sidebar
     Given a WP install

--- a/features/widget-reset.feature
+++ b/features/widget-reset.feature
@@ -94,3 +94,31 @@ Feature: Reset WordPress sidebars
       """
       0
       """
+
+  Scenario: Testing movement of widgets while reset
+    Given a WP install
+
+    When I run `wp theme install twentysixteen --activate`
+    Then STDOUT should not be empty
+
+    When I run `wp widget add calendar sidebar-2 --title="Calendar"`
+    Then STDOUT should not be empty
+    And I run `wp widget add search sidebar-2 --title="Quick Search"`
+    Then STDOUT should not be empty
+
+    When I run `wp widget list sidebar-2 --format=ids`
+    Then STDOUT should be:
+      """
+      search-3 calendar-1
+      """
+    When I run `wp widget list wp_inactive_widgets --format=ids`
+    Then STDOUT should be empty
+
+    When I run `wp widget reset sidebar-2`
+    And I run `wp widget list sidebar-2 --format=ids`
+    Then STDOUT should be empty
+    And I run `wp widget list wp_inactive_widgets --format=ids`
+    Then STDOUT should be:
+      """
+      calendar-1 search-3
+      """

--- a/php/commands/widget.php
+++ b/php/commands/widget.php
@@ -325,6 +325,12 @@ class Widget_Command extends WP_CLI_Command {
 	 *     $ wp widget reset sidebar-1 sidebar-2
 	 *     Success: Sidebar 'sidebar-1' reset.
 	 *     Success: Sidebar 'sidebar-2' reset.
+	 *
+	 *     # Reset all sidebars
+	 *     $ wp widget reset --all
+	 *     Success: Sidebar 'sidebar-1' reset.
+	 *     Success: Sidebar 'sidebar-2' reset.
+	 *     Success: Sidebar 'sidebar-3' reset.
 	 */
 	public function reset( $args, $assoc_args ) {
 

--- a/php/commands/widget.php
+++ b/php/commands/widget.php
@@ -305,6 +305,75 @@ class Widget_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Reset sidebar.
+	 *
+	 * Removes all widgets from the sidebar and place those to Inactive Widgets.
+	 *
+	 * [<sidebar-id>...]
+	 * : One or more sidebars to reset.
+	 *
+	 * [--all]
+	 * : If set, all sidebars will be reset.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Reset a sidebar
+	 *     $ wp widget reset sidebar-1
+	 *     Success: Sidebar 'sidebar-1' reset.
+	 *
+	 *     # Reset multiple sidebars
+	 *     $ wp widget reset sidebar-1 sidebar-2
+	 *     Success: Sidebar 'sidebar-1' reset.
+	 *     Success: Sidebar 'sidebar-2' reset.
+	 */
+	public function reset( $args, $assoc_args ) {
+
+		global $wp_registered_sidebars;
+
+		$all = \WP_CLI\Utils\get_flag_value( $assoc_args, 'all', false );
+
+		// Bail if no arguments and no all flag.
+		if ( ! $all && empty( $args ) ) {
+			WP_CLI::error( 'Please specify one or more sidebars, or use --all.' );
+		}
+
+		// Fetch all sidebars if all flag is set.
+		if ( $all ) {
+			$args = array_keys( $wp_registered_sidebars );
+		}
+
+		// Sidebar ID wp_inactive_widgets is reserved by WP core for inactive widgets.
+		if ( isset( $args['wp_inactive_widgets'] ) ) {
+			unset( $args['wp_inactive_widgets'] );
+		}
+
+		// Check if no registered sidebar.
+		if ( empty( $args ) ) {
+			WP_CLI::error( 'No sidebar registered.' );
+		}
+
+		foreach ( $args as $sidebar_id ) {
+			if ( ! array_key_exists( $sidebar_id, $wp_registered_sidebars ) ) {
+				WP_CLI::warning( sprintf( 'Invalid sidebar: %s', $sidebar_id ) );
+				continue;
+			}
+
+			$widgets = $this->get_sidebar_widgets( $sidebar_id );
+			if ( empty( $widgets ) ) {
+				WP_CLI::warning( sprintf( "'%s' is already empty.", $sidebar_id ) );
+			}
+			else {
+				foreach ( $widgets as $widget ) {
+					$widget_id = $widget->id;
+					list( $name, $option_index, $new_sidebar_id, $sidebar_index ) = $this->get_widget_data( $widget_id );
+					$this->move_sidebar_widget( $widget_id, $new_sidebar_id, 'wp_inactive_widgets', $sidebar_index, 0 );
+				}
+				WP_CLI::success( sprintf( "Sidebar '%s' reset.", $sidebar_id ) );
+			}
+		}
+	}
+
+	/**
 	 * Check whether a sidebar is a valid sidebar
 	 *
 	 * @param string $sidebar_id

--- a/php/commands/widget.php
+++ b/php/commands/widget.php
@@ -307,7 +307,7 @@ class Widget_Command extends WP_CLI_Command {
 	/**
 	 * Reset sidebar.
 	 *
-	 * Removes all widgets from the sidebar and place those to Inactive Widgets.
+	 * Removes all widgets from the sidebar and places them in Inactive Widgets.
 	 *
 	 * [<sidebar-id>...]
 	 * : One or more sidebars to reset.
@@ -366,7 +366,7 @@ class Widget_Command extends WP_CLI_Command {
 
 			$widgets = $this->get_sidebar_widgets( $sidebar_id );
 			if ( empty( $widgets ) ) {
-				WP_CLI::warning( sprintf( "'%s' is already empty.", $sidebar_id ) );
+				WP_CLI::warning( sprintf( "Sidebar '%s' is already empty.", $sidebar_id ) );
 			}
 			else {
 				foreach ( $widgets as $widget ) {


### PR DESCRIPTION
Initially at https://github.com/wp-cli/wp-cli/issues/3063, reset was supposed to be kept under sidebar. But after https://github.com/wp-cli/wp-cli/pull/3071 reset feature is kept under widget command. 

Fixes #3063