### PR TITLE
In CoreUpgrader use global namespace for WP_Error

### DIFF
--- a/php/WP_CLI/CoreUpgrader.php
+++ b/php/WP_CLI/CoreUpgrader.php
@@ -30,7 +30,7 @@ class CoreUpgrader extends \Core_Upgrader {
 			return $package; //must be a local file..
 
 		if ( empty( $package ) )
-			return new WP_Error( 'no_package', $this->strings['no_package'] );
+			return new \WP_Error( 'no_package', $this->strings['no_package'] );
 
 		$filename = pathinfo( $package, PATHINFO_FILENAME );
 		$ext = pathinfo( $package, PATHINFO_EXTENSION );


### PR DESCRIPTION
Prevents a fatal error if `$package` is empty.