### PR TITLE
Add --include-columns flag to search-replace command

### DIFF
--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -16,10 +16,10 @@ Feature: Do global search/replace
       """
 
     When I run `wp search-replace foo bar --include-columns=post_content`
-    Then STDOUT should not contain:
-      """
-      guid
-      """
+    Then STDOUT should be a table containing rows:
+    | Table    | Column       | Replacements | Type |
+    | wp_posts | post_content | 0            | SQL  |
+
 
   Scenario: Multisite search/replace
     Given a WP multisite install

--- a/features/search-replace.feature
+++ b/features/search-replace.feature
@@ -15,6 +15,12 @@ Feature: Do global search/replace
       guid
       """
 
+    When I run `wp search-replace foo bar --include-columns=post_content`
+    Then STDOUT should not contain:
+      """
+      guid
+      """
+
   Scenario: Multisite search/replace
     Given a WP multisite install
     And I run `wp site create --slug="foo" --title="foo" --email="foo@example.com"`

--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -37,6 +37,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	private $recurse_objects;
 	private $regex;
 	private $skip_columns;
+	private $include_columns;
 
 	/**
 	 * Search/replace strings in the database.
@@ -95,6 +96,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 * : Do not perform the replacement on specific columns. Use commas to
 	 * specify multiple columns. 'guid' is skipped by default.
 	 *
+	 * [--include-columns=<columns>]
+	 * : Perform the replacement on specific columns. Use commas to
+	 * specify multiple columns.
+	 *
 	 * [--precise]
 	 * : Force the use of PHP (instead of SQL) which is more thorough,
 	 * but slower.
@@ -145,6 +150,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 		$this->regex           =  \WP_CLI\Utils\get_flag_value( $assoc_args, 'regex' );
 
 		$this->skip_columns = explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-columns' ) );
+		$this->include_columns = array_filter( explode( ',', \WP_CLI\Utils\get_flag_value( $assoc_args, 'include-columns' ) ) );
 
 		if ( $old === $new && ! $this->regex ) {
 			WP_CLI::warning( "Replacement value '{$old}' is identical to search value '{$new}'. Skipping operation." );
@@ -201,6 +207,10 @@ class Search_Replace_Command extends WP_CLI_Command {
 			}
 
 			foreach ( $columns as $col ) {
+				if ( ! empty( $this->include_columns ) && ! in_array( $col, $this->include_columns ) ) {
+					continue;
+				}
+
 				if ( in_array( $col, $this->skip_columns ) ) {
 					continue;
 				}


### PR DESCRIPTION
As per the discussion on issue #3140 - This pull request adds a `--include-columns=<columns>` flag to the `search-replace` command.