### PR TITLE
Register `--http=<url>` global parameter

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -258,3 +258,12 @@ Feature: Global flags
       global: bar.dev
       local: foo.dev
       """
+
+  Scenario: Using --http=<url> requires wp-cli/restful
+    Given an empty directory
+
+    When I try `wp --http=foo.dev`
+    Then STDERR should be:
+      """
+      Error: RESTful WP-CLI needs to be installed. Try 'wp package install wp-cli/restful'.
+      """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -756,6 +756,10 @@ class Runner {
 			}
 		}
 
+		if ( isset( $this->config['http'] ) && ! class_exists( '\WP_REST_CLI\Runner' ) ) {
+			WP_CLI::error( "RESTful WP-CLI needs to be installed. Try 'wp package install wp-cli/restful'." );
+		}
+
 		if ( isset( $this->config['require'] ) ) {
 			foreach ( $this->config['require'] as $path ) {
 				if ( ! file_exists( $path ) ) {

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -13,6 +13,12 @@ return array(
 		'desc' => 'Perform operation against a remote server over SSH.',
 	),
 
+	'http' => array(
+		'runtime' => '=<http>',
+		'file' => '<http>',
+		'desc' => 'Perform operation against a remote WordPress install over HTTP.',
+	),
+
 	'url' => array(
 		'runtime' => '=<url>',
 		'file' => '<url>',


### PR DESCRIPTION
We don't register new global parameters often, but this one is needed
for RESTful WP-CLI.

Fixes #3107