### PR TITLE
Improve media import error handling

### DIFF
--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -153,6 +153,6 @@ Feature: Manage WordPress attachments
     When I try `wp media import gobbledygook.png --porcelain`
     Then STDERR should contain:
       """
-      Error: No images imported.
+      Warning: Unable to import file 'gobbledygook.png'. Reason: File doesn't exist.
       """
     And the return code should be 1

--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -120,3 +120,39 @@ Feature: Manage WordPress attachments
       """
       Alt\Here
       """
+
+  Scenario: Import multiple images
+    Given download:
+      | path                        | url                                              |
+      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
+
+    When I run `wp media import 'http://wp-cli.org/behat-data/codeispoetry.png' {CACHE_DIR}/large-image.jpg`
+    Then STDOUT should contain:
+      """
+      Success: Imported 2 of 2 images.
+      """
+
+  Scenario: Fail to import one image but continue trying the next
+    When I try `wp media import gobbledygook.png 'http://wp-cli.org/behat-data/codeispoetry.png'`
+    Then STDERR should contain:
+      """
+      Error: Only imported 1 of 2 images.
+      """
+    And the return code should be 1
+
+  Scenario: Fail when download_url() fails
+    When I try `wp media import 'http://wp-cli.org/404'`
+    Then STDERR should be:
+      """
+      Warning: Unable to import file 'http://wp-cli.org/404'. Reason: Not Found
+      Error: No images imported.
+      """
+    And the return code should be 1
+
+  Scenario: Return a non-zero exit code when encountering an error in --porcelain mode
+    When I try `wp media import gobbledygook.png --porcelain`
+    Then STDERR should contain:
+      """
+      Error: No images imported.
+      """
+    And the return code should be 1

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -203,7 +203,7 @@ class Media_Command extends WP_CLI_Command {
 				if ( is_wp_error( $tempfile ) ) {
 					WP_CLI::warning( sprintf(
 						"Unable to import file '%s'. Reason: %s",
-						$file, implode( ', ', $success->get_error_messages() )
+						$file, implode( ', ', $tempfile->get_error_messages() )
 					) );
 					$errors++;
 					continue;

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -282,6 +282,8 @@ class Media_Command extends WP_CLI_Command {
 		}
 		if ( ! Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
 			Utils\report_batch_operation_results( 'image', 'import', count( $args ), $successes, $errors );
+		} elseif ( $errors ) {
+			WP_CLI::halt( 1 );
 		}
 	}
 

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -195,7 +195,7 @@ class Media_Command extends WP_CLI_Command {
 				if ( !file_exists( $file ) ) {
 					WP_CLI::warning( "Unable to import file '$file'. Reason: File doesn't exist." );
 					$errors++;
-					break;
+					continue;
 				}
 				$tempfile = $this->make_copy( $file );
 			} else {

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -200,6 +200,14 @@ class Media_Command extends WP_CLI_Command {
 				$tempfile = $this->make_copy( $file );
 			} else {
 				$tempfile = download_url( $file );
+				if ( is_wp_error( $tempfile ) ) {
+					WP_CLI::warning( sprintf(
+						"Unable to import file '%s'. Reason: %s",
+						$file, implode( ', ', $success->get_error_messages() )
+					) );
+					$errors++;
+					continue;
+				}
 			}
 
 			$file_array = array(


### PR DESCRIPTION
- Addresses #3721
- This has 3 related parts, each isolated in their own commit
- Does not (yet) include any tests

1. When a local file is not found, continue to the next file (if there is one) instead of breaking - this matches similar behavior of other errors that allow the command to keep going and try with the following images.
1. Checks the return value of `download_url()` to see if it is a `WP_Error` - this is another thing that bit me when that function returned an error and `wp-cli` didn't really make it clear why the command failed.
1. With the `--porcelain` flag, make sure we return a non-zero exit code if there are any errors.