### PR TITLE
add validation for slug of the plugin/theme

### DIFF
--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -93,3 +93,12 @@ Feature: Scaffold plugin unit tests
       """
       MYSQL_DATABASE
       """
+
+  Scenario: Scaffold plugin tests with invalid slug
+    Given a WP install
+
+    When I try `wp scaffold plugin-tests .`
+    Then STDERR should contain:
+      """
+      Error: Invalid plugin slug specified.
+      """

--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -102,3 +102,9 @@ Feature: Scaffold plugin unit tests
       """
       Error: Invalid plugin slug specified.
       """
+
+    When I try `wp scaffold plugin-tests ../`
+    Then STDERR should contain:
+      """
+      Error: Invalid plugin slug specified.
+      """

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -75,8 +75,16 @@ Feature: Scaffold theme unit tests
       """
 
   Scenario: Scaffold theme tests with invalid slug
+
     When I try `wp scaffold theme-tests .`
     Then STDERR should contain:
       """
       Error: Invalid theme slug specified.
       """
+
+    When I try `wp scaffold theme-tests ../`
+    Then STDERR should contain:
+      """
+      Error: Invalid theme slug specified.
+      """
+

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -73,3 +73,10 @@ Feature: Scaffold theme unit tests
       """
       MYSQL_DATABASE
       """
+
+  Scenario: Scaffold theme tests with invalid slug
+    When I try `wp scaffold theme-tests .`
+    Then STDERR should contain:
+      """
+      Error: Invalid theme slug specified.
+      """

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -54,6 +54,19 @@ Feature: WordPress code scaffolding
       Success: Network enabled the 'Zombieland' theme.
       """
 
+  Scenario: Scaffold a child theme with invalid slug
+    Given a WP install
+    When I try `wp scaffold child-theme . --parent_theme=simple-life`
+    Then STDERR should contain:
+      """
+      Error: Invalid theme slug specified.
+      """
+    When I try `wp scaffold child-theme ../ --parent_theme=simple-life`
+    Then STDERR should contain:
+      """
+      Error: Invalid theme slug specified.
+      """
+
   @tax @cpt
   Scenario: Scaffold a Custom Taxonomy and Custom Post Type and write it to active theme
     Given a WP install
