### PR TITLE
add `ssh -F` support

### DIFF
--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -43,6 +43,7 @@ class Configurator {
 		'path',
 		'ssh',
 		'http',
+		'ssh-config',
 	);
 
 	/**

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -352,7 +352,7 @@ class Runner {
 			array_shift( $wp_args );
 			$runtime_alias = array();
 			foreach( $this->aliases[ $this->alias ] as $key => $value ) {
-				if ( 'ssh' === $key ) {
+				if ( 'ssh' === $key || 'ssh-config' === $key ) {
 					continue;
 				}
 				$runtime_alias[ $key ] = $value;
@@ -369,10 +369,18 @@ class Runner {
 			}
 		}
 
+		if ( ! empty( $this->aliases[ $this->alias ]['ssh-config'] )
+					&& is_file( $this->aliases[ $this->alias ]['ssh-config'] ) ) {
+			$ssh_config = $this->aliases[ $this->alias ]['ssh-config'];
+		} else {
+			$ssh_config = '';
+		}
+
 		$unescaped_command = sprintf(
-			'ssh -q %s%s %s %s',
+			'ssh -q %s%s%s %s %s',
 			$port ? '-p ' . (int) $port . ' ' : '',
 			$host,
+			$ssh_config ? '-F ' . $ssh_config : '',
 			$is_tty ? '-t' : '-T',
 			$pre_cmd . $wp_binary . ' ' . implode( ' ', array_map( 'escapeshellarg', $wp_args ) )
 		);
@@ -380,9 +388,10 @@ class Runner {
 		WP_CLI::debug( 'Running SSH command: ' . $unescaped_command, 'bootstrap' );
 
 		$escaped_command = sprintf(
-			'ssh -q %s%s %s %s',
+			'ssh -q %s%s%s %s %s',
 			$port ? '-p ' . (int) $port . ' ' : '',
 			escapeshellarg( $host ),
+			$ssh_config ? ' -F ' . escapeshellarg( $ssh_config ) : '',
 			$is_tty ? '-t' : '-T',
 			escapeshellarg( $pre_cmd . $wp_binary . ' ' . implode( ' ', array_map( 'escapeshellarg', $wp_args ) ) )
 		);


### PR DESCRIPTION
It is an alias of `ssh -F`

Example:

Place `wp-cli.yml` like following.
```
@vvv
    ssh: vvv.dev
    ssh-config: ./ssh-config
```

And run `vagrant ssh-config > ./ssh-config`.
Then we can run like `wp @vvv plugin list` in the working directory.

It looks useful for vagrant users and people who have many servers.