### PR TITLE
Add WordPress Coding Standards to newly-scaffolded plugins

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -306,11 +306,14 @@ Feature: WordPress code scaffolding
       install-wp-tests.sh
       """
     And the {PLUGIN_DIR}/hello-world/phpunit.xml.dist file should exist
+    And the {PLUGIN_DIR}/hello-world/phpcs.ruleset.xml file should exist
     And the {PLUGIN_DIR}/hello-world/circle.yml file should not exist
     And the {PLUGIN_DIR}/hello-world/.gitlab-ci.yml file should not exist
     And the {PLUGIN_DIR}/hello-world/.travis.yml file should contain:
       """
-      script: phpunit
+      script:
+        - phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')
+        - phpunit
       """
 
     When I run `wp eval "if ( is_executable( '{PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh' ) ) { echo 'executable'; } else { exit( 1 ); }"`

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -642,6 +642,7 @@ class Scaffold_Command extends WP_CLI_Command {
 		$to_copy = array(
 			'install-wp-tests.sh' => $bin_dir,
 			'phpunit.xml.dist'    => $plugin_dir,
+			'phpcs.ruleset.xml'   => $plugin_dir,
 		);
 
 		foreach ( $to_copy as $file => $dir ) {

--- a/templates/phpcs.ruleset.xml
+++ b/templates/phpcs.ruleset.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards for Plugins">
+	<description>Generally-applicable sniffs for WordPress plugins</description>
+
+	<rule ref="WordPress-Core" />
+	<rule ref="WordPress-Docs" />
+
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+</ruleset>

--- a/templates/plugin-circle.mustache
+++ b/templates/plugin-circle.mustache
@@ -1,6 +1,8 @@
 machine:
   php:
     version: 5.6.22
+  environment:
+    PATH: $HOME/.composer/vendor/bin:$PATH
 
 dependencies:
   pre:
@@ -9,5 +11,9 @@ dependencies:
 test:
   pre:
     - bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 latest
+    - |
+      composer global require wp-coding-standards/wpcs
+      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
   override:
+    - phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')
     - phpunit

--- a/templates/plugin-travis.mustache
+++ b/templates/plugin-travis.mustache
@@ -25,12 +25,17 @@ matrix:
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - |
     if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
       composer global require "phpunit/phpunit=5.6.*"
     else
       composer global require "phpunit/phpunit=4.8.*"
     fi
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - |
+    composer global require wp-coding-standards/wpcs
+    phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
 
-script: phpunit
+script:
+  - phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')
+  - phpunit


### PR DESCRIPTION
Installation for use in CI is essentially:

```
export PATH="$HOME/.composer/vendor/bin:$PATH"
composer global require wp-coding-standards/wpcs
phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
```

Fixes #310