### PR TITLE
Prevent error notice from `wp_guess_url()` when core isn't installed

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -990,6 +990,12 @@ class Runner {
 		$this->maybe_update_url_from_domain_constant();
 		WP_CLI::do_hook( 'after_wp_config_load' );
 
+		// Prevent error notice from wp_guess_url() when core isn't installed
+		if ( $this->cmd_starts_with( array( 'core', 'is-installed' ) )
+			&& ! defined( 'COOKIEHASH' ) ) {
+			define( 'COOKIEHASH', md5( 'wp-cli' ) );
+		}
+
 		// Load WP-CLI utilities
 		require WP_CLI_ROOT . '/php/utils-wp.php';
 


### PR DESCRIPTION
WordPress 4.7 attempts to log a user in after installing. Included in
this was a change to `wp_cookie_constants()` such that it uses
`wp_guess_url()` to set the default `COOKIEHASH`, instead of an empty
string. Because CLI doesn't use cookies, we can prevent this notice by
setting `COOKIEHASH` earlier.

Fixes #3710