### PR TITLE
Handle `dead_db()` error on `nocache_headers` filter

### DIFF
--- a/features/framework.feature
+++ b/features/framework.feature
@@ -178,3 +178,28 @@ Feature: Load WP-CLI
       """
       http://example.com
       """
+
+  Scenario: Handle error when WordPress cannot connect to the database host
+    Given a WP install
+    And a wp-debug.php file:
+      """
+      <?php
+      define( 'WP_DEBUG', true );
+      """
+    And a invalid-host.php file:
+      """
+      <?php
+      define( 'DB_HOST', 'localghost' );
+      """
+
+    When I try `wp --require=invalid-host.php option get home`
+    Then STDERR should contain:
+      """
+      Error: Error establishing a database connection
+      """
+
+    When I try `wp --require=invalid-host.php --require=wp-debug.php option get home`
+    Then STDERR should contain:
+      """
+      Error: Error establishing a database connection
+      """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1053,6 +1053,12 @@ class Runner {
 		WP_CLI::add_wp_hook( 'wp_redirect', 'WP_CLI\\Utils\\wp_redirect_handler' );
 
 		WP_CLI::add_wp_hook( 'nocache_headers', function( $headers ){
+			// WordPress might be calling nocache_headers() because of a dead db
+			global $wpdb;
+			if ( ! empty( $wpdb->error ) ) {
+				Utils\wp_die_handler( $wpdb->error );
+			}
+			// Otherwise, WP might be calling nocache_headers() because WP isn't installed
 			Utils\wp_not_installed();
 			return $headers;
 		});
@@ -1092,14 +1098,6 @@ class Runner {
 		// Use our own debug mode handling instead of WP core
 		WP_CLI::add_wp_hook( 'enable_wp_debug_mode_checks', function( $ret ) {
 			Utils\wp_debug_mode();
-
-			// Check to see of wpdb is errored, instead of waiting for dead_db()
-			require_wp_db();
-			global $wpdb;
-			if ( ! empty( $wpdb->error ) ) {
-				Utils\wp_die_handler( $wpdb->error );
-			}
-
 			return false;
 		});
 

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -54,6 +54,7 @@ function wp_die_handler( $message ) {
 		$message = $message->get_error_message();
 	}
 
+	$message = trim( $message );
 	if ( preg_match( '|^\<h1>(.+?)</h1>|', $message, $matches ) ) {
 		$message = $matches[1];
 	}


### PR DESCRIPTION
WordPress conveniently calls `nocache_headers()` inside of `dead_db()`,
which means we can swoop in and display the database error ourselves.

`enable_wp_debug_mode_checks` is too early, because `wp_die()` isn't yet
defined for `$wpdb` to call.

Fixes #3433