### PR TITLE
Add a blank line before the list in DocBlock of `WP_CLI::runcommand()`

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -943,6 +943,7 @@ class WP_CLI {
 	 *
 	 * Launch a new child process, or run the command in the current process.
 	 * Optionally:
+	 *
 	 * * Prevent halting script execution on error.
 	 * * Capture and return STDOUT, or full details about command execution.
 	 * * Parse JSON output if the command rendered it.


### PR DESCRIPTION
See https://wp-cli.org/docs/internal-api/wp-cli-runcommand/#notes

<img width="878" alt="bildschirmfoto 2016-12-02 um 13 05 58" src="https://cloud.githubusercontent.com/assets/617637/20833693/3c496b64-b891-11e6-904d-20e163023f90.png">