### PR TITLE
Fix runcommand's proc_open to inherit parent environment

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1018,23 +1018,7 @@ class WP_CLI {
 
 			$runcommand = "{$php_bin} {$script_path} {$runtime_config} {$command}";
 
-			$env_vars = array(
-				'HOME',
-				'PATH',
-				'WP_CLI_AUTO_CHECK_UPDATE_DAYS',
-				'WP_CLI_CACHE_DIR',
-				'WP_CLI_CONFIG_PATH',
-				'WP_CLI_DISABLE_AUTO_CHECK_UPDATE',
-				'WP_CLI_PACKAGES_DIR',
-				'WP_CLI_PHP_USED',
-				'WP_CLI_PHP',
-				'WP_CLI_STRICT_ARGS_MODE',
-			);
-			$env = array();
-			foreach( $env_vars as $var ) {
-				$env[ $var ] = getenv( $var );
-			}
-			$proc = proc_open( $runcommand, $descriptors, $pipes, getcwd(), $env );
+			$proc = proc_open( $runcommand, $descriptors, $pipes, getcwd(), NULL );
 
 			if ( $return ) {
 				$stdout = stream_get_contents( $pipes[1] );
@@ -1155,4 +1139,3 @@ class WP_CLI {
 		self::add_command( $name, $class );
 	}
 }
-


### PR DESCRIPTION
This fixes #3729. proc_open will inherit the parent environment if you
pass NULL for the environment parameter
(http://php.net/manual/en/function.proc-open.php). I've verified that
this works properly by testing this fix against my wp-config that
contained environment variables.