### PR TITLE
If `add_filter()` is already available, use it in `WP_CLI::add_hook()`

### DIFF
--- a/features/skip-themes.feature
+++ b/features/skip-themes.feature
@@ -10,6 +10,7 @@ Feature: Skipping themes
       """
       true
       """
+    And STDERR should be empty
 
     # The specified theme should be skipped
     When I run `wp --skip-themes=default eval 'var_export( function_exists( "kubrick_head" ) );'`
@@ -17,6 +18,7 @@ Feature: Skipping themes
       """
       false
       """
+    And STDERR should be empty
     
     # All themes should be skipped
     When I run `wp --skip-themes eval 'var_export( function_exists( "kubrick_head" ) );'`
@@ -24,6 +26,7 @@ Feature: Skipping themes
       """
       false
       """
+    And STDERR should be empty
     
     # Skip another theme
     When I run `wp --skip-themes=classic eval 'var_export( function_exists( "kubrick_head" ) );'`
@@ -31,6 +34,7 @@ Feature: Skipping themes
       """
       true
       """
+    And STDERR should be empty
     
     # The specified theme should still show up as an active theme
     When I run `wp --skip-themes theme status default`
@@ -38,6 +42,7 @@ Feature: Skipping themes
       """
       Active
       """
+    And STDERR should be empty
 
     # Skip several themes
     When I run `wp --skip-themes=classic,default eval 'var_export( function_exists( "kubrick_head" ) );'`
@@ -45,6 +50,7 @@ Feature: Skipping themes
       """
       false
       """
+    And STDERR should be empty
 
   Scenario: Skip parent and child themes
     Given a WP install
@@ -56,12 +62,14 @@ Feature: Skipping themes
       """
       true
       """
+    And STDERR should be empty
 
     When I run `wp --skip-themes=jolene eval 'var_export( function_exists( "jolene_setup" ) );'`
     Then STDOUT should be:
       """
       false
       """
+    And STDERR should be empty
 
     When I run `wp theme activate biker`
     When I run `wp eval 'var_export( function_exists( "jolene_setup" ) );'`
@@ -69,36 +77,42 @@ Feature: Skipping themes
       """
       true
       """
+    And STDERR should be empty
 
     When I run `wp eval 'var_export( function_exists( "biker_setup" ) );'`
     Then STDOUT should be:
       """
       true
       """
+    And STDERR should be empty
 
     When I run `wp --skip-themes=biker eval 'var_export( function_exists( "jolene_setup" ) );'`
     Then STDOUT should be:
       """
       false
       """
+    And STDERR should be empty
 
     When I run `wp --skip-themes=biker eval 'var_export( function_exists( "biker_setup" ) );'`
     Then STDOUT should be:
       """
       false
       """
+    And STDERR should be empty
 
     When I run `wp --skip-themes=biker eval 'echo get_template_directory();'`
     Then STDOUT should contain:
       """
       wp-content/themes/jolene
       """
+    And STDERR should be empty
 
     When I run `wp --skip-themes=biker eval 'echo get_stylesheet_directory();'`
     Then STDOUT should contain:
       """
       wp-content/themes/biker
       """
+    And STDERR should be empty
 
   Scenario: Skipping multiple themes via config file
     Given a WP install
@@ -117,6 +131,7 @@ Feature: Skipping themes
       """
       A classic
       """
+    And STDERR should be empty
 
     # The default theme should show up as an installed theme
     When I run `wp theme status`
@@ -124,6 +139,7 @@ Feature: Skipping themes
       """
       I default
       """
+    And STDERR should be empty
     
     And I run `wp theme activate default`
 
@@ -133,3 +149,4 @@ Feature: Skipping themes
       """
       false
       """
+    And STDERR should be empty

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -274,9 +274,15 @@ class WP_CLI {
 	 */
 	public static function add_wp_hook( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
 		global $wp_filter, $merged_filters;
-		$idx = self::wp_hook_build_unique_id( $tag, $function_to_add, $priority );
-		$wp_filter[$tag][$priority][$idx] = array('function' => $function_to_add, 'accepted_args' => $accepted_args);
-		unset( $merged_filters[ $tag ] );
+
+		if ( function_exists( 'add_filter' ) ) {
+			add_filter( $tag, $function_to_add, $priority, $accepted_args );
+		} else {
+			$idx = self::wp_hook_build_unique_id( $tag, $function_to_add, $priority );
+			$wp_filter[$tag][$priority][$idx] = array('function' => $function_to_add, 'accepted_args' => $accepted_args);
+			unset( $merged_filters[ $tag ] );
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
This gracefully lets WP-CLI use the tentative `WP_Hook` implementation
in WP 4.7. Even if `WP_Hook` gets pulled, it's better to use
`add_filter()` if it's available.

Fixes #3382