### PR TITLE
Add links to source, docs and issues to `composer.json`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,11 @@
 	"keywords": [ "cli", "wordpress" ],
 	"homepage": "http://wp-cli.org",
 	"license": "MIT",
+	"support": {
+		"issues": "https://github.com/wp-cli/wp-cli/issues",
+		"source": "https://github.com/wp-cli/wp-cli",
+		"docs": "https://make.wordpress.org/cli/handbook/"
+	},
 	"bin": [
 		"bin/wp.bat", "bin/wp"
 	],


### PR DESCRIPTION
Add links to source, docs and issues to `composer.json`.

These are programmatically scanned in several places (like packagist.org) to provide direct access to these resources.