### PR TITLE
Fix backwards compat shim to only affect `wp site create

### DIFF
--- a/features/site.feature
+++ b/features/site.feature
@@ -27,6 +27,9 @@ Feature: Manage sites in a multisite installation
       1 2
       """
 
+    When I run `wp site list --site_id=2 --format=ids`
+    Then STDOUT should be empty
+
     When I run `wp --url=first.example.com option get home`
     Then STDOUT should be:
       """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -471,8 +471,8 @@ class Runner {
 			unset( $assoc_args['admin_name'] );
 		}
 
-		// site --site_id=  ->  site --network_id=
-		if ( count( $args ) > 0 && 'site' == $args[0] && isset( $assoc_args['site_id'] ) ) {
+		// site create --site_id=  ->  site create --network_id=
+		if ( count( $args ) >= 2 && 'site' === $args[0] && 'create' === $args[1] && isset( $assoc_args['site_id'] ) ) {
 			$assoc_args['network_id'] = $assoc_args['site_id'];
 			unset( $assoc_args['site_id'] );
 		}


### PR DESCRIPTION
Fixes #3226