### PR TITLE
Introduce `WP_CLI_STRICT_ARGS_MODE` for dealing with arg ambiguity

### DIFF
--- a/tests/test-configurator.php
+++ b/tests/test-configurator.php
@@ -36,6 +36,20 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase {
 
   }
 
+  function testExtractAssocGlobalLocal() {
+    $args = Configurator::extract_assoc( array( '--url=foo.dev', '--path=wp', 'foo', '--bar=', '--baz=text', '--url=bar.dev' ) );
+
+    $this->assertCount( 1, $args[0] );
+    $this->assertCount( 5, $args[1] );
+    $this->assertCount( 2, $args[2] );
+    $this->assertCount( 3, $args[3] );
+
+    $this->assertEquals( 'url', $args[2][0][0] );
+    $this->assertEquals( 'foo.dev', $args[2][0][1] );
+    $this->assertEquals( 'url', $args[3][2][0] );
+    $this->assertEquals( 'bar.dev', $args[3][2][1] );
+  }
+
   function testExtractAssocDoubleDashInValue() {
     $args = Configurator::extract_assoc( array( '--test=text--text' ) );
 


### PR DESCRIPTION
Consider a command like:

```
wp widget add rss sidebar-1 1 --url="http://wp-cli.org/feed/"
```

Historically, the `--url=<url>` parameter has been treated like a global
runtime argument, which has meant a command can't easily use it as its
own. Now, using the `WP_CLI_STRICT_ARGS_MODE` will tell WP-CLI to treat
any arguments before the command as global, and after the command as
local.

For instance:

```
WP_CLI_STRICT_ARGS_MODE=1 wp --url=wp.dev/site2 widget add rss sidebar-1 1
--url="http://wp-cli.org/feed/"
```

In this example, `--url=wp.dev/site2` is the global argument, setting
WP-CLI to run against 'site2' on a WP multisite install.
`--url="http://wp-cli.org/feed/"` is the local argument, setting the RSS
feed widget with the proper URL.

I've thought long and hard about making a breaking change, and enforcing
strict args mode by default. At this point, I don't think it will ever
be worth it, given the majority use case isn't impacted by it, and it's
a better user experience to be able to supply arguments in an ambigious
order. When you need to be strict, you can use the environment variable.

Fixes #1222