### PR TITLE
Ensure `wp core download --version=latest` produces versioned cache key

### DIFF
--- a/features/core-download.feature
+++ b/features/core-download.feature
@@ -210,3 +210,18 @@ Feature: Download WordPress
       md5 hash verified: 90c93a15092b2d5d4c960ec1fc183e07
       Success: WordPress downloaded.
       """
+
+  Scenario: Using --version=latest should produce a cache key of the version number, not 'latest'
+    Given an empty directory
+    And an empty cache
+
+    When I run `wp core download --version=latest`
+    Then STDOUT should contain:
+      """
+      Success: WordPress downloaded.
+      """
+
+    When I run `wp core version`
+    Then save STDOUT as {VERSION}
+    And the {SUITE_CACHE_DIR}/core/wordpress-latest-en_US.tar.gz file should not exist
+    And the {SUITE_CACHE_DIR}/core/wordpress-{VERSION}-en_US.tar.gz file should exist

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -133,7 +133,7 @@ class Core_Command extends WP_CLI_Command {
 
 		$locale = \WP_CLI\Utils\get_flag_value( $assoc_args, 'locale', 'en_US' );
 
-		if ( isset( $assoc_args['version'] ) ) {
+		if ( isset( $assoc_args['version'] ) && 'latest' !== $assoc_args['version'] ) {
 			$version = $assoc_args['version'];
 			$version = ( in_array( strtolower( $version ), array( 'trunk', 'nightly' ) ) ? 'nightly' : $version );
 			//nightly builds are only available in .zip format


### PR DESCRIPTION
Fixes #3466