### PR TITLE
Support installing a WP-CLI package based on a Git URL

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -119,6 +119,7 @@ Feature: Install WP-CLI packages
       trendwerk/faker
       """
 
+  @github-api
   Scenario: Install a package from a Git URL
     Given an empty directory
 

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -86,10 +86,13 @@ Feature: Install WP-CLI packages
       alice
       """
 
-    When I run `wp package list`
-    Then STDOUT should contain:
+    When I run `wp package list --fields=name`
+    Then STDOUT should be a table containing rows:
+      | name                |
+      | trendwerk/faker     |
+    And STDOUT should not contain:
       """
-      trendwerk/faker
+      nelmio/alice
       """
 
     When I run `wp package uninstall trendwerk/faker`
@@ -114,4 +117,50 @@ Feature: Install WP-CLI packages
     Then STDOUT should not contain:
       """
       trendwerk/faker
+      """
+
+  Scenario: Install a package from a Git URL
+    Given an empty directory
+
+    When I run `wp package path`
+    Then save STDOUT as {PACKAGE_PATH}
+
+    When I try `wp package install git@github.com:wp-cli.git`
+    Then STDERR should be:
+      """
+      Error: Couldn't parse package name from expected path '<name>/<package>'.
+      """
+
+    When I run `wp package install git@github.com:wp-cli/google-sitemap-generator-cli.git`
+    Then STDOUT should contain:
+      """
+      Installing package wp-cli/google-sitemap-generator-cli (dev-master)
+      Updating {PACKAGE_PATH}composer.json to require the package...
+      Registering git@github.com:wp-cli/google-sitemap-generator-cli.git as a VCS repository...
+      Using Composer to install the package...
+      """
+    And STDOUT should contain:
+      """
+      Success: Package installed successfully.
+      """
+
+    When I run `wp package list --fields=name`
+    Then STDOUT should be a table containing rows:
+      | name                                |
+      | wp-cli/google-sitemap-generator-cli |
+
+    When I run `wp package uninstall wp-cli/google-sitemap-generator-cli`
+    Then STDOUT should contain:
+      """
+      Removing require statement from {PACKAGE_PATH}composer.json
+      """
+    And STDOUT should contain:
+      """
+      Success: Uninstalled package.
+      """
+
+    When I run `wp package list --fields=name`
+    Then STDOUT should not contain:
+      """
+      wp-cli/google-sitemap-generator-cli
       """


### PR DESCRIPTION
`wp package list` will display all local packages now, not just those in
the package index

Related #2532, #2565