### PR TITLE
Add `--force` option to `core config`

### DIFF
--- a/features/core-config.feature
+++ b/features/core-config.feature
@@ -79,3 +79,21 @@ Feature: Manage wp-config
       """
       define( 'WPLANG', '' );
       """
+
+    When I try `wp core config {CORE_CONFIG_SETTINGS}`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      Error: The 'wp-config.php' file already exists.
+      """
+
+    When I run `wp core config {CORE_CONFIG_SETTINGS} --locale=ja --force`
+    Then the return code should be 0
+    And STDOUT should contain:
+      """
+      Success: Generated 'wp-config.php' file.
+      """
+    And the wp-config.php file should contain:
+      """
+      define( 'WPLANG', 'ja' );
+      """

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -332,6 +332,9 @@ class Core_Command extends WP_CLI_Command {
 	 * [--skip-check]
 	 * : If set, the database connection is not checked.
 	 *
+	 * [--force]
+	 * : If set, the database connection is not checked.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Standard wp-config.php file
@@ -351,7 +354,7 @@ class Core_Command extends WP_CLI_Command {
 	 */
 	public function config( $_, $assoc_args ) {
 		global $wp_version;
-		if ( Utils\locate_wp_config() ) {
+		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' ) && Utils\locate_wp_config() ) {
 			WP_CLI::error( "The 'wp-config.php' file already exists." );
 		}
 

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -333,7 +333,7 @@ class Core_Command extends WP_CLI_Command {
 	 * : If set, the database connection is not checked.
 	 *
 	 * [--force]
-	 * : If set, the database connection is not checked.
+	 * : Overwrites existing files, if present.
 	 *
 	 * ## EXAMPLES
 	 *


### PR DESCRIPTION
To overwrites existing wp-config.php.

```
$ wp core config --dbname=testing --dbuser=wp --force
```