### PR TITLE
Fix `--skip-plugins` for network-activated plugins (v0.24.1)

### DIFF
--- a/features/skip-plugins.feature
+++ b/features/skip-plugins.feature
@@ -4,16 +4,10 @@ Feature: Skipping plugins
     Given a WP install
     And I run `wp plugin activate hello akismet`
 
-    When I run `wp eval 'var_export( defined("AKISMET_VERSION") );'`
+    When I run `wp eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
     Then STDOUT should be:
       """
-      true
-      """
-
-    When I run `wp eval 'var_export( function_exists( "hello_dolly" ) );'`
-    Then STDOUT should be:
-      """
-      true
+      truetrue
       """
 
     # The specified plugin should be skipped
@@ -31,10 +25,10 @@ Feature: Skipping plugins
       """
 
     # The un-specified plugin should continue to be loaded
-    When I run `wp --skip-plugins=akismet eval 'var_export( function_exists( "hello_dolly" ) );'`
+    When I run `wp --skip-plugins=akismet eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
     Then STDOUT should be:
       """
-      true
+      falsetrue
       """
 
     # Can specify multiple plugins to skip
@@ -45,15 +39,10 @@ Feature: Skipping plugins
       """
 
     # No plugins should be loaded when --skip-plugins doesn't have a value
-    When I run `wp --skip-plugins eval 'var_export( defined("AKISMET_VERSION") );'`
+    When I run `wp --skip-plugins eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
     Then STDOUT should be:
       """
-      false
-      """
-    When I run `wp --skip-plugins eval 'var_export( function_exists( "hello_dolly" ) );'`
-    Then STDOUT should be:
-      """
-      false
+      falsefalse
       """
 
   Scenario: Skipping multiple plugins via config file
@@ -88,17 +77,29 @@ Feature: Skipping plugins
 
   Scenario: Skip network active plugins
     Given a WP multisite install
-    And I run `wp plugin deactivate akismet`
-    And I run `wp plugin activate --network akismet`
+    And I run `wp plugin deactivate akismet hello`
+    And I run `wp plugin activate --network akismet hello`
 
-    When I run `wp eval 'var_export( defined("AKISMET_VERSION") );'`
+    When I run `wp eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
     Then STDOUT should be:
       """
-      true
+      truetrue
       """
 
-    When I run `wp --skip-plugins=akismet eval 'var_export( defined("AKISMET_VERSION") );'`
+    When I run `wp --skip-plugins eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
     Then STDOUT should be:
       """
-      false
+      falsefalse
+      """
+
+    When I run `wp --skip-plugins=akismet eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
+    Then STDOUT should be:
+      """
+      falsetrue
+      """
+
+    When I run `wp --skip-plugins=hello eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
+    Then STDOUT should be:
+      """
+      truefalse
       """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1139,12 +1139,20 @@ class Runner {
 			if ( ! is_array( $plugins ) ) {
 				return $plugins;
 			}
-			foreach( $plugins as $key => $plugin ) {
-				if ( Utils\is_plugin_skipped( $plugin ) ) {
-					unset( $plugins[ $key ] );
+			foreach( $plugins as $a => $b ) {
+				// active_sitewide_plugins stores plugin name as the key
+				if ( false !== strpos( current_filter(), 'active_sitewide_plugins' ) && Utils\is_plugin_skipped( $a ) ) {
+					unset( $plugins[ $a ] );
+				// active_plugins stores plugin name as the value
+				} else if ( false !== strpos( current_filter(), 'active_plugins' ) && Utils\is_plugin_skipped( $b ) ) {
+					unset( $plugins[ $a ] );
 				}
 			}
-			return array_values( $plugins );
+			// Reindex because active_plugins expects a numeric index
+			if ( false !== strpos( current_filter(), 'active_plugins' ) ) {
+				$plugins = array_values( $plugins );
+			}
+			return $plugins;
 		};
 
 		$hooks = array(


### PR DESCRIPTION
Using `--skip-plugins=<slug>` should only disable that specific plugin,
not all network-activated plugins.

Also makes the tests a bit more comprehensive.

Reported in #3216