### PR TITLE
Issues 3817 Existing PDF previews not deleted on media regenerate.

### DIFF
--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -172,47 +172,6 @@ Feature: Regenerate WordPress attachments
       Success: Regenerated 2 of 2 images
       """
 
-  Scenario: Only regenerate images which are missing sizes
-    Given download:
-      | path                        | url                                              |
-      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
-    And a wp-content/mu-plugins/media-settings.php file:
-      """
-      <?php
-      add_action( 'after_setup_theme', function(){
-        add_image_size( 'test1', 125, 125, true );
-      });
-      """
-    And I run `wp option update uploads_use_yearmonth_folders 0`
-
-    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported attachment" --porcelain`
-    Then save STDOUT as {ATTACHMENT_ID}
-    And the wp-content/uploads/large-image-125x125.jpg file should exist
-
-    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My second imported attachment" --porcelain`
-    Then save STDOUT as {ATTACHMENT_ID2}
-
-    When I run `rm wp-content/uploads/large-image-125x125.jpg`
-    Then the wp-content/uploads/large-image-125x125.jpg file should not exist
-
-    When I run `wp media regenerate --only-missing --yes`
-    Then STDOUT should contain:
-      """
-      Found 2 images to regenerate.
-      """
-    And STDOUT should contain:
-      """
-      1/2 No thumbnail regeneration needed for "My second imported attachment"
-      """
-    And STDOUT should contain:
-      """
-      2/2 Regenerated thumbnails for "My imported attachment"
-      """
-    And STDOUT should contain:
-      """
-      Success: Regenerated 2 of 2 images
-      """
-
   Scenario: Regenerate images which are missing globally-defined image sizes
     Given download:
       | path                        | url                                              |

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -14,7 +14,7 @@ Feature: Regenerate WordPress attachments
     Given download:
       | path                              | url                                                   |
       | {CACHE_DIR}/large-image.jpg       | http://wp-cli.org/behat-data/large-image.jpg          |
-      | {CACHE_DIR}/minimal-us-letter.pdf | http://localhost/behat-data/minimal-us-letter.pdf     |
+      | {CACHE_DIR}/minimal-us-letter.pdf | http://wp-cli.org/behat-data/minimal-us-letter.pdf    |
     And a wp-content/mu-plugins/media-settings.php file:
       """
       <?php
@@ -61,7 +61,7 @@ Feature: Regenerate WordPress attachments
     Given download:
       | path                              | url                                                   |
       | {CACHE_DIR}/large-image.jpg       | http://wp-cli.org/behat-data/large-image.jpg          |
