### PR TITLE
Process `--activate` flag on `language install` even if already installed

### DIFF
--- a/features/core-language.feature
+++ b/features/core-language.feature
@@ -21,6 +21,7 @@ Feature: Manage translation files for a WordPress install
       """
       Success: Language installed.
       """
+
     When I run `ls {SUITE_CACHE_DIR}/translation | grep core-default-`
     Then STDOUT should contain:
       """
@@ -31,10 +32,14 @@ Feature: Manage translation files for a WordPress install
       en_GB
       """
 
-    When I try `wp core language install en_GB`
-    Then STDERR should be:
+    When I try `wp core language install en_AU`
+    Then STDERR should contain:
       """
-      Warning: Language already installed.
+      Warning: Language 'en_AU' already installed.
+      """
+    And STDOUT should contain:
+      """
+      Success: Language already installed.
       """
 
     When I run `wp core language list --fields=language,english_name,status`
@@ -83,6 +88,16 @@ Feature: Manage translation files for a WordPress install
       | az        | Azerbaijani      | uninstalled   |
       | en_GB     | English (UK)     | active        |
 
+    When I run `wp core language install en_AU --activate`
+    Then STDERR should contain:
+      """
+      Warning: Language 'en_AU' already installed.
+      """
+    And STDOUT should contain:
+      """
+      Success: Language activated.
+      """
+
     When I run `wp core language activate en_US`
     Then STDOUT should be:
       """
@@ -95,7 +110,6 @@ Feature: Manage translation files for a WordPress install
       | ar        | Arabic                  | uninstalled   |
       | en_US     | English (United States) | active        |
       | en_GB     | English (UK)            | installed     |
-
 
     When I try `wp core language activate invalid_lang`
     Then STDERR should be:
@@ -117,7 +131,7 @@ Feature: Manage translation files for a WordPress install
       Error: Language not installed.
       """
 
-    When I run `wp core language install --activate en_GB`
+    When I run `wp core language install en_GB --activate`
     Then the wp-content/languages/admin-en_GB.po file should exist
     And the wp-content/languages/en_GB.po file should exist
     And STDOUT should contain:

--- a/features/core-language.feature
+++ b/features/core-language.feature
@@ -21,6 +21,7 @@ Feature: Manage translation files for a WordPress install
       """
       Success: Language installed.
       """
+    And STDERR should be empty
 
     When I run `ls {SUITE_CACHE_DIR}/translation | grep core-default-`
     Then STDOUT should contain:
@@ -33,13 +34,9 @@ Feature: Manage translation files for a WordPress install
       """
 
     When I try `wp core language install en_AU`
-    Then STDERR should contain:
+    Then STDERR should be:
       """
       Warning: Language 'en_AU' already installed.
-      """
-    And STDOUT should contain:
-      """
-      Success: Language already installed.
       """
 
     When I run `wp core language list --fields=language,english_name,status`
@@ -98,6 +95,14 @@ Feature: Manage translation files for a WordPress install
       Success: Language activated.
       """
 
+    When I run `wp core language install en_AU --activate`
+    Then STDERR should contain:
+      """
+      Warning: Language 'en_AU' already installed.
+      Warning: Language 'en_AU' already active.
+      """
+    And STDOUT should be empty
+
     When I run `wp core language activate en_US`
     Then STDOUT should be:
       """
@@ -139,6 +144,7 @@ Feature: Manage translation files for a WordPress install
       Success: Language installed.
       Success: Language activated.
       """
+    And STDERR should be empty
 
     When I try `wp core language install invalid_lang`
     Then STDERR should be:

--- a/php/WP_CLI/CommandWithTranslation.php
+++ b/php/WP_CLI/CommandWithTranslation.php
@@ -276,6 +276,13 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 			$language_code = '';
 		}
 
+		if ( $language_code === get_locale() ) {
+			\WP_CLI::warning( "Language '{$language_code}' is already active." );
+			\WP_CLI::success( "Language already activated." );
+
+			return;
+		}
+
 		update_option( 'WPLANG', $language_code );
 		\WP_CLI::success( "Language activated." );
 	}

--- a/php/WP_CLI/CommandWithTranslation.php
+++ b/php/WP_CLI/CommandWithTranslation.php
@@ -139,7 +139,6 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 
 		if ( in_array( $language_code, $available ) ) {
 			\WP_CLI::warning( "Language '{$language_code}' already installed." );
-			\WP_CLI::success( "Language already installed." );
 		} else {
 			$response = $this->download_language_pack( $language_code );
 
@@ -277,8 +276,7 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 		}
 
 		if ( $language_code === get_locale() ) {
-			\WP_CLI::warning( "Language '{$language_code}' is already active." );
-			\WP_CLI::success( "Language already activated." );
+			\WP_CLI::warning( "Language '{$language_code}' already active." );
 
 			return;
 		}

--- a/php/WP_CLI/CommandWithTranslation.php
+++ b/php/WP_CLI/CommandWithTranslation.php
@@ -138,19 +138,20 @@ abstract class CommandWithTranslation extends \WP_CLI_Command {
 		$available = $this->get_installed_languages();
 
 		if ( in_array( $language_code, $available ) ) {
-			\WP_CLI::warning( "Language already installed." );
-			exit;
+			\WP_CLI::warning( "Language '{$language_code}' already installed." );
+			\WP_CLI::success( "Language already installed." );
+		} else {
+			$response = $this->download_language_pack( $language_code );
+
+			if ( is_wp_error( $response ) ) {
+				\WP_CLI::error( $response );
+			} else {
+				\WP_CLI::success( "Language installed." );
+			}
 		}
 
-		$response = $this->download_language_pack( $language_code );
-		if ( ! is_wp_error( $response ) ) {
-			\WP_CLI::success( "Language installed." );
-
-			if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'activate' ) ) {
-				$this->activate( array( $language_code ), array() );
-			}
-		} else {
-			\WP_CLI::error( $response );
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'activate' ) ) {
+			$this->activate( array( $language_code ), array() );
 		}
 
 	}


### PR DESCRIPTION
Fixes #3843