### PR TITLE
Pass `$wp_version` through to `translations_api()`

### DIFF
--- a/features/core-language.feature
+++ b/features/core-language.feature
@@ -144,3 +144,14 @@ Feature: Manage translation files for a WordPress install
       """
       Warning: The 'en_GB' language is active.
       """
+
+  @require-wp-4.0
+  Scenario: Ensure correct language is installed for WP version
+    Given a WP install
+    And I run `wp core download --version=4.5.3 --force`
+
+    When I run `wp core language install nl_NL`
+    Then STDOUT should contain:
+      """
+      Downloading translation from https://downloads.wordpress.org/translation/core/4.5.3
+      """

--- a/php/WP_CLI/CommandWithTranslation.php
+++ b/php/WP_CLI/CommandWithTranslation.php
@@ -362,8 +362,9 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 	 */
 	protected function get_all_languages() {
 		require_once ABSPATH . '/wp-admin/includes/translation-install.php';
+		require ABSPATH . WPINC . '/version.php';
 
-		$response = translations_api( $this->obj_type );
+		$response = translations_api( $this->obj_type, array( 'version' => $wp_version ) );
 		if ( is_wp_error( $response ) ) {
 			\WP_CLI::error( $response );
 		}


### PR DESCRIPTION
This is needed for WordPress to report the correct language download
file.

Fixes #3747