### PR TITLE
Fix Exception in test suite when no `WP_VERSION` is provided

### DIFF
--- a/ci/prepare.sh
+++ b/ci/prepare.sh
@@ -30,9 +30,5 @@ echo $CLI_VERSION > PHAR_BUILD_VERSION
 # Install CodeSniffer things
 ./ci/prepare-codesniffer.sh
 
-./bin/wp core download --version=$WP_VERSION --path='/tmp/wp-cli-test core-download-cache/'
-
-./bin/wp core version --path='/tmp/wp-cli-test core-download-cache/'
-
 mysql -e 'CREATE DATABASE wp_cli_test;' -uroot
 mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -77,8 +77,10 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		if ( is_readable( self::$cache_dir . '/wp-config-sample.php' ) )
 			return;
 
-		$version = getenv( 'WP_VERSION' ) ? '--version=' . getenv( 'WP_VERSION' ) : '';
-		$cmd = Utils\esc_cmd( 'wp core download --force --path=%s %s', self::$cache_dir, $version );
+		$cmd = Utils\esc_cmd( 'wp core download --force --path=%s', self::$cache_dir );
+		if ( getenv( 'WP_VERSION' ) ) {
+			$cmd .= Utils\esc_cmd( ' --version=%s', getenv( 'WP_VERSION' ) );
+		}
 		Process::create( $cmd, null, self::get_process_env_variables() )->run_check();
 	}
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -91,6 +91,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		echo $result->stdout;
 		echo PHP_EOL;
 		self::cache_wp_files();
+		$result = Process::create( Utils\esc_cmd( 'wp core version --path=%s', self::$cache_dir ) , null, self::get_process_env_variables() )->run_check();
+		echo 'WordPress ' . $result->stdout;
+		echo PHP_EOL;
 	}
 
 	/**


### PR DESCRIPTION
Regression from #3383

Before merging, verify the appropriate WP version is being used in each test run.