### PR TITLE
Fix error output on menu location list with format ids #3083

### DIFF
--- a/features/menu.feature
+++ b/features/menu.feature
@@ -55,6 +55,12 @@ Feature: Manage WordPress menus
       | slug            | locations       |
       | primary-menu    | primary         |
 
+     When I run `wp menu location list --format=ids`
+     Then STDOUT should be:
+     """
+     primary
+     """
+
     When I run `wp menu location remove primary-menu primary`
     And I run `wp menu list --fields=slug,locations`
     Then STDOUT should be a table containing rows:

--- a/php/commands/menu.php
+++ b/php/commands/menu.php
@@ -766,7 +766,17 @@ class Menu_Location_Command extends WP_CLI_Command {
 		}
 
 		$formatter = new \WP_CLI\Formatter( $assoc_args, array( 'location', 'description' ) );
-		$formatter->display_items( $location_objs );
+
+		if ( 'ids' == $formatter->format ) {
+			$ids = array_map(
+				function($o) {
+					return $o->location;
+				}, $location_objs
+			);
+			$formatter->display_items( $ids );
+		} else {
+			$formatter->display_items( $location_objs );
+		}
 	}
 
 	/**

--- a/php/commands/menu.php
+++ b/php/commands/menu.php
@@ -732,6 +732,7 @@ class Menu_Location_Command extends WP_CLI_Command {
 	 *   - json
 	 *   - count
 	 *   - yaml
+	 *   - ids
 	 * ---
 	 *
 	 * ## AVAILABLE FIELDS


### PR DESCRIPTION
As mentioned in #3083 reverted changed made in #3092 

Now the location itself gets outputted when you run `wp menu location list --format=ids`