### PR TITLE
Support for installing packages from zip archives

### DIFF
--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace WP_CLI;
+
+use Exception;
+use PharData;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use WP_CLI;
+use WP_CLI\Utils;
+use ZipArchive;
+
+/**
+ * Extract a provided archive file.
+ */
+class Extractor {
+
+	/**
+	 * Extract the archive file to a specific destination.
+	 *
+	 * @param string $dest
+	 */
+	public static function extract( $tarball_or_zip, $dest ) {
+		if ( preg_match( '/\.zip$/', $tarball_or_zip ) ) {
+			return self::extract_zip( $tarball_or_zip, $dest );
+		}
+
+		if ( preg_match( '/\.tar\.gz$/', $tarball_or_zip ) ) {
+			return self::extract_tarball( $tarball_or_zip, $dest );
+		}
+		throw new \Exception( 'Extension not supported.' );
+	}
+
+	/**
+	 * Extract a ZIP file to a specific destination.
+	 *
+	 * @param string $zipfile
+	 * @param string $dest
+	 */
+	private static function extract_zip( $zipfile, $dest ) {
+		if ( ! class_exists( 'ZipArchive' ) ) {
+			throw new Exception( 'Extracting a zip file requires ZipArchive.' );
+		}
+		$zip = new ZipArchive();
+		$res = $zip->open( $zipfile );
+		if ( true === $res ) {
+			$tempdir = implode( DIRECTORY_SEPARATOR, Array (
+				dirname( $zipfile ),
+				basename( $zipfile, '.zip' ),
+				$zip->getNameIndex( 0 )
+			) );
+
+			$zip->extractTo( dirname( $tempdir ) );
+			$zip->close();
+
+			self::copy_overwrite_files( $tempdir, $dest );
+			self::rmdir( dirname( $tempdir ) );
+		} else {
+			throw Exception( $res );
+		}
+	}
+
+	/**
+	 * Extract a tarball to a specific destination.
+	 *
+	 * @param string $tarball
+	 * @param string $dest
+	 */
+	private static function extract_tarball( $tarball, $dest ) {
+		if ( ! class_exists( 'PharData' ) ) {
+			$cmd = "tar xz --strip-components=1 --directory=%s -f $tarball";
+			WP_CLI::launch( Utils\esc_cmd( $cmd, $dest ) );
+			return;
+		}
+		$phar = new PharData( $tarball );
+		$tempdir = implode( DIRECTORY_SEPARATOR, Array (
+			dirname( $tarball ),
+			basename( $tarball, '.tar.gz' ),
+			$phar->getFileName()
+		) );
+
+		$phar->extractTo( dirname( $tempdir ), null, true );
+
+		self::copy_overwrite_files( $tempdir, $dest );
+
+		self::rmdir( dirname( $tempdir ) );
+	}
+
+	public static function copy_overwrite_files( $source, $dest ) {
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $source, RecursiveDirectoryIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::SELF_FIRST);
+
+		$error = 0;
+
+		if ( ! is_dir( $dest ) ) {
+			mkdir( $dest, 0777, true );
+		}
+
+		foreach ( $iterator as $item ) {
+
+			$dest_path = $dest . DIRECTORY_SEPARATOR . $iterator->getSubPathName();
+
+			if ( $item->isDir() ) {
+				if ( !is_dir( $dest_path ) ) {
+					mkdir( $dest_path );
+				}
+			} else {
+				if ( file_exists( $dest_path ) && is_writable( $dest_path ) ) {
+					copy( $item, $dest_path );
+				} elseif ( ! file_exists( $dest_path ) ) {
+					copy( $item, $dest_path );
+				} else {
+					$error = 1;
+					WP_CLI::warning( "Unable to copy '" . $iterator->getSubPathName() . "' to current directory." );
+				}
+			}
+		}
+
+		if ( $error ) {
+			throw new Exception( 'There was an error overwriting existing files.' );
+		}
+	}
+
+	public static function rmdir( $dir ) {
+		$files = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $dir, RecursiveDirectoryIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+
+		foreach ( $files as $fileinfo ) {
+			$todo = $fileinfo->isDir() ? 'rmdir' : 'unlink';
+			$todo( $fileinfo->getRealPath() );
+		}
+		rmdir( $dir );
+	}
+
+}

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -136,20 +136,25 @@ class Package_Command extends WP_CLI_Command {
 	 * * Package name from WP-CLI's package index.
 	 * * Git URL accessible by the current shell user.
 	 * * Path to a directory on the local machine.
+	 * * Local or remote .zip file.
 	 *
-	 * Note: When installing a local directory, WP-CLI simply registers a
+	 * When installing a local directory, WP-CLI simply registers a
 	 * reference to the directory. If you move or delete the directory, WP-CLI's
 	 * reference breaks.
 	 *
+	 * When installing a .zip file, WP-CLI extracts the package to
+	 * `~/.wp-cli/packages/local/<package-name>`.
+	 *
 	 * ## OPTIONS
 	 *
-	 * <name|git|path>
-	 * : Name, git URL, or directory path for the package to install. Names can
-	 * optionally include a version constraint (e.g. wp-cli/server-command:@stable)
+	 * <name|git|path|zip>
+	 * : Name, git URL, directory path, or .zip file for the package to install.
+	 * Names can optionally include a version constraint
+	 * (e.g. wp-cli/server-command:@stable).
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Install the latest development version from the package index
+	 *     # Install the latest development version from the package index.
 	 *     $ wp package install wp-cli/server-command
 	 *     Installing package wp-cli/server-command (dev-master)
 	 *     Updating /home/person/.wp-cli/packages/composer.json to require the package...
@@ -167,11 +172,14 @@ class Package_Command extends WP_CLI_Command {
 	 *     ---
 	 *     Success: Package installed successfully.
 	 *
-	 *     # Install the latest stable version
+	 *     # Install the latest stable version.
 	 *     $ wp package install wp-cli/server-command:@stable
 	 *
-	 *     # Install a package hosted at a git URL
+	 *     # Install a package hosted at a git URL.
 	 *     $ wp package install git@github.com:runcommand/hook.git
+	 *
+	 *     # Install a package in a .zip file.
+	 *     $ wp package install google-sitemap-generator-cli.zip
 	 */
 	public function install( $args, $assoc_args ) {
 		list( $package_name ) = $args;


### PR DESCRIPTION
```
$ wp package install
https://github.com/wp-cli/google-sitemap-generator-cli/archive/master.zip
$ wp package install google-sitemap-generator-cli.zip
```

Archives are extracted to `<packages-dir>/local/<package-name>`, and
installed as a path repository.

Fixes #2532