### PR TITLE
localize when `wp core language activate`

### DIFF
--- a/features/core-language.feature
+++ b/features/core-language.feature
@@ -117,13 +117,46 @@ Feature: Manage translation files for a WordPress install
       Error: Language not installed.
       """
 
-    When I run `wp core language install --activate en_GB`
-    Then the wp-content/languages/admin-en_GB.po file should exist
-    And the wp-content/languages/en_GB.po file should exist
+    When I run `wp core language install --activate ja`
+    Then the wp-content/languages/admin-ja.po file should exist
+    And the wp-content/languages/ja.po file should exist
     And STDOUT should contain:
       """
       Success: Language installed.
       Success: Language activated.
+      """
+
+    When I run `wp option get date_format`
+    Then STDOUT should contain:
+      """
+      Y年n月j日
+      """
+
+    When I run `wp option get timezone_string`
+    Then STDOUT should contain:
+      """
+      Asia/Tokyo
+      """
+
+    When I run `wp core language install --activate tr_TR`
+    Then the wp-content/languages/admin-tr_TR.po file should exist
+    And the wp-content/languages/tr_TR.po file should exist
+    And STDOUT should contain:
+      """
+      Success: Language installed.
+      Success: Language activated.
+      """
+
+    When I run `wp option get date_format`
+    Then STDOUT should contain:
+      """
+      j M Y
+      """
+
+    When I run `wp option get timezone_string`
+    Then STDOUT should contain:
+      """
+      Europe/Istanbul
       """
 
     When I try `wp core language install invalid_lang`

--- a/features/core-language.feature
+++ b/features/core-language.feature
@@ -117,7 +117,7 @@ Feature: Manage translation files for a WordPress install
       Error: Language not installed.
       """
 
-    When I run `wp core language install --activate ja`
+    When I run `wp core language install --activate --set-date-time ja`
     Then the wp-content/languages/admin-ja.po file should exist
     And the wp-content/languages/ja.po file should exist
     And STDOUT should contain:
@@ -138,12 +138,19 @@ Feature: Manage translation files for a WordPress install
       Asia/Tokyo
       """
 
-    When I run `wp core language install --activate tr_TR`
+    When I run `wp core language install tr_TR`
     Then the wp-content/languages/admin-tr_TR.po file should exist
     And the wp-content/languages/tr_TR.po file should exist
     And STDOUT should contain:
       """
       Success: Language installed.
+      """
+
+    When I run `wp core language activate tr_TR --set-date-time`
+    Then the wp-content/languages/admin-tr_TR.po file should exist
+    And the wp-content/languages/tr_TR.po file should exist
+    And STDOUT should contain:
+      """
       Success: Language activated.
       """
 

--- a/features/core-language.feature
+++ b/features/core-language.feature
@@ -117,6 +117,47 @@ Feature: Manage translation files for a WordPress install
       Error: Language not installed.
       """
 
+    When I run `wp core language install --activate en_GB`
+    Then the wp-content/languages/admin-en_GB.po file should exist
+    And the wp-content/languages/en_GB.po file should exist
+    And STDOUT should contain:
+      """
+      Success: Language installed.
+      Success: Language activated.
+      """
+
+    When I run `wp option get date_format`
+    Then STDOUT should contain:
+      """
+      F j, Y
+      """
+
+    When I run `wp option get timezone_string`
+    Then STDOUT should be:
+      """
+
+      """
+
+    When I run `wp core language activate en_GB`
+    Then the wp-content/languages/admin-en_GB.po file should exist
+    And the wp-content/languages/en_GB.po file should exist
+    And STDOUT should contain:
+      """
+      Success: Language activated.
+      """
+
+    When I run `wp option get date_format`
+    Then STDOUT should contain:
+      """
+      F j, Y
+      """
+
+    When I run `wp option get timezone_string`
+    Then STDOUT should be:
+      """
+
+      """
+
     When I run `wp core language install --activate --set-date-time ja`
     Then the wp-content/languages/admin-ja.po file should exist
     And the wp-content/languages/ja.po file should exist

