### PR TITLE
Support `--version=(nightly|trunk)` for `wp core update`

### DIFF
--- a/features/core-update.feature
+++ b/features/core-update.feature
@@ -215,3 +215,22 @@ Feature: Update WordPress core
       """
       Success: WordPress updated successfully.
       """
+
+  Scenario Outline: Use `--version=(nightly|trunk)` to update to the latest nightly version
+    Given a WP install
+
+    When I run `wp core update --version=<version>`
+    Then STDOUT should contain:
+      """
+      Updating to version nightly (en_US)...
+      Downloading update from https://wordpress.org/nightly-builds/wordpress-latest.zip...
+      """
+    And STDOUT should contain:
+      """
+      Success: WordPress updated successfully.
+      """
+
+    Examples:
+    | version    |
+    | trunk      |
+    | nightly    |

--- a/php/WP_CLI/CoreUpgrader.php
+++ b/php/WP_CLI/CoreUpgrader.php
@@ -55,7 +55,7 @@ class CoreUpgrader extends \Core_Upgrader {
 		$cache_key = "core/{$filename}-{$update->locale}.{$ext}";
 		$cache_file = $cache->has( $cache_key );
 
-		if ( $cache_file ) {
+		if ( $cache_file && false === stripos( $package, 'https://wordpress.org/nightly-builds/' ) ) {
 			WP_CLI::log( "Using cached file '$cache_file'..." );
 			copy( $cache_file, $temp );
 			return $temp;
@@ -77,7 +77,9 @@ class CoreUpgrader extends \Core_Upgrader {
 			if ( ! is_null( $req ) && $req->status_code !== 200 ) {
 				return new \WP_Error( 'download_failed', $this->strings['download_failed'] );
 			}
-			$cache->import( $cache_key, $temp );
+			if ( false === stripos( $package, 'https://wordpress.org/nightly-builds/' ) ) {
+				$cache->import( $cache_key, $temp );
+			}
 			return $temp;
 		}
 	}

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -1178,11 +1178,15 @@ EOT;
 	 *
 	 * @alias upgrade
 	 */
-	function update( $args, $assoc_args ) {
+	public function update( $args, $assoc_args ) {
 		global $wp_version;
 
 		$update = $from_api = null;
 		$upgrader = 'WP_CLI\\CoreUpgrader';
+
+		if ( 'trunk' === Utils\get_flag_value( $assoc_args, 'version' ) ) {
+			$assoc_args['version'] = 'nightly';
+		}
 
 		if ( ! empty( $args[0] ) ) {
 
@@ -1228,7 +1232,8 @@ EOT;
 			}
 
 		} else if (	\WP_CLI\Utils\wp_version_compare( $assoc_args['version'], '<' )
-					|| \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) ) {
+			|| 'nightly' === $assoc_args['version']
+			|| \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) ) {
 
 			$version = $assoc_args['version'];
 			$locale = \WP_CLI\Utils\get_flag_value( $assoc_args, 'locale', get_locale() );

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -1138,7 +1138,7 @@ EOT;
 	 * : Only perform updates for minor releases (e.g. update from WP 4.3 to 4.3.3 instead of 4.4.2).
 	 *
 	 * [--version=<version>]
-	 * : Update to a specific version, instead of to the latest version.
+	 * : Update to a specific version, instead of to the latest version. Alternatively accepts 'nightly'.
 	 *
 	 * [--force]
 	 * : Update even when installed WP version is greater than the requested version.


### PR DESCRIPTION
Don't ever cache it, however.

Fixes #3643