### PR TITLE
Add forward slash in the end to $WP_CORE_DIR in install-wp-tests.sh

### DIFF
--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -83,7 +83,7 @@ install_test_suite() {
 
 	if [ ! -f wp-tests-config.php ]; then
 		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -83,6 +83,8 @@ install_test_suite() {
 
 	if [ ! -f wp-tests-config.php ]; then
 		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
 		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php


### PR DESCRIPTION
This PR always add a forward slash in the end to `$WP_CORE_DIR` used in  `ABSPATH` value substitution (in *wp-tests-config.php* file).

In effect by running a command like (overriding default `$WP_CORE_DIR` value):

```bash
WP_TESTS_DIR=/my/path/wordpress-tests-lib WP_CORE_DIR=/my/path/wordpress bash bin/install-wp-tests.sh wordpress_test root ''
```

the generated *wp-tests-config.php* file will contain a line like:

```php
define( 'ABSPATH', '/my/path/wordpress' );
```
without slash in the end. This causes all test units will fail with a message like:

```
PHP Fatal error:  require(): Failed opening required '/my/path/wordpresswp-includes/load.php' (include_path='.') in /my/path/wordpress/wp-settings.php on line 21
```

PS: If we are boring about double final slash we could add a statement like

```bash
WP_CORE_DIR=${WP_CORE_DIR/%\//} 
```
or, by disturbing `sed`:
```bash
WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
```

to remove all final slashes.