### PR TITLE
Run help for `wp db *` set of commands at same point as command

### DIFF
--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -11,3 +11,41 @@ Feature: Import a WordPress database
       """
       Success: Imported from 'wp_cli_test.sql'.
       """
+
+  Scenario: Help runs properly at various points of a functional WP install
+    Given an empty directory
+
+    When I run `wp help db import`
+    Then STDOUT should contain:
+      """
+      wp db import
+      """
+
+    When I run `wp core download`
+    Then STDOUT should not be empty
+    And the wp-config-sample.php file should exist
+
+    When I run `wp help db import`
+    Then STDOUT should contain:
+      """
+      wp db import
+      """
+
+    When I run `wp core config {CORE_CONFIG_SETTINGS}`
+    Then STDOUT should not be empty
+    And the wp-config.php file should exist
+
+    When I run `wp help db import`
+    Then STDOUT should contain:
+      """
+      wp db import
+      """
+
+    When I run `wp db create`
+    Then STDOUT should not be empty
+
+    When I run `wp help db import`
+    Then STDOUT should contain:
+      """
+      wp db import
+      """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -897,7 +897,8 @@ class Runner {
 				"Either create one manually or use `wp core config`." );
 		}
 
-		if ( $this->cmd_starts_with( array( 'db' ) ) && !$this->cmd_starts_with( array( 'db', 'tables' ) ) ) {
+		if ( ( $this->cmd_starts_with( array( 'db' ) ) || $this->cmd_starts_with( array( 'help', 'db' ) ) )
+			&& ! $this->cmd_starts_with( array( 'db', 'tables' ) ) ) {
 			eval( $this->get_wp_config_code() );
 			$this->_run_command();
 			exit;


### PR DESCRIPTION
This will enable `wp help db import` to be run when WordPress has been
downloaded, a `wp-config.php` has been created, but WordPress hasn't yet
been installed.