-      | {CACHE_DIR}/minimal-us-letter.pdf | http://localhost/behat-data/minimal-us-letter.pdf     |
+      | {CACHE_DIR}/minimal-us-letter.pdf | http://wp-cli.org/behat-data/minimal-us-letter.pdf    |
     And a wp-content/mu-plugins/media-settings.php file:
       """
       <?php

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -12,6 +12,71 @@ Feature: Regenerate WordPress attachments
 
   Scenario: Delete existing thumbnails when media is regenerated
     Given download:
+      | path                        | url                                              |
+      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
+    And a wp-content/mu-plugins/media-settings.php file:
+      """
+      <?php
+      add_action( 'after_setup_theme', function(){
+        add_image_size( 'test1', 125, 125, true );
+      });
+      """
+    And I run `wp option update uploads_use_yearmonth_folders 0`
+
+    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported attachment" --porcelain`
+    Then save STDOUT as {ATTACHMENT_ID}
+    And the wp-content/uploads/large-image-125x125.jpg file should exist
+
+    Given a wp-content/mu-plugins/media-settings.php file:
+      """
+      <?php
+      add_action( 'after_setup_theme', function(){
+        add_image_size( 'test1', 200, 200, true );
+      });
+      """
+    When I run `wp media regenerate --yes`
+    Then STDOUT should contain:
+      """
+      Success: Regenerated 1 of 1 images.
+      """
+    And the wp-content/uploads/large-image-125x125.jpg file should not exist
+    And the wp-content/uploads/large-image-200x200.jpg file should exist
+
+  Scenario: Skip deletion of existing thumbnails when media is regenerated
+    Given download:
+      | path                        | url                                              |
+      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
+    And a wp-content/mu-plugins/media-settings.php file:
+      """
+      <?php
+      add_action( 'after_setup_theme', function(){
+        add_image_size( 'test1', 125, 125, true );
+      });
+      """
+    And I run `wp option update uploads_use_yearmonth_folders 0`
+
+    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported attachment" --porcelain`
+    Then save STDOUT as {ATTACHMENT_ID}
+    And the wp-content/uploads/large-image-125x125.jpg file should exist
+
+    Given a wp-content/mu-plugins/media-settings.php file:
+      """
+      <?php
+      add_action( 'after_setup_theme', function(){
+        add_image_size( 'test1', 200, 200, true );
+      });
+      """
+    When I run `wp media regenerate --skip-delete --yes`
+    Then STDOUT should contain:
+      """
+      Success: Regenerated 1 of 1 images.
+      """
+    And the wp-content/uploads/large-image-125x125.jpg file should exist
+    And the wp-content/uploads/large-image-200x200.jpg file should exist
+
+  @require-wp-4.7.1
+  Scenario: Delete existing thumbnails when media including PDF is regenerated
+    Given download:
       | path                              | url                                                   |
       | {CACHE_DIR}/large-image.jpg       | http://wp-cli.org/behat-data/large-image.jpg          |
       | {CACHE_DIR}/minimal-us-letter.pdf | http://wp-cli.org/behat-data/minimal-us-letter.pdf    |
@@ -57,7 +122,8 @@ Feature: Regenerate WordPress attachments
     And the wp-content/uploads/minimal-us-letter-125x125.jpg file should not exist
     And the wp-content/uploads/minimal-us-letter-200x200.jpg file should exist
 
-  Scenario: Skip deletion of existing thumbnails when media is regenerated
+  @require-wp-4.7.1
+  Scenario: Skip deletion of existing thumbnails when media including PDF is regenerated
     Given download:
       | path                              | url                                                   |
       | {CACHE_DIR}/large-image.jpg       | http://wp-cli.org/behat-data/large-image.jpg          |

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -12,39 +12,8 @@ Feature: Regenerate WordPress attachments
 
   Scenario: Delete existing thumbnails when media is regenerated
     Given download:
-      | path                        | url                                              |
-      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
-    And a wp-content/mu-plugins/media-settings.php file:
-      """
-      <?php
-      add_action( 'after_setup_theme', function(){
-        add_image_size( 'test1', 125, 125, true );
-      });
-      """
-    And I run `wp option update uploads_use_yearmonth_folders 0`
-
-    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported attachment" --porcelain`
-    Then save STDOUT as {ATTACHMENT_ID}
-    And the wp-content/uploads/large-image-125x125.jpg file should exist
-
-    Given a wp-content/mu-plugins/media-settings.php file:
-      """
-      <?php
-      add_action( 'after_setup_theme', function(){
-        add_image_size( 'test1', 200, 200, true );
-      });
-      """
-    When I run `wp media regenerate --yes`
-    Then STDOUT should contain:
-      """
-      Success: Regenerated 1 of 1 images.
-      """
-    And the wp-content/uploads/large-image-125x125.jpg file should not exist
-    And the wp-content/uploads/large-image-200x200.jpg file should exist
-
-  Scenario: Delete existing thumbnails when PDF media is regenerated
-    Given download:
-      | path                        | url                                              |
+      | path                              | url                                                   |
+      | {CACHE_DIR}/large-image.jpg       | http://wp-cli.org/behat-data/large-image.jpg          |
       | {CACHE_DIR}/minimal-us-letter.pdf | http://localhost/behat-data/minimal-us-letter.pdf     |
     And a wp-content/mu-plugins/media-settings.php file:
       """
