### PR TITLE
Provide more verbosity in `wp_die()` handler

### DIFF
--- a/features/db.feature
+++ b/features/db.feature
@@ -9,7 +9,7 @@ Feature: Perform database operations
     Then STDOUT should be empty
     And STDERR should be:
       """
-      Error: Can’t select database
+      Error: Can’t select database. We were able to connect to the database server (which means your username and password is okay) but not able to select the `wp_cli_test` database.
       """
 
     When I run `wp db create`

--- a/features/framework.feature
+++ b/features/framework.feature
@@ -195,11 +195,11 @@ Feature: Load WP-CLI
     When I try `wp --require=invalid-host.php option get home`
     Then STDERR should contain:
       """
-      Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can’t contact the database server at `localghost`. This could mean your host’s database server is down.
+      Error: Error establishing a database connection.
       """
 
     When I try `wp --require=invalid-host.php --require=wp-debug.php option get home`
     Then STDERR should contain:
       """
-      Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can’t contact the database server at `localghost`. This could mean your host’s database server is down.
+      Error: Error establishing a database connection.
       """

--- a/features/framework.feature
+++ b/features/framework.feature
@@ -195,11 +195,11 @@ Feature: Load WP-CLI
     When I try `wp --require=invalid-host.php option get home`
     Then STDERR should contain:
       """
-      Error: Error establishing a database connection
+      Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can’t contact the database server at `localghost`. This could mean your host’s database server is down.
       """
 
     When I try `wp --require=invalid-host.php --require=wp-debug.php option get home`
     Then STDERR should contain:
       """
-      Error: Error establishing a database connection
+      Error: Error establishing a database connection. This either means that the username and password information in your `wp-config.php` file is incorrect or we can’t contact the database server at `localghost`. This could mean your host’s database server is down.
       """

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -54,11 +54,20 @@ function wp_die_handler( $message ) {
 		$message = $message->get_error_message();
 	}
 
-	$message = trim( $message );
-	if ( preg_match( '|^\<h1>(.+?)</h1>|', $message, $matches ) ) {
-		$message = $matches[1];
+	$original_message = $message = trim( $message );
+	if ( preg_match( '|^\<h1>(.+?)</h1>|', $original_message, $matches ) ) {
+		$message = $matches[1] . '.';
+	}
+	if ( preg_match( '|\<p>(.+?)</p>|', $original_message, $matches ) ) {
+		$message .= ' ' . $matches[1];
 	}
 
+	$search_replace = array(
+		'<code>'    => '`',
+		'</code>'   => '`',
+	);
+	$message = str_replace( array_keys( $search_replace ), array_values( $search_replace ), $message );
+	$message = strip_tags( $message );
 	$message = html_entity_decode( $message, ENT_COMPAT, 'UTF-8' );
 
 	\WP_CLI::error( $message );


### PR DESCRIPTION
This gives the end user more detail when a database connection fails,
instead of a cryptic message.

Fixes #3188