### PR TITLE
Add missing heading in doc of cli cmd-dump

### DIFF
--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -430,6 +430,8 @@ class CLI_Command extends WP_CLI_Command {
 	/**
 	 * Dump the list of installed commands, as JSON.
 	 *
+	 * ## EXAMPLES
+	 *
 	 *     # Dump the list of installed commands
 	 *     $ wp cli cmd-dump
 	 *     {"name":"wp","description":"Manage WordPress through the command-line.","longdesc":"\n\n## GLOBAL PARAMETERS\n\n  --path=<path>\n      Path to the WordPress files.\n\n  --ssh=<ssh>\n      Perform operation against a remote server over SSH.\n\n  --url=<url>\n      Pretend request came from given URL. In multisite, this argument is how the target site is specified. \n\n  --user=<id|login|email>\n


### PR DESCRIPTION
`## EXAMPLES` is missing in the doc of `cli cmd-dump`. So detail in this page is not as expected. http://wp-cli.org/commands/cli/cmd-dump/