### PR TITLE
Use `html_entity_decode()` for decoding entities in upgrader strings

### DIFF
--- a/php/WP_CLI/UpgraderSkin.php
+++ b/php/WP_CLI/UpgraderSkin.php
@@ -42,6 +42,7 @@ class UpgraderSkin extends \WP_Upgrader_Skin {
 			return;
 
 		$string = str_replace( '&#8230;', '...', strip_tags( $string ) );
+		$string = html_entity_decode( $string, ENT_QUOTES, get_bloginfo( 'charset' ) );
 
 		\WP_CLI::log( $string );
 	}


### PR DESCRIPTION
This fixes displaying entities like `&#160;` in CLI context.

<img width="902" alt="bildschirmfoto 2016-11-24 um 12 18 59" src="https://cloud.githubusercontent.com/assets/617637/20596745/376f5b0a-b240-11e6-88c5-d0c0e3acfbbd.png">

I've left the `str_replace( '&#8230;', '...',` part as is because `...` is more visible than `…` IMO.