### PR TITLE
Fix merge behavior when positionals passed and also defined in `wp-cli.yml`

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -175,6 +175,21 @@ Feature: Have a config file
       administrator
       """
 
+    When I try `wp user create examplejane`
+    Then STDERR should be:
+      """
+      Error: Sorry, that email address is already used!
+      """
+
+    When I run `wp user create examplejane jane@example.com`
+    Then STDOUT should not be empty
+
+    When I run `wp user get examplejane --field=roles`
+    Then STDOUT should contain:
+      """
+      administrator
+      """
+
   Scenario: Command-specific configs
     Given a WP install
     And a wp-cli.yml file:

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -364,11 +364,13 @@ class Subcommand extends CompositeCommand {
 		$extra_positionals = array();
 		foreach( $extra_args as $k => $v ) {
 			if ( is_numeric( $k ) ) {
-				$extra_positionals[ $k ] = $v;
+				if ( ! isset( $args[ $k ] ) ) {
+					$extra_positionals[ $k ] = $v;
+				}
 				unset( $extra_args[ $k ] );
 			}
 		}
-		$args = array_merge( $extra_positionals, $args );
+		$args = $args + $extra_positionals;
 
 		list( $to_unset, $args, $assoc_args, $extra_args ) = $this->validate_args( $args, $assoc_args, $extra_args );
 


### PR DESCRIPTION
The passed positionals should take precedent over defaults defined in
`wp-cli.yml`