### PR TITLE
Prevent "Password Changed" Email Notification Upon User Creation

### DIFF
--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -327,6 +327,12 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 
 		$user->role = \WP_CLI\Utils\get_flag_value( $assoc_args, 'role', get_option('default_role') );
 		self::validate_role( $user->role );
+		
+		// Don't send emails if --send-email is not given.
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'send-email' ) ) {
+			add_filter( 'send_password_change_email', '__return_false' );
+			add_filter( 'send_email_change_email', '__return_false' );
+		}
 
 		if ( is_multisite() ) {
 			$ret = wpmu_validate_user_signup( $user->user_login, $user->user_email );


### PR DESCRIPTION
This overrides the `send_password_change_email` and `send_email_change_email` filters if `--send-email` is not supplied on the command line for `wp user create`. The filters return false, which prevent the email from going out. The email is generated by the WP function `wp_update_user()`.