### PR TITLE
Use `get_blog_details()` for the site URL when creating a new site

### DIFF
--- a/features/site.feature
+++ b/features/site.feature
@@ -59,7 +59,7 @@ Feature: Manage sites in a multisite installation
     When I run `wp site delete {SITE_ID} --yes`
     Then STDOUT should be:
       """
-      Success: The site at 'http://example.com/first' was deleted.
+      Success: The site at 'http://example.com/first/' was deleted.
       """
 
     When I try the previous command again
@@ -90,13 +90,13 @@ Feature: Manage sites in a multisite installation
     When I run `wp site create --slug=first`
     Then STDOUT should be:
       """
-      Success: Site 2 created: http://example.com/first
+      Success: Site 2 created: http://example.com/first/
       """
 
     When I run `wp site delete --slug=first --yes`
     Then STDOUT should be:
       """
-      Success: The site at 'http://example.com/first' was deleted.
+      Success: The site at 'http://example.com/first/' was deleted.
       """
 
     When I try the previous command again

--- a/features/site.feature
+++ b/features/site.feature
@@ -90,7 +90,7 @@ Feature: Manage sites in a multisite installation
     When I run `wp site create --slug=first`
     Then STDOUT should be:
       """
-      Success: Site 2 created: example.com/first/
+      Success: Site 2 created: http://example.com/first/
       """
 
     When I run `wp site delete --slug=first --yes`

--- a/features/site.feature
+++ b/features/site.feature
@@ -90,7 +90,7 @@ Feature: Manage sites in a multisite installation
     When I run `wp site create --slug=first`
     Then STDOUT should be:
       """
-      Success: Site 2 created: http://example.com/first/
+      Success: Site 2 created: http://example.com/first
       """
 
     When I run `wp site delete --slug=first --yes`

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -389,7 +389,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
 			WP_CLI::line( $id );
 		} else {
-			$blog = get_blog_details( $blog_id );
+			$blog = get_blog_details( $id );
 			WP_CLI::success( "Site $id created: $blog->siteurl" );
 		}
 	}

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -290,7 +290,7 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 	 * ## EXAMPLES
 	 *
 	 *     $ wp site create --slug=example
-	 *     Success: Site 3 created: www.example.com/example/
+	 *     Success: Site 3 created: http://www.example.com/example/
 	 */
 	public function create( $_, $assoc_args ) {
 		if ( !is_multisite() ) {
@@ -386,10 +386,12 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 			WP_CLI::error( $id->get_error_message() );
 		}
 
-		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) )
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
 			WP_CLI::line( $id );
-		else
-			WP_CLI::success( "Site $id created: $url" );
+		} else {
+			$blog = get_blog_details( $blog_id );
+			WP_CLI::success( "Site $id created: $blog->siteurl" );
+		}
 	}
 
 	/**

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -257,11 +257,13 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 			WP_CLI::error( "Site not found." );
 		}
 
-		WP_CLI::confirm( "Are you sure you want to delete the '$blog->siteurl' site?", $assoc_args );
+		$site_url = trailingslashit( $blog->siteurl );
+
+		WP_CLI::confirm( "Are you sure you want to delete the '$site_url' site?", $assoc_args );
 
 		wpmu_delete_blog( $blog->blog_id, ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'keep-tables' ) );
 
-		WP_CLI::success( "The site at '$blog->siteurl' was deleted." );
+		WP_CLI::success( "The site at '$site_url' was deleted." );
 	}
 
 	/**
@@ -389,8 +391,8 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
 			WP_CLI::line( $id );
 		} else {
-			$blog = get_blog_details( $id );
-			WP_CLI::success( "Site $id created: $blog->siteurl" );
+			$site_url = trailingslashit( get_site_url( $id ) );
+			WP_CLI::success( "Site $id created: $site_url" );
 		}
 	}
 


### PR DESCRIPTION
This ensures that the correct site URL is returned when the `wpmu_new_blog` action is used to change site details.

Fixes #3415.