### PR TITLE
Change installing message in composer dependency

### DIFF
--- a/php/WP_CLI/PackageManagerEventSubscriber.php
+++ b/php/WP_CLI/PackageManagerEventSubscriber.php
@@ -23,7 +23,8 @@ class PackageManagerEventSubscriber implements EventSubscriberInterface {
 	}
 
 	public static function pre_install( PackageEvent $event ) {
-		WP_CLI::log( ' - Installing package' );
+		$operation_message = $event->getOperation()->__toString();
+		WP_CLI::log( ' - ' . $operation_message );
 	}
 
 	public static function post_install( PackageEvent $event ) {


### PR DESCRIPTION
Sample output:

```
Installing package markri/wp-sec (dev-master)
Updating /home/nilambar/.wp-cli/packages/composer.json to require the package...
Using Composer to install the package...
---
Loading composer repositories with package information
Updating dependencies
Resolving dependencies through SAT
Dependency resolution completed in 0.002 seconds
Analyzed 474 packages to resolve dependencies
Analyzed 233 rules to resolve dependencies
 - Installing guzzlehttp/promises (1.2.0)
 - Warning: guzzlehttp/guzzle 6.2.x-dev requires guzzlehttp/promises ^1.0 -> satisfiable by guzzlehttp/promises[1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.1.0, 1.2.0, 1.0.x-dev].
 - Installing psr/http-message (dev-master f6561bf)
 - Installing guzzlehttp/psr7 (dev-master 64862e8)
 - Installing guzzlehttp/guzzle (dev-master a0d7517)
 - Installing markri/wp-sec (dev-master adae718)
Writing lock file
Generating autoload files
---
Success: Package installed successfully.
```

Fixes #3417 