### PR TITLE
Preserve case for --version argument in core download (when it makes sense)

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -188,4 +188,25 @@ Feature: Download WordPress
     And STDERR should contain:
     """
     Error: Nightly builds are only available for the en_US locale.
-		"""
+    """
+
+  Scenario: Installing a release candidate or beta version
+    Given an empty directory
+    And an empty cache
+
+    # Test with incorrect case.
+    When I try `wp core download --version=4.6-rc2`
+    Then the return code should be 1
+    Then STDERR should contain:
+      """
+      Error: Release not found.
+      """
+
+    When I run `wp core download --version=4.6-RC2`
+    Then the wp-settings.php file should exist
+    And STDOUT should contain:
+      """
+      Downloading WordPress 4.6-RC2 (en_US)...
+      md5 hash verified: 90c93a15092b2d5d4c960ec1fc183e07
+      Success: WordPress downloaded.
+      """

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -134,8 +134,8 @@ class Core_Command extends WP_CLI_Command {
 		$locale = \WP_CLI\Utils\get_flag_value( $assoc_args, 'locale', 'en_US' );
 
 		if ( isset( $assoc_args['version'] ) ) {
-			$version = strtolower( $assoc_args['version'] );
-			$version = ( 'trunk' === $version ? 'nightly' : $version );
+			$version = $assoc_args['version'];
+			$version = ( in_array( strtolower( $version ), array( 'trunk', 'nightly' ) ) ? 'nightly' : $version );
 			//nightly builds are only available in .zip format
 			$ext     = ( 'nightly' === $version ? 'zip' : 'tar.gz' );
 			$download_url = $this->get_download_url( $version, $locale, $ext );


### PR DESCRIPTION
Fixes #3282.

I know this is something you can easily patch yourselves, but I wanted to submit the PR in case that helps. Let me know if there's something I need to adjust before you can (maybe) merge this 😸.