### PR TITLE
Introduce `WP_CLI::runcommand()`, the best way to run WP-CLI commands

### DIFF
--- a/features/core-update-db.feature
+++ b/features/core-update-db.feature
@@ -55,7 +55,7 @@ Feature: Update core's database
       Success: WordPress database upgraded on 3/3 sites.
       """
 
-  Scenario: Update db across network
+  Scenario: Update db across network, dry run
     Given a WP multisite install
     And I run `wp core download --version=4.1 --force`
     And I run `wp option update db_version 29630`

--- a/features/rewrite.feature
+++ b/features/rewrite.feature
@@ -68,6 +68,7 @@ Feature: Manage WordPress rewrites
 
     When I run `wp rewrite structure /%year%/%monthnum%/%day%/%postname%/ --hard`
     Then the .htaccess file should exist
+    And the return code should be 0
 
   Scenario: Generate .htaccess on hard flush with a global config
     Given a WP install
@@ -78,6 +79,7 @@ Feature: Manage WordPress rewrites
 
     When I run `WP_CLI_CONFIG_PATH=config.yml wp rewrite structure /%year%/%monthnum%/%day%/%postname%/ --hard`
     Then the .htaccess file should exist
+    And the return code should be 0
 
   Scenario: Error when trying to generate .htaccess on a multisite install
     Given a WP multisite install
@@ -91,9 +93,11 @@ Feature: Manage WordPress rewrites
       """
       Warning: WordPress can't generate .htaccess file for a multisite install.
       """
+    And the return code should be 0
 
     When I try `wp rewrite structure /%year%/%monthnum%/%day%/%postname%/ --hard`
     Then STDERR should contain:
       """
       Warning: WordPress can't generate .htaccess file for a multisite install.
       """
+    And the return code should be 0

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -178,6 +178,14 @@ Feature: Run a WP-CLI command
     And STDERR should be empty
     And the return code should be 0
 
+    When I run `wp <flag> --no-exit_error run 'option get foo$bar'`
+    Then STDOUT should be:
+      """
+      returned: NULL
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
     Examples:
       | flag        |
       | --no-launch |

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -17,6 +17,9 @@ Feature: Run a WP-CLI command
        * [--launch]
        * : Launch a new process for the command.
        *
+       * [--exit_error]
+       * : Exit on error.
+       *
        * [--return[=<return>]]
        * : Capture and return output.
        *
@@ -156,6 +159,24 @@ Feature: Run a WP-CLI command
       Error: 1
       """
     And the return code should be 1
+
+    Examples:
+      | flag        |
+      | --no-launch |
+      | --launch    |
+
+  Scenario Outline: Override erroring on exit
+    When I try `wp run <flag> --no-exit_error --return=all 'eval "WP_CLI::error( var_export( get_current_user_id(), true ) );"'`
+    Then STDOUT should be:
+      """
+      returned: array (
+        'stdout' => '',
+        'stderr' => 'Error: 1',
+        'return_code' => 1,
+      )
+      """
+    And STDERR should be empty
+    And the return code should be 0
 
     Examples:
       | flag        |

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -1,3 +1,4 @@
+@require-php-5.4
 Feature: Run a WP-CLI command
 
   Background:

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -31,8 +31,8 @@ Feature: Run a WP-CLI command
         - command.php
       """
 
-  Scenario: Run a WP-CLI command in the same process, rendering output
-    When I run `wp run 'option get home' --no-launch`
+  Scenario Outline: Run a WP-CLI command and render output
+    When I run `wp <flag> run 'option get home'`
     Then STDOUT should be:
       """
       http://example.com
@@ -40,7 +40,7 @@ Feature: Run a WP-CLI command
       """
     And the return code should be 0
 
-    When I run `wp --no-launch run 'eval "echo wp_get_current_user()->user_login . PHP_EOL;"'`
+    When I run `wp <flag> run 'eval "echo wp_get_current_user()->user_login . PHP_EOL;"'`
     Then STDOUT should be:
       """
       admin
@@ -48,17 +48,27 @@ Feature: Run a WP-CLI command
       """
     And the return code should be 0
 
-  Scenario: Run a WP-CLI command in the same process, capturing output
-    When I run `wp run --no-launch --capture 'option get home'`
+    Examples:
+      | flag        |
+      | --no-launch |
+      | --launch    |
+
+  Scenario Outline: Run a WP-CLI command and capture output
+    When I run `wp run <flag> --capture 'option get home'`
     Then STDOUT should be:
       """
       returned: 'http://example.com'
       """
     And the return code should be 0
 
