### PR TITLE
dont attempt to rename ZIPs being installed from raw github sources

### DIFF
--- a/features/plugin-install.feature
+++ b/features/plugin-install.feature
@@ -51,6 +51,21 @@ Feature: Install WordPress plugins
     And STDERR should be empty
     And the wp-content/plugins/one-time-login directory should exist
 
+  Scenario: Don't attempt to rename ZIPs coming from a GitHub raw source
+    Given a WP install
+
+    When I run `wp plugin install https://github.com/Miller-Media/modern-wordpress/raw/master/builds/modern-framework-stable.zip`
+    Then STDOUT should contain:
+      """
+      Plugin installed successfully.
+      """
+    And STDOUT should not contain:
+      """
+      Renamed Github-based project from
+      """
+    And STDERR should be empty
+    And the wp-content/plugins/modern-framework directory should exist
+
   Scenario: Installing respects WP_PROXY_HOST and WP_PROXY_PORT
     Given a WP install
     And a invalid-proxy-details.php file:

--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -145,7 +145,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 						&& 'github.com' === parse_url( $local_or_remote_zip_file, PHP_URL_HOST ) ) {
 					$filter = function( $source, $remote_source, $upgrader ) use ( $local_or_remote_zip_file ) {
 						// Don't attempt to rename ZIPs uploaded to the releases page
-						if ( preg_match( '#github\.com/([^/]+)/([^/]+)/releases/download/#', $local_or_remote_zip_file ) ) {
+						if ( preg_match( '#github\.com/([^/]+)/([^/]+)/releases/download/#', $local_or_remote_zip_file ) || preg_match( '#github\.com/([^/]+)/([^/]+)/raw/#', $local_or_remote_zip_file ) ) {
 							return $source;
 						}
 						$branch_length = strlen( pathinfo( $local_or_remote_zip_file, PATHINFO_FILENAME ) );


### PR DESCRIPTION
In regards to https://github.com/wp-cli/wp-cli/pull/3821

Without adding any additional flag, expected behavior of installing from a raw github source url should be exactly the same as installing from a source url on the releases page. This change reflects that.