### PR TITLE
Improve help of ssh

### DIFF
--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -8,8 +8,8 @@ return array(
 	),
 
 	'ssh' => array(
-		'runtime' => '=[<user>]@<host>[:<port>][<path>]',
-		'file' => '[<user>]@<host>[:<port>][<path>]',
+		'runtime' => '=[<user>@]<host>[:<port>][<path>]',
+		'file' => '[<user>@]<host>[:<port>][<path>]',
 		'desc' => 'Perform operation against a remote server over SSH.',
 	),
 

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -8,8 +8,8 @@ return array(
 	),
 
 	'ssh' => array(
-		'runtime' => '=<user>[:<pass>]@<host>[:<port>]<path>',
-		'file' => '<user>[:<pass>]@<host>[:<port>]<path>',
+		'runtime' => '=[<user>]@<host>[:<port>][<path>]',
+		'file' => '[<user>]@<host>[:<port>][<path>]',
 		'desc' => 'Perform operation against a remote server over SSH.',
 	),
 


### PR DESCRIPTION
I am not sure that is my pull-request better or not. 
But I feel we should improve help for `--ssh`.

```
$ wp help
  ...
  --ssh=<user>[:<pass>]@<host>[:<port>]<path>
      Perform operation against a remote server over SSH.
```