### PR TITLE
Deprecate `wp (term|comment) url` in favor of `wp (term|comment) list`

### DIFF
--- a/features/comment.feature
+++ b/features/comment.feature
@@ -103,6 +103,24 @@ Feature: Manage WordPress comments
       #comment-1
       """
 
+  Scenario: List the URLs of comments
+    When I run `wp comment create --comment_post_ID=1 --porcelain`
+    Then save STDOUT as {COMMENT_ID}
+
+    When I run `wp comment url 1 {COMMENT_ID}`
+    Then STDOUT should be:
+      """
+      http://example.com/?p=1#comment-1
+      http://example.com/?p=1#comment-{COMMENT_ID}
+      """
+
+    When I run `wp comment url {COMMENT_ID} 1`
+    Then STDOUT should be:
+      """
+      http://example.com/?p=1#comment-{COMMENT_ID}
+      http://example.com/?p=1#comment-1
+      """
+
   Scenario: Count comments
     When I run `wp comment count 1`
     Then STDOUT should contain:

--- a/features/term.feature
+++ b/features/term.feature
@@ -138,6 +138,13 @@ Feature: Manage WordPress terms
       http://example.com/?cat=3
       """
 
+    When I run `wp term url category {SECOND_TERM_ID} {TERM_ID}`
+    Then STDOUT should be:
+      """
+      http://example.com/?cat=3
+      http://example.com/?cat=2
+      """
+
   Scenario: Make sure WordPress receives the slashed data it expects
     When I run `wp term create category 'My\Term' --description='My\Term\Description' --porcelain`
     Then save STDOUT as {TERM_ID}

--- a/features/user.feature
+++ b/features/user.feature
@@ -295,3 +295,14 @@ Feature: Manage WordPress users
 
     When I run `wp user create testuser3 testuser3@example.com --send-email`
     Then an email should be sent
+
+  Scenario: List URLs of one or more users
+    Given a WP install
+    And I run `wp user create bob bob@gmail.com --role=contributor`
+
+    When I run `wp user list --include=1,2 --field=url`
+    Then STDOUT should be:
+      """
+      http://example.com/?author=1
+      http://example.com/?author=2
+      """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -535,8 +535,8 @@ class Runner {
 			}
 		}
 
-		// (post|site) url  --> (post|site) list --*__in --field=url
-		if ( count( $args ) >= 2 && in_array( $args[0], array( 'post', 'site' ) ) && 'url' === $args[1] ) {
+		// (post|site|term) url  --> (post|site) list --*__in --field=url
+		if ( count( $args ) >= 2 && in_array( $args[0], array( 'post', 'site', 'term' ) ) && 'url' === $args[1] ) {
 			switch ( $args[0] ) {
 				case 'post':
 					$post_ids = array_slice( $args, 2 );
@@ -550,6 +550,17 @@ class Runner {
 					$site_ids = array_slice( $args, 2 );
 					$args = array( 'site', 'list' );
 					$assoc_args['site__in'] = implode( ',', $site_ids );
+					$assoc_args['field'] = 'url';
+					break;
+				case 'term':
+					$taxonomy = '';
+					if ( isset( $args[2] ) ) {
+						$taxonomy = $args[2];
+					}
+					$term_ids = array_slice( $args, 3 );
+					$args = array( 'term', 'list', $taxonomy );
+					$assoc_args['include'] = implode( ',', $term_ids );
+					$assoc_args['orderby'] = 'include';
 					$assoc_args['field'] = 'url';
 					break;
 			}

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -535,8 +535,8 @@ class Runner {
 			}
 		}
 
-		// (post|site|term) url  --> (post|site) list --*__in --field=url
-		if ( count( $args ) >= 2 && in_array( $args[0], array( 'post', 'site', 'term' ) ) && 'url' === $args[1] ) {
+		// (post|comment|site|term) url  --> (post|comment|site|term) list --*__in --field=url
+		if ( count( $args ) >= 2 && in_array( $args[0], array( 'post', 'comment', 'site', 'term' ) ) && 'url' === $args[1] ) {
 			switch ( $args[0] ) {
 				case 'post':
 					$post_ids = array_slice( $args, 2 );
@@ -544,6 +544,13 @@ class Runner {
 					$assoc_args['post__in'] = implode( ',', $post_ids );
 					$assoc_args['post_type'] = 'any';
 					$assoc_args['orderby'] = 'post__in';
+					$assoc_args['field'] = 'url';
+					break;
+				case 'comment':
+					$comment_ids = array_slice( $args, 2 );
+					$args = array( 'comment', 'list' );
+					$assoc_args['comment__in'] = implode( ',', $comment_ids );
+					$assoc_args['orderby'] = 'comment__in';
 					$assoc_args['field'] = 'url';
 					break;
 				case 'site':

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -101,6 +101,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 	 * * cap_key
 	 * * allcaps
 	 * * filter
+	 * * url
 	 *
 	 * ## EXAMPLES
 	 *
@@ -155,7 +156,7 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 					return $user;
 
 				$user->roles = implode( ',', $user->roles );
-
+				$user->url = get_author_posts_url( $user->ID, $user->user_nicename );
 				return $user;
 			} );
 


### PR DESCRIPTION
Also adds support for `wp user list --field=url`

Fixes #2070