### PR TITLE
Tweak `remove_filter()` function call.

### DIFF
--- a/php/WP_CLI/CommandWithUpgrade.php
+++ b/php/WP_CLI/CommandWithUpgrade.php
@@ -167,7 +167,7 @@ abstract class CommandWithUpgrade extends \WP_CLI_Command {
 					$slug = $file_upgrader->result['destination_name'];
 					$result = true;
 					if ( $filter ) {
-						remove_filter( 'upgrader_source_selection', $filter, 10, 3 );
+						remove_filter( 'upgrader_source_selection', $filter, 10 );
 					}
 					$successes++;
 				} else {


### PR DESCRIPTION
The `remove_filter()` function only takes 3 arguments.

From the source code:
```
/**
 * Removes a function from a specified filter hook.
 *
 * This function removes a function attached to a specified filter hook. This
 * method can be used to remove default functions attached to a specific filter
 * hook and possibly replace them with a substitute.
 *
 * To remove a hook, the $function_to_remove and $priority arguments must match
 * when the hook was added. This goes for both filters and actions. No warning
 * will be given on removal failure.
 *
 * @since 1.2.0
 *
 * @global array $wp_filter         Stores all of the filters
 *
 * @param string   $tag                The filter hook to which the function to be removed is hooked.
 * @param callable $function_to_remove The name of the function which should be removed.
 * @param int      $priority           Optional. The priority of the function. Default 10.
 * @return bool    Whether the function existed before it was removed.
 */
function remove_filter( $tag, $function_to_remove, $priority = 10 ) { /* ... */ }
```