### PR TITLE
improve bash completion

### DIFF
--- a/features/cli-bash-completion.feature
+++ b/features/cli-bash-completion.feature
@@ -79,6 +79,38 @@ Feature: `wp cli completions` tasks
     And STDERR should be empty
     And the return code should be 0
 
+    When I run `wp cli completions --line='wp bogus-comand ' --point=100`
+    Then STDOUT should be empty
+
+    When I run `wp cli completions --line='wp eva' --point=100`
+    Then STDOUT should contain:
+      """
+      eval
+      """
+    And STDOUT should contain:
+      """
+      eval-file
+      """
+
+    When I run `wp cli completions --line='wp core config --dbname=' --point=100`
+    Then STDOUT should be empty
+
+    When I run `wp cli completions --line='wp core config --dbname=foo ' --point=100`
+    Then STDOUT should not contain:
+      """
+      --dbname=
+      """
+    And STDOUT should contain:
+      """
+      --extra-php
+      """
+
+    When I run `wp cli completions --line='wp media import ' --point=100`
+    Then STDOUT should contain:
+      """
+      <file>
+      """
+
   Scenario: Bash Completion with SSH aliases
     Given an empty directory
     And a wp-cli.yml file:
@@ -174,38 +206,3 @@ Feature: `wp cli completions` tasks
       """
     And STDERR should be empty
     And the return code should be 0
-
-  Scenario: Generate completions
-    Given an empty directory
-
-    When I run `wp cli completions --line='wp bogus-comand ' --point=100`
-    Then STDOUT should be empty
-
-    When I run `wp cli completions --line='wp eva' --point=100`
-    Then STDOUT should contain:
-      """
-      eval
-      """
-    And STDOUT should contain:
-      """
-      eval-file
-      """
-
-    When I run `wp cli completions --line='wp core config --dbname=' --point=100`
-    Then STDOUT should be empty
-
-    When I run `wp cli completions --line='wp core config --dbname=foo ' --point=100`
-    Then STDOUT should not contain:
-      """
-      --dbname=
-      """
-    And STDOUT should contain:
-      """
-      --extra-php
-      """
-
-    When I run `wp cli completions --line='wp media import ' --point=100`
-    Then STDOUT should contain:
-      """
-      <file>
-      """

--- a/features/cli-bash-completion.feature
+++ b/features/cli-bash-completion.feature
@@ -15,6 +15,18 @@ Feature: `wp cli completions` tasks
     And STDERR should be empty
     And the return code should be 0
 
+    When I run `wp cli completions --line="wp co" --point=100`
+    Then STDOUT should contain:
+      """
+      comment
+      """
+    And STDOUT should contain:
+      """
+      core
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
     When I run `wp cli completions --line="wp core " --point=100`
     Then STDOUT should contain:
       """

--- a/features/cli-bash-completion.feature
+++ b/features/cli-bash-completion.feature
@@ -51,6 +51,22 @@ Feature: `wp cli completions` tasks
     And STDERR should be empty
     And the return code should be 0
 
+    When I run `wp cli completions --line="wp core" --point=100`
+    Then STDOUT should contain:
+      """
+      core
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    When I run `wp cli completions --line="wp core " --point=100`
+    Then STDOUT should contain:
+      """
+      language
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
   Scenario: Bash Completion with SSH aliases
     Given an empty directory
     And a wp-cli.yml file:
@@ -127,6 +143,22 @@ Feature: `wp cli completions` tasks
     And STDOUT should contain:
       """
       post-type
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    When I run `wp cli completions --line="wp help core" --point=100`
+    Then STDOUT should contain:
+      """
+      core
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    When I run `wp cli completions --line="wp help core " --point=100`
+    Then STDOUT should contain:
+      """
+      language
       """
     And STDERR should be empty
     And the return code should be 0

--- a/features/cli-bash-completion.feature
+++ b/features/cli-bash-completion.feature
@@ -174,3 +174,38 @@ Feature: `wp cli completions` tasks
       """
     And STDERR should be empty
     And the return code should be 0
+
+  Scenario: Generate completions
+    Given an empty directory
+
+    When I run `wp cli completions --line='wp bogus-comand ' --point=100`
+    Then STDOUT should be empty
+
+    When I run `wp cli completions --line='wp eva' --point=100`
+    Then STDOUT should contain:
+      """
+      eval
+      """
+    And STDOUT should contain:
+      """
+      eval-file
+      """
+
+    When I run `wp cli completions --line='wp core config --dbname=' --point=100`
+    Then STDOUT should be empty
+
+    When I run `wp cli completions --line='wp core config --dbname=foo ' --point=100`
+    Then STDOUT should not contain:
+      """
+      --dbname=
+      """
+    And STDOUT should contain:
+      """
+      --extra-php
+      """
+
+    When I run `wp cli completions --line='wp media import ' --point=100`
+    Then STDOUT should contain:
+      """
+      <file>
+      """

--- a/features/flags.feature
+++ b/features/flags.feature
@@ -181,38 +181,6 @@ Feature: Global flags
       [31;1mError:
       """
 
-  Scenario: Generate completions
-    Given an empty directory
-
-    When I run `wp cli completions --line='wp bogus-comand ' --point=100`
-    Then STDOUT should be empty
-
-    When I run `wp cli completions --line='wp eva' --point=100`
-    Then STDOUT should be:
-      """
-      eval 
-      eval-file 
-      """
-
-    When I run `wp cli completions --line='wp core config --dbname=' --point=100`
-    Then STDOUT should be empty
-
-    When I run `wp cli completions --line='wp core config --dbname=foo ' --point=100`
-    Then STDOUT should not contain:
-      """
-      --dbname=
-      """
-    And STDOUT should contain:
-      """
-      --extra-php 
-      """
-
-    When I run `wp cli completions --line='wp media import ' --point=100`
-    Then STDOUT should contain:
-      """
-      <file> 
-      """
-
   Scenario: Use `WP_CLI_STRICT_ARGS_MODE` to distinguish between global and local args
     Given an empty directory
     And a cmd.php file:

--- a/php/WP_CLI/Completions.php
+++ b/php/WP_CLI/Completions.php
@@ -16,6 +16,9 @@ class Completions {
 
 		// last word is either empty or an incomplete subcommand
 		$this->cur_word = end( $this->words );
+		if ( "" !== $this->cur_word ) {
+			array_pop( $this->words );
+		}
 
 		$is_alias = false;
 		$is_help = false;

--- a/php/WP_CLI/Completions.php
+++ b/php/WP_CLI/Completions.php
@@ -16,7 +16,7 @@ class Completions {
 
 		// last word is either empty or an incomplete subcommand
 		$this->cur_word = end( $this->words );
-		if ( "" !== $this->cur_word ) {
+		if ( "" !== $this->cur_word && ! preg_match( "/^\-/", $this->cur_word ) ) {
 			array_pop( $this->words );
 		}
 


### PR DESCRIPTION
When I run following

```
$ wp core[tab]
```

It should complement like following.

```
$ wp core[space]
```

And when I run following.

```
$ wp core[space][tab][tab]
```

It should complement like following.

```
$ wp core[space]
check-update        install             multisite-convert   update-db 
config              is-installed        multisite-install   verify-checksums 
download            language            update              version 
```

Thanks!