### PR TITLE
Only skip replace when array is a reference to an existing array

### DIFF
--- a/php/WP_CLI/SearchReplacer.php
+++ b/php/WP_CLI/SearchReplacer.php
@@ -68,10 +68,17 @@ class SearchReplacer {
 							if ( self::check_arrays_referenced( $data, $existing_data ) ) {
 								return $data;
 							}
-							// Now check to see if any child values are references
-							foreach( $existing_data as $i => $j ) {
-								if ( self::check_arrays_referenced( $data, $j ) ) {
-									return $data;
+							// Check to see if any child values are going to cause
+							// recursion. If so, assume $data is storing a reference
+							// to itself
+							foreach( $data as $k => $v ) {
+								if ( $v === $data ) {
+									ob_start();
+									var_dump( $v );
+									$export = ob_get_clean();
+									if ( stripos( $export, '*RECURSION*' ) ) {
+										return $data;
+									}
 								}
 							}
 						}

--- a/tests/test-search-replace.php
+++ b/tests/test-search-replace.php
@@ -37,6 +37,20 @@ class UnserializeReplaceTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'bar', $new_array['prop'] );
 	}
 
+	function testArraySameValues() {
+		$old_array = array(
+			'prop1' => array(
+				'foo',
+			),
+			'prop2' => array(
+				'foo',
+			),
+		);
+		$new_array = self::recursive_unserialize_replace( 'foo', 'bar', $old_array, false, true );
+		$this->assertEquals( 'bar', $new_array['prop1'][0] );
+		$this->assertEquals( 'bar', $new_array['prop2'][0] );
+	}
+
 	function testMixedObjectArrayLoop() {
 		$old_object = new stdClass();
 		$old_object->prop = 'foo';


### PR DESCRIPTION
When two arrays contain the same value, we want both to be replaced.

Fixes #3656