### PR TITLE
Make --skip-plugins work on selected plugins

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1140,11 +1140,15 @@ class Runner {
 				return $plugins;
 			}
 			foreach( $plugins as $key => $plugin ) {
-				if ( Utils\is_plugin_skipped( $plugin ) ) {
+				if ( is_numeric( $key ) && Utils\is_plugin_skipped( $plugin ) ) {
+					unset( $plugins[ $key ] );
+				}
+				// sitewide filters are flipped...
+				elseif ( is_numeric( $plugin ) && Utils\is_plugin_skipped( $key ) ) {
 					unset( $plugins[ $key ] );
 				}
 			}
-			return array_values( $plugins );
+			return $plugins;
 		};
 
 		$hooks = array(


### PR DESCRIPTION
--skip-plugins isn't honoring the list of plugins to skip.  Currently it's either skipping or enabling all plugins.  The issue is with the plugins filter in php/WP_CLI/Runner.php... *_active_sitewide_plugins filters pass arrays with plugins as keys, *_active_plugins filters pass arrays with plugins as values, so the filter which is assigned to both needs to handle both.

The symptom of the bug is running something like:

$wp --skip-plugins=hello jetpack
Error: 'jetpack' is not a registered wp command. See 'wp help'.

Where jetpack should still be enabled and only hello plugin skipped.