### PR TITLE
Ensure `WP_INSTALLING` is set for `wp core update-db`

### DIFF
--- a/features/core-update-db.feature
+++ b/features/core-update-db.feature
@@ -88,3 +88,19 @@ Feature: Update core's database
       """
       Success: WordPress database upgraded on 3/3 sites.
       """
+
+  Scenario: Ensure update-db sets WP_INSTALLING constant
+    Given a WP install
+    And a before.php file:
+      """
+      <?php
+      WP_CLI::add_hook( 'before_invoke:core update-db', function(){
+        WP_CLI::log( 'WP_INSTALLING: ' . var_export( WP_INSTALLING, true ) );
+      });
+      """
+
+    When I run `wp --require=before.php core update-db`
+    Then STDOUT should contain:
+      """
+      WP_INSTALLING: true
+      """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -875,7 +875,8 @@ class Runner {
 			exit;
 		}
 
-		if ( $this->cmd_starts_with( array( 'core', 'is-installed' ) ) ) {
+		if ( $this->cmd_starts_with( array( 'core', 'is-installed' )
+			|| $this->cmd_starts_with( array( 'core', 'update-db' ) ) ) ) {
 			define( 'WP_INSTALLING', true );
 		}
 

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -875,8 +875,8 @@ class Runner {
 			exit;
 		}
 
-		if ( $this->cmd_starts_with( array( 'core', 'is-installed' )
-			|| $this->cmd_starts_with( array( 'core', 'update-db' ) ) ) ) {
+		if ( $this->cmd_starts_with( array( 'core', 'is-installed' ) )
+			|| $this->cmd_starts_with( array( 'core', 'update-db' ) ) ) {
 			define( 'WP_INSTALLING', true );
 		}
 


### PR DESCRIPTION
Core's `wp-admin/upgrade.php` sets this constant, so we should too.