### PR TITLE
Add missing line break in FeatureContext.php

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -19,7 +19,7 @@ if ( file_exists( __DIR__ . '/utils.php' ) ) {
 		if ( ! empty( $composer->autoload->files ) ) {
 			$contents = 'require:' . PHP_EOL;
 			foreach( $composer->autoload->files as $file ) {
-				$contents .= '  - ' . dirname( dirname( dirname( __FILE__ ) ) ) . '/' . $file;
+				$contents .= '  - ' . dirname( dirname( dirname( __FILE__ ) ) ) . '/' . $file . PHP_EOL;
 			}
 			@mkdir( sys_get_temp_dir() . '/wp-cli-package-test/' );
 			$project_config = sys_get_temp_dir() . '/wp-cli-package-test/config.yml';


### PR DESCRIPTION
When setting several files for autoloading in `composer.json`, code on top of FeatureContext.php generates this wrong WP-CLI global config:
```
require:
  - file1.php  - file2.php
```

which, when testing, results in this (hard to debug) error:

```
Required file 'file2.php' doesn't exist (from global config.yml).
```

After correction, the correct config file is generated:
```
require:
  - file1.php
  - file2.php
```