### PR TITLE
add --ci=gitlab for wp scaffold plugin-tests

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -307,6 +307,7 @@ Feature: WordPress code scaffolding
       """
     And the {PLUGIN_DIR}/hello-world/phpunit.xml.dist file should exist
     And the {PLUGIN_DIR}/hello-world/circle.yml file should not exist
+    And the {PLUGIN_DIR}/hello-world/.gitlab-ci.yml file should not exist
     And the {PLUGIN_DIR}/hello-world/.travis.yml file should contain:
       """
       script: phpunit
@@ -331,6 +332,21 @@ Feature: WordPress code scaffolding
     And the {PLUGIN_DIR}/circle.yml file should contain:
       """
       version: 5.6.14
+      """
+
+  Scenario: Scaffold plugin tests with Gitlab as the provider
+    Given a WP install
+    And I run `wp scaffold plugin hello-world --skip-tests`
+
+    When I run `wp plugin path hello-world --dir`
+    Then save STDOUT as {PLUGIN_DIR}
+
+    When I run `wp scaffold plugin-tests hello-world --ci=gitlab`
+    Then STDOUT should not be empty
+    And the {PLUGIN_DIR}/.travis.yml file should not exist
+    And the {PLUGIN_DIR}/.gitlab-ci.yml file should contain:
+      """
+      MYSQL_DATABASE
       """
 
   Scenario: Scaffold starter code for a theme

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -558,6 +558,7 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * options:
 	 *   - travis
 	 *   - circle
+	 *	 - gitlab
 	 * ---
 	 *
 	 * [--force]
@@ -633,6 +634,8 @@ class Scaffold_Command extends WP_CLI_Command {
 			$files_to_create["$plugin_dir/.travis.yml"] = Utils\mustache_render( 'plugin-travis.mustache', compact( 'wp_versions_to_test' ) );
 		} else if ( 'circle' === $assoc_args['ci'] ) {
 			$files_to_create["$plugin_dir/circle.yml"] = Utils\mustache_render( 'plugin-circle.mustache' );
+		} else if ( 'gitlab' === $assoc_args['ci'] ) {
+			$files_to_create["$plugin_dir/.gitlab-ci.yml"] = Utils\mustache_render( 'plugin-gitlab.mustache' );
 		}
 		$files_written = $this->create_files( $files_to_create, $force );
 

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 3 ]; then
-	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
 	exit 1
 fi
 

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -10,7 +10,7 @@ DB_USER=$2
 DB_PASS=$3
 DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
-SKIP_DB_CREATE=${6:-false}
+SKIP_DB_CREATE=${6-false}
 
 WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -10,6 +10,7 @@ DB_USER=$2
 DB_PASS=$3
 DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6:-false}
 
 WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
@@ -95,6 +96,11 @@ install_test_suite() {
 }
 
 install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
 	# parse DB_HOST for port or socket references
 	local PARTS=(${DB_HOST//\:/ })
 	local DB_HOSTNAME=${PARTS[0]};

--- a/templates/plugin-gitlab.mustache
+++ b/templates/plugin-gitlab.mustache
@@ -1,0 +1,34 @@
+variables:
+  # Configure mysql service (https://hub.docker.com/_/mysql/)
+  MYSQL_DATABASE: wordpress_tests
+  MYSQL_ROOT_PASSWORD: mysql
+
+before_script:
+  # Install dependencies
+  
+  # update the docker
+  - apt-get clean
+  - apt-get -yqq update
+
+  # instll the required packages for the running CI tests
+  - apt-get -yqqf install zip unzip subversion mysql-client libmysqlclient-dev --fix-missing
+
+  # PHP extensions
+  - docker-php-ext-enable mbstring mcrypt mysqli pdo_mysql intl gd zip bz2
+
+  # Set up WordPress tests
+  - bash bin/install-wp-tests.sh wordpress_tests root mysql mysql latest true
+
+PHPunit:PHP5.3:MySQL:
+  image: tetraweb/php:5.3
+  services:
+    - mysql:5.6
+  script:
+  - phpunit --configuration phpunit.xml.dist
+
+PHPunit:PHP5.6:MySQL:
+  image: tetraweb/php:5.6
+  services:
+    - mysql:5.6
+  script:
+  - phpunit --configuration phpunit.xml.dist


### PR DESCRIPTION
##### Adds option --ci=gitlab

1. Adds file .gitlab-ci.yml for Gitlab CI configurations
2. Adds new option to `install-wp-tests.sh` to skip creating a database as Gitlab does not require creating a database. The variable `SKIP_DB_CREATE` defaults to `false` until set true when calling the file.

##### Results
1. Tests passing for Gitlab here - [Gitlab tests](https://gitlab.com/Nikchavan/test-wp-plugin/builds/2411349#down-build-trace)
2. Travis tests are unaffected after the changes to `install-wp-tests-sh` - [Github tests](https://travis-ci.org/Nikschavan/test-wp-plugin/builds/145178414)

See #2199