### PR TITLE
Update editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 4
 
-[*.json,*.yml,*.feature]
+[*.{json,yml,feature}]
 indent_style = space
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,6 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
+[composer.json]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This is an equivalent update for the changes proposed in wp-cli/scaffold-package-command#44

One important difference is that the existing editorconfig for 2 space rules was not working as matching multiple strings need to be wrapped in curly braces.  See the docs on [wildcards](http://editorconfig.org/#wildcards).