### PR TITLE
Fix behavior of autoload parameter for `wp option (add|update)` (v0.25.0)

### DIFF
--- a/features/option.feature
+++ b/features/option.feature
@@ -141,3 +141,63 @@ Feature: Manage WordPress options
     Then STDOUT should be a table containing rows:
       | option_name  | option_value   | autoload |
       | hello        | island         | yes      |
+
+  @require-wp-4.2
+  Scenario: Managed autoloaded options
+    Given a WP install
+
+    When I run `wp option add wp_autoload_1 enabled --autoload=yes`
+    Then STDOUT should be:
+      """
+      Success: Added 'wp_autoload_1' option.
+      """
+    And STDERR should be empty
+
+    When I run `wp option add wp_autoload_2 implicit`
+    Then STDOUT should be:
+      """
+      Success: Added 'wp_autoload_2' option.
+      """
+    And STDERR should be empty
+
+    When I run `wp option add wp_autoload_3 disabled --autoload=no`
+    Then STDOUT should be:
+      """
+      Success: Added 'wp_autoload_3' option.
+      """
+    And STDERR should be empty
+
+    When I run `wp option list --search='wp_autoload*' --fields=option_name,option_value,autoload`
+    Then STDOUT should be a table containing rows:
+      | option_name   | option_value   | autoload |
+      | wp_autoload_1 | enabled        | yes      |
+      | wp_autoload_2 | implicit       | yes      |
+      | wp_autoload_3 | disabled       | no       |
+
+    When I run `wp option update wp_autoload_1 disabled --autoload=no`
+    Then STDOUT should be:
+      """
+      Success: Updated 'wp_autoload_1' option.
+      """
+    And STDERR should be empty
+
+    When I run `wp option update wp_autoload_2 implicit2`
+    Then STDOUT should be:
+      """
+      Success: Updated 'wp_autoload_2' option.
+      """
+    And STDERR should be empty
+
+    When I run `wp option update wp_autoload_3 enabled --autoload=yes`
+    Then STDOUT should be:
+      """
+      Success: Updated 'wp_autoload_3' option.
+      """
+    And STDERR should be empty
+
+    When I run `wp option list --search='wp_autoload*' --fields=option_name,option_value,autoload`
+    Then STDOUT should be a table containing rows:
+      | option_name   | option_value   | autoload |
+      | wp_autoload_1 | disabled       | no       |
+      | wp_autoload_2 | implicit2      | yes      |
+      | wp_autoload_3 | enabled        | yes      |

--- a/php/commands/option.php
+++ b/php/commands/option.php
@@ -90,10 +90,9 @@ class Option_Command extends WP_CLI_Command {
 	 * [--autoload=<autoload>]
 	 * : Should this option be automatically loaded.
 	 * ---
-	 * default: yes
 	 * options:
-	 *   - yes
-	 *   - no
+	 *   - 'yes'
+	 *   - 'no'
 	 * ---
 	 *
 	 * ## EXAMPLES
@@ -261,10 +260,9 @@ class Option_Command extends WP_CLI_Command {
 	 * [--autoload=<autoload>]
 	 * : Requires WP 4.2. Should this option be automatically loaded.
 	 * ---
-	 * default: yes
 	 * options:
-	 *   - yes
-	 *   - no
+	 *   - 'yes'
+	 *   - 'no'
 	 * ---
 	 *
 	 * [--format=<format>]


### PR DESCRIPTION
YAML interprets `yes` and `no` to be boolean values, which breaks the
default value for the underlying command. Instead, we need to make sure
these options are quoted. No default value is necessary because null is
an acceptable default value.

See #3209