-    When I run `wp --no-launch --capture run 'eval "echo wp_get_current_user()->user_login . PHP_EOL;"'`
+    When I run `wp <flag> --capture run 'eval "echo wp_get_current_user()->user_login . PHP_EOL;"'`
     Then STDOUT should be:
       """
       returned: 'admin'
       """
     And the return code should be 0
+
+    Examples:
+      | flag        |
+      | --no-launch |
+      | --launch    |

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -148,6 +148,20 @@ Feature: Run a WP-CLI command
       | --no-launch |
       | --launch    |
 
+  Scenario Outline: Exit on error by default
+    When I try `wp run <flag> 'eval "WP_CLI::error( var_export( get_current_user_id(), true ) );"'`
+    Then STDOUT should be empty
+    And STDERR should be:
+      """
+      Error: 1
+      """
+    And the return code should be 1
+
+    Examples:
+      | flag        |
+      | --no-launch |
+      | --launch    |
+
   Scenario Outline: Installed packages work as expected
     When I run `wp package install wp-cli/scaffold-package-command`
     Then STDERR should be empty

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -16,7 +16,7 @@ Feature: Run a WP-CLI command
        * [--launch]
        * : Launch a new process for the command.
        *
-       * [--capture]
+       * [--return[=<return>]]
        * : Capture and return output.
        */
       WP_CLI::add_command( 'run', function( $args, $assoc_args ){
@@ -56,7 +56,7 @@ Feature: Run a WP-CLI command
       | --launch    |
 
   Scenario Outline: Run a WP-CLI command and capture output
-    When I run `wp run <flag> --capture 'option get home'`
+    When I run `wp run <flag> --return 'option get home'`
     Then STDOUT should be:
       """
       returned: 'http://example.com'
@@ -64,7 +64,7 @@ Feature: Run a WP-CLI command
     And STDERR should be empty
     And the return code should be 0
 
-    When I run `wp <flag> --capture run 'eval "echo wp_get_current_user()->user_login . PHP_EOL;"'`
+    When I run `wp <flag> --return run 'eval "echo wp_get_current_user()->user_login . PHP_EOL;"'`
     Then STDOUT should be:
       """
       returned: 'admin'

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -31,6 +31,12 @@ Feature: Run a WP-CLI command
       require:
         - command.php
       """
+    And a config.yml file:
+      """
+      user get:
+        0: admin
+        field: user_email
+      """
 
   Scenario Outline: Run a WP-CLI command and render output
     When I run `wp <flag> run 'option get home'`
@@ -46,6 +52,15 @@ Feature: Run a WP-CLI command
     Then STDOUT should be:
       """
       admin
+      returned: NULL
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    When I run `WP_CLI_CONFIG_PATH=config.yml wp <flag> run 'user get'`
+    Then STDOUT should be:
+      """
+      admin@example.com
       returned: NULL
       """
     And STDERR should be empty
@@ -69,6 +84,14 @@ Feature: Run a WP-CLI command
     Then STDOUT should be:
       """
       returned: 'admin'
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    When I run `WP_CLI_CONFIG_PATH=config.yml wp --return <flag> run 'user get'`
+    Then STDOUT should be:
+      """
+      returned: 'admin@example.com'
       """
     And STDERR should be empty
     And the return code should be 0

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -19,6 +19,9 @@ Feature: Run a WP-CLI command
        *
        * [--return[=<return>]]
        * : Capture and return output.
+       *
+       * [--parse=<format>]
+       * : Parse returned output as a particular format.
        */
       WP_CLI::add_command( 'run', function( $args, $assoc_args ){
         $ret = WP_CLI::runcommand( $args[0], $assoc_args );
@@ -124,6 +127,21 @@ Feature: Run a WP-CLI command
       """
     And STDERR should be empty
     And the return code should be 0
+
+    Examples:
+      | flag        |
+      | --no-launch |
+      | --launch    |
+
+  Scenario Outline: Use 'parse=json' to parse JSON output
+    When I run `wp run --return --parse=json <flag> 'user get admin --fields=user_login,user_email --format=json'`
+    Then STDOUT should be:
+      """
+      returned: array (
+        'user_login' => 'admin',
+        'user_email' => 'admin@example.com',
+      )
+      """
 
     Examples:
       | flag        |

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -22,6 +22,7 @@ Feature: Run a WP-CLI command
        */
       WP_CLI::add_command( 'run', function( $args, $assoc_args ){
         $ret = WP_CLI::runcommand( $args[0], $assoc_args );
+        $ret = is_object( $ret ) ? (array) $ret : $ret;
         WP_CLI::log( 'returned: ' . var_export( $ret, true ) );
       });
       """

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -38,6 +38,7 @@ Feature: Run a WP-CLI command
       http://example.com
       returned: NULL
       """
+    And STDERR should be empty
     And the return code should be 0
 
     When I run `wp <flag> run 'eval "echo wp_get_current_user()->user_login . PHP_EOL;"'`
@@ -46,6 +47,7 @@ Feature: Run a WP-CLI command
       admin
       returned: NULL
       """
+    And STDERR should be empty
     And the return code should be 0
 
     Examples:
@@ -59,6 +61,7 @@ Feature: Run a WP-CLI command
       """
       returned: 'http://example.com'
       """
+    And STDERR should be empty
     And the return code should be 0
 
     When I run `wp <flag> --capture run 'eval "echo wp_get_current_user()->user_login . PHP_EOL;"'`
@@ -66,6 +69,7 @@ Feature: Run a WP-CLI command
       """
       returned: 'admin'
       """
+    And STDERR should be empty
     And the return code should be 0
 
     Examples:

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -88,6 +88,34 @@ Feature: Run a WP-CLI command
     And STDERR should be empty
     And the return code should be 0
 
+    When I run `wp <flag> --return=stderr run 'eval "echo wp_get_current_user()->user_login . PHP_EOL;"'`
+    Then STDOUT should be:
+      """
+      returned: ''
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    When I run `wp <flag> --return=return_code run 'eval "echo wp_get_current_user()->user_login . PHP_EOL;"'`
+    Then STDOUT should be:
+      """
+      returned: 0
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    When I run `wp <flag> --return=all run 'eval "echo wp_get_current_user()->user_login . PHP_EOL;"'`
+    Then STDOUT should be:
+      """
+      returned: array (
+        'stdout' => 'admin',
+        'stderr' => '',
+        'return_code' => 0,
+      )
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
     When I run `WP_CLI_CONFIG_PATH=config.yml wp --return <flag> run 'user get'`
     Then STDOUT should be:
       """

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -1,0 +1,64 @@
+Feature: Run a WP-CLI command
+
+  Background:
+    Given a WP install
+    And a command.php file:
+      """
+      <?php
+      /**
+       * Run a WP-CLI command with WP_CLI::runcommand();
+       *
+       * ## OPTIONS
+       *
+       * <command>
+       * : Command to run, quoted.
+       *
+       * [--launch]
+       * : Launch a new process for the command.
+       *
+       * [--capture]
+       * : Capture and return output.
+       */
+      WP_CLI::add_command( 'run', function( $args, $assoc_args ){
+        $ret = WP_CLI::runcommand( $args[0], $assoc_args );
+        WP_CLI::log( 'returned: ' . var_export( $ret, true ) );
+      });
+      """
+    And a wp-cli.yml file:
+      """
+      user: admin
+      require:
+        - command.php
+      """
+
+  Scenario: Run a WP-CLI command in the same process, rendering output
+    When I run `wp run 'option get home' --no-launch`
+    Then STDOUT should be:
+      """
+      http://example.com
+      returned: NULL
+      """
+    And the return code should be 0
+
+    When I run `wp --no-launch run 'eval "echo wp_get_current_user()->user_login . PHP_EOL;"'`
+    Then STDOUT should be:
+      """
+      admin
+      returned: NULL
+      """
+    And the return code should be 0
+
+  Scenario: Run a WP-CLI command in the same process, capturing output
+    When I run `wp run --no-launch --capture 'option get home'`
+    Then STDOUT should be:
+      """
+      returned: 'http://example.com'
+      """
+    And the return code should be 0
+
+    When I run `wp --no-launch --capture run 'eval "echo wp_get_current_user()->user_login . PHP_EOL;"'`
+    Then STDOUT should be:
+      """
+      returned: 'admin'
+      """
+    And the return code should be 0

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -100,3 +100,19 @@ Feature: Run a WP-CLI command
       | flag        |
       | --no-launch |
       | --launch    |
+
+  Scenario Outline: Installed packages work as expected
+    When I run `wp package install wp-cli/scaffold-package-command`
+    Then STDERR should be empty
+
+    When I run `wp <flag> run 'help scaffold package'`
+    Then STDOUT should contain:
+      """
+      wp scaffold package <name>
+      """
+    And STDERR should be empty
+
+    Examples:
+    | flag        |
+    | --no-launch |
+    | --launch    |

--- a/php/WP_CLI/ExitException.php
+++ b/php/WP_CLI/ExitException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace WP_CLI;
+
+class ExitException extends \Exception {}

--- a/php/WP_CLI/Loggers/Execution.php
+++ b/php/WP_CLI/Loggers/Execution.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace WP_CLI\Loggers;
+
+/**
+ * Execution logger captures all STDOUT and STDERR writes
+ */
+class Execution extends Base {
+
+	/**
+	 * Captured writes to STDOUT.
+	 */
+	public $stdout = '';
+
+	/**
+	 * Captured writes to STDERR.
+	 */
+	public $stderr = '';
+
+	/**
+	 * Write an informational message to STDOUT.
+	 *
+	 * @param string $message Message to write.
+	 */
+	public function info( $message ) {
+		$this->write( 'STDOUT', $message . "\n" );
+	}
+
+	/**
+	 * Write a success message, prefixed with "Success: ".
+	 *
+	 * @param string $message Message to write.
+	 */
+	public function success( $message ) {
+		$this->_line( $message, 'Success', '%G' );
+	}
+
+	/**
+	 * Write a warning message to STDERR, prefixed with "Warning: ".
+	 *
+	 * @param string $message Message to write.
+	 */
+	public function warning( $message ) {
+		$this->_line( $message, 'Warning', '%C', 'STDERR' );
+	}
+
+	/**
+	 * Write an message to STDERR, prefixed with "Error: ".
+	 *
+	 * @param string $message Message to write.
+	 */
+	public function error( $message ) {
+		$this->_line( $message, 'Error', '%R', 'STDERR' );
+	}
+
+	/**
+	 * Similar to error( $message ), but outputs $message in a red box
+	 *
+	 * @param  array $message Message to write.
+	 */
+	public function error_multi_line( $message_lines ) {
+		$message = implode( "\n", $message_lines );
+
+		$this->write( 'STDERR', \WP_CLI::colorize( "%RError:%n\n$message\n" ) );
+		$this->write( 'STDERR', \WP_CLI::colorize( "%R---------%n\n\n" ) );
+	}
+
+	/**
+	 * Write a string to a resource.
+	 *
+	 * @param resource $handle Commonly STDOUT or STDERR.
+	 * @param string $str Message to write.
+	 */
+	protected function write( $handle, $str ) {
+		switch( $handle ) {
+			case 'STDOUT':
+				$this->stdout .= $str;
+				break;
+			case 'STDERR':
+				$this->stderr .= $str;
+				break;
+		}
+	}
+}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -924,12 +924,14 @@ class WP_CLI {
 	 */
 	public static function runcommand( $command, $options = array() ) {
 		$defaults = array(
-			'launch' => true, // Launch a new process, or reuse the existing.
-			'return' => false, // Capture and return output, or render in realtime.
-			'parse'  => false, // Parse returned output as a particular format.
+			'launch'     => true, // Launch a new process, or reuse the existing.
+			'exit_error' => true, // Exit on error by default.
+			'return'     => false, // Capture and return output, or render in realtime.
+			'parse'      => false, // Parse returned output as a particular format.
 		);
 		$options = array_merge( $defaults, $options );
 		$launch = $options['launch'];
+		$exit_error = $options['exit_error'];
 		$return = $options['return'];
 		$parse = $options['parse'];
 		$retval = null;
@@ -978,6 +980,8 @@ class WP_CLI {
 			$return_code = proc_close( $proc );
 			if ( -1 == $return_code ) {
 				self::warning( "Spawned process returned exit code -1, which could be caused by a custom compiled version of PHP that uses the --enable-sigchild option." );
+			} else if ( $return_code && $exit_error ) {
+				exit( $return_code );
 			}
 			if ( true === $return || 'stdout' === $return ) {
 				$retval = trim( $stdout );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -912,7 +912,7 @@ class WP_CLI {
 	 * Run a WP-CLI command.
 	 *
 	 * ```
-	 * $plugins = WP_CLI::run_command( 'plugin list' );
+	 * $plugins = WP_CLI::run_command( 'plugin list', array( 'capture' => true ) );
 	 * ```
 	 *
 	 * @access public
@@ -928,16 +928,48 @@ class WP_CLI {
 			'capture' => false, // Capture STDOUT, or render on the fly
 		);
 		$options = array_merge( $defaults, $options );
+		$launch = $options['launch'];
+		$capture = $options['capture'];
 		$retval = null;
-		if ( empty( $options['launch'] ) ) {
+		if ( $launch ) {
+			if ( $capture ) {
+				$descriptors = array(
+					0 => STDIN,
+					1 => array( 'pipe', 'w' ),
+					2 => array( 'pipe', 'w' ),
+				);
+			} else {
+				$descriptors = array(
+					0 => STDIN,
+					1 => STDOUT,
+					2 => STDERR,
+				);
+			}
+
+			$php_bin = self::get_php_binary();
+			$script_path = $GLOBALS['argv'][0];
+			$runcommand = "{$php_bin} {$script_path} {$command}";
+
+			$env = array();
+			$proc = proc_open( $runcommand, $descriptors, $pipes, getcwd(), $env );
+
+			if ( $capture ) {
+				$stdout = stream_get_contents( $pipes[1] );
+				fclose( $pipes[1] );
+				$stderr = stream_get_contents( $pipes[2] );
+				fclose( $pipes[2] );
+				$retval = trim( $stdout );
+			}
+			$return_code = proc_close( $proc );
+		} else {
 			$configurator = self::get_configurator();
 			$argv = Utils\parse_str_to_argv( $command );
 			list( $args, $assoc_args, $runtime_config ) = $configurator->parse_args( $argv );
-			if ( ! empty( $options['capture'] ) ) {
+			if ( $capture ) {
 				ob_start();
 			}
 			self::get_runner()->run_command( $args, $assoc_args );
-			if ( ! empty( $options['capture'] ) ) {
+			if ( $capture ) {
 				$retval = trim( ob_get_clean() );
 			}
 		}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -950,7 +950,21 @@ class WP_CLI {
 			$script_path = $GLOBALS['argv'][0];
 			$runcommand = "{$php_bin} {$script_path} {$command}";
 
+			$env_vars = array(
+				'HOME',
+				'WP_CLI_AUTO_CHECK_UPDATE_DAYS',
+				'WP_CLI_CACHE_DIR',
+				'WP_CLI_CONFIG_PATH',
+				'WP_CLI_DISABLE_AUTO_CHECK_UPDATE',
+				'WP_CLI_PACKAGES_DIR',
+				'WP_CLI_PHP_USED',
+				'WP_CLI_PHP',
+				'WP_CLI_STRICT_ARGS_MODE',
+			);
 			$env = array();
+			foreach( $env_vars as $var ) {
+				$env[ $var ] = getenv( $var );
+			}
 			$proc = proc_open( $runcommand, $descriptors, $pipes, getcwd(), $env );
 
 			if ( $should_return ) {
@@ -961,6 +975,9 @@ class WP_CLI {
 				$return = trim( $stdout );
 			}
 			$return_code = proc_close( $proc );
+			if ( -1 == $return_code ) {
+				self::warning( "Spawned process returned exit code -1, which could be caused by a custom compiled version of PHP that uses the --enable-sigchild option." );
+			}
 		} else {
 			$configurator = self::get_configurator();
 			$argv = Utils\parse_str_to_argv( $command );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -646,6 +646,23 @@ class WP_CLI {
 	}
 
 	/**
+	 * Halt script execution with a specific return code.
+	 *
+	 * Permits script execution to be overloaded by `WP_CLI::runcommand()`
+	 *
+	 * @access public
+	 * @category Output
+	 *
+	 * @param integer $return_code
+	 */
+	public static function halt( $return_code ) {
+		if ( self::$capture_exit ) {
+			throw new ExitException( null, $return_code );
+		}
+		exit( $return_code );
+	}
+
+	/**
 	 * Display a multi-line error message in a red box. Doesn't exit script.
 	 *
 	 * Error message is written to STDERR.

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -984,7 +984,7 @@ class WP_CLI {
 			} else if ( 'return_code' === $return ) {
 				$retval = $return_code;
 			} else if ( 'all' === $return ) {
-				$retval = array(
+				$retval = (object) array(
 					'stdout'      => trim( $stdout ),
 					'stderr'      => trim( $stderr ),
 					'return_code' => $return_code,
@@ -1009,7 +1009,7 @@ class WP_CLI {
 				} else if ( 'return_code' === $return ) {
 					$retval = $return_code;
 				} else if ( 'all' === $return ) {
-					$retval = array(
+					$retval = (object) array(
 						'stdout'      => trim( $stdout ),
 						'stderr'      => trim( $stderr ),
 						'return_code' => $return_code,

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -912,7 +912,7 @@ class WP_CLI {
 	 * Run a WP-CLI command.
 	 *
 	 * ```
-	 * $plugins = WP_CLI::run_command( 'plugin list', array( 'capture' => true ) );
+	 * $plugins = WP_CLI::run_command( 'plugin list', array( 'return' => true ) );
 	 * ```
 	 *
 	 * @access public
@@ -924,15 +924,15 @@ class WP_CLI {
 	 */
 	public static function runcommand( $command, $options = array() ) {
 		$defaults = array(
-			'launch'  => true, // Launch a new process, or reuse the existing.
-			'capture' => false, // Capture STDOUT, or render on the fly
+			'launch' => true, // Launch a new process, or reuse the existing.
+			'return' => false, // Capture and return output, or render in realtime.
 		);
 		$options = array_merge( $defaults, $options );
 		$launch = $options['launch'];
-		$capture = $options['capture'];
-		$retval = null;
+		$should_return = $options['return'];
+		$return = null;
 		if ( $launch ) {
-			if ( $capture ) {
+			if ( $should_return ) {
 				$descriptors = array(
 					0 => STDIN,
 					1 => array( 'pipe', 'w' ),
@@ -953,27 +953,27 @@ class WP_CLI {
 			$env = array();
 			$proc = proc_open( $runcommand, $descriptors, $pipes, getcwd(), $env );
 
-			if ( $capture ) {
+			if ( $should_return ) {
 				$stdout = stream_get_contents( $pipes[1] );
 				fclose( $pipes[1] );
 				$stderr = stream_get_contents( $pipes[2] );
 				fclose( $pipes[2] );
-				$retval = trim( $stdout );
+				$return = trim( $stdout );
 			}
 			$return_code = proc_close( $proc );
 		} else {
 			$configurator = self::get_configurator();
 			$argv = Utils\parse_str_to_argv( $command );
 			list( $args, $assoc_args, $runtime_config ) = $configurator->parse_args( $argv );
-			if ( $capture ) {
+			if ( $should_return ) {
 				ob_start();
 			}
 			self::get_runner()->run_command( $args, $assoc_args );
-			if ( $capture ) {
-				$retval = trim( ob_get_clean() );
+			if ( $should_return ) {
+				$return = trim( ob_get_clean() );
 			}
 		}
-		return $retval;
+		return $return;
 	}
 
 	/**

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -912,7 +912,7 @@ class WP_CLI {
 	 * Run a WP-CLI command.
 	 *
 	 * ```
-	 * $plugins = WP_CLI::run_command( 'plugin list', array( 'return' => true ) );
+	 * $plugins = WP_CLI::run_command( 'plugin list --format=json', array( 'return' => true ) );
 	 * ```
 	 *
 	 * @access public
@@ -926,10 +926,12 @@ class WP_CLI {
 		$defaults = array(
 			'launch' => true, // Launch a new process, or reuse the existing.
 			'return' => false, // Capture and return output, or render in realtime.
+			'parse'  => false, // Parse returned output as a particular format.
 		);
 		$options = array_merge( $defaults, $options );
 		$launch = $options['launch'];
 		$return = $options['return'];
+		$parse = $options['parse'];
 		$retval = null;
 		if ( $launch ) {
 			if ( $return ) {
@@ -1016,6 +1018,10 @@ class WP_CLI {
 					);
 				}
 			}
+		}
+		if ( ( true === $return || 'stdout' === $return )
+			&& 'json' === $parse ) {
+			$retval = json_decode( $retval, true );
 		}
 		return $retval;
 	}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1044,11 +1044,11 @@ class WP_CLI {
 			list( $args, $assoc_args, $runtime_config ) = $configurator->parse_args( $argv );
 			if ( $return ) {
 				ob_start();
+				$existing_logger = self::$logger;
+				self::$logger = new WP_CLI\Loggers\Execution;
 			}
 			if ( ! $exit_error ) {
 				self::$capture_exit = true;
-				$existing_logger = self::$logger;
-				self::$logger = new WP_CLI\Loggers\Execution;
 			}
 			try {
 				self::get_runner()->run_command( $args, $assoc_args );
@@ -1056,9 +1056,9 @@ class WP_CLI {
 			} catch( ExitException $e ) {
 				$return_code = $e->getCode();
 			}
-			$execution_logger = self::$logger;
-			self::$logger = $existing_logger;
 			if ( $return ) {
+				$execution_logger = self::$logger;
+				self::$logger = $existing_logger;
 				$stdout = trim( ob_get_clean() );
 				$stderr = $execution_logger->stderr;
 				if ( true === $return || 'stdout' === $return ) {

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -817,6 +817,8 @@ class WP_CLI {
 	/**
 	 * Run a WP-CLI command in a new process reusing the current runtime arguments.
 	 *
+	 * Use `WP_CLI::runcommand()` instead, which is easier to use and works better.
+	 *
 	 * Note: While this command does persist a limited set of runtime arguments,
 	 * it *does not* persist environment variables. Practically speaking, WP-CLI
 	 * packages won't be loaded when using WP_CLI::launch_self() because the
@@ -922,8 +924,20 @@ class WP_CLI {
 	/**
 	 * Run a WP-CLI command.
 	 *
+	 * Launch a new child process, or run the command in the current process.
+	 * Optionally:
+	 * * Prevent halting script execution on error.
+	 * * Capture and return STDOUT, or full details about command execution.
+	 * * Parse JSON output if the command rendered it.
+	 *
 	 * ```
-	 * $plugins = WP_CLI::run_command( 'plugin list --format=json', array( 'return' => true ) );
+	 * $options = array(
+	 *   'return'     => true,  // Return 'STDOUT'; use 'all' for full object.
+	 *   'parse'      => 'json' // Parse captured STDOUT to JSON array.
+	 *   'launch'     => false, // Reuse the current process.
+	 *   'exit_error' => true,  // Halt script execution on error.
+	 * );
+	 * $plugins = WP_CLI::runcommand( 'plugin list --format=json', $options );
 	 * ```
 	 *
 	 * @access public
@@ -1058,6 +1072,8 @@ class WP_CLI {
 	/**
 	 * Run a given command within the current process using the same global
 	 * parameters.
+	 *
+	 * Use `WP_CLI::runcommand()` instead, which is easier to use and works better.
 	 *
 	 * To run a command using a new process with the same global parameters,
 	 * use WP_CLI::launch_self(). To run a command using a new process with

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -931,16 +931,7 @@ class WP_CLI {
 		$retval = null;
 		if ( empty( $options['launch'] ) ) {
 			$configurator = self::get_configurator();
-			preg_match_all ('/(?<=^|\s)([\'"]?)(.+?)(?<!\\\\)\1(?=$|\s)/', $command, $matches );
-			$argv = isset( $matches[0] ) ? $matches[0] : array();
-			$argv = array_map( function( $arg ){
-				foreach( array( '"', "'" ) as $char ) {
-					if ( $char === substr( $arg, 0, 1 ) && $char === substr( $arg, -1 ) ) {
-						$arg = substr( $arg, 1, -1 );
-					}
-				}
-				return $arg;
-			}, $argv );
+			$argv = Utils\parse_str_to_argv( $command );
 			list( $args, $assoc_args, $runtime_config ) = $configurator->parse_args( $argv );
 			if ( ! empty( $options['capture'] ) ) {
 				ob_start();

--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -269,7 +269,7 @@ class CLI_Command extends WP_CLI_Command {
 			if ( empty( $updates ) ) {
 				$update_type = $this->get_update_type_str( $assoc_args );
 				WP_CLI::success( "WP-CLI is at the latest{$update_type}version." );
-				exit(0);
+				return;
 			}
 
 			$newest = $updates[0];

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -435,14 +435,14 @@ class Core_Command extends WP_CLI_Command {
 
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'network' ) ) {
 			if ( is_blog_installed() && is_multisite() ) {
-				exit( 0 );
+				WP_CLI::halt( 0 );
 			} else {
-				exit( 1 );
+				WP_CLI::halt( 1 );
 			}
 		} else if ( is_blog_installed() ) {
-			exit( 0 );
+			WP_CLI::halt( 0 );
 		} else {
-			exit( 1 );
+			WP_CLI::halt( 1 );
 		}
 	}
 

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -1337,7 +1337,11 @@ EOT;
 			foreach( $it as $blog ) {
 				$total++;
 				$url = $blog->domain . $blog->path;
-				$process = WP_CLI::launch_self( 'core update-db', array(), array( 'dry-run' => $dry_run ), false, true, array( 'url' => $url ) );
+				$cmd = "--url={$url} core update-db";
+				if ( $dry_run ) {
+					$cmd .= ' --dry-run';
+				}
+				$process = WP_CLI::runcommand( $cmd, array( 'return' => 'all' ) );
 				if ( 0 == $process->return_code ) {
 					// See if we can parse the stdout
 					if ( preg_match( '#Success: (.+)#', $process->stdout, $matches ) ) {

--- a/php/commands/export.php
+++ b/php/commands/export.php
@@ -186,7 +186,7 @@ class Export_Command extends WP_CLI_Command {
 		}
 
 		if ( $has_errors ) {
-			exit(1);
+			WP_CLI::halt(1);
 		}
 	}
 

--- a/php/commands/option.php
+++ b/php/commands/option.php
@@ -63,8 +63,9 @@ class Option_Command extends WP_CLI_Command {
 
 		$value = get_option( $key );
 
-		if ( false === $value )
-			die(1);
+		if ( false === $value ) {
+			WP_CLI::halt( 1 );
+		}
 
 		WP_CLI::print_value( $value, $assoc_args );
 	}

--- a/php/commands/plugin.php
+++ b/php/commands/plugin.php
@@ -800,9 +800,9 @@ class Plugin_Command extends \WP_CLI\CommandWithUpgrade {
 	 */
 	public function is_installed( $args, $assoc_args = array() ) {
 		if ( $this->fetcher->get( $args[0] ) ) {
-			exit( 0 );
+			WP_CLI::halt( 0 );
 		} else {
-			exit( 1 );
+			WP_CLI::halt( 1 );
 		}
 	}
 

--- a/php/commands/rewrite.php
+++ b/php/commands/rewrite.php
@@ -146,14 +146,16 @@ class Rewrite_Command extends WP_CLI_Command {
 		// Launch a new process to flush rewrites because core expects flush
 		// to happen after rewrites are set
 		$new_assoc_args = array();
+		$cmd = 'rewrite flush';
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'hard' ) ) {
+			$cmd .= ' --hard';
 			$new_assoc_args['hard'] = true;
 			if ( ! in_array( 'mod_rewrite', (array) WP_CLI::get_config( 'apache_modules' ) ) ) {
 				WP_CLI::warning( "Regenerating a .htaccess file requires special configuration. See usage docs." );
 			}
 		}
 
-		$process_run = WP_CLI::launch_self( 'rewrite flush', array(), $new_assoc_args, true, true, array( 'apache_modules', WP_CLI::get_config( 'apache_modules' ) ) );
+		$process_run = WP_CLI::runcommand( $cmd );
 		if ( ! empty( $process_run->stderr ) ) {
 			// Strip "Warning: "
 			WP_CLI::warning( substr( $process_run->stderr, 9 ) );

--- a/php/commands/site-option.php
+++ b/php/commands/site-option.php
@@ -52,8 +52,9 @@ class Site_Option_Command extends WP_CLI_Command {
 
 		$value = get_site_option( $key );
 
-		if ( false === $value )
-			die(1);
+		if ( false === $value ) {
+			WP_CLI::halt(1);
+		}
 
 		WP_CLI::print_value( $value, $assoc_args );
 	}

--- a/php/commands/theme.php
+++ b/php/commands/theme.php
@@ -665,9 +665,9 @@ class Theme_Command extends \WP_CLI\CommandWithUpgrade {
 		$theme = wp_get_theme( $args[0] );
 
 		if ( $theme->exists() ) {
-			exit( 0 );
+			WP_CLI::halt( 0 );
 		} else {
-			exit( 1 );
+			WP_CLI::halt( 1 );
 		}
 	}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -799,3 +799,27 @@ function report_batch_operation_results( $noun, $verb, $total, $successes, $fail
 		}
 	}
 }
+
+/**
+ * Parse a string of command line arguments into an $argv-esqe variable.
+ *
+ * @access public
+ * @category Input
+ *
+ * @param string $arguments
+ * @return array
+ */
+function parse_str_to_argv( $arguments ) {
+	preg_match_all ('/(?<=^|\s)([\'"]?)(.+?)(?<!\\\\)\1(?=$|\s)/', $arguments, $matches );
+	$argv = isset( $matches[0] ) ? $matches[0] : array();
+	$argv = array_map( function( $arg ){
+		foreach( array( '"', "'" ) as $char ) {
+			if ( $char === substr( $arg, 0, 1 ) && $char === substr( $arg, -1 ) ) {
+				$arg = substr( $arg, 1, -1 );
+				break;
+			}
+		}
+		return $arg;
+	}, $argv );
+	return $argv;
+}

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -108,5 +108,23 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 	}
 
+	public function testParseStrToArgv() {
+		$this->assertEquals( array(), Utils\parse_str_to_argv( '' ) );
+		$this->assertEquals( array(
+			'option',
+			'get',
+			'home',
+		), Utils\parse_str_to_argv( 'option get home' ) );
+		$this->assertEquals( array(
+			'core',
+			'download',
+			'--path=/var/www/',
+		), Utils\parse_str_to_argv( 'core download --path=/var/www/' ) );
+		$this->assertEquals( array(
+			'eval',
+			'echo wp_get_current_user()->user_login;',
+		), Utils\parse_str_to_argv( 'eval "echo wp_get_current_user()->user_login;"' ) );
+	}
+
 }
 


### PR DESCRIPTION
* [x] Launch a new process, rendering output.
* [x] Launch a new process, capturing output.
* [x] Reuse existing process, rendering output.
* [x] Reuse existing process, capturing output.
* [x] Ensure environment variables and WP-CLI config are passed through when launching new process.
* [x] Prevent halting script execution when reusing existing process.
* [x] Return command execution as full object, or specific return values.
* [x] Abstract command parsing to `Utils\parse_str_to_argv()` with tests. 
* [x] Use `parse=json` to parse JSON output.
* [x] Use `WP_CLI::runcommand()` where `::launch_self()` is currently used.
* [x] PHPDoc with examples.

Fixes #3139