@@ -59,8 +28,12 @@ Feature: Regenerate WordPress attachments
       """
     And I run `wp option update uploads_use_yearmonth_folders 0`
 
-    When I run `wp media import {CACHE_DIR}/minimal-us-letter.pdf --title="My imported attachment" --porcelain`
+    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported attachment" --porcelain`
     Then save STDOUT as {ATTACHMENT_ID}
+    And the wp-content/uploads/large-image-125x125.jpg file should exist
+
+    When I run `wp media import {CACHE_DIR}/minimal-us-letter.pdf --title="My imported PDF attachment" --porcelain`
+    Then save STDOUT as {ATTACHMENT_ID2}
     And the wp-content/uploads/minimal-us-letter-125x125.jpg file should exist
 
     Given a wp-content/mu-plugins/media-settings.php file:
@@ -77,20 +50,27 @@ Feature: Regenerate WordPress attachments
     When I run `wp media regenerate --yes`
     Then STDOUT should contain:
       """
-      Success: Regenerated 1 of 1 images.
+      Success: Regenerated 2 of 2 images.
       """
+    And the wp-content/uploads/large-image-125x125.jpg file should not exist
+    And the wp-content/uploads/large-image-200x200.jpg file should exist
     And the wp-content/uploads/minimal-us-letter-125x125.jpg file should not exist
     And the wp-content/uploads/minimal-us-letter-200x200.jpg file should exist
 
   Scenario: Skip deletion of existing thumbnails when media is regenerated
     Given download:
-      | path                        | url                                              |
-      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
+      | path                              | url                                                   |
+      | {CACHE_DIR}/large-image.jpg       | http://wp-cli.org/behat-data/large-image.jpg          |
+      | {CACHE_DIR}/minimal-us-letter.pdf | http://localhost/behat-data/minimal-us-letter.pdf     |
     And a wp-content/mu-plugins/media-settings.php file:
       """
       <?php
       add_action( 'after_setup_theme', function(){
         add_image_size( 'test1', 125, 125, true );
+        add_filter( 'fallback_intermediate_image_sizes', function( $fallback_sizes ){
+          $fallback_sizes[] = 'test1';
+          return $fallback_sizes;
+        });
       });
       """
     And I run `wp option update uploads_use_yearmonth_folders 0`
@@ -99,20 +79,30 @@ Feature: Regenerate WordPress attachments
     Then save STDOUT as {ATTACHMENT_ID}
     And the wp-content/uploads/large-image-125x125.jpg file should exist
 
+    When I run `wp media import {CACHE_DIR}/minimal-us-letter.pdf --title="My imported PDF attachment" --porcelain`
+    Then save STDOUT as {ATTACHMENT_ID2}
+    And the wp-content/uploads/minimal-us-letter-125x125.jpg file should exist
+
     Given a wp-content/mu-plugins/media-settings.php file:
       """
       <?php
       add_action( 'after_setup_theme', function(){
         add_image_size( 'test1', 200, 200, true );
+        add_filter( 'fallback_intermediate_image_sizes', function( $fallback_sizes ){
+          $fallback_sizes[] = 'test1';
+          return $fallback_sizes;
+        });
       });
       """
     When I run `wp media regenerate --skip-delete --yes`
     Then STDOUT should contain:
       """
-      Success: Regenerated 1 of 1 images.
+      Success: Regenerated 2 of 2 images.
       """
     And the wp-content/uploads/large-image-125x125.jpg file should exist
     And the wp-content/uploads/large-image-200x200.jpg file should exist
+    And the wp-content/uploads/minimal-us-letter-125x125.jpg file should exist
+    And the wp-content/uploads/minimal-us-letter-200x200.jpg file should exist
 
   Scenario: Provide helpful error messages when media can't be regenerated
     Given download:
@@ -139,6 +129,47 @@ Feature: Regenerate WordPress attachments
       """
       Warning: Can't find "My imported attachment" (ID {ATTACHMENT_ID}).
       Error: No images regenerated.
