### PR TITLE
Add WP-CLI version to package manager's `composer.json`

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -405,3 +405,79 @@ Feature: Install WP-CLI packages
       """
       wp-cli/community-command
       """
+
+  Scenario: Install a package requiring a WP-CLI version that doesn't match
+    Given an empty directory
+    And a new Phar with version "0.23.0"
+    And a path-command/command.php file:
+      """
+      <?php
+      WP_CLI::add_command( 'community-command', function(){
+        WP_CLI::success( "success!" );
+      }, array( 'when' => 'before_wp_load' ) );
+      """
+    And a path-command/composer.json file:
+      """
+      {
+        "name": "wp-cli/community-command",
+        "description": "A demo community command.",
+        "license": "MIT",
+        "minimum-stability": "dev",
+        "autoload": {
+          "files": [ "command.php" ]
+        },
+        "require": {
+          "wp-cli/wp-cli": ">=0.24.0"
+        },
+        "require-dev": {
+          "behat/behat": "~2.5"
+        }
+      }
+      """
+
+    When I try `{PHAR_PATH} package install path-command`
+    Then STDOUT should contain:
+      """
+      wp-cli/community-command dev-master requires wp-cli/wp-cli >=0.24.0
+      """
+    And STDERR should contain:
+      """
+      Error: Package installation failed
+      """
+    And the return code should be 1
+
+  Scenario: Install a package requiring a WP-CLI version that does match
+    Given an empty directory
+    And a new Phar with version "0.23.0"
+    And a path-command/command.php file:
+      """
+      <?php
+      WP_CLI::add_command( 'community-command', function(){
+        WP_CLI::success( "success!" );
+      }, array( 'when' => 'before_wp_load' ) );
+      """
+    And a path-command/composer.json file:
+      """
+      {
+        "name": "wp-cli/community-command",
+        "description": "A demo community command.",
+        "license": "MIT",
+        "minimum-stability": "dev",
+        "autoload": {
+          "files": [ "command.php" ]
+        },
+        "require": {
+          "wp-cli/wp-cli": ">=0.22.0"
+        },
+        "require-dev": {
+          "behat/behat": "~2.5"
+        }
+      }
+      """
+
+    When I run `{PHAR_PATH} package install path-command`
+    Then STDOUT should contain:
+      """
+      Success: Package installed.
+      """
+    And the return code should be 0

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -446,6 +446,12 @@ Feature: Install WP-CLI packages
       """
     And the return code should be 1
 
+    When I run `cat {PACKAGE_PATH}composer.json`
+    Then STDOUT should contain:
+      """
+      "version": "0.23.0",
+      """
+
   Scenario: Install a package requiring a WP-CLI version that does match
     Given an empty directory
     And a new Phar with version "0.23.0"
@@ -481,3 +487,51 @@ Feature: Install WP-CLI packages
       Success: Package installed.
       """
     And the return code should be 0
+
+    When I run `cat {PACKAGE_PATH}composer.json`
+    Then STDOUT should contain:
+      """
+      "version": "0.23.0",
+      """
+
+  Scenario: Install a package requiring a WP-CLI alpha version that does match
+    Given an empty directory
+    And a new Phar with version "0.23.0-alpha-90ecad6"
+    And a path-command/command.php file:
+      """
+      <?php
+      WP_CLI::add_command( 'community-command', function(){
+        WP_CLI::success( "success!" );
+      }, array( 'when' => 'before_wp_load' ) );
+      """
+    And a path-command/composer.json file:
+      """
+      {
+        "name": "wp-cli/community-command",
+        "description": "A demo community command.",
+        "license": "MIT",
+        "minimum-stability": "dev",
+        "autoload": {
+          "files": [ "command.php" ]
+        },
+        "require": {
+          "wp-cli/wp-cli": ">=0.22.0"
+        },
+        "require-dev": {
+          "behat/behat": "~2.5"
+        }
+      }
+      """
+
+    When I run `{PHAR_PATH} package install path-command`
+    Then STDOUT should contain:
+      """
+      Success: Package installed.
+      """
+    And the return code should be 0
+
+    When I run `cat {PACKAGE_PATH}composer.json`
+    Then STDOUT should contain:
+      """
+      "version": "0.23.0-alpha",
+      """

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -249,7 +249,7 @@ class Package_Command extends WP_CLI_Command {
 		$composer_backup = file_get_contents( $composer_json_obj->getPath() );
 		$json_manipulator = new JsonManipulator( $composer_backup );
 		$json_manipulator->addMainKey( 'name', 'wp-cli/wp-cli' );
-		$json_manipulator->addMainKey( 'version', WP_CLI_VERSION );
+		$json_manipulator->addMainKey( 'version', self::get_wp_cli_version_composer() );
 		$json_manipulator->addLink( 'require', $package_name, $version );
 		$json_manipulator->addConfigSetting( 'secure-http', true );
 
@@ -718,6 +718,14 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Get the WP-CLI version for composer.json
+	 */
+	private static function get_wp_cli_version_composer() {
+		preg_match( '#^[0-9\.]+(-(alpha|beta)[^-]{0,})?#', WP_CLI_VERSION, $matches );
+		return isset( $matches[0] ) ? $matches[0] : '';
+	}
+
+	/**
 	 * Create a default composer.json, should one not already exist
 	 *
 	 * @param string $composer_path Where the composer.json should be created
@@ -751,6 +759,7 @@ class Package_Command extends WP_CLI_Command {
 		$options = array(
 			'name' => 'wp-cli/wp-cli',
 			'description' => 'Installed community packages used by WP-CLI',
+			'version' => self::get_wp_cli_version_composer(),
 			'authors' => array( $author ),
 			'homepage' => self::PACKAGE_INDEX_URL,
 			'require' => new stdClass,

--- a/php/commands/package.php
+++ b/php/commands/package.php
@@ -249,6 +249,7 @@ class Package_Command extends WP_CLI_Command {
 		$composer_backup = file_get_contents( $composer_json_obj->getPath() );
 		$json_manipulator = new JsonManipulator( $composer_backup );
 		$json_manipulator->addMainKey( 'name', 'wp-cli/wp-cli' );
+		$json_manipulator->addMainKey( 'version', WP_CLI_VERSION );
 		$json_manipulator->addLink( 'require', $package_name, $version );
 		$json_manipulator->addConfigSetting( 'secure-http', true );
 


### PR DESCRIPTION
This one little trick lets Composer handle WP-CLI version constraints
defined in a package's `composer.json`

Fixes #2675