### PR TITLE
Support installing a WP-CLI package at a local path

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -165,3 +165,77 @@ Feature: Install WP-CLI packages
       """
       wp-cli/google-sitemap-generator-cli
       """
+
+  Scenario: Install a package at an existing path
+    Given an empty directory
+    And a path-command/command.php file:
+      """
+      <?php
+      WP_CLI::add_command( 'community-command', function(){
+        WP_CLI::success( "success!" );
+      }, array( 'when' => 'before_wp_load' ) );
+      """
+    And a path-command/composer.json file:
+      """
+      {
+        "name": "wp-cli/community-command",
+        "description": "A demo community command.",
+        "license": "MIT",
+        "minimum-stability": "dev",
+        "require": {
+        },
+        "autoload": {
+          "files": [ "command.php" ]
+        },
+        "require-dev": {
+          "behat/behat": "~2.5"
+        }
+      }
+      """
+
+    When I run `wp package path`
+    Then save STDOUT as {PACKAGE_PATH}
+
+    When I run `pwd`
+    Then save STDOUT as {CURRENT_PATH}
+
+    When I run `wp package install path-command`
+    Then STDOUT should contain:
+      """
+      Installing package wp-cli/community-command (dev-master)
+      Updating {PACKAGE_PATH}composer.json to require the package...
+      Registering {CURRENT_PATH}/path-command as a path repository...
+      Using Composer to install the package...
+      """
+    And STDOUT should contain:
+      """
+      Success: Package installed successfully.
+      """
+
+    When I run `wp package list --fields=name`
+    Then STDOUT should be a table containing rows:
+      | name                            |
+      | wp-cli/community-command        |
+
+    When I run `wp community-command`
+    Then STDOUT should be:
+      """
+      Success: success!
+      """
+
+    When I run `wp package uninstall wp-cli/community-command`
+    Then STDOUT should contain:
+      """
+      Removing require statement from {PACKAGE_PATH}composer.json
+      """
+    And STDOUT should contain:
+      """
+      Success: Uninstalled package.
+      """
+    And the path-command directory should exist
+
+    When I run `wp package list --fields=name`
+    Then STDOUT should not contain:
+      """
+      wp-cli/community-command
+      """


### PR DESCRIPTION
For packages not listed in the package index:

```
wp package install path-to/command-directory
```

Fixes #2565