### PR TITLE
Sync package composer repository on install

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -2,10 +2,14 @@ Feature: Install WP-CLI packages
 
   Scenario: Install a package with an http package index url in package composer.json
     Given an empty directory
-    And a packages/composer.json file:
+    And a composer.json file:
       """
       {
         "repositories": {
+          "test" : {
+            "type": "path",
+            "url": "./dummy-package/"
+          },
           "wp-cli": {
             "type": "composer",
             "url": "http://wp-cli.org/package-index/"
@@ -13,7 +17,14 @@ Feature: Install WP-CLI packages
         }
       }
       """
-    When I run `WP_CLI_PACKAGES_DIR=$PWD/packages wp package install runcommand/hook --debug`
+    And a dummy-package/composer.json file:
+	  """
+	  {
+	    "name": "wp-cli/restful",
+	    "description": "This is a dummy package we will install instead of actually installing the real package. This prevents the test from hanging indefinitely for some reason, even though it passes. The 'name' must match a real package as it is checked against the package index."
+	  }
+	  """
+    When I run `WP_CLI_PACKAGES_DIR=. wp package install wp-cli/restful --debug`
     Then STDOUT should contain:
 	  """
 	  Updating package index repository url...
@@ -22,11 +33,11 @@ Feature: Install WP-CLI packages
 	  """
 	  Success: Package installed
 	  """
-    And the packages/composer.json file should contain:
+    And the composer.json file should contain:
       """
       "url": "https://wp-cli.org/package-index/"
       """
-    And the packages/composer.json file should not contain:
+    And the composer.json file should not contain:
       """
       "url": "http://wp-cli.org/package-index/"
       """

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -2,7 +2,7 @@ Feature: Install WP-CLI packages
 
   Scenario: Install a package with an http package index url in package composer.json
     Given an empty directory
-    And a composer.json file:
+    And a packages/composer.json file:
       """
       {
         "repositories": {
@@ -13,17 +13,20 @@ Feature: Install WP-CLI packages
         }
       }
       """
-    When I run `WP_CLI_PACKAGES_DIR=. wp --info`
+    When I run `WP_CLI_PACKAGES_DIR=$PWD/packages wp package install runcommand/hook --debug`
     Then STDOUT should contain:
-      """
-      WP-CLI packages dir:	.
-      """
-    When I run `WP_CLI_PACKAGES_DIR=. wp package install runcommand/hook`
-    Then the composer.json file should contain:
+	  """
+	  Updating package index repository url...
+	  """
+    And STDOUT should contain:
+	  """
+	  Success: Package installed
+	  """
+    And the packages/composer.json file should contain:
       """
       "url": "https://wp-cli.org/package-index/"
       """
-    And the composer.json file should not contain:
+    And the packages/composer.json file should not contain:
       """
       "url": "http://wp-cli.org/package-index/"
       """

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -13,19 +13,17 @@ Feature: Install WP-CLI packages
         }
       }
       """
-    When I run `rm -rf /tmp/wp-cli-package-install-test/ && mkdir /tmp/wp-cli-package-install-test/ && mv composer.json /tmp/wp-cli-package-install-test/`
-    Then the /tmp/wp-cli-package-install-test/composer.json file should exist
-    When I run `WP_CLI_PACKAGES_DIR=/tmp/wp-cli-package-install-test/ wp --info`
+    When I run `WP_CLI_PACKAGES_DIR=. wp --info`
     Then STDOUT should contain:
       """
-      WP-CLI packages dir:	/tmp/wp-cli-package-install-test/
+      WP-CLI packages dir:	.
       """
-    When I run `WP_CLI_PACKAGES_DIR=/tmp/wp-cli-package-install-test/ wp package install runcommand/hook`
-    Then the /tmp/wp-cli-package-install-test/composer.json file should contain:
+    When I run `WP_CLI_PACKAGES_DIR=. wp package install runcommand/hook`
+    Then the composer.json file should contain:
       """
       "url": "https://wp-cli.org/package-index/"
       """
-    And the /tmp/wp-cli-package-install-test/composer.json file should not contain:
+    And the composer.json file should not contain:
       """
       "url": "http://wp-cli.org/package-index/"
       """

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -1,5 +1,35 @@
 Feature: Install WP-CLI packages
 
