### PR TITLE
When checking for additional files, only check core directories

### DIFF
--- a/features/core-verify-checksums.feature
+++ b/features/core-verify-checksums.feature
@@ -85,3 +85,17 @@ Feature: Validate checksums for WordPress install
       """
       Success: WordPress install verifies against checksums.
       """
+
+  Scenario: Verify core checksums with a plugin that has wp-admin
+    Given a WP install
+    And a wp-content/plugins/akismet/wp-admin/extra-file.txt file:
+      """
+      hello world
+      """
+
+    When I run `wp core verify-checksums`
+    Then STDOUT should be:
+      """
+      Success: WordPress install verifies against checksums.
+      """
+    And STDERR should be empty

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -1073,7 +1073,8 @@ EOT;
 
 		$core_files = array();
 		foreach ( $files as $file_info ) {
-			if ( $file_info->isFile() && ( false !== strpos( $file_info->getPathname(), 'wp-admin/' ) || false !== strpos( $file_info->getPathname(), 'wp-includes/' ) ) ) {
+			$pathname = substr( $file_info->getPathname(), strlen( ABSPATH ) );
+			if ( $file_info->isFile() && ( 0 === strpos( $pathname, 'wp-admin/' ) || 0 === strpos( $pathname, 'wp-includes/' ) ) ) {
 				$core_files[] = str_replace( ABSPATH, '', $file_info->getPathname() );
 			}
 		}
@@ -1082,7 +1083,7 @@ EOT;
 	}
 
 	private function only_core_files_filter( $file ) {
-		return ( false !== strpos( $file, 'wp-admin/' ) || false !== strpos( $file, 'wp-includes/' ) );
+		return ( 0 === strpos( $file, 'wp-admin/' ) || 0 === strpos( $file, 'wp-includes/' ) );
 	}
 
 	/**


### PR DESCRIPTION
Core's `wp-admin/` and `wp-includes/` directories are immediately after
ABSPATH. Don't flag files inside of `wp-admin/` and `wp-includes/`
directories in plugins.

Fixes #3214