### PR TITLE
Fix allowing env. values to permit specific binary

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -906,15 +906,15 @@ class WP_CLI {
 	 * @return string
 	 */
 	public static function get_php_binary() {
-		if ( defined( 'PHP_BINARY' ) )
-			return PHP_BINARY;
-
 		if ( getenv( 'WP_CLI_PHP_USED' ) )
 			return getenv( 'WP_CLI_PHP_USED' );
 
 		if ( getenv( 'WP_CLI_PHP' ) )
 			return getenv( 'WP_CLI_PHP' );
 
+		if ( defined( 'PHP_BINARY' ) )
+			return PHP_BINARY;
+		
 		return 'php';
 	}
 

--- a/php/commands/server.php
+++ b/php/commands/server.php
@@ -81,7 +81,7 @@ class Server_Command extends WP_CLI_Command {
 		}
 
 		$cmd = \WP_CLI\Utils\esc_cmd( '%s -S %s -t %s -c %s %s',
-			PHP_BINARY,
+			WP_CLI::get_php_binary(),
 			$assoc_args['host'] . ':' . $assoc_args['port'],
 			$docroot,
 			$assoc_args['config'],


### PR DESCRIPTION
Per the function comment "Environment values permit specific binaries to be indicated". Currently not possible as PHP_BINARY ***always*** present as defined constant (which can NEVER be overridden unless one uses runkit_extension; dated, not supported)