@@ -314,6 +327,19 @@ Feature: WordPress code scaffolding
     Then STDOUT should contain:
       """
       Success: Switched to 'Starter-theme' theme.
+      """
+
+  Scenario: Scaffold starter code for a theme with invalid slug
+    Given a WP install
+    When I try `wp scaffold _s .`
+    Then STDERR should contain:
+      """
+      Error: Invalid theme slug specified.
+      """
+    When I try `wp scaffold _s ../`
+    Then STDERR should contain:
+      """
+      Error: Invalid theme slug specified.
       """
 
   Scenario: Scaffold plugin and tests for non-standard plugin directory

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -271,6 +271,19 @@ Feature: WordPress code scaffolding
       Plugin 'hello-world' network activated.
       """
 
+  Scenario: Scaffold a plugin with invalid slug
+    Given a WP install
+    When I try `wp scaffold plugin .`
+    Then STDERR should contain:
+      """
+      Error: Invalid plugin slug specified.
+      """
+    When I try `wp scaffold plugin ../`
+    Then STDERR should contain:
+      """
+      Error: Invalid plugin slug specified.
+      """
+
   Scenario: Scaffold starter code for a theme
     Given a WP install
     Given I run `wp theme path`

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -239,6 +239,10 @@ class Scaffold_Command extends WP_CLI_Command {
 		$url        = "http://underscores.me";
 		$timeout    = 30;
 
+		if ( in_array( $theme_slug, array( '.', '..' ) ) ) {
+			WP_CLI::error( "Invalid theme slug specified." );
+		}
+
 		$data = wp_parse_args( $assoc_args, array(
 			'theme_name' => ucfirst( $theme_slug ),
 			'author'     => "Me",
@@ -353,6 +357,10 @@ class Scaffold_Command extends WP_CLI_Command {
 	 */
 	function child_theme( $args, $assoc_args ) {
 		$theme_slug = $args[0];
+
+		if ( in_array( $theme_slug, array( '.', '..' ) ) ) {
+			WP_CLI::error( "Invalid theme slug specified." );
+		}
 
 		$data = wp_parse_args( $assoc_args, array(
 			'theme_name' => ucfirst( $theme_slug ),
@@ -494,6 +502,10 @@ class Scaffold_Command extends WP_CLI_Command {
 		$plugin_slug    = $args[0];
 		$plugin_name    = ucwords( str_replace( '-', ' ', $plugin_slug ) );
 		$plugin_package = str_replace( ' ', '_', $plugin_name );
+
+		if ( in_array( $plugin_slug, array( '.', '..' ) ) ) {
+			WP_CLI::error( "Invalid plugin slug specified." );
+		}
 
 		$data = wp_parse_args( $assoc_args, array(
 			'plugin_slug'         => $plugin_slug,
@@ -662,6 +674,9 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		if ( ! empty( $args[0] ) ) {
 			$slug = $args[0];
+			if ( in_array( $slug, array( '.', '..' ) ) ) {
+				WP_CLI::error( "Invalid {$type} slug specified." );
+			}
 			if ( 'theme' === $type ) {
 				$theme = wp_get_theme( $slug );
 				if ( $theme->exists() ) {

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -648,9 +648,6 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		if ( ! empty( $args[0] ) ) {
 			$slug = $args[0];
-			if ( ! preg_match( "/^[a-zA-Z0-9\-_]+$/", $slug ) ) {
-				WP_CLI::error( "Invalid {$type} slug specified." );
-			}
 			if ( 'theme' === $type ) {
 				$theme = wp_get_theme( $slug );
 				if ( $theme->exists() ) {
@@ -664,6 +661,11 @@ class Scaffold_Command extends WP_CLI_Command {
 			if ( empty( $assoc_args['dir'] ) && ! is_dir( $target_dir ) ) {
 				WP_CLI::error( "Invalid {$type} slug specified." );
 			}
+		}
+
+		if ( ( 'plugin' === $type && realpath( $target_dir ) === WP_PLUGIN_DIR )
+				|| ( 'theme' === $type && realpath( $target_dir ) === WP_CONTENT_DIR . '/themes' ) ) {
+			WP_CLI::error( "Invalid {$type} slug specified." );
 		}
 
 		if ( ! empty( $assoc_args['dir'] ) ) {

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -648,6 +648,9 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		if ( ! empty( $args[0] ) ) {
 			$slug = $args[0];
+			if ( preg_match( "#\.|\/#", $slug ) ) {
+				WP_CLI::error( "Invalid {$type} slug specified." );
+			}
 			if ( 'theme' === $type ) {
 				$theme = wp_get_theme( $slug );
 				if ( $theme->exists() ) {
@@ -661,11 +664,6 @@ class Scaffold_Command extends WP_CLI_Command {
 			if ( empty( $assoc_args['dir'] ) && ! is_dir( $target_dir ) ) {
 				WP_CLI::error( "Invalid {$type} slug specified." );
 			}
-		}
-
-		if ( ( 'plugin' === $type && realpath( $target_dir ) === WP_PLUGIN_DIR )
-				|| ( 'theme' === $type && realpath( $target_dir ) === WP_CONTENT_DIR . '/themes' ) ) {
-			WP_CLI::error( "Invalid {$type} slug specified." );
 		}
 
 		if ( ! empty( $assoc_args['dir'] ) ) {

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -648,6 +648,9 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		if ( ! empty( $args[0] ) ) {
 			$slug = $args[0];
+			if ( ! preg_match( "/^[a-zA-Z0-9\-_]+$/", $slug ) ) {
+				WP_CLI::error( "Invalid {$type} slug specified." );
+			}
 			if ( 'theme' === $type ) {
 				$theme = wp_get_theme( $slug );
 				if ( $theme->exists() ) {

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -648,9 +648,6 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		if ( ! empty( $args[0] ) ) {
 			$slug = $args[0];
-			if ( preg_match( "#\.|\/#", $slug ) ) {
-				WP_CLI::error( "Invalid {$type} slug specified." );
-			}
 			if ( 'theme' === $type ) {
 				$theme = wp_get_theme( $slug );
 				if ( $theme->exists() ) {
@@ -664,6 +661,11 @@ class Scaffold_Command extends WP_CLI_Command {
 			if ( empty( $assoc_args['dir'] ) && ! is_dir( $target_dir ) ) {
 				WP_CLI::error( "Invalid {$type} slug specified." );
 			}
+		}
+
+		if ( ( "theme" === $type && 'themes' !== basename( dirname( realpath( $target_dir ) ) ) )
+				|| ( "plugin" === $type && 'plugins' !== basename( dirname( realpath( $target_dir ) ) ) ) ) {
+			WP_CLI::error( "Invalid {$type} slug specified." );
 		}
 
 		if ( ! empty( $assoc_args['dir'] ) ) {


### PR DESCRIPTION
Test files will be generated under the `wp-content/themes` when I made a mistake and ran a command like following.

```
$ cd wp-content/themes/twentyseventeen/
$ wp scaffold theme-tests .
Success: Created test files.
```

Then:

```
wp-content/themes
├── .travis.yml
├── bin
├── index.php
├── phpcs.ruleset.xml
├── phpunit.xml.dist
├── tests
├── twentyfifteen
├── twentyseventeen
```

Slug of the plugin/theme should be validated.