### PR TITLE
Added to html_entity_decode to log write so special chars in translat…

### DIFF
--- a/php/WP_CLI/Loggers/Base.php
+++ b/php/WP_CLI/Loggers/Base.php
@@ -54,7 +54,7 @@ abstract class Base {
 	 * @param string $str Message to write.
 	 */
 	protected function write( $handle, $str ) {
-		fwrite( $handle, $str );
+		fwrite( $handle, html_entity_decode( $str ) );
 	}
 
 	/**


### PR DESCRIPTION
Made translations a bit nicer by html entity decoding the translations. 
Original output would be:

`Plugin is succesvol ge&#239;nstalleerd.`

Now output will be:

`Plugin is succesvol geïnstalleerd.`