### PR TITLE
Permit running test suite with `WP_VERSION` env variable

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -77,7 +77,8 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		if ( is_readable( self::$cache_dir . '/wp-config-sample.php' ) )
 			return;
 
-		$cmd = Utils\esc_cmd( 'wp core download --force --path=%s', self::$cache_dir );
+		$version = getenv( 'WP_VERSION' ) ? '--version=' . getenv( 'WP_VERSION' ) : '';
+		$cmd = Utils\esc_cmd( 'wp core download --force --path=%s %s', self::$cache_dir, $version );
 		Process::create( $cmd, null, self::get_process_env_variables() )->run_check();
 	}
 


### PR DESCRIPTION
Normally, WP-CLI pays attention to `WP_VERSION` as a part of the setup
process. This makes it easier for developers running the test suite
locally to use `WP_VERSION` too:

```
WP_VERSION=trunk behat features/skip-themes.feature
```

See #3382