### PR TITLE
Don't persist `url:` in `wp-cli.yml` when alias is used

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -244,3 +244,34 @@ Feature: Create shortcuts to specific WordPress installs
       """
       Error: Cannot use '@all' when no aliases are registered.
       """
+
+  Scenario: Alias for a subsite of a multisite install
+    Given a WP multisite subdomain install
+    And a wp-cli.yml file:
+      """
+      url: example.com
+      @subsite:
+        url: subsite.example.com
+      """
+
+    When I run `wp site create --slug=subsite`
+    Then STDOUT should not be empty
+
+    When I run `wp option get siteurl`
+    Then STDOUT should be:
+      """
+      http://example.com
+      """
+
+    When I run `wp @subsite option get siteurl`
+    Then STDOUT should be:
+      """
+      http://subsite.example.com
+      """
+
+    When I try `wp @subsite option get siteurl --url=subsite.example.com`
+    Then STDERR should be:
+      """
+      Error: Parameter errors:
+       unknown --url parameter
+      """

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -213,10 +213,10 @@ class Configurator {
 	 *
 	 * @param string $path Path to YAML file.
 	 */
-	public function merge_yml( $path ) {
+	public function merge_yml( $path, $current_alias = null ) {
 		$yaml = self::load_yml( $path );
 		if ( ! empty( $yaml['_']['inherit'] ) ) {
-			$this->merge_yml( $yaml['_']['inherit'] );
+			$this->merge_yml( $yaml['_']['inherit'], $current_alias );
 		}
 		foreach ( $yaml as $key => $value ) {
 			if ( preg_match( '#' . self::ALIAS_REGEX . '#', $key ) ) {
@@ -251,6 +251,9 @@ class Configurator {
 				self::arrayify( $value );
 				$this->config[ $key ] = array_merge( $this->config[ $key ], $value );
 			} else {
+				if ( $current_alias && in_array( $key, self::$alias_spec, true ) ) {
+					continue;
+				}
 				$this->config[ $key ] = $value;
 			}
 		}

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -632,10 +632,10 @@ class Runner {
 			$this->global_config_path = $this->get_global_config_path();
 			$this->project_config_path = $this->get_project_config_path();
 
-			$configurator->merge_yml( $this->global_config_path );
+			$configurator->merge_yml( $this->global_config_path, $this->alias );
 			$config = $configurator->to_array();
 			$this->_required_files['global'] = $config[0]['require'];
-			$configurator->merge_yml( $this->project_config_path );
+			$configurator->merge_yml( $this->project_config_path, $this->alias );
 			$config = $configurator->to_array();
 			$this->_required_files['project'] = $config[0]['require'];
 		}


### PR DESCRIPTION
When an alias is used, it should completely override user, url, path, ssh, and http.

Fixes #3444