### PR TITLE
Add testcase to assert `wp db query` runs before WP loads

### DIFF
--- a/features/db-query.feature
+++ b/features/db-query.feature
@@ -1,0 +1,23 @@
+Feature: Query the database with WordPress' MySQL config
+
+  Scenario: Database querying shouldn't load any plugins
+    Given a WP install
+    And a wp-content/mu-plugins/error.php file:
+      """
+      <?php
+      WP_CLI::error( "Plugin loaded." );
+      """
+
+    When I try `wp option get home`
+    Then STDERR should be:
+      """
+      Error: Plugin loaded.
+      """
+
+    When I run `wp db query "SELECT COUNT(ID) FROM wp_posts;"`
+    Then STDOUT should be:
+      """
+      COUNT(ID)
+      2
+      """
+    And STDERR should be empty


### PR DESCRIPTION
See #3435