### PR TITLE
Support passing arguments to `WP_CLI::do_hook()`

### DIFF
--- a/features/framework.feature
+++ b/features/framework.feature
@@ -203,3 +203,24 @@ Feature: Load WP-CLI
       """
       Error: Error establishing a database connection.
       """
+
+  Scenario: Allow WP_CLI hooks to pass arguments to callbacks
+    Given an empty directory
+    And a my-command.php file:
+      """
+      <?php
+
+      WP_CLI::add_hook( 'foo', function( $bar ){
+        WP_CLI::log( $bar );
+      });
+      WP_CLI::add_command( 'my-command', function( $args ){
+        WP_CLI::do_hook( 'foo', $args[0] );
+      }, array( 'when' => 'before_wp_load' ) );
+      """
+
+    When I run `wp --require=my-command.php my-command bar`
+    Then STDOUT should be:
+      """
+      bar
+      """
+    And STDERR should be empty

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -248,11 +248,17 @@ class WP_CLI {
 	public static function do_hook( $when ) {
 		self::$hooks_passed[] = $when;
 
-		if ( !isset( self::$hooks[ $when ] ) )
+		if ( !isset( self::$hooks[ $when ] ) ) {
 			return;
+		}
 
 		foreach ( self::$hooks[ $when ] as $callback ) {
-			call_user_func( $callback );
+			if ( func_num_args() > 1 ) {
+				$args = array_slice( func_get_args(), 1 );
+				call_user_func_array( $callback, $args );
+			} else {
+				call_user_func( $callback );
+			}
 		}
 	}
 


### PR DESCRIPTION
Originally #3394