### PR TITLE
Prevent email notifications when users are created

### DIFF
--- a/features/bootstrap/support.php
+++ b/features/bootstrap/support.php
@@ -8,6 +8,12 @@ function assertEquals( $expected, $actual ) {
 	}
 }
 
+function assertNotEquals( $expected, $actual ) {
+	if ( $expected == $actual ) {
+		throw new Exception( "Actual value: " . var_export( $actual, true ) );
+	}
+}
+
 function assertNumeric( $actual ) {
 	if ( !is_numeric( $actual ) ) {
 		throw new Exception( "Actual value: " . var_export( $actual, true ) );

--- a/features/extra/no-mail.php
+++ b/features/extra/no-mail.php
@@ -1,6 +1,7 @@
 <?php
 
-function wp_mail() {
-	// do nothing
+function wp_mail( $to ) {
+	// Log for testing purposes
+	WP_CLI::log( "WP-CLI test suite: Sent email to {$to}." );
 }
 

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -190,3 +190,12 @@ $steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|
 	}
 );
 
+$steps->Then( '/^an email should (be sent|not be sent)$/', function( $world, $expected ) {
+	if ( 'be sent' === $expected ) {
+		assertNotEquals( 0, $world->email_sends );
+	} else if ( 'not be sent' === $expected ) {
+		assertEquals( 0, $world->email_sends );
+	} else {
+		throw new Exception( 'Invalid expectation' );
+	}
+});

--- a/features/steps/when.php
+++ b/features/steps/when.php
@@ -14,6 +14,11 @@ function invoke_proc( $proc, $mode ) {
 	return $proc->$method();
 }
 
+function capture_email_sends( $stdout ) {
+	$stdout = preg_replace( '#WP-CLI test suite: Sent email to.+\n?#', '', $stdout, -1, $email_sends );
+	return array( $stdout, $email_sends );
+}
+
 $steps->When( '/^I launch in the background `([^`]+)`$/',
 	function ( $world, $cmd ) {
 		$world->background_proc( $cmd );
@@ -24,6 +29,7 @@ $steps->When( '/^I (run|try) `([^`]+)`$/',
 	function ( $world, $mode, $cmd ) {
 		$cmd = $world->replace_variables( $cmd );
 		$world->result = invoke_proc( $world->proc( $cmd ), $mode );
+		list( $world->result->stdout, $world->email_sends ) = capture_email_sends( $world->result->stdout );
 	}
 );
 
@@ -31,6 +37,7 @@ $steps->When( "/^I (run|try) `([^`]+)` from '([^\s]+)'$/",
 	function ( $world, $mode, $cmd, $subdir ) {
 		$cmd = $world->replace_variables( $cmd );
 		$world->result = invoke_proc( $world->proc( $cmd, array(), $subdir ), $mode );
+		list( $world->result->stdout, $world->email_sends ) = capture_email_sends( $world->result->stdout );
 	}
 );
 
@@ -41,6 +48,7 @@ $steps->When( '/^I (run|try) the previous command again$/',
 
 		$proc = Process::create( $world->result->command, $world->result->cwd, $world->result->env );
 		$world->result = invoke_proc( $proc, $mode );
+		list( $world->result->stdout, $world->email_sends ) = capture_email_sends( $world->result->stdout );
 	}
 );
 

--- a/features/user.feature
+++ b/features/user.feature
@@ -286,3 +286,12 @@ Feature: Manage WordPress users
       """
       My\New\User
       """
+
+  Scenario: Don't send user creation emails by default
+    Given a WP multisite install
+
+    When I run `wp user create testuser2 testuser2@example.com`
+    Then an email should not be sent
+
+    When I run `wp user create testuser3 testuser3@example.com --send-email`
+    Then an email should be sent

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -328,6 +328,11 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 		$user->role = \WP_CLI\Utils\get_flag_value( $assoc_args, 'role', get_option('default_role') );
 		self::validate_role( $user->role );
 
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'send-email' ) ) {
+			add_filter( 'send_password_change_email', '__return_false' );
+			add_filter( 'send_email_change_email', '__return_false' );
+		}
+
 		if ( is_multisite() ) {
 			$ret = wpmu_validate_user_signup( $user->user_login, $user->user_email );
 			if ( is_wp_error( $ret['errors'] ) && ! empty( $ret['errors']->errors ) ) {


### PR DESCRIPTION
Email notifications should only be sent when `--send-email` is provided.

Fixes #3182