### PR TITLE
Warn when `WP_CLI::launch()` ends up with `return_code=-1`

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -783,6 +783,10 @@ class WP_CLI {
 		$proc = Process::create( $command );
 		$results = $proc->run();
 
+		if ( -1 == $results->return_code ) {
+			 self::warning( "Spawned process returned exit code {$results->return_code}, which could be caused by a custom compiled version of PHP that uses the --enable-sigchild option." );
+		}
+
 		if ( $results->return_code && $exit_on_error )
 			exit( $results->return_code );
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -784,7 +784,7 @@ class WP_CLI {
 		$results = $proc->run();
 
 		if ( -1 == $results->return_code ) {
-			 self::warning( "Spawned process returned exit code {$results->return_code}, which could be caused by a custom compiled version of PHP that uses the --enable-sigchild option." );
+			self::warning( "Spawned process returned exit code {$results->return_code}, which could be caused by a custom compiled version of PHP that uses the --enable-sigchild option." );
 		}
 
 		if ( $results->return_code && $exit_on_error )


### PR DESCRIPTION
Fixes #3412