### PR TITLE
Apply backwards compat conversions when using the same process

### DIFF
--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -236,3 +236,20 @@ Feature: Run a WP-CLI command
     | flag        |
     | --no-launch |
     | --launch    |
+
+  Scenario Outline: Apply backwards compat conversions
+    Given a WP install
+
+    When I run `wp <flag> run 'term url category 1'`
+    Then STDOUT should be:
+      """
+      http://example.com/?cat=1
+      returned: NULL
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    Examples:
+    | flag        |
+    | --no-launch |
+    | --launch    |

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -288,10 +288,14 @@ class Runner {
 	/**
 	 * Find the WP-CLI command to run given arguments, and invoke it.
 	 *
-	 * @param array $args Positional arguments including command name
-	 * @param array $assoc_args
+	 * @param array $args        Positional arguments including command name
+	 * @param array $assoc_args  Associative arguments for the command.
+	 * @param array $options     Configuration options for the function.
 	 */
-	public function run_command( $args, $assoc_args = array() ) {
+	public function run_command( $args, $assoc_args = array(), $options = array() ) {
+		if ( ! empty( $options['back_compat_conversions'] ) ) {
+			list( $args, $assoc_args ) = self::back_compat_conversions( $args, $assoc_args );
+		}
 		$r = $this->find_command_to_run( $args );
 		if ( is_string( $r ) ) {
 			WP_CLI::error( $r );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1063,7 +1063,7 @@ class WP_CLI {
 				self::$capture_exit = true;
 			}
 			try {
-				self::get_runner()->run_command( $args, $assoc_args );
+				self::get_runner()->run_command( $args, $assoc_args, array( 'back_compat_conversions' => true ) );
 				$return_code = 0;
 			} catch( ExitException $e ) {
 				$return_code = $e->getCode();


### PR DESCRIPTION
Doing so increases simularity between launching a new process and
reusing an existing process.

Fixes #3620