### PR TITLE
coding standards fixes - utils/make-phar.php

### DIFF
--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -15,7 +15,7 @@ list( $args, $assoc_args, $runtime_config ) = $configurator->parse_args( array_s
 
 if ( ! isset( $args[0] ) || empty( $args[0] ) ) {
 	echo "usage: php -dphar.readonly=0 $argv[0] <path> [--quiet] [--version=same|patch|minor|major|x.y.z] [--store-version]\n";
-	exit(1);
+	exit( 1 );
 }
 
 define( 'DEST_PATH', $args[0] );
@@ -38,8 +38,9 @@ if ( isset( $runtime_config['version'] ) ) {
 function add_file( $phar, $path ) {
 	$key = str_replace( WP_CLI_ROOT, '', $path );
 
-	if ( !BE_QUIET )
+	if ( ! BE_QUIET ) {
 		echo "$key - $path\n";
+	}
 
 	$phar[ $key ] = file_get_contents( $path );
 }
@@ -47,8 +48,9 @@ function add_file( $phar, $path ) {
 function set_file_contents( $phar, $path, $content ) {
 	$key = str_replace( WP_CLI_ROOT, '', $path );
 
-	if ( !BE_QUIET )
+	if ( ! BE_QUIET ) {
 		echo "$key - $path\n";
+	}
 
 	$phar[ $key ] = $content;
 }
@@ -57,44 +59,42 @@ $phar = new Phar( DEST_PATH, 0, 'wp-cli.phar' );
 
 $phar->startBuffering();
 
-// PHP files
+// PHP files.
 $finder = new Finder();
 $finder
 	->files()
-	->ignoreVCS(true)
-	->name('*.php')
-	->in(WP_CLI_ROOT . '/php')
-	->in(WP_CLI_ROOT . '/features')
-	->in(WP_CLI_ROOT . '/vendor/wp-cli')
-	->in(WP_CLI_ROOT . '/vendor/mustache')
-	->in(WP_CLI_ROOT . '/vendor/rmccue/requests')
-	->in(WP_CLI_ROOT . '/vendor/composer')
-	->in(WP_CLI_ROOT . '/vendor/psr')
-	->in(WP_CLI_ROOT . '/vendor/seld')
-	->in(WP_CLI_ROOT . '/vendor/symfony')
-	->in(WP_CLI_ROOT . '/vendor/nb/oxymel')
-	->in(WP_CLI_ROOT . '/vendor/ramsey/array_column')
-	->in(WP_CLI_ROOT . '/vendor/mustangostang')
-	->in(WP_CLI_ROOT . '/vendor/justinrainbow/json-schema')
-	->exclude('test')
-	->exclude('tests')
-	->exclude('Test')
-	->exclude('Tests')
-	->exclude('php-cli-tools/examples')
-	;
+	->ignoreVCS( true )
+	->name( '*.php' )
+	->in( WP_CLI_ROOT . '/php' )
+	->in( WP_CLI_ROOT . '/features' )
+	->in( WP_CLI_ROOT . '/vendor/wp-cli' )
+	->in( WP_CLI_ROOT . '/vendor/mustache' )
+	->in( WP_CLI_ROOT . '/vendor/rmccue/requests' )
+	->in( WP_CLI_ROOT . '/vendor/composer' )
+	->in( WP_CLI_ROOT . '/vendor/psr' )
+	->in( WP_CLI_ROOT . '/vendor/seld' )
+	->in( WP_CLI_ROOT . '/vendor/symfony' )
+	->in( WP_CLI_ROOT . '/vendor/nb/oxymel' )
+	->in( WP_CLI_ROOT . '/vendor/ramsey/array_column' )
+	->in( WP_CLI_ROOT . '/vendor/mustangostang' )
+	->in( WP_CLI_ROOT . '/vendor/justinrainbow/json-schema' )
+	->exclude( 'test' )
+	->exclude( 'tests' )
+	->exclude( 'Test' )
+	->exclude( 'Tests' )
+	->exclude( 'php-cli-tools/examples' );
 
 foreach ( $finder as $file ) {
 	add_file( $phar, $file );
 }
 
-// other files
+// Other files.
 $finder = new Finder();
 $finder
 	->files()
-	->ignoreVCS(true)
-	->ignoreDotFiles(false)
-	->in( WP_CLI_ROOT . '/templates')
-	;
+	->ignoreVCS( true )
+	->ignoreDotFiles( false )
+	->in( WP_CLI_ROOT . '/templates' );
 
 foreach ( $finder as $file ) {
 	add_file( $phar, $file );
@@ -121,4 +121,4 @@ EOB
 
 $phar->stopBuffering();
 
-echo "Generated " . DEST_PATH . "\n";
+echo 'Generated ' . DEST_PATH . "\n";


### PR DESCRIPTION
I started to fix coding standards.
When I have a moment, I will send a PR.

Actually, I did it for some files.
https://github.com/miya0001/wp-cli/commits/coding-standard

But I will send a pull request as an each file because I want to see the result of Travis CI.

The ruleset is following.

```
<?xml version="1.0"?>
<ruleset name="WordPress Coding Standards via https://github.com/Automattic/_s/blob/master/codesniffer.ruleset.xml">
	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->

	<!-- Set a description for this ruleset. -->
	<description>A custom set of code standard rules to check for WP-CLI</description>

	<exclude-pattern>vendor/*</exclude-pattern>
	<exclude-pattern>codesniffer/*</exclude-pattern>
	<exclude-pattern>PHP_Codesniffer-VariableAnalysis/*</exclude-pattern>

	<!-- Include the WordPress ruleset, with exclusions. -->
	<rule ref="WordPress">
		<exclude name="Squiz.Commenting.FunctionComment.Missing" />
		<exclude name="Squiz.Commenting.ClassComment.Missing" />
		<exclude name="Squiz.Commenting.FileComment.Missing" />
		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
		<exclude name="WordPress.XSS.EscapeOutput.OutputNotEscaped" />
		<exclude name="WordPress.VIP.FileSystemWritesDisallow.FileWriteDetected" />
	</rule>
</ruleset>
```