### PR TITLE
Don't attempt to rename ZIPs uploaded to GitHub's releases page

### DIFF
--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -36,6 +36,21 @@ Feature: Install WordPress plugins
     And the wp-content/plugins/one-time-login directory should exist
     And the wp-content/plugins/one-time-login-master directory should not exist
 
+  Scenario: Don't attempt to rename ZIPs uploaded to GitHub's releases page
+    Given a WP install
+
+    When I run `wp plugin install https://github.com/danielbachhuber/one-time-login/releases/download/v0.1.2/one-time-login.0.1.2.zip`
+    Then STDOUT should contain:
+      """
+      Plugin installed successfully.
+      """
+    And STDOUT should not contain:
+      """
+      Renamed Github-based project from
+      """
+    And STDERR should be empty
+    And the wp-content/plugins/one-time-login directory should exist
+
   Scenario: Installing respects WP_PROXY_HOST and WP_PROXY_PORT
     Given a WP install
     And a invalid-proxy-details.php file:

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -144,6 +144,10 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 				if ( strpos( $local_or_remote_zip_file, '://' ) !== false
 						&& 'github.com' === parse_url( $local_or_remote_zip_file, PHP_URL_HOST ) ) {
 					$filter = function( $source, $remote_source, $upgrader ) use ( $local_or_remote_zip_file ) {
+						// Don't attempt to rename ZIPs uploaded to the releases page
+						if ( preg_match( '#github\.com/([^/]+)/([^/]+)/releases/download/#', $local_or_remote_zip_file ) ) {
+							return $source;
+						}
 						$branch_length = strlen( pathinfo( $local_or_remote_zip_file, PATHINFO_FILENAME ) );
 						if ( $branch_length ) {
 							$new_path = substr( rtrim( $source, '/' ), 0, - ( $branch_length + 1 ) ) . '/';
@@ -151,7 +155,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 								WP_CLI::log( "Renamed Github-based project from '" . basename( $source ) . "' to '" . basename( $new_path ) . "'." );
 								return $new_path;
 							} else {
-								return new \WP_CLI( 'wpcli_install_gitub', "Couldn't move Github-based project to appropriate directory." );
+								return new \WP_Error( 'wpcli_install_gitub', "Couldn't move Github-based project to appropriate directory." );
 							}
 						}
 						return $source;


### PR DESCRIPTION
Also fixes incorrect use of `WP_Error`

Fixes #3775