### PR TITLE
Revert "Use `dist: trusty` on Travis"

### DIFF
--- a/templates/plugin-travis.mustache
+++ b/templates/plugin-travis.mustache
@@ -1,7 +1,5 @@
 language: php
 
-dist: trusty
-
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Reverts wp-cli/wp-cli#3529

See https://github.com/travis-ci/travis-ci/issues/6842#issuecomment-259307424