### PR TITLE
Remove unsupported ids output of menu locations #3083

### DIFF
--- a/php/commands/menu.php
+++ b/php/commands/menu.php
@@ -731,7 +731,6 @@ class Menu_Location_Command extends WP_CLI_Command {
 	 *   - csv
 	 *   - json
 	 *   - count
-	 *   - ids
 	 *   - yaml
 	 * ---
 	 *


### PR DESCRIPTION
Menu locations doesn't have ids, so they can't be outputted

Fixes #3083