### PR TITLE
Remove branch names from directories created for Github-based ZIPs

### DIFF
--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -1,0 +1,21 @@
+Feature: Install WordPress plugins
+
+  Scenario: Branch names should be removed from Github projects
+    Given a WP install
+
+    When I run `wp plugin install https://github.com/runcommand/one-time-login/archive/master.zip --activate`
+    Then STDOUT should contain:
+      """
+      Downloading install package from https://github.com/runcommand/one-time-login/archive/master.zip
+      """
+    And STDOUT should contain:
+      """
+      Moved Github-based project from 'one-time-login-master' to 'one-time-login'.
+      """
+    And STDOUT should contain:
+      """
+      Plugin installed successfully.
+      """
+    And STDERR should be empty
+    And the wp-content/plugins/one-time-login directory should exist
+    And the wp-content/plugins/one-time-login-master directory should not exist


### PR DESCRIPTION
Ideally, we'd perform this transformation in the original unzip -> move
process. However, it's not easily possible to hook into it.

Fixes #2994