### PR TITLE
Allow dot in aliases

### DIFF
--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -32,7 +32,7 @@ class Configurator {
 	/**
 	 * @var string ALIAS_REGEX Regex pattern used to define an alias
 	 */
-	const ALIAS_REGEX = '^@[A-Za-z0-9-_]+$';
+	const ALIAS_REGEX = '^@[A-Za-z0-9-_\.]+$';
 
 	/**
 	 * @var array ALIAS_SPEC Arguments that can be used in an alias

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -32,7 +32,7 @@ class Configurator {
 	/**
 	 * @var string ALIAS_REGEX Regex pattern used to define an alias
 	 */
-	const ALIAS_REGEX = '^@[A-Za-z0-9-_\.]+$';
+	const ALIAS_REGEX = '^@[A-Za-z0-9-_\.\-]+$';
 
 	/**
 	 * @var array ALIAS_SPEC Arguments that can be used in an alias


### PR DESCRIPTION
I want to use hostname in aliases like following.

```
@example.com:
  ssh: user@example.com/var/www/html
@example.jp:
  ssh: user@example.jp/var/www/html
```