### PR TITLE
Code styling for WP_CLI\CoreUpgrader and WP_CLI\LanguagePackUpgrader

### DIFF
--- a/php/WP_CLI/CoreUpgrader.php
+++ b/php/WP_CLI/CoreUpgrader.php
@@ -11,7 +11,16 @@ use WP_CLI;
  */
 class CoreUpgrader extends \Core_Upgrader {
 
-	function download_package( $package ) {
+	/**
+	 * Caches the download, and uses cached if available.
+	 *
+	 * @access public
+	 *
+	 * @param string $package The URI of the package. If this is the full path to an
+	 *                        existing local file, it will be returned untouched.
+	 * @return string|WP_Error The full path to the downloaded package file, or a WP_Error object.
+	 */
+	public function download_package( $package ) {
 
 		/**
 		 * Filter whether to return the package.
@@ -23,19 +32,23 @@ class CoreUpgrader extends \Core_Upgrader {
 		 * @param object  $this    The WP_Upgrader instance.
 		 */
 		$reply = apply_filters( 'upgrader_pre_download', false, $package, $this );
-		if ( false !== $reply )
+		if ( false !== $reply ) {
 			return $reply;
+		}
 
-		if ( ! preg_match('!^(http|https|ftp)://!i', $package) && file_exists($package) ) //Local file or remote?
-			return $package; //must be a local file..
+		// Check if package is a local or remote file. Bail if it's local.
+		if ( ! preg_match( '!^(http|https|ftp)://!i', $package ) && file_exists( $package ) ) {
+			return $package;
+		}
 
-		if ( empty( $package ) )
+		if ( empty( $package ) ) {
 			return new \WP_Error( 'no_package', $this->strings['no_package'] );
+		}
 
 		$filename = pathinfo( $package, PATHINFO_FILENAME );
 		$ext = pathinfo( $package, PATHINFO_EXTENSION );
 
-		$temp = \WP_CLI\Utils\get_temp_dir() . uniqid('wp_') . '.' . $ext;
+		$temp = \WP_CLI\Utils\get_temp_dir() . uniqid( 'wp_' ) . '.' . $ext;
 
 		$cache = WP_CLI::get_cache();
 		$update = $GLOBALS['wp_cli_update_obj'];
@@ -47,13 +60,13 @@ class CoreUpgrader extends \Core_Upgrader {
 			copy( $cache_file, $temp );
 			return $temp;
 		} else {
-			// We need to use a temporary file because piping from cURL to tar is flaky
-			// on MinGW (and probably in other environments too).
-			$temp = sys_get_temp_dir() . '/' . uniqid('wp_') . '.' . $ext;
-
-			$headers = array('Accept' => 'application/json');
+			/*
+			 * Download to a temporary file because piping from cURL to tar is flaky
+			 * on MinGW (and probably in other environments too).
+			 */
+			$headers = array( 'Accept' => 'application/json' );
 			$options = array(
-				'timeout' => 600,  // 10 minutes ought to be enough for everybody
+				'timeout'  => 600,  // 10 minutes ought to be enough for everybody.
 				'filename' => $temp
 			);
 
@@ -67,7 +80,5 @@ class CoreUpgrader extends \Core_Upgrader {
 			$cache->import( $cache_key, $temp );
 			return $temp;
 		}
-
 	}
-
 }


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/pull/3595#issuecomment-262598544

* Adds missing DocBlock for `download_package()`
* Adds missing brackets
* Whitespace cleanup
* Removes the declaration of a second `$temp` variable. This was introduced in https://github.com/wp-cli/wp-cli/commit/5fbcb26b8b1cca7aa29a1ac8b163b80aa9d96b2c.