### PR TITLE
missing global namespace separator in CommandWithTranslation.php

### DIFF
--- a/php/WP_CLI/CommandWithTranslation.php
+++ b/php/WP_CLI/CommandWithTranslation.php
@@ -344,7 +344,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 
 		$response = translations_api( $this->obj_type );
 		if ( is_wp_error( $response ) ) {
-			WP_CLI::error( $response );
+			\WP_CLI::error( $response );
 		}
 		$translations = ! empty( $response['translations'] ) ? $response['translations'] : array();
 


### PR DESCRIPTION
cf. https://github.com/wp-cli/wp-cli/issues/2670#issuecomment-233898650