### PR TITLE
enables bash completion on `wp help`

### DIFF
--- a/features/cli-bash-completion.feature
+++ b/features/cli-bash-completion.feature
@@ -118,3 +118,15 @@ Feature: `wp cli completions` tasks
       """
     And STDERR should be empty
     And the return code should be 0
+
+    When I run `wp cli completions --line="wp help " --point=100`
+    Then STDOUT should not contain:
+      """
+      @example
+      """
+    And STDOUT should contain:
+      """
+      post-type
+      """
+    And STDERR should be empty
+    And the return code should be 0

--- a/features/cli-bash-completion.feature
+++ b/features/cli-bash-completion.feature
@@ -15,6 +15,42 @@ Feature: `wp cli completions` tasks
     And STDERR should be empty
     And the return code should be 0
 
+    When I run `wp cli completions --line="wp core " --point=100`
+    Then STDOUT should contain:
+      """
+      install
+      """
+    And STDOUT should contain:
+      """
+      update
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    When I run `wp cli completions --line="wp help " --point=100`
+    Then STDOUT should contain:
+      """
+      rewrite
+      """
+    And STDOUT should contain:
+      """
+      media
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    When I run `wp cli completions --line="wp help core language " --point=100`
+    Then STDOUT should contain:
+      """
+      install
+      """
+    And STDOUT should contain:
+      """
+      update
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
   Scenario: Bash Completion with SSH aliases
     Given an empty directory
     And a wp-cli.yml file:
@@ -59,6 +95,26 @@ Feature: `wp cli completions` tasks
     And STDOUT should contain:
       """
       eval
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    When I run `wp cli completions --line="wp @example plugin " --point=100`
+    Then STDOUT should contain:
+      """
+      list
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    When I run `wp cli completions --line="wp help core language " --point=100`
+    Then STDOUT should contain:
+      """
+      install
+      """
+    And STDOUT should contain:
+      """
+      update
       """
     And STDERR should be empty
     And the return code should be 0

--- a/php/WP_CLI/Completions.php
+++ b/php/WP_CLI/Completions.php
@@ -18,12 +18,16 @@ class Completions {
 		$this->cur_word = end( $this->words );
 
 		$is_alias = false;
+		$is_help = false;
 		if ( ! empty( $this->words[0] ) && preg_match( "/^@/", $this->words[0] ) ) {
 			array_shift( $this->words );
 			// `wp @al` is false, but `wp @all ` is true.
 			if ( count( $this->words ) ) {
 				$is_alias = true;
 			}
+		} elseif ( ! empty( $this->words[0] ) && 'help' === $this->words[0] ) {
+			array_shift( $this->words );
+			$is_help = true;
 		}
 
 		$r = $this->get_command( $this->words );
@@ -44,7 +48,7 @@ class Completions {
 
 		if ( $command->can_have_subcommands() ) {
 			// add completion when command is `wp` and alias isn't set.
-			if ( "wp" === $command->get_name() && false === $is_alias ) {
+			if ( "wp" === $command->get_name() && false === $is_alias && false == $is_help ) {
 				$aliases = \WP_CLI::get_configurator()->get_aliases();
 				foreach ( $aliases as $name => $_ ) {
 					$this->add( "$name " );


### PR DESCRIPTION
Like following.
Thanks!

```
$ wp help 
cache            eval             network          role             super-admin 
cap              eval-file        option           scaffold         taxonomy 
cli              export           package          search-replace   term 
comment          help             plugin           server           theme 
core             import           post             shell            transient 
cron             media            post-type        sidebar          user 
db               menu             rewrite          site             widget 
```