+      """
+
+  Scenario: Only regenerate images which are missing sizes
+    Given download:
+      | path                        | url                                              |
+      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
+    And a wp-content/mu-plugins/media-settings.php file:
+      """
+      <?php
+      add_action( 'after_setup_theme', function(){
+        add_image_size( 'test1', 125, 125, true );
+      });
+      """
+    And I run `wp option update uploads_use_yearmonth_folders 0`
+
+    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported attachment" --porcelain`
+    Then save STDOUT as {ATTACHMENT_ID}
+    And the wp-content/uploads/large-image-125x125.jpg file should exist
+
+    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My second imported attachment" --porcelain`
+    Then save STDOUT as {ATTACHMENT_ID2}
+
+    When I run `rm wp-content/uploads/large-image-125x125.jpg`
+    Then the wp-content/uploads/large-image-125x125.jpg file should not exist
+
+    When I run `wp media regenerate --only-missing --yes`
+    Then STDOUT should contain:
+      """
+      Found 2 images to regenerate.
+      """
+    And STDOUT should contain:
+      """
+      1/2 No thumbnail regeneration needed for "My second imported attachment"
+      """
+    And STDOUT should contain:
+      """
+      2/2 Regenerated thumbnails for "My imported attachment"
+      """
+    And STDOUT should contain:
+      """
+      Success: Regenerated 2 of 2 images
       """
 
   Scenario: Only regenerate images which are missing sizes

--- a/php/commands/media.php
+++ b/php/commands/media.php
@@ -317,10 +317,10 @@ class Media_Command extends WP_CLI_Command {
 		}
 
 		if ( ! $skip_delete ) {
-			$this->remove_old_images( $id );
+			$this->remove_old_images( $id, $fullsizepath );
 		}
 
-		if ( ! $only_missing || $this->needs_regeneration( $id ) ) {
+		if ( ! $only_missing || $this->needs_regeneration( $id, $fullsizepath ) ) {
 
 			$metadata = wp_generate_attachment_metadata( $id, $fullsizepath );
 			if ( is_wp_error( $metadata ) ) {
@@ -343,17 +343,10 @@ class Media_Command extends WP_CLI_Command {
 		}
 	}
 
-	private function remove_old_images( $att_id ) {
-		$wud = wp_upload_dir();
-
+	private function remove_old_images( $att_id, $fullsizepath ) {
 		$metadata = wp_get_attachment_metadata( $att_id );
 
-		if ( empty( $metadata['file'] ) ) {
-			return;
-		}
-
-		$dir_path = $wud['basedir'] . '/' . dirname( $metadata['file'] ) . '/';
-		$original_path = $dir_path . basename( $metadata['file'] );
+		$dir_path = dirname( $fullsizepath ) . '/';
 
 		if ( empty( $metadata['sizes'] ) ) {
 			return;
@@ -362,7 +355,7 @@ class Media_Command extends WP_CLI_Command {
 		foreach ( $metadata['sizes'] as $size_info ) {
 			$intermediate_path = $dir_path . $size_info['file'];
 
-			if ( $intermediate_path == $original_path )
+			if ( $intermediate_path === $fullsizepath )
 				continue;
 
 			if ( file_exists( $intermediate_path ) )
@@ -370,17 +363,10 @@ class Media_Command extends WP_CLI_Command {
 		}
 	}
 
-	private function needs_regeneration( $att_id ) {
-		$wud = wp_upload_dir();
-
+	private function needs_regeneration( $att_id, $fullsizepath ) {
 		$metadata = wp_get_attachment_metadata($att_id);
 
-		if ( empty($metadata['file'] ) ) {
-			return false;
-		}
-
-		$dir_path = $wud['basedir'] . '/' . dirname( $metadata['file'] ) . '/';
-		$original_path = $dir_path . basename( $metadata['file'] );
+		$dir_path = dirname( $fullsizepath ) . '/';
 
 		if ( empty( $metadata['sizes'] ) ) {
 			return true;
@@ -393,7 +379,7 @@ class Media_Command extends WP_CLI_Command {
 		foreach( $metadata['sizes'] as $size_info ) {
 			$intermediate_path = $dir_path . $size_info['file'];
 
-			if ( $intermediate_path == $original_path )
+			if ( $intermediate_path === $fullsizepath )
 				continue;
 
 			if ( ! file_exists( $intermediate_path ) ) {


### PR DESCRIPTION
This is a fix suggested for issue #3817, passing down the `$fullsizepath` from `process_regeneration()`.

The behat test requires a test PDF, "minimal-us-letter.pdf", to be uploaded, which I've uploaded to core trac [minimal-us-letter.pdf](https://core.trac.wordpress.org/raw-attachment/ticket/39875/minimal-us-letter.pdf), and temporarily uses "localhost" instead of "wp-cli.org" to run.
