### PR TITLE
Checkout data directory in install-wp-tests.sh

### DIFF
--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -79,7 +79,7 @@ install_test_suite() {
 	if [ ! -d $WP_TESTS_DIR ]; then
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/ $WP_TESTS_DIR
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -80,6 +80,7 @@ install_test_suite() {
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
 		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -79,7 +79,7 @@ install_test_suite() {
 	if [ ! -d $WP_TESTS_DIR ]; then
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/ $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then


### PR DESCRIPTION
PHP Notice occurred in trunk. ( for WordPress 4.7 )
> Notice: /tmp/wordpress-tests-lib/includes/../data/themedir1 is not readable in /tmp/wordpress/wp-includes/theme.php on line 471

So, checkout all phpunit suite.



