### PR TITLE
Improve DB import. #3820

### DIFF
--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -12,6 +12,18 @@ Feature: Import a WordPress database
       Success: Imported from 'wp_cli_test.sql'.
       """
 
+  Scenario: Import from database name path by default and skip speed optimization
+    Given a WP install
+
+    When I run `wp db export wp_cli_test.sql`
+    Then the wp_cli_test.sql file should exist
+
+    When I run `wp db import --skip-optimization`
+    Then STDOUT should be:
+      """
+      Success: Imported from 'wp_cli_test.sql'.
+      """
+
   Scenario: Help runs properly at various points of a functional WP install
     Given an empty directory
 


### PR DESCRIPTION
Hi again,

this pull requests includes a fix for issue #3820.

By default, calling `wp db import` will disable auto-commit and (unique and foreign) key checks, and hence speed up the import (for larger dumps). When using `STDIN`, this is not easily possible (but also not necessary).

In order to somehow _force_ the old behavior, I introduced a new flag `skip-optimization`.

First tests with a (very simple!) database dump showed this is effective.

In case you want to test this yourself, the [dump is here](https://github.com/wp-cli/wp-cli/files/793126/data.sql.gz). It includes only a single table, `data`, with a single column that is used as primary key, and 50,000 rows.

I ran **10 imports** each with the new and with the forced old behavior.
Skipping the optimization resulted in times **between 8.620 and 10.061 seconds**, while the optimized import only took **between 8.282 and 8.841 seconds**.
Again, this is only a very simple test - and I expect even more speed gain for real WordPress dumps.

What do you think?