### PR TITLE
Only append random hash to `wp export` file

### DIFF
--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -1,0 +1,21 @@
+Feature: Export a WordPress database
+
+  Scenario: Database exports with random hash applied
+    Given a WP install
+
+    When I run `wp db export --porcelain`
+    Then STDOUT should contain:
+      """
+      wp_cli_test-
+      """
+    And the wp_cli_test.sql file should not exist
+
+  Scenario: Database export to a specified file path
+    Given a WP install
+
+    When I run `wp db export wp_cli_test.sql --porcelain`
+    Then STDOUT should contain:
+      """
+      wp_cli_test.sql
+      """
+    And the wp_cli_test.sql file should exist

--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -1,0 +1,13 @@
+Feature: Import a WordPress database
+
+  Scenario: Import from database name path by default
+    Given a WP install
+
+    When I run `wp db export wp_cli_test.sql`
+    Then the wp_cli_test.sql file should exist
+
+    When I run `wp db import`
+    Then STDOUT should be:
+      """
+      Success: Imported from 'wp_cli_test.sql'.
+      """

--- a/php/commands/db.php
+++ b/php/commands/db.php
@@ -289,7 +289,12 @@ class DB_Command extends WP_CLI_Command {
 	 * @alias dump
 	 */
 	public function export( $args, $assoc_args ) {
-		$result_file = $this->get_file_name( $args );
+		if ( ! empty( $args[0] ) ) {
+			$result_file = $args[0];
+		} else {
+			$hash = substr( md5( mt_rand() ), 0, 7 );
+			$result_file = sprintf( '%s-%s.sql', DB_NAME, $hash );;
+		}
 		$stdout = ( '-' === $result_file );
 		$porcelain = \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' );
 
@@ -352,7 +357,11 @@ class DB_Command extends WP_CLI_Command {
 	 *     Success: Imported from 'wordpress_dbase.sql'.
 	 */
 	public function import( $args, $assoc_args ) {
-		$result_file = $this->get_file_name( $args );
+		if ( ! empty( $args[0] ) ) {
+			$result_file = $args[0];
+		} else {
+			$result_file = sprintf( '%s.sql', DB_NAME );
+		}
 
 		if ( '-' === $result_file ) {
 			$descriptors = array(
@@ -446,15 +455,6 @@ class DB_Command extends WP_CLI_Command {
 				WP_CLI::line( $table );
 			}
 		}
-	}
-
-	private function get_file_name( $args ) {
-		if ( empty( $args ) ) {
-			$hash = substr( md5( mt_rand() ), 0, 7 );
-			return sprintf( '%s-%s.sql', DB_NAME, $hash );
-		}
-
-		return $args[0];
 	}
 
 	private static function get_create_query() {


### PR DESCRIPTION
`wp import` should continue to attempt to import `{DB_NAME}.sql` when no
other value is provided

Bug introduced in #3765