### PR TITLE
Use `--stable` to install or reinstall the latest stable version

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -115,7 +115,7 @@ Feature: `wp cli` tasks
     And STDERR should be empty
     And the return code should be 0
 
-  @github-api
+  @github-api @less-than-php-7
   Scenario: Install WP-CLI stable
     Given an empty directory
     And a new Phar with version "0.14.0"

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -115,6 +115,43 @@ Feature: `wp cli` tasks
     And STDERR should be empty
     And the return code should be 0
 
+  @github-api
+  Scenario: Install WP-CLI stable
+    Given an empty directory
+    And a new Phar with version "0.14.0"
+    And a session file:
+      """
+      y
+      """
+
+    When I run `{PHAR_PATH} cli check-update --minor --field=version`
+    Then STDOUT should not be empty
+    And save STDOUT as {UPDATE_VERSION}
+
+    When I run `{PHAR_PATH} cli update --stable < session`
+    Then STDOUT should contain:
+      """
+      You have version 0.14.0. Would you like to update to the latest stable release? [y/n]
+      """
+    And STDOUT should contain:
+      """
+      Success: Updated WP-CLI to the latest stable release.
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    When I run `{PHAR_PATH} cli check-update`
+    Then STDOUT should be:
+      """
+      Success: WP-CLI is at the latest version.
+      """
+
+    When I run `{PHAR_PATH} cli version`
+    Then STDOUT should be:
+      """
+      WP-CLI {UPDATE_VERSION}
+      """
+
   Scenario: Dump the list of global parameters with values
     Given a WP install
 

--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -182,7 +182,19 @@ class CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Fetch most recent update matching the requirements. Returns the available versions if there are updates, or empty if no update available.
+	 * Update WP-CLI.
+	 *
+	 * Default behavior is to check the releases API for a newer version, and
+	 * prompt if one is available.
+	 *
+	 * Use `--stable` to install or reinstall the latest stable version.
+	 *
+	 * Use `--nightly` to install the latest built version of the master branch.
+	 * While not recommended for production, nightly contains the latest and
+	 * greatest, and should be stable enough for development and staging
+	 * environments.
+	 *
+	 * Only works for the Phar installation mechanism.
 	 *
 	 * ## OPTIONS
 	 *
@@ -194,6 +206,9 @@ class CLI_Command extends WP_CLI_Command {
 	 *
 	 * [--major]
 	 * : Only perform major updates.
+	 *
+	 * [--stable]
+	 * : Update to the latest stable release. Skips update check.
 	 *
 	 * [--nightly]
 	 * : Update to the latest built version of the master branch. Potentially unstable.
@@ -223,12 +238,12 @@ class CLI_Command extends WP_CLI_Command {
 			WP_CLI::error( sprintf( "%s is not writable by current user.", dirname( $old_phar ) ) );
 		}
 
-		if ( isset( $assoc_args['nightly'] ) ) {
-
+		if ( Utils\get_flag_value( $assoc_args, 'nightly' ) ) {
 			WP_CLI::confirm( sprintf( 'You have version %s. Would you like to update to the latest nightly?', WP_CLI_VERSION ), $assoc_args );
-
 			$download_url = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar';
-
+		} else if ( Utils\get_flag_value( $assoc_args, 'stable' ) ) {
+			WP_CLI::confirm( sprintf( 'You have version %s. Would you like to update to the latest stable release?', WP_CLI_VERSION ), $assoc_args );
+			$download_url = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar';
 		} else {
 
 			$updates = $this->get_updates( $assoc_args );
@@ -283,8 +298,10 @@ class CLI_Command extends WP_CLI_Command {
 			WP_CLI::error( sprintf( "Cannot move %s to %s", $temp, $old_phar ) );
 		}
 
-		if ( isset( $assoc_args['nightly'] ) ) {
+		if ( Utils\get_flag_value( $assoc_args, 'nightly' ) ) {
 			$updated_version = 'the latest nightly release';
+		} else if ( Utils\get_flag_value( $assoc_args, 'stable' ) ) {
+			$updated_version = 'the latest stable release';
 		} else {
 			$updated_version = $newest['version'];
 		}


### PR DESCRIPTION
Skips the update check, so this both lets you roll back from `--nightly`
or reinstall an existing stable copy.

Updates docs too, which were completely incorrect.

Fixes #2942, #3260