### PR TITLE
Replace deprecated Composer constants.

### DIFF
--- a/php/WP_CLI/PackageManagerEventSubscriber.php
+++ b/php/WP_CLI/PackageManagerEventSubscriber.php
@@ -6,7 +6,7 @@ use \Composer\DependencyResolver\Rule;
 use \Composer\EventDispatcher\Event;
 use \Composer\EventDispatcher\EventSubscriberInterface;
 use \Composer\Installer\PackageEvent;
-use \Composer\Script\ScriptEvents;
+use Composer\Installer\PackageEvents;
 use \WP_CLI;
 
 /**
@@ -17,8 +17,8 @@ class PackageManagerEventSubscriber implements EventSubscriberInterface {
 	public static function getSubscribedEvents() {
 
 		return array(
-			ScriptEvents::PRE_PACKAGE_INSTALL => 'pre_install',
-			ScriptEvents::POST_PACKAGE_INSTALL => 'post_install',
+			PackageEvents::PRE_PACKAGE_INSTALL => 'pre_install',
+			PackageEvents::POST_PACKAGE_INSTALL => 'post_install',
 			);
 	}
 


### PR DESCRIPTION
From the Composer source code:
```
    /**
     * The PRE_PACKAGE_INSTALL event occurs before a package is installed.
     *
     * The event listener method receives a Composer\Installer\PackageEvent instance.
     *
     * @deprecated Use Composer\Installer\PackageEvents::PRE_PACKAGE_INSTALL instead.
     * @var string
     */
    const PRE_PACKAGE_INSTALL = 'pre-package-install';

    /**
     * The POST_PACKAGE_INSTALL event occurs after a package is installed.
     *
     * The event listener method receives a Composer\Installer\PackageEvent instance.
     *
     * @deprecated Use Composer\Installer\PackageEvents::POST_PACKAGE_INSTALL instead.
     * @var string
     */
    const POST_PACKAGE_INSTALL = 'post-package-install';
```