### PR TITLE
Allow WP_CLI hooks to pass arguments to callbacks

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -248,11 +248,15 @@ class WP_CLI {
 	public static function do_hook( $when ) {
 		self::$hooks_passed[] = $when;
 
-		if ( !isset( self::$hooks[ $when ] ) )
+		if ( !isset( self::$hooks[ $when ] ) ) {
 			return;
+		}
+
+		self::debug( $when, 'do_hook' );
 
 		foreach ( self::$hooks[ $when ] as $callback ) {
-			call_user_func( $callback );
+			$args = func_num_args() > 1 ? array_slice( func_get_args(), 1 ) : array();
+			call_user_func_array( $callback, $args );
 		}
 	}
 


### PR DESCRIPTION
This is a fairly small change to make which allows any number of arguments to be passed to a WP_CLI hook.

Eg:
```php
WP_CLI::do_hook('some_hook', $a, $b, $c, ...);
```
And in the callback
```php
function callback($a, $b, $c) { ... }
```

Pretty small change needed to make this happen.  

I also added a line to the debug log for each hook.

![image](https://cloud.githubusercontent.com/assets/1621608/18420031/3ee39982-787a-11e6-954b-1a584baaa3f3.png)

I'm happy to add a few tests for this as well, but I thought I'd get some feedback first.

This change is relevant to #3354.
