### PR TITLE
Add a simple progress indicator to `wp media regenerate`

### DIFF
--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -134,11 +134,11 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      No thumbnail regeneration needed for "My second imported attachment"
+      1/2 No thumbnail regeneration needed for "My second imported attachment"
       """
     And STDOUT should contain:
       """
-      Regenerated thumbnails for "My imported attachment"
+      2/2 Regenerated thumbnails for "My imported attachment"
       """
     And STDOUT should contain:
       """
@@ -170,7 +170,7 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      Regenerated thumbnails for "My imported attachment"
+      1/1 Regenerated thumbnails for "My imported attachment"
       """
     And STDOUT should contain:
       """
@@ -185,7 +185,7 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      No thumbnail regeneration needed for "My imported attachment"
+      1/1 No thumbnail regeneration needed for "My imported attachment"
       """
     And STDOUT should contain:
       """

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -90,8 +90,8 @@ class Media_Command extends WP_CLI_Command {
 			_n( 'image', 'images', $count ) ) );
 
 		$errored = false;
-		foreach ( $images->posts as $id ) {
-			if ( ! $this->_process_regeneration( $id, $skip_delete, $only_missing ) ) {
+		foreach ( $images->posts as $number => $id ) {
+			if ( ! $this->_process_regeneration( $id, $skip_delete, $only_missing, ( $number + 1 ) . '/' . $count ) ) {
 				$errored = true;
 			}
 		}
@@ -275,7 +275,7 @@ class Media_Command extends WP_CLI_Command {
 		return $filename;
 	}
 
-	private function _process_regeneration( $id, $skip_delete = false, $only_missing = false ) {
+	private function _process_regeneration( $id, $skip_delete = false, $only_missing = false, $progress = '' ) {
 
 		$fullsizepath = get_attached_file( $id );
 
@@ -299,16 +299,16 @@ class Media_Command extends WP_CLI_Command {
 			}
 
 			if ( empty( $metadata ) ) {
-				WP_CLI::warning( "Couldn't regenerate thumbnails for $att_desc." );
+				WP_CLI::warning( "$progress Couldn't regenerate thumbnails for $att_desc." );
 				return false;
 			}
 
 			wp_update_attachment_metadata( $id, $metadata );
 
-			WP_CLI::log( "Regenerated thumbnails for $att_desc." );
+			WP_CLI::log( "$progress Regenerated thumbnails for $att_desc." );
 			return true;
 		} else {
-			WP_CLI::log( "No thumbnail regeneration needed for $att_desc." );
+			WP_CLI::log( "$progress No thumbnail regeneration needed for $att_desc." );
 			return true;
 		}
 	}

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -275,7 +275,7 @@ class Media_Command extends WP_CLI_Command {
 		return $filename;
 	}
 
-	private function _process_regeneration( $id, $skip_delete = false, $only_missing = false, $progress = '' ) {
+	private function _process_regeneration( $id, $skip_delete = false, $only_missing = false, $progress ) {
 
 		$fullsizepath = get_attached_file( $id );
 


### PR DESCRIPTION
Adds a `$current/$count` prefix to `wp media regenerate`'s progress logs.