### PR TITLE
Log the current alias when executing an alias group

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -224,6 +224,15 @@ Feature: Create shortcuts to specific WordPress installs
     When I run `wp @all option get home`
     Then STDOUT should be:
       """
+      @subdir1
+      http://apple.com
+      @subdir2
+      http://google.com
+      """
+
+    When I run `wp @all option get home --quiet`
+    Then STDOUT should be:
+      """
       http://apple.com
       http://google.com
       """

--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -183,6 +183,15 @@ Feature: Create shortcuts to specific WordPress installs
     When I run `wp @both option get home`
     Then STDOUT should be:
       """
+      @subdir1
+      http://apple.com
+      @subdir2
+      http://google.com
+      """
+
+    When I run `wp @both option get home --quiet`
+    Then STDOUT should be:
+      """
       http://apple.com
       http://google.com
       """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -700,10 +700,9 @@ class Runner {
 		$config_path = escapeshellarg( $config_path );
 
 		foreach( $aliases as $alias ) {
-
+			WP_CLI::log( $alias );
 			$args = implode( ' ', array_map( 'escapeshellarg', $this->arguments ) );
 			$assoc_args = Utils\assoc_args_to_str( $this->assoc_args );
-
 			$full_command = "WP_CLI_CONFIG_PATH={$config_path} {$php_bin} {$script_path} {$alias} {$args} {$assoc_args}";
 			$proc = proc_open( $full_command, array( STDIN, STDOUT, STDERR ), $pipes );
 			proc_close( $proc );


### PR DESCRIPTION
This is helpful information for the end user. If the execution output is
being passed to another system, the log can be disabled with `--quiet`

Fixes #3192