### PR TITLE
Use `--prompt=<assoc>` to prompt for specific associative args

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -66,6 +66,26 @@ Feature: Manage WordPress installation
       http://localhost:8001
       """
 
+  Scenario: Install WordPress by prompting for the admin email and password
+    Given an empty directory
+    And WP files
+    And wp-config.php
+    And a database
+    And a session file:
+      """
+      wpcli
+      admin@example.com
+      """
+
+    When I run `wp core install --url=localhost:8001 --title=Test --admin_user=wpcli --prompt=admin_email,admin_password < session`
+    Then STDOUT should not be empty
+
+    When I run `wp eval 'echo home_url();'`
+    Then STDOUT should be:
+      """
+      http://localhost:8001
+      """
+
   Scenario: Install WordPress with an https scheme
     Given an empty directory
     And WP files

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -142,10 +142,26 @@ class Subcommand extends CompositeCommand {
 
 		$spec = array_values( $spec );
 
+		$prompt_args = WP_CLI::get_config( 'prompt' );
+		if ( true !== $prompt_args ) {
+			$prompt_args = explode( ',', $prompt_args );
+		}
+
 		// 'positional' arguments are positional (aka zero-indexed)
 		// so $args needs to be reset before prompting for new arguments
 		$args = array();
 		foreach( $spec as $key => $spec_arg ) {
+
+			// When prompting for specific arguments (e.g. --prompt=user_pass),
+			// ignore all arguments that don't match
+			if ( is_array( $prompt_args ) ) {
+				if ( 'assoc' !== $spec_arg['type'] ) {
+					continue;
+				}
+				if ( ! in_array( $spec_arg['name'], $prompt_args, true ) ) {
+					continue;
+				}
+			}
 
 			$current_prompt = ( $key + 1 ) . '/' . count( $spec ) . ' ';
 			$default = ( $spec_arg['optional'] ) ? '' : false;

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -336,6 +336,10 @@ class Core_Command extends WP_CLI_Command {
 	 *     $ define( 'WP_DEBUG_LOG', true );
 	 *     $ PHP
 	 *     Success: Generated 'wp-config.php' file.
+	 *
+	 *     # Avoid disclosing password to bash history by reading from password.txt
+	 *     $ wp core config --dbname=testing --dbuser=wp --prompt=dbpass < password.txt
+	 *     Success: Generated 'wp-config.php' file.
 	 */
 	public function config( $_, $assoc_args ) {
 		global $wp_version;
@@ -469,8 +473,12 @@ class Core_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
+	 *     # Install WordPress in 5 seconds
 	 *     $ wp core install --url=example.com --title=Example --admin_user=supervisor --admin_password=strongpassword --admin_email=info@example.com
 	 *     Success: WordPress installed successfully.
+	 *
+	 *     # Install WordPress without disclosing admin_password to bash history
+	 *     $ wp core install --url=example.com --title=Example --admin_user=supervisor --admin_email=info@example.com --prompt=admin_password < admin_password.txt
 	 */
 	public function install( $args, $assoc_args ) {
 		if ( $this->_install( $assoc_args ) ) {

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -85,10 +85,10 @@ return array(
 	),
 
 	'prompt' => array(
-		'runtime' => '',
+		'runtime' => '[=<assoc>]',
 		'file' => false,
 		'default' => false,
-		'desc' => 'Prompt the user to enter values for all command arguments.',
+		'desc' => 'Prompt the user to enter values for all command arguments, or a subset specified as comma-separated values.',
 	),
 
 	'quiet' => array(


### PR DESCRIPTION
For instance:

```
wp core config --dbname=testing --dbuser=wp --prompt=dbpass <
password.txt
```

This approach lets users avoid exposing secure data in bash history.

Fixes #129