### PR TITLE
Allow plugins to be installed from raw github sources without renaming the directory

### DIFF
--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -143,9 +143,9 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 				$filter = false;
 				if ( strpos( $local_or_remote_zip_file, '://' ) !== false
 						&& 'github.com' === parse_url( $local_or_remote_zip_file, PHP_URL_HOST ) ) {
-					$filter = function( $source, $remote_source, $upgrader ) use ( $local_or_remote_zip_file, $assoc_args ) {
+					$filter = function( $source, $remote_source, $upgrader ) use ( $local_or_remote_zip_file ) {
 						// Don't attempt to rename ZIPs uploaded to the releases page
-						if ( preg_match( '#github\.com/([^/]+)/([^/]+)/releases/download/#', $local_or_remote_zip_file ) || \WP_CLI\Utils\get_flag_value( $assoc_args, 'github-release' ) ) {
+						if ( preg_match( '#github\.com/([^/]+)/([^/]+)/releases/download/#', $local_or_remote_zip_file ) && ! preg_match( '#/raw/#', $local_or_remote_zip_file ) ) {
 							return $source;
 						}
 						$branch_length = strlen( pathinfo( $local_or_remote_zip_file, PATHINFO_FILENAME ) );

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -143,9 +143,9 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 				$filter = false;
 				if ( strpos( $local_or_remote_zip_file, '://' ) !== false
 						&& 'github.com' === parse_url( $local_or_remote_zip_file, PHP_URL_HOST ) ) {
-					$filter = function( $source, $remote_source, $upgrader ) use ( $local_or_remote_zip_file ) {
+					$filter = function( $source, $remote_source, $upgrader ) use ( $local_or_remote_zip_file, $assoc_args ) {
 						// Don't attempt to rename ZIPs uploaded to the releases page
-						if ( preg_match( '#github\.com/([^/]+)/([^/]+)/releases/download/#', $local_or_remote_zip_file ) ) {
+						if ( preg_match( '#github\.com/([^/]+)/([^/]+)/releases/download/#', $local_or_remote_zip_file ) || \WP_CLI\Utils\get_flag_value( $assoc_args, 'github-release' ) ) {
 							return $source;
 						}
 						$branch_length = strlen( pathinfo( $local_or_remote_zip_file, PATHINFO_FILENAME ) );


### PR DESCRIPTION
In regards to:
https://github.com/wp-cli/wp-cli/pull/3821

Here is a solution that does not add a flag, it simply allows raw sources to be installed as expected.