### PR TITLE
Run Behat in strict mode

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -8,7 +8,7 @@ vendor/bin/phpunit
 BEHAT_TAGS=$(php ci/behat-tags.php)
 
 # Run the functional tests
-vendor/bin/behat --format progress $BEHAT_TAGS
+vendor/bin/behat --format progress $BEHAT_TAGS --strict
 
 # Run CodeSniffer
 ./codesniffer/scripts/phpcs --standard=./ci/ php/


### PR DESCRIPTION
Doing so ensures any undefined steps will fail the build, instead of
permitting it to pass