### PR TITLE
Ensure automatic parent theme installation uses http cacher

### DIFF
--- a/features/theme-install.feature
+++ b/features/theme-install.feature
@@ -37,3 +37,37 @@ Feature: Install WordPress themes
       Error: No themes installed.
       """
     And the return code should be 1
+
+  Scenario: Ensure automatic parent theme installation uses http cacher
+    Given a WP install
+    And an empty cache
+
+    When I run `wp theme install stargazer`
+    Then STDOUT should contain:
+      """
+      Success: Installed 1 of 1 themes.
+      """
+    And STDOUT should not contain:
+      """
+      Using cached file
+      """
+
+    When I run `wp theme uninstall stargazer`
+    Then STDOUT should contain:
+      """
+      Success: Deleted 1 of 1 themes.
+      """
+
+    When I run `wp theme install buntu`
+    Then STDOUT should contain:
+      """
+      Success: Installed 1 of 1 themes.
+      """
+    And STDOUT should contain:
+      """
+      This theme requires a parent theme.
+      """
+    And STDOUT should contain:
+      """
+      Using cached file
+      """

--- a/php/WP_CLI/UpgraderSkin.php
+++ b/php/WP_CLI/UpgraderSkin.php
@@ -28,6 +28,11 @@ class UpgraderSkin extends \WP_Upgrader_Skin {
 	}
 
 	function feedback( $string ) {
+
+		if ( 'parent_theme_prepare_install' === $string ) {
+			\WP_CLI::get_http_cache_manager()->whitelist_package( $this->api->download_link, 'theme', $this->api->slug, $this->api->version );
+		}
+
 		if ( isset( $this->upgrader->strings[$string] ) )
 			$string = $this->upgrader->strings[$string];
 


### PR DESCRIPTION
It's a bit of a hack to put this in the upgrader feedback skin, but
there isn't a clear action to hook into.

Fixes #3674