### PR TITLE
When globalizing `wp-config.php` vars, ensure local scope is globalized

### DIFF
--- a/features/framework.feature
+++ b/features/framework.feature
@@ -224,3 +224,31 @@ Feature: Load WP-CLI
       bar
       """
     And STDERR should be empty
+
+  Scenario: WP-CLI sets $table_prefix appropriately on multisite
+    Given a WP multisite install
+    And I run `wp site create --slug=first`
+
+    When I run `wp eval 'global $table_prefix; echo $table_prefix;'`
+    Then STDOUT should be:
+      """
+      wp_
+      """
+
+    When I run `wp eval 'global $blog_id; echo $blog_id;'`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp --url=example.com/first eval 'global $table_prefix; echo $table_prefix;'`
+    Then STDOUT should be:
+      """
+      wp_2_
+      """
+
+    When I run `wp --url=example.com/first eval 'global $blog_id; echo $blog_id;'`
+    Then STDOUT should be:
+      """
+      2
+      """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -983,7 +983,8 @@ class Runner {
 			if ( array_key_exists( $key, $wp_cli_original_defined_vars ) || 'wp_cli_original_defined_vars' === $key ) {
 				continue;
 			}
-			$GLOBALS[ $key ] = $var;
+			global $$key;
+			$$key = $var;
 		}
 
 		$this->maybe_update_url_from_domain_constant();


### PR DESCRIPTION
The previous implementation would only assign the value to the global
variable, when the current context also needs to be considered global.

Fixes #3694