### PR TITLE
add .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+export WP_CLI_BIN_DIR=/tmp/wp-cli-phar
+export WP_VERSION=latest


### PR DESCRIPTION
If `.envrc` and `direnv` exist, `.envrc` is loaded into the bash.
https://github.com/direnv/direnv

```
$ cd wp-cli
direnv: loading .envrc
direnv: export +WP_CLI_BIN_DIR +WP_VERSION
$ echo $WP_CLI_BIN_DIR
/tmp/wp-cli-phar
```

It is useful.
How about it?