### PR TITLE
Fix grammar in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you have a WordPress.org account, you may also consider joining the `#cli` ch
 
 A **command** is an atomic unit of WP-CLI functionality. `wp plugin install` ([doc](https://wp-cli.org/commands/plugin/install/)) is one command. `wp plugin activate` ([doc](https://wp-cli.org/commands/plugin/activate/)) is another.
 
-WP-CLI comes with dozens of commands. It's easier than it looks to create a custom WP-CLI command. Read the [commands cookbook](https://wp-cli.org/docs/commands-cookbook/) to learn more. Browse the [internal API docs](http://wp-cli.org/docs/internal-api/) to discovery a variety of helpful functions you can use in your custom WP-CLI command.
+WP-CLI comes with dozens of commands. It's easier than it looks to create a custom WP-CLI command. Read the [commands cookbook](https://wp-cli.org/docs/commands-cookbook/) to learn more. Browse the [internal API docs](http://wp-cli.org/docs/internal-api/) to discover a variety of helpful functions you can use in your custom WP-CLI command.
 
 ## Contributing
 


### PR DESCRIPTION
Browse the [internal API docs](http://wp-cli.org/docs/internal-api/) to discovery a variety of helpful functions you can use in your custom WP-CLI command.

`discovery` is changed to `discover`.
