### PR TITLE
Automatic Password generation on Install does not work

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -683,11 +683,6 @@ class Core_Command extends WP_CLI_Command {
 			WP_CLI::set_url( $assoc_args['url'] );
 		}
 
-		if ( empty( $assoc_args['admin_password'] ) ) {
-			$assoc_args['admin_password'] = wp_generate_password();
-			WP_CLI::log( "Admin password: {$assoc_args['admin_password']}" );
-		}
-
 		$public = true;
 
 		// @codingStandardsIgnoreStart
@@ -704,6 +699,10 @@ class Core_Command extends WP_CLI_Command {
 
 		if ( ! empty( $GLOBALS['wpdb']->last_error ) ) {
 			WP_CLI::error( 'Installation produced database errors, and may have partially or completely failed.' );
+		}
+
+		if ( empty( $admin_password ) ) {
+			WP_CLI::log( "Admin password: {$result['password']}" );
 		}
 
 		// Confirm the uploads directory exists


### PR DESCRIPTION
#3535 was recently done to allow for a default password to be generated using `wp core install`.  However, it does not appear to correctly install the generated password in the system, as the admin user is unable to log in after the install has completed using the randomly generated password.

I did some digging, and the problem is that in https://github.com/wp-cli/wp-cli/blob/master/php/commands/core.php#L673 the `extract` occurs with a blank value, and the subsequent Admin Password is set to the `$assoc_args` array...which has already had its values extracted.  So the blank value already in `$assoc_args['admin_password']` which is now set to `$admin_password` gets passed into `wp_install()` on line 699, instead of the randomly generated password..

The fix is to simply move the block up from line https://github.com/wp-cli/wp-cli/blob/master/php/commands/core.php#L686 to above the extract at line 673.

Better yet, however, is the pull request submitted which lets `wp_install` handle the password generation by default (see https://developer.wordpress.org/reference/functions/wp_install/), and prints out the returned generated password that's in `$result['password']`.  This ensures that we follow Wordpress best practices, and keep up to date changes submitted from Wordpress without modifying the local codebase.