### PR TITLE
Fix strict standard error about variable reference

### DIFF
--- a/php/WP_CLI/CommandWithTranslation.php
+++ b/php/WP_CLI/CommandWithTranslation.php
@@ -192,7 +192,8 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 		// Formats the updates list.
 		foreach ( $updates as $update ) {
 			if ( 'plugin' == $update->type ) {
-				$plugin_data = array_shift( get_plugins( '/' . $update->slug ) );
+				$plugins	 = get_plugins( '/' . $update->slug );
+				$plugin_data = array_shift( $plugins );
 				$name		 = $plugin_data['Name'];
 			} elseif ( 'theme' == $update->type ) {
 				$theme_data	 = wp_get_theme( $update->slug );


### PR DESCRIPTION
When ran the command `wp core language update` I got the following error :

```
PHP Strict standards:  Only variables should be passed by reference in .../wp-cli/wp-cli/php/WP_CLI/CommandWithTranslation.php on line 169
PHP Stack trace:
PHP   1. {main}() .../wp-cli/wp-cli/php/boot-fs.php:0
PHP   2. include() .../wp-cli/wp-cli/php/boot-fs.php:17
PHP   3. WP_CLI\Runner->start() .../wp-cli/wp-cli/php/wp-cli.php:21
PHP   4. WP_CLI\Runner->_run_command() .../wp-cli/wp-cli/php/WP_CLI/Runner.php:906
PHP   5. WP_CLI\Runner->run_command() .../wp-cli/wp-cli/php/WP_CLI/Runner.php:319
PHP   6. WP_CLI\Dispatcher\Subcommand->invoke() .../wp-cli/wp-cli/php/WP_CLI/Runner.php:312
PHP   7. call_user_func:{.../wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:372}() .../wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:372
PHP   8. WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}() .../wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:372
PHP   9. call_user_func:{.../wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:67}() .../wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:67
PHP  10. WP_CLI\CommandWithTranslation->update() .../wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:67
```

It's about the `array_shift` call on the `get_plugins` function result directly.
This commit fix that by introducing a transition variable.