+  Scenario: Install a package with an old package index url in package composer.json
+    Given an empty directory
+    And a composer.json file:
+      """
+      {
+        "repositories": {
+          "wp-cli": {
+            "type": "composer",
+            "url": "http://wp-cli.org/package-index/"
+          }
+        }
+      }
+      """
+    When I run `rm -rf /tmp/wp-cli-package-install-test/ && mkdir /tmp/wp-cli-package-install-test/ && mv composer.json /tmp/wp-cli-package-install-test/`
+    Then the /tmp/wp-cli-package-install-test/composer.json file should exist
+    When I run `WP_CLI_PACKAGES_DIR=/tmp/wp-cli-package-install-test/ wp --info`
+    Then STDOUT should contain:
+      """
+      WP-CLI packages dir:	/tmp/wp-cli-package-install-test/
+      """
+    When I run `WP_CLI_PACKAGES_DIR=/tmp/wp-cli-package-install-test/ wp package install runcommand/hook`
+    Then the /tmp/wp-cli-package-install-test/composer.json file should contain:
+      """
+      "url": "https://wp-cli.org/package-index/"
+      """
+    And the /tmp/wp-cli-package-install-test/composer.json file should not contain:
+      """
+      "url": "http://wp-cli.org/package-index/"
+      """
+
   Scenario: Install a package with 'wp-cli/wp-cli' as a dependency
     Given a WP install
 

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -1,6 +1,6 @@
 Feature: Install WP-CLI packages
 
-  Scenario: Install a package with an old package index url in package composer.json
+  Scenario: Install a package with an http package index url in package composer.json
     Given an empty directory
     And a composer.json file:
       """

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -187,7 +187,6 @@ class Package_Command extends WP_CLI_Command {
 		// If the composer file does not contain the current package index url, refresh the repository definition.
 		if ( false === strpos( $composer_backup, self::PACKAGE_INDEX_URL ) ) {
 			WP_CLI::log( 'Updating package index repository url...' );
-			$json_manipulator->removeRepository( 'wp-cli' );
 			$json_manipulator->addRepository( 'wp-cli', array( 'type' => 'composer', 'url' => self::PACKAGE_INDEX_URL ) );
 		}
 

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -184,8 +184,9 @@ class Package_Command extends WP_CLI_Command {
 		$json_manipulator->addLink( 'require', $package_name, $version );
 		$json_manipulator->addConfigSetting( 'secure-http', true );
 
-		// If the composer file does not contain the current package index url, refresh the repository definition.
-		if ( false === strpos( $composer_backup, self::PACKAGE_INDEX_URL ) ) {
+		$composer_backup_decoded = json_decode( $composer_backup, true );
+		// If the composer file does not contain the current package index repository, refresh the repository definition.
+		if ( empty( $composer_backup_decoded['repositories']['wp-cli']['url'] ) || self::PACKAGE_INDEX_URL != $composer_backup_decoded['repositories']['wp-cli']['url'] ) {
 			WP_CLI::log( 'Updating package index repository url...' );
 			$json_manipulator->addRepository( 'wp-cli', array( 'type' => 'composer', 'url' => self::PACKAGE_INDEX_URL ) );
 		}

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -183,6 +183,14 @@ class Package_Command extends WP_CLI_Command {
 		$json_manipulator->addMainKey( 'name', 'wp-cli/wp-cli' );
 		$json_manipulator->addLink( 'require', $package_name, $version );
 		$json_manipulator->addConfigSetting( 'secure-http', true );
+
+		// If the composer file does not contain the current package index url, refresh the repository definition.
+		if ( false === strpos( $composer_backup, self::PACKAGE_INDEX_URL ) ) {
+			WP_CLI::log( 'Updating package index repository url...' );
+			$json_manipulator->removeRepository( 'wp-cli' );
+			$json_manipulator->addRepository( 'wp-cli', array( 'type' => 'composer', 'url' => self::PACKAGE_INDEX_URL ) );
+		}
+
 		file_put_contents( $composer_json_obj->getPath(), $json_manipulator->getContents() );
 		try {
 			$composer = $this->get_composer();


### PR DESCRIPTION
Right now, older installs of WP-CLI error when trying to install a new package due to the package index url not being updated from http to https.  This fails when composer goes to query the package index over http, since `secure_http` is being set to true (I believe this is also the default now).  Some users may not know how to correct this manually, and they shouldn't really have to.

This PR performs a simple check when preparing to install a package.  If the current package index isn't found in the composer config file, then it will refresh the definition for the package index repository.

fixes #3275 