### PR TITLE
Simpler fix for search-replace reference vs value issues

### DIFF
--- a/php/WP_CLI/SearchReplacer.php
+++ b/php/WP_CLI/SearchReplacer.php
@@ -56,20 +56,8 @@ class SearchReplacer {
 
 				if ( is_array( $data ) || is_object( $data ) ) {
 					// If we've seen this exact object or array before, short circuit
-					// Avoid infinite loops when there's a cycle
 					if ( in_array( $data, $visited_data, true ) ) {
-						if ( is_object( $data ) ) {
-							return $data;
-						}
-						// Only short-circuit when the array is passed by reference
-						if ( is_array( $data ) ) {
-							ob_start();
-							print_r( $data );
-							$test = ob_get_clean();
-							if ( preg_match( '#\*RECURSION\*#', $test ) ) {
-								return $data;
-							}
-						}
+						return $data; // Avoid infinite loops when there's a cycle
 					}
 					// Add this data to the list of
 					$visited_data[] = $data;
@@ -110,6 +98,5 @@ class SearchReplacer {
 
 		return $data;
 	}
-
 }
 

--- a/php/WP_CLI/SearchReplacer.php
+++ b/php/WP_CLI/SearchReplacer.php
@@ -42,7 +42,7 @@ class SearchReplacer {
 	 * @param int          $recursion_level Current recursion depth within the original data.
 	 * @param array        $visited_data    Data that has been seen in previous recursion iterations.
 	 */
-	private function _run( $data, $serialised, $recursion_level = 0, &$visited_data = array() ) {
+	private function _run( $data, $serialised, $recursion_level = 0, $visited_data = array() ) {
 
 		// some unseriliased data cannot be re-serialised eg. SimpleXMLElements
 		try {


### PR DESCRIPTION
I think this is a cleaner fix for #3656.  The cycle detection when replacing inside an object graph was almost correct before #3708.  The only issue was that `$visited_data` was passed by reference, but it should really be passed by value.

`$visited_data` is the current path into the object tree, and we are inside a cycle if the current element is the same as any of its ancestors.  This "path" should be reset when going inside a different branch of the tree, rather than having its elements accumulate over the entire replace operation.

Note: this relies on the fact that by default, PHP passes arrays by value rather than by reference, which I [did not know](http://stackoverflow.com/a/2030924) and did not expect.