### PR TITLE
Add `wp cli aliases` alias

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -112,6 +112,14 @@ Feature: Create shortcuts to specific WordPress installs
         path: testdir
       """
 
+    When I run `wp cli aliases`
+    Then STDOUT should be YAML containing:
+      """
+      @all: Run command against every registered alias.
+      @testdir:
+        path: testdir
+      """
+
     When I run `wp cli alias --format=json`
     Then STDOUT should be JSON containing:
       """

--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -519,6 +519,8 @@ class CLI_Command extends WP_CLI_Command {
 	 *     @both:
 	 *       - @prod
 	 *       - @dev
+	 *
+	 * @alias aliases
 	 */
 	public function alias( $_, $assoc_args ) {
 		WP_CLI::print_value( WP_CLI::get_runner()->aliases, $assoc_args );


### PR DESCRIPTION
It's annoying to accidentally type this and get an error.