### PR TITLE
wp post delete revisions success message

### DIFF
--- a/php/commands/post.php
+++ b/php/commands/post.php
@@ -253,10 +253,11 @@ class Post_Command extends \WP_CLI\CommandWithDBObject {
 
 		parent::_delete( $args, $assoc_args, function ( $post_id, $assoc_args ) {
 			$status = get_post_status( $post_id );
+			$post_type = get_post_type( $post_id );
 			$r = wp_delete_post( $post_id, $assoc_args['force'] );
 
 			if ( $r ) {
-				$action = $assoc_args['force'] || 'trash' === $status ? 'Deleted' : 'Trashed';
+				$action = $assoc_args['force'] || 'trash' === $status || 'revision' === $post_type ? 'Deleted' : 'Trashed';
 
 				return array( 'success', "$action post $post_id." );
 			} else {


### PR DESCRIPTION
When deleting revisions (e.g. `wp post delete $(wp post list --post_type='revision' --format=ids)`), the success message reads `Success: Trashed post {$post_id}`, which is incorrect.