### PR TITLE
Don't trigger cron when ALTERNATE_WP_CRON is defined

### DIFF
--- a/features/cron.feature
+++ b/features/cron.feature
@@ -280,3 +280,27 @@ Feature: Manage WP-Cron events and schedules
       """
       Executed a total of 0 cron event(s)
       """
+
+  Scenario: Don't trigger cron when ALTERNATE_WP_CRON is defined
+    Given a alternate-wp-cron.php file:
+      """
+      <?php
+      define( 'ALTERNATE_WP_CRON', true );
+      """
+    And a wp-cli.yml file:
+      """
+      require:
+        - alternate-wp-cron.php
+      """
+
+    When I run `wp eval 'var_export( ALTERNATE_WP_CRON );'`
+    Then STDOUT should be:
+      """
+      true
+      """
+
+    When I run `wp option get home`
+    Then STDOUT should be:
+      """
+      http://example.com
+      """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1014,6 +1014,13 @@ class Runner {
 			return $headers;
 		});
 
+		// ALTERNATE_WP_CRON might trigger a redirect, which we can't handle
+		if ( defined( 'ALTERNATE_WP_CRON' ) && ALTERNATE_WP_CRON ) {
+			$this->add_wp_hook( 'muplugins_loaded', function() {
+				remove_action( 'init', 'wp_cron' );
+			});
+		}
+
 		// Get rid of warnings when converting single site to multisite
 		if ( defined( 'WP_INSTALLING' ) && $this->is_multisite() ) {
 			$values = array(


### PR DESCRIPTION
`ALTERNATE_WP_CRON` tries to redirect, which we can't handle.

Fixes #3104