### PR TITLE
Default to a randomly generated password for `--admin_password=<pass>`

### DIFF
--- a/features/core-install.feature
+++ b/features/core-install.feature
@@ -168,7 +168,6 @@ Feature: Install WordPress core
       """
       Success: WordPress installed successfully.
       """
-    And STDERR should be empty
 
   Scenario: Install WordPress multisite without specifying the password
     Given an empty directory
@@ -185,4 +184,3 @@ Feature: Install WordPress core
       """
       Success: Network installed. Don't forget to set up rewrite rules.
       """
-    And STDERR should be empty

--- a/features/core-install.feature
+++ b/features/core-install.feature
@@ -152,3 +152,37 @@ Feature: Install WordPress core
       """
       wp_users
       """
+
+  Scenario: Install WordPress without specifying the admin password
+    Given an empty directory
+    And WP files
+    And wp-config.php
+    And a database
+
+    When I run `wp core install --url=localhost:8001 --title=Test --admin_user=wpcli --admin_email=wpcli@example.org`
+    Then STDOUT should contain:
+      """
+      Admin password:
+      """
+    And STDOUT should contain:
+      """
+      Success: WordPress installed successfully.
+      """
+    And STDERR should be empty
+
+  Scenario: Install WordPress multisite without specifying the password
+    Given an empty directory
+    And WP files
+    And wp-config.php
+    And a database
+
+    When I run `wp core multisite-install --url=foobar.org --title=Test --admin_user=wpcli --admin_email=admin@example.com`
+    Then STDOUT should contain:
+      """
+      Admin password:
+      """
+    And STDOUT should contain:
+      """
+      Success: Network installed. Don't forget to set up rewrite rules.
+      """
+    And STDERR should be empty

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -462,8 +462,8 @@ class Core_Command extends WP_CLI_Command {
 	 * --admin_user=<username>
 	 * : The name of the admin user.
 	 *
-	 * --admin_password=<password>
-	 * : The password for the admin user.
+	 * [--admin_password=<password>]
+	 * : The password for the admin user. Defaults to randomly generated string.
 	 *
 	 * --admin_email=<email>
 	 * : The email address for the admin user.
@@ -558,8 +558,8 @@ class Core_Command extends WP_CLI_Command {
 	 * default: admin
 	 * ---
 	 *
-	 * --admin_password=<password>
-	 * : The password for the admin user.
+	 * [--admin_password=<password>]
+	 * : The password for the admin user. Defaults to randomly generated string.
 	 *
 	 * --admin_email=<email>
 	 * : The email address for the admin user.
@@ -662,6 +662,11 @@ class Core_Command extends WP_CLI_Command {
 		// which is normally a runtime argument
 		if ( isset( $assoc_args['url'] ) ) {
 			WP_CLI::set_url( $assoc_args['url'] );
+		}
+
+		if ( empty( $assoc_args['admin_password'] ) ) {
+			$assoc_args['admin_password'] = wp_generate_password();
+			WP_CLI::log( "Admin password: {$assoc_args['admin_password']}" );
 		}
 
 		$public = true;


### PR DESCRIPTION
This more closely mirrors WordPress' behavior of generating a default
password for the admin user.

Fixes #3534