### PR TITLE
Ensure `wp core update-db --network --dry-run` is actually dry

### DIFF
--- a/features/core-update-db.feature
+++ b/features/core-update-db.feature
@@ -26,7 +26,7 @@ Feature: Update core's database
     Then STDOUT should be:
       """
       Performing a dry run, with no database modification.
-      Success: WordPress database upgraded successfully from db version 29630 to 30133.
+      Success: WordPress database will be upgraded from db version 29630 to 30133.
       """
 
     When I run `wp option get db_version`
@@ -57,6 +57,8 @@ Feature: Update core's database
 
   Scenario: Update db across network
     Given a WP multisite install
+    And I run `wp core download --version=4.1 --force`
+    And I run `wp option update db_version 29630`
     And I run `wp site create --slug=foo`
     And I run `wp site create --slug=bar`
     And I run `wp site create --slug=burrito --porcelain`
@@ -73,6 +75,14 @@ Feature: Update core's database
     Then STDOUT should contain:
       """
       Performing a dry run, with no database modification.
+      """
+    And STDOUT should contain:
+      """
+      WordPress database will be upgraded from db version
+      """
+    And STDOUT should not contain:
+      """
+      WordPress database upgraded successfully from db version
       """
     And STDOUT should contain:
       """

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -1398,11 +1398,12 @@ EOT;
 			foreach( $it as $blog ) {
 				$total++;
 				$url = $blog->domain . $blog->path;
-				$process = WP_CLI::launch_self( 'core update-db', array(), array(), false, true, array( 'url' => $url, 'dry-run' => $dry_run ) );
+				$process = WP_CLI::launch_self( 'core update-db', array(), array( 'dry-run' => $dry_run ), false, true, array( 'url' => $url ) );
 				if ( 0 == $process->return_code ) {
 					// See if we can parse the stdout
 					if ( preg_match( '#Success: (.+)#', $process->stdout, $matches ) ) {
-						$message = "{$matches[1]} on {$url}";
+						$message = rtrim( $matches[1], '.' );
+						$message = "{$message} on {$url}";
 					} else {
 						$message = "Database upgraded successfully on {$url}";
 					}
@@ -1420,10 +1421,12 @@ EOT;
 			require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
 			$wp_current_db_version = __get_option( 'db_version' );
 			if ( $wp_db_version != $wp_current_db_version ) {
-				if ( ! $dry_run ) {
+				if ( $dry_run ) {
+					WP_CLI::success( "WordPress database will be upgraded from db version {$wp_current_db_version} to {$wp_db_version}." );
+				} else {
 					wp_upgrade();
+					WP_CLI::success( "WordPress database upgraded successfully from db version {$wp_current_db_version} to {$wp_db_version}." );
 				}
-				WP_CLI::success( "WordPress database upgraded successfully from db version {$wp_current_db_version} to {$wp_db_version}." );
 			} else {
 				WP_CLI::success( "WordPress database already at latest db version {$wp_db_version}." );
 			}


### PR DESCRIPTION
Updates messaging to ensure the message reflects whether or not
`--dry-run` has been provided.

Fixes #3345