### PR TITLE
Remove XDebug from PHP runtime within Travis CI environment.

### DIFF
--- a/ci/prepare.sh
+++ b/ci/prepare.sh
@@ -6,6 +6,9 @@ set -ex
 
 WP_CLI_BIN_DIR=${WP_CLI_BIN_DIR-/tmp/wp-cli-phar}
 
+# Disable XDebug to speed up Composer and test suites.
+phpenv config-rm xdebug.ini
+
 composer install --no-interaction --prefer-source
 
 CLI_VERSION=$(head -n 1 VERSION)


### PR DESCRIPTION
Uses the snippet from the Travis CI Docs found here:

[https://docs.travis-ci.com/user/languages/php#Disabling-preinstalled-PHP-extensions](https://docs.travis-ci.com/user/languages/php#Disabling-preinstalled-PHP-extensions)

Fixes #3812