### PR TITLE
Correct reference of WP_CLI to use global namespace

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -713,7 +713,7 @@ function get_temp_dir() {
 	}
 
 	if ( ! @is_writable( $temp ) ) {
-		WP_CLI::warning( "Temp directory isn't writable: {$temp}" );
+		\WP_CLI::warning( "Temp directory isn't writable: {$temp}" );
 	}
 
 	return $trailingslashit( $temp );


### PR DESCRIPTION
This line causes a fatal as it tries to resolve the class as `WP_CLI\Utils\WP_CLI`.