### PR TITLE
Fix typo in `$prompt` private property.

### DIFF
--- a/php/WP_CLI/REPL.php
+++ b/php/WP_CLI/REPL.php
@@ -4,7 +4,7 @@ namespace WP_CLI;
 
 class REPL {
 
-	private $promt;
+	private $prompt;
 
 	public function __construct( $prompt ) {
 		$this->prompt = $prompt;


### PR DESCRIPTION
`$promt` => `$prompt`