### PR TITLE
Add documentation for hidden 'wp site list' param.

### DIFF
--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -435,6 +435,9 @@ class Site_Command extends \WP_CLI\CommandWithDBObject {
 	 * : Filter by one or more fields (see "Available Fields" section). However,
 	 * 'url' isn't an available filter, because it's created from domain + path.
 	 *
+	 * [--site__in=<value>]
+	 * : Only list the sites with these blog_id values (comma-separated).
+	 *
 	 * [--field=<field>]
 	 * : Prints the value of a single field for each site.
 	 *


### PR DESCRIPTION
Props to @nathanielks for pointing this out to me—seems like it would be good to have the `site__in` param in the documentation for the `wp site list` command.