### PR TITLE
Support 'trunk' and 'nightly' version arguments for wp core download.

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -96,20 +96,20 @@ Feature: Download WordPress
       File removed: wp-content
       """
 
-  Scenario: Installing trunk
+  Scenario: Installing nightly
     Given an empty directory
     And an empty cache
 
-    When I run `wp core download --version=trunk`
+    When I run `wp core download --version=nightly`
     Then the wp-settings.php file should exist
-    And the {SUITE_CACHE_DIR}/core/wordpress-trunk-en_US.zip file should exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-nightly-en_US.zip file should exist
     And STDOUT should contain:
       """
-      Downloading WordPress trunk (en_US)...
+      Downloading WordPress nightly (en_US)...
       """
     And STDERR should contain:
       """
-      Warning: md5 hash checks are not available for trunk downloads.
+      Warning: md5 hash checks are not available for nightly downloads.
       """
     And STDOUT should contain:
       """
@@ -117,19 +117,19 @@ Feature: Download WordPress
       """
 
 	# test core zip cache
-    When I run `wp core download --version=trunk --force`
+    When I run `wp core download --version=nightly --force`
     Then the wp-settings.php file should exist
     And STDOUT should contain:
     """
-    Using cached file '{SUITE_CACHE_DIR}/core/wordpress-trunk-en_US.zip'...
+    Using cached file '{SUITE_CACHE_DIR}/core/wordpress-nightly-en_US.zip'...
     """
 
-  Scenario: Installing trunk over an existing install
+  Scenario: Installing nightly over an existing install
     Given an empty directory
     And an empty cache
     When I run `wp core download --version=4.5.3`
     Then the wp-settings.php file should exist
-    When I run `wp core download --version=trunk --force`
+    When I run `wp core download --version=nightly --force`
     Then STDERR should not contain:
       """
       Warning: Failed to find WordPress version. Please cleanup files manually.
@@ -143,10 +143,10 @@ Feature: Download WordPress
       Success: WordPress downloaded.
       """
 
-  Scenario: Installing a version over trunk
+  Scenario: Installing a version over nightly
     Given an empty directory
     And an empty cache
-    When I run `wp core download --version=trunk`
+    When I run `wp core download --version=nightly`
     Then the wp-settings.php file should exist
     And STDERR should not contain:
       """
@@ -161,19 +161,19 @@ Feature: Download WordPress
       File removed: wp-content
       """
 
-  Scenario: Nightly is an alias for trunk
+  Scenario: Trunk is an alias for nightly
     Given an empty directory
     And an empty cache
-    When I run `wp core download --version=nightly`
+    When I run `wp core download --version=trunk`
     Then the wp-settings.php file should exist
-    And the {SUITE_CACHE_DIR}/core/wordpress-trunk-en_US.zip file should exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-nightly-en_US.zip file should exist
     And STDOUT should contain:
       """
-      Downloading WordPress trunk (en_US)...
+      Downloading WordPress nightly (en_US)...
       """
     And STDERR should contain:
       """
-      Warning: md5 hash checks are not available for trunk downloads.
+      Warning: md5 hash checks are not available for nightly downloads.
       """
     And STDOUT should contain:
       """

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -117,7 +117,7 @@ Feature: Download WordPress
       """
 
 	# test core zip cache
-    When I run `wp core download --version=trunk`
+    When I run `wp core download --version=trunk --force`
     Then the wp-settings.php file should exist
     And STDOUT should contain:
     """

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -179,3 +179,14 @@ Feature: Download WordPress
       """
       Success: WordPress downloaded.
       """
+
+  Scenario: Installing nightly for a non-default locale
+    Given an empty directory
+    And an empty cache
+
+    When I try `wp core download --version=nightly --locale=de_DE`
+		Then the return code should be 1
+    And STDERR should contain:
+    """
+    Error: Nightly builds are only available for the en_US locale.
+		"""

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -95,3 +95,87 @@ Feature: Download WordPress
       """
       File removed: wp-content
       """
