### PR TITLE
Add examples for user session commands

### DIFF
--- a/features/user-session.feature
+++ b/features/user-session.feature
@@ -30,7 +30,7 @@ Feature: Manage user session
     When I run `wp user session destroy admin --all`
     Then STDOUT should be:
       """
-      Success: Destroyed all sessions. 0 remaining.
+      Success: Destroyed all sessions.
       """
 
     And I run `wp user session list admin --format=count`

--- a/php/commands/user-session.php
+++ b/php/commands/user-session.php
@@ -60,8 +60,8 @@ class User_Session_Command extends WP_CLI_Command {
 	 *
 	 *     # Destroy all sessions for all users.
 	 *     $ wp user list --field=ID | xargs wp user session destroy --all
-	 *     Success: Destroyed all sessions. 0 remaining.
-	 *     Success: Destroyed all sessions. 0 remaining.
+	 *     Success: Destroyed all sessions.
+	 *     Success: Destroyed all sessions.
 	 */
 	public function destroy( $args, $assoc_args ) {
 		$user    = $this->fetcher->get_check( $args[0] );
@@ -75,8 +75,7 @@ class User_Session_Command extends WP_CLI_Command {
 
 		if ( $all ) {
 			$manager->destroy_all();
-			$remaining = count( $manager->get_all() );
-			WP_CLI::success( sprintf( 'Destroyed all sessions. %s remaining.', $remaining ) );
+			WP_CLI::success( 'Destroyed all sessions.' );
 			return;
 		}
 

--- a/php/commands/user-session.php
+++ b/php/commands/user-session.php
@@ -5,6 +5,16 @@
  *
  * ## EXAMPLES
  *
+ *     # List a user's sessions.
+ *     $ wp user session list admin@example.com --format=csv
+ *     login_time,expiration_time,ip,ua
+ *     "2016-01-01 12:34:56","2016-02-01 12:34:56",127.0.0.1,"Mozilla/5.0..."
+ *
+ *     # Destroy the most recent session of the given user.
+ *     $ wp user session destroy admin
+ *     Success: Destroyed session. 3 sessions remaining.
+ *
+ * @package wp-cli
  */
 class User_Session_Command extends WP_CLI_Command {
 
@@ -36,19 +46,19 @@ class User_Session_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Destroy the most recent session of the given user
+	 *     # Destroy the most recent session of the given user.
 	 *     $ wp user session destroy admin
 	 *     Success: Destroyed session. 3 sessions remaining.
 	 *
-	 *     # Destroy a specific session of the given user
+	 *     # Destroy a specific session of the given user.
 	 *     $ wp user session destroy admin e073ad8540a9c2...
 	 *     Success: Destroyed session. 2 sessions remaining.
 	 *
-	 *     # Destroy all the sessions of the given user
+	 *     # Destroy all the sessions of the given user.
 	 *     $ wp user session destroy admin --all
 	 *     Success: Destroyed all sessions.
 	 *
-	 *     # Destroy all sessions for all users
+	 *     # Destroy all sessions for all users.
 	 *     $ wp user list --field=ID | xargs wp user session destroy --all
 	 *     Success: Destroyed all sessions. 0 remaining.
 	 *     Success: Destroyed all sessions. 0 remaining.
@@ -131,7 +141,7 @@ class User_Session_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # List a user's sessions
+	 *     # List a user's sessions.
 	 *     $ wp user session list admin@example.com --format=csv
 	 *     login_time,expiration_time,ip,ua
 	 *     "2016-01-01 12:34:56","2016-02-01 12:34:56",127.0.0.1,"Mozilla/5.0..."


### PR DESCRIPTION
Add examples for user session class.

@danielbachhuber When `destroy --all` is used, success message is like this:
`Destroyed all sessions. 0 remaining.`
I feel `0 remaining.` is redundant here as `all` is already mentioned in the earlier sentence. Thoughts?
