### PR TITLE
Revert "Proxy Github API requests through `https://github-api.wp-cli.org`"

### DIFF
--- a/ci/behat-tags.php
+++ b/ci/behat-tags.php
@@ -37,6 +37,9 @@ $skip_tags = array_merge(
 	version_tags( 'less-than-php', PHP_VERSION, '>' )
 );
 
+# Skip Github API tests by default because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612
+$skip_tags[] = '@github-api';
+
 if ( !empty( $skip_tags ) ) {
 	echo '--tags=~' . implode( '&&~', $skip_tags );
 }

--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -312,7 +312,7 @@ class CLI_Command extends WP_CLI_Command {
 	 * Returns update information.
 	 */
 	private function get_updates( $assoc_args ) {
-		$url = 'https://github-api.wp-cli.org/repos/wp-cli/wp-cli/releases';
+		$url = 'https://api.github.com/repos/wp-cli/wp-cli/releases';
 
 		$options = array(
 			'timeout' => 30
@@ -321,7 +321,7 @@ class CLI_Command extends WP_CLI_Command {
 		$headers = array(
 			'Accept' => 'application/json'
 		);
-		$response = Utils\http_request( 'GET', $url, array(), $headers, $options );
+		$response = Utils\http_request( 'GET', $url, $headers, $options );
 
 		if ( ! $response->success || 200 !== $response->status_code ) {
 			WP_CLI::error( sprintf( "Failed to get latest version (HTTP code %d).", $response->status_code ) );


### PR DESCRIPTION
Reverts wp-cli/wp-cli#3428

Proxy is intermittently returning 403 and failing builds, and I don't know why.

See #3426