### PR TITLE
Display default core language in "wp core version --extra".

### DIFF
--- a/features/core-version.feature
+++ b/features/core-version.feature
@@ -24,7 +24,7 @@ Feature: Find version for WordPress install
     And an empty cache
 
     When I run `wp core download --version=4.4.2 --locale=de_DE`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       Success: WordPress downloaded.
       """

--- a/features/core-version.feature
+++ b/features/core-version.feature
@@ -16,4 +16,5 @@ Feature: Find version for WordPress install
       WordPress version: 4.4.2
       Database revision: 35700
       TinyMCE version:   4.208 (4208-20151113)
+      Language:          en_US
       """

--- a/features/core-version.feature
+++ b/features/core-version.feature
@@ -16,5 +16,5 @@ Feature: Find version for WordPress install
       WordPress version: 4.4.2
       Database revision: 35700
       TinyMCE version:   4.208 (4208-20151113)
-      Language:          en_US
+      Package Language:  en_US
       """

--- a/features/core-version.feature
+++ b/features/core-version.feature
@@ -16,5 +16,24 @@ Feature: Find version for WordPress install
       WordPress version: 4.4.2
       Database revision: 35700
       TinyMCE version:   4.208 (4208-20151113)
-      Package Language:  en_US
+      Package language:  en_US
+      """
+
+  Scenario: Installing WordPress for a non-default locale and verify core extended version information.
+    Given an empty directory
+    And an empty cache
+
+    When I run `wp core download --version=4.4.2 --locale=de_DE`
+    Then STDOUT should be:
+      """
+      Success: WordPress downloaded.
+      """
+
+    When I run `wp core version --extra`
+    Then STDOUT should be:
+      """
+      WordPress version: 4.4.2
+      Database revision: 35700
+      TinyMCE version:   4.208 (4208-20151113)
+      Package language:  de_DE
       """

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -945,9 +945,10 @@ EOT;
 			}
 
 			echo \WP_CLI\Utils\mustache_render( 'versions.mustache', array(
-				'wp-version'  => $details['wp_version'],
-				'db-version'  => $details['wp_db_version'],
-				'mce-version' => ( $human_readable_tiny_mce ?
+				'wp-version'    => $details[ 'wp_version' ],
+				'db-version'    => $details[ 'wp_db_version' ],
+				'local-package' => ! empty( $details[ 'wp_local_package' ] ) ? $details[ 'wp_local_package' ] : 'en_US',
+				'mce-version'   => ( $human_readable_tiny_mce ?
 					"$human_readable_tiny_mce ({$details['tinymce_version']})"
 					: $details['tinymce_version']
 				)

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -945,9 +945,12 @@ EOT;
 			}
 
 			echo \WP_CLI\Utils\mustache_render( 'versions.mustache', array(
-				'wp-version'    => $details[ 'wp_version' ],
-				'db-version'    => $details[ 'wp_db_version' ],
-				'local-package' => ! empty( $details[ 'wp_local_package' ] ) ? $details[ 'wp_local_package' ] : 'en_US',
+				'wp-version'    => $details['wp_version'],
+				'db-version'    => $details['wp_db_version'],
+				'local-package' => ( empty( $details['wp_local_package'] ) ?
+					'en_US'
+					: $details['wp_local_package']
+				),
 				'mce-version'   => ( $human_readable_tiny_mce ?
 					"$human_readable_tiny_mce ({$details['tinymce_version']})"
 					: $details['tinymce_version']

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -930,7 +930,7 @@ EOT;
 	 *     WordPress version: 4.5.2
 	 *     Database revision: 36686
 	 *     TinyMCE version:   4.310 (4310-20160418)
-	 *     Package Language:  en_US
+	 *     Package language:  en_US
 	 *
 	 * @when before_wp_load
 	 */

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -930,6 +930,7 @@ EOT;
 	 *     WordPress version: 4.5.2
 	 *     Database revision: 36686
 	 *     TinyMCE version:   4.310 (4310-20160418)
+	 *     Package Language:  en_US
 	 *
 	 * @when before_wp_load
 	 */

--- a/templates/versions.mustache
+++ b/templates/versions.mustache
@@ -1,3 +1,4 @@
 WordPress version: {{wp-version}}
 Database revision: {{db-version}}
 TinyMCE version:   {{mce-version}}
+Package Language:  {{local-package}}

--- a/templates/versions.mustache
+++ b/templates/versions.mustache
@@ -1,4 +1,4 @@
 WordPress version: {{wp-version}}
 Database revision: {{db-version}}
 TinyMCE version:   {{mce-version}}
-Package Language:  {{local-package}}
+Package language:  {{local-package}}


### PR DESCRIPTION
Fixes #3219 