--- a/php/WP_CLI/CommandWithTranslation.php
+++ b/php/WP_CLI/CommandWithTranslation.php
@@ -276,6 +276,22 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 		}
 
 		update_option( 'WPLANG', $language_code );
+
+		// Reload textdomain.
+		unload_textdomain( 'default' );
+		if ( $language_code ) {
+			load_textdomain( 'default', WP_LANG_DIR . "/admin-$language_code.mo" );
+		}
+
+		$localizations = array(
+			'timezone_string' => _x( '0', 'default GMT offset or timezone string' ),
+			'date_format' => __( 'M jS Y' ),
+		);
+
+		foreach ( $localizations as $key => $value ) {
+			update_option( $key, $value );
+		}
+
 		\WP_CLI::success( "Language activated." );
 	}
 

--- a/php/WP_CLI/CommandWithTranslation.php
+++ b/php/WP_CLI/CommandWithTranslation.php
@@ -123,6 +123,9 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 	 * [--activate]
 	 * : If set, the language will be activated immediately after install.
 	 *
+	 * [--set-date-time]
+	 * : Set `timezone_string` and `date_format` to active locale.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Install the Japanese language.
@@ -147,7 +150,8 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 			\WP_CLI::success( "Language installed." );
 
 			if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'activate' ) ) {
-				$this->activate( array( $language_code ), array() );
+				$set_date_time = \WP_CLI\Utils\get_flag_value( $assoc_args, 'set-date-time' );
+				$this->activate( array( $language_code ), array( 'set-date-time' => $set_date_time ) );
 			}
 		} else {
 			\WP_CLI::error( $response );
@@ -254,6 +258,9 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 	 * <language>
 	 * : Language code to activate.
 	 *
+	 * [--set-date-time]
+	 * : Set `timezone_string` and `date_format` to active locale.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp core language activate ja
@@ -277,19 +284,21 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 
 		update_option( 'WPLANG', $language_code );
 
-		// Reload textdomain.
-		unload_textdomain( 'default' );
-		if ( $language_code ) {
-			load_textdomain( 'default', WP_LANG_DIR . "/admin-$language_code.mo" );
-		}
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'set-date-time' ) ) {
+			// Reload textdomain.
+			unload_textdomain( 'default' );
+			if ( $language_code ) {
+				load_textdomain( 'default', WP_LANG_DIR . "/admin-$language_code.mo" );
+			}
 
-		$localizations = array(
-			'timezone_string' => _x( '0', 'default GMT offset or timezone string' ),
-			'date_format' => __( 'M jS Y' ),
-		);
+			$localizations = array(
+				'timezone_string' => _x( '0', 'default GMT offset or timezone string' ),
+				'date_format' => __( 'M jS Y' ),
+			);
 
-		foreach ( $localizations as $key => $value ) {
-			update_option( $key, $value );
+			foreach ( $localizations as $key => $value ) {
+				update_option( $key, $value );
+			}
 		}
 
 		\WP_CLI::success( "Language activated." );

--- a/php/WP_CLI/CommandWithTranslation.php
+++ b/php/WP_CLI/CommandWithTranslation.php
@@ -151,7 +151,11 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 
 			if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'activate' ) ) {
 				$set_date_time = \WP_CLI\Utils\get_flag_value( $assoc_args, 'set-date-time' );
-				$this->activate( array( $language_code ), array( 'set-date-time' => $set_date_time ) );
+				if ( true === $set_date_time ) {
+					$this->activate( array( $language_code ), array( 'set-date-time' => $set_date_time ) );
+				} else {
+					$this->activate( array( $language_code ), array() );
+				}
 			}
 		} else {
 			\WP_CLI::error( $response );


### PR DESCRIPTION
Change timezone string and date_format when language is activated.

Fixes #3731