### PR TITLE
Remove statement in docs that search-replace skips 'guid' column

### DIFF
--- a/php/commands/search-replace.php
+++ b/php/commands/search-replace.php
@@ -64,7 +64,7 @@ class Search_Replace_Command extends WP_CLI_Command {
 	 *
 	 * [--skip-columns=<columns>]
 	 * : Do not perform the replacement on specific columns. Use commas to
-	 * specify multiple columns. 'guid' is skipped by default.
+	 * specify multiple columns.
 	 *
 	 * [--include-columns=<columns>]
 	 * : Perform the replacement on specific columns. Use commas to


### PR DESCRIPTION
This fixes #3732.

I've removed the statement in the documentation that search-replace skips the 'guid' column by default because it doesn't.

I've checked the functional tests - they are in line with the code. No changes to tests are required. The code and tests both include `guid` columns by default.  The documentation change brings the documentation in line with the code and tests.

I've done a search through the whole of the WP-CLI code for the string 'guid' - as far as I can tell nothing else needs to be modified.

As part of the original issue I also searched `php/commands/search-replace.php` for usages of `skip-columns` and I don't believe any other changes are necessary.

My only remaining question is: are the online docs at wp-cli.org, and the build-in help auto-generated? I suspect that they are created from the code comments. But not sure if we need to do anything to make that happen? Probably part of the release process, I guess?