### PR TITLE
Drop erroneous `@github-api` label on this scenario

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -121,7 +121,7 @@ Feature: `wp cli` tasks
     When I run `wp cli param-dump --with-values | grep -o '"current":' | uniq -c`
     Then STDOUT should be:
       """
-           15 "current":
+           17 "current":
       """
     And STDERR should be empty
     And the return code should be 0

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -115,7 +115,6 @@ Feature: `wp cli` tasks
     And STDERR should be empty
     And the return code should be 0
 
-  @github-api
   Scenario: Dump the list of global parameters with values
     Given a WP install
 


### PR DESCRIPTION
From 9e480000ad068cd1c64f3927adabeb3687ed6209