+
+  Scenario: Installing trunk
+    Given an empty directory
+    And an empty cache
+
+    When I run `wp core download --version=trunk`
+    Then the wp-settings.php file should exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-trunk-en_US.zip file should exist
+    And STDOUT should contain:
+      """
+      Downloading WordPress trunk (en_US)...
+      """
+    And STDERR should contain:
+      """
+      Warning: md5 hash checks are not available for trunk downloads.
+      """
+    And STDOUT should contain:
+      """
+      Success: WordPress downloaded.
+      """
+
+	# test core zip cache
+    When I run `wp core download --version=trunk`
+    Then the wp-settings.php file should exist
+    And STDOUT should contain:
+    """
+    Using cached file '{SUITE_CACHE_DIR}/core/wordpress-trunk-en_US.zip'...
+    """
+
+  Scenario: Installing trunk over an existing install
+    Given an empty directory
+    And an empty cache
+    When I run `wp core download --version=4.5.3`
+    Then the wp-settings.php file should exist
+    When I run `wp core download --version=trunk --force`
+    Then STDERR should not contain:
+      """
+      Warning: Failed to find WordPress version. Please cleanup files manually.
+      """
+    And STDERR should contain:
+      """
+      Warning: Failed to fetch checksums. Please cleanup files manually.
+      """
+    And STDOUT should contain:
+      """
+      Success: WordPress downloaded.
+      """
+
+  Scenario: Installing a version over trunk
+    Given an empty directory
+    And an empty cache
+    When I run `wp core download --version=trunk`
+    Then the wp-settings.php file should exist
+    And STDERR should not contain:
+      """
+      Warning: Failed to find WordPress version. Please cleanup files manually.
+      """
+
+    When I run `wp core download --version=4.3.2 --force`
+    Then the wp-includes/rest-api.php file should not exist
+    And the wp-includes/class-wp-comment.php file should not exist
+    And STDOUT should not contain:
+      """
+      File removed: wp-content
+      """
+
+  Scenario: Nightly is an alias for trunk
+    Given an empty directory
+    And an empty cache
+    When I run `wp core download --version=nightly`
+    Then the wp-settings.php file should exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-trunk-en_US.zip file should exist
+    And STDOUT should contain:
+      """
+      Downloading WordPress trunk (en_US)...
+      """
+    And STDERR should contain:
+      """
+      Warning: md5 hash checks are not available for trunk downloads.
+      """
+    And STDOUT should contain:
+      """
+      Success: WordPress downloaded.
+      """

--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -102,7 +102,7 @@ Feature: Download WordPress
 
     When I run `wp core download --version=nightly`
     Then the wp-settings.php file should exist
-    And the {SUITE_CACHE_DIR}/core/wordpress-nightly-en_US.zip file should exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-nightly-en_US.zip file should not exist
     And STDOUT should contain:
       """
       Downloading WordPress nightly (en_US)...
@@ -116,10 +116,10 @@ Feature: Download WordPress
       Success: WordPress downloaded.
       """
 
-	# test core zip cache
+	# we shouldn't cache nightly builds
     When I run `wp core download --version=nightly --force`
     Then the wp-settings.php file should exist
-    And STDOUT should contain:
+    And STDOUT should not contain:
     """
     Using cached file '{SUITE_CACHE_DIR}/core/wordpress-nightly-en_US.zip'...
     """
@@ -166,7 +166,6 @@ Feature: Download WordPress
     And an empty cache
     When I run `wp core download --version=trunk`
     Then the wp-settings.php file should exist
-    And the {SUITE_CACHE_DIR}/core/wordpress-nightly-en_US.zip file should exist
     And STDOUT should contain:
       """
       Downloading WordPress nightly (en_US)...

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -159,6 +159,9 @@ class Core_Command extends WP_CLI_Command {
 		$extension  = 'tar.gz';
 		if ( 'zip' === $path_parts['extension'] ) {
 			$extension  = 'zip';
+			if ( ! class_exists( 'ZipArchive' ) ) {
+				WP_CLI::error( 'Extracting a zip file requires ZipArchive.' );
+			}
 		}
 
 		$cache = WP_CLI::get_cache();

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -1404,7 +1404,7 @@ EOT;
 	private function get_download_url( $version, $locale = 'en_US', $file_type = 'zip' ) {
 
 		if ( 'nightly' === $version ) {
-			if ( 'zip' === $version ) {
+			if ( 'zip' === $file_type ) {
 				return 'https://wordpress.org/nightly-builds/wordpress-latest.zip';
 			} else {
 				WP_CLI::error( 'Nightly builds are only available in .zip format.' );

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -262,7 +262,7 @@ class Core_Command extends WP_CLI_Command {
 
 	private static function _extract_zip( $zipfile, $dest ) {
 		if ( ! class_exists( 'ZipArchive' ) ) {
-			throw new \Exception( 'Extracting a zip file requires PharData' );
+			throw new \Exception( 'Extracting a zip file requires ZipArchive.' );
 		}
 		$zip = new ZipArchive();
 		$res = $zip->open( $zipfile );

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -136,7 +136,9 @@ class Core_Command extends WP_CLI_Command {
 		if ( isset( $assoc_args['version'] ) ) {
 			$version = strtolower( $assoc_args['version'] );
 			$version = ( 'trunk' === $version ? 'nightly' : $version );
-			$download_url = $this->get_download_url($version, $locale, 'tar.gz');
+			//nightly builds are only avialable in .zip format
+			$ext     = ( 'nightly' === $version ? 'zip' : 'tar.gz' );
+			$download_url = $this->get_download_url( $version, $locale, $ext );
 		} else {
 			$offer = $this->get_download_offer( $locale );
 			if ( !$offer ) {

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -225,8 +225,11 @@ class Core_Command extends WP_CLI_Command {
 			} catch ( Exception $e ) {
 				WP_CLI::error( "Couldn't extract WordPress archive. " . $e->getMessage() );
 			}
-			$cache->import( $cache_key, $temp );
-			unlink($temp);
+
+			if ( 'nightly' !== $version ) {
+				$cache->import( $cache_key, $temp );
+			}
+			unlink( $temp );
 		}
 
 		if ( $wordpress_present ) {

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -207,7 +207,7 @@ class Core_Command extends WP_CLI_Command {
 					WP_CLI::error( "md5 hash for download ({$md5_file}) is different than the release hash ({$md5_response->body})." );
 				}
 			} else {
-				WP_CLI::warning( 'md5 hash checks are not available for trunk downloads' );
+				WP_CLI::warning( 'md5 hash checks are not available for trunk downloads.' );
 			}
 
 			try {

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -136,7 +136,7 @@ class Core_Command extends WP_CLI_Command {
 		if ( isset( $assoc_args['version'] ) ) {
 			$version = strtolower( $assoc_args['version'] );
 			$version = ( 'trunk' === $version ? 'nightly' : $version );
-			//nightly builds are only avialable in .zip format
+			//nightly builds are only available in .zip format
 			$ext     = ( 'nightly' === $version ? 'zip' : 'tar.gz' );
 			$download_url = $this->get_download_url( $version, $locale, $ext );
 		} else {

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -148,6 +148,10 @@ class Core_Command extends WP_CLI_Command {
 			$download_url = str_replace( '.zip', '.tar.gz', $offer['download'] );
 		}
 
+		if ( 'nightly' === $version && 'en_US' !== $locale ) {
+			WP_CLI::error( 'Nightly builds are only available for the en_US locale.' );
+		}
+
 		$from_version = '';
 		if ( file_exists( $download_dir . 'wp-includes/version.php' ) ) {
 			global $wp_version;

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -95,7 +95,7 @@ class Core_Command extends WP_CLI_Command {
 	 * : Select which language you want to download.
 	 *
 	 * [--version=<version>]
-	 * : Select which version you want to download.
+	 * : Select which version you want to download. Accepts a version number, 'latest' or 'nightly'
 	 *
 	 * [--force]
 	 * : Overwrites existing files, if present.

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -135,7 +135,7 @@ class Core_Command extends WP_CLI_Command {
 
 		if ( isset( $assoc_args['version'] ) ) {
 			$version = strtolower( $assoc_args['version'] );
-			$version = ( 'nightly' === $version ? 'trunk' : $version );
+			$version = ( 'trunk' === $version ? 'nightly' : $version );
 			$download_url = $this->get_download_url($version, $locale, 'tar.gz');
 		} else {
 			$offer = $this->get_download_offer( $locale );
@@ -194,7 +194,7 @@ class Core_Command extends WP_CLI_Command {
 				WP_CLI::error( "Couldn't access download URL (HTTP code {$response->status_code})." );
 			}
 
-			if ( 'trunk' !== $version ) {
+			if ( 'nightly' !== $version ) {
 				$md5_response = Utils\http_request( 'GET', $download_url . '.md5' );
 				if ( 20 != substr( $md5_response->status_code, 0, 2 ) ) {
 					WP_CLI::error( "Couldn't access md5 hash for release (HTTP code {$response->status_code})." );
@@ -208,7 +208,7 @@ class Core_Command extends WP_CLI_Command {
 					WP_CLI::error( "md5 hash for download ({$md5_file}) is different than the release hash ({$md5_response->body})." );
 				}
 			} else {
-				WP_CLI::warning( 'md5 hash checks are not available for trunk downloads.' );
+				WP_CLI::warning( 'md5 hash checks are not available for nightly downloads.' );
 			}
 
 			try {
@@ -1394,7 +1394,7 @@ EOT;
 	 */
 	private function get_download_url( $version, $locale = 'en_US', $file_type = 'zip' ) {
 
-		if ( 'trunk' === $version ) {
+		if ( 'nightly' === $version ) {
 			return 'https://wordpress.org/nightly-builds/wordpress-latest.zip';
 		} elseif ( 'en_US' === $locale ) {
 			$url = 'https://wordpress.org/wordpress-' . $version . '.' . $file_type;

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -1400,7 +1400,11 @@ EOT;
 	private function get_download_url( $version, $locale = 'en_US', $file_type = 'zip' ) {
 
 		if ( 'nightly' === $version ) {
-			return 'https://wordpress.org/nightly-builds/wordpress-latest.zip';
+			if ( 'zip' === $version ) {
+				return 'https://wordpress.org/nightly-builds/wordpress-latest.zip';
+			} else {
+				WP_CLI::error( 'Nightly builds are only available in .zip format.' );
+			}
 		} elseif ( 'en_US' === $locale ) {
 			$url = 'https://wordpress.org/wordpress-' . $version . '.' . $file_type;
 

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -234,13 +234,17 @@ class Core_Command extends WP_CLI_Command {
 
 	private static function _extract( $tarball_or_zip, $dest ) {
 		$path_parts = pathinfo( $tarball_or_zip );
+		$extension  = strtolower( $path_parts['extension'] );
 
-		switch ( strtolower( $path_parts['extension'] ) ) {
+		switch ( $extension ) {
 			case 'zip':
 				self::_extract_zip( $tarball_or_zip, $dest );
 				break;
-			default;
+			case 'tar.gz':
 				self::_extract_tarball( $tarball_or_zip, $dest );
+				break;
+			default;
+				WP_CLI::error( sprintf( 'Extension %s not supported.', $extension ) );
 				break;
 		}
 	}

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -238,19 +238,16 @@ class Core_Command extends WP_CLI_Command {
 
 	private static function _extract( $tarball_or_zip, $dest ) {
 		$path_parts = pathinfo( $tarball_or_zip );
-		$extension  = strtolower( $path_parts['extension'] );
 
-		switch ( $extension ) {
-			case 'zip':
-				self::_extract_zip( $tarball_or_zip, $dest );
-				break;
-			case 'tar.gz':
-				self::_extract_tarball( $tarball_or_zip, $dest );
-				break;
-			default;
-				WP_CLI::error( sprintf( 'Extension %s not supported.', $extension ) );
-				break;
+		if ( preg_match( '/\.zip$/', $tarball_or_zip ) ) {
+			return self::_extract_zip( $tarball_or_zip, $dest );
 		}
+
+		if ( preg_match( '/\.tar\.gz$/', $tarball_or_zip ) ) {
+			return self::_extract_tarball( $tarball_or_zip, $dest );
+		}
+
+		WP_CLI::error( sprintf( 'Extension %s not supported.', $extension ) );
 	}
 
 	private static function _extract_tarball( $tarball, $dest ) {

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -135,6 +135,7 @@ class Core_Command extends WP_CLI_Command {
 
 		if ( isset( $assoc_args['version'] ) ) {
 			$version = strtolower( $assoc_args['version'] );
+			$version = ( 'nightly' === $version ? 'trunk' : $version );
 			$download_url = $this->get_download_url($version, $locale, 'tar.gz');
 		} else {
 			$offer = $this->get_download_offer( $locale );
@@ -193,7 +194,7 @@ class Core_Command extends WP_CLI_Command {
 				WP_CLI::error( "Couldn't access download URL (HTTP code {$response->status_code})." );
 			}
 
-			if ( 'trunk' !== $version && 'nightly' !== $version ) {
+			if ( 'trunk' !== $version ) {
 				$md5_response = Utils\http_request( 'GET', $download_url . '.md5' );
 				if ( 20 != substr( $md5_response->status_code, 0, 2 ) ) {
 					WP_CLI::error( "Couldn't access md5 hash for release (HTTP code {$response->status_code})." );
@@ -1393,7 +1394,7 @@ EOT;
 	 */
 	private function get_download_url( $version, $locale = 'en_US', $file_type = 'zip' ) {
 
-		if ( 'trunk' === $version || 'nightly' === $version ) {
+		if ( 'trunk' === $version ) {
 			return 'https://wordpress.org/nightly-builds/wordpress-latest.zip';
 		} elseif ( 'en_US' === $locale ) {
 			$url = 'https://wordpress.org/wordpress-' . $version . '.' . $file_type;

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -1409,7 +1409,9 @@ EOT;
 			} else {
 				WP_CLI::error( 'Nightly builds are only available in .zip format.' );
 			}
-		} elseif ( 'en_US' === $locale ) {
+		}
+
+		if ( 'en_US' === $locale ) {
 			$url = 'https://wordpress.org/wordpress-' . $version . '.' . $file_type;
 
 			return $url;


### PR DESCRIPTION
Fixes #3113 

- Modifies Core_Command::get_download_url() to interpret 'trunk' and 'nightly' versions
- Core_Command::get_download_url() now conforms to WordPress coding standards
- Adds support for downloading and extracting .zip files as nightly builds are own available in zip format.
- wp core download --version=trunk is only supported if ZipArchive is present.