### PR TITLE
Add a testcase that `wp plugin install` fails with invalid proxy deets

### DIFF
--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -19,3 +19,26 @@ Feature: Install WordPress plugins
     And STDERR should be empty
     And the wp-content/plugins/one-time-login directory should exist
     And the wp-content/plugins/one-time-login-master directory should not exist
+
+  Scenario: Installing respects WP_PROXY_HOST and WP_PROXY_PORT
+    Given a WP install
+    And a invalid-proxy-details.php file:
+      """
+      <?php
+      define( 'WP_PROXY_HOST', 'https://wp-cli.org' );
+      define( 'WP_PROXY_PORT', '443' );
+      """
+
+    When I try `wp --require=invalid-proxy-details.php plugin install edit-flow`
+    Then STDERR should contain:
+      """
+      Warning: edit-flow: An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration.
+      """
+    And STDOUT should be empty
+
+    When I run `wp plugin install edit-flow`
+    Then STDOUT should contain:
+      """
+      Plugin installed successfully.
+      """
+    And STDERR should be empty


### PR DESCRIPTION
See #3361