### PR TITLE
Use default php.ini when `wp server` is run without `--config=`

### DIFF
--- a/php/commands/server.php
+++ b/php/commands/server.php
@@ -63,7 +63,7 @@ class Server_Command extends WP_CLI_Command {
 			'host' => 'localhost',
 			'port' => 8080,
 			'docroot' => false,
-			'config' => false,
+			'config' => get_cfg_var( 'cfg_file_path' )
 		);
 		$assoc_args = array_merge( $defaults, $assoc_args );
 


### PR DESCRIPTION
It seems that since #3330 `wp server` no longer loads a system installed `php.ini` (in my case `/etc/php.ini` on macOS Sierra running system PHP 5.6.25). This patch tweaks the command to use use whatever `php.ini` is set at runtime if the user has not specified one via `--config=` or `wp-cli.yml`.