### PR TITLE
added flag to indicate a github release that should not be renamed

### DIFF
--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -143,9 +143,9 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 				$filter = false;
 				if ( strpos( $local_or_remote_zip_file, '://' ) !== false
 						&& 'github.com' === parse_url( $local_or_remote_zip_file, PHP_URL_HOST ) ) {
-					$filter = function( $source, $remote_source, $upgrader ) use ( $local_or_remote_zip_file ) {
+					$filter = function( $source, $remote_source, $upgrader ) use ( $local_or_remote_zip_file, $assoc_args ) {
 						// Don't attempt to rename ZIPs uploaded to the releases page
-						if ( preg_match( '#github\.com/([^/]+)/([^/]+)/releases/download/#', $local_or_remote_zip_file ) ) {
+						if ( preg_match( '#github\.com/([^/]+)/([^/]+)/releases/download/#', $local_or_remote_zip_file ) || \WP_CLI\Utils\get_flag_value( $assoc_args, 'github-release' ) ) {
 							return $source;
 						}
 						$branch_length = strlen( pathinfo( $local_or_remote_zip_file, PATHINFO_FILENAME ) );


### PR DESCRIPTION
WP CLI automatically renames plugin install directories when installed from a github url that aren't explicitly uploaded as a release. This can be a problem since there is no way to override this behavior.

In our case, we maintain an installation zip as a file committed to our repo which is updated on each release because the built version of our plugin actually contains dependencies and other files which are not present in the repo itself.

Therefore, installing from the command line generates either a fatal error when attempting to rename the folder, or produces the wrong plugin slug.

A simple fix for this is to add a flag which will allow this behavior to be bypassed.

Example:
```
$ wp plugin install https://github.com/Miller-Media/modern-wordpress/raw/master/builds/modern-framework-stable.zip --github-release --activate
```