### PR TITLE
Persist `PATH` when launching a child process

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1011,6 +1011,7 @@ class WP_CLI {
 
 			$env_vars = array(
 				'HOME',
+				'PATH',
 				'WP_CLI_AUTO_CHECK_UPDATE_DAYS',
 				'WP_CLI_CACHE_DIR',
 				'WP_CLI_CONFIG_PATH',


### PR DESCRIPTION
The `PATH` can contain the path to a MySQL binary, which is important
for connecting to the correct database.

Fixes #3681