### PR TITLE
Use `--by=id` to explicitly handle terms as ids

### DIFF
--- a/features/post-term.feature
+++ b/features/post-term.feature
@@ -103,3 +103,93 @@ Feature: Manage post term
       """
       Error: Invalid taxonomy foo2.
       """
+
+  Scenario: Add terms by term id
+    Given a WP install
+
+    When I run `wp term create post_tag 3 --porcelain`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp term create post_tag 4 --porcelain`
+    Then STDOUT should be:
+      """
+      3
+      """
+
+    When I run `wp term create post_tag 2 --porcelain`
+    Then STDOUT should be:
+      """
+      4
+      """
+
+    When I run `wp post term add 1 post_tag 4`
+    Then STDOUT should contain:
+      """
+      Success: Added term.
+      """
+
+    When I run `wp post term add 1 post_tag 2`
+    Then STDOUT should contain:
+      """
+      Success: Added term.
+      """
+
+    When I run `wp post term list 1 post_tag --fields=term_id,name,slug`
+    Then STDOUT should be a table containing rows:
+      | term_id | name | slug |
+      | 4       | 2    | 2    |
+      | 3       | 4    | 4    |
+
+    When I run `wp post term remove 1 post_tag 4 2`
+    Then STDOUT should be:
+      """
+      Success: Deleted term.
+      """
+
+    When I run `wp post term add 1 post_tag 4 --by=id`
+    Then STDOUT should contain:
+      """
+      Success: Added term.
+      """
+
+    When I run `wp post term list 1 post_tag --fields=term_id,name,slug`
+    Then STDOUT should be a table containing rows:
+      | term_id | name | slug |
+      | 4       | 2    | 2    |
+
+    When I run `wp post term add 1 post_tag 3 --by=slug`
+    Then STDOUT should contain:
+      """
+      Success: Added term.
+      """
+
+    When I run `wp post term list 1 post_tag --fields=term_id,name,slug`
+    Then STDOUT should be a table containing rows:
+      | term_id | name | slug |
+      | 2       | 3    | 3    |
+      | 4       | 2    | 2    |
+
+    When I run `wp post term remove 1 post_tag 2 --by=id`
+    Then STDOUT should be:
+      """
+      Success: Deleted term.
+      """
+
+    When I run `wp post term list 1 post_tag --fields=term_id,name,slug`
+    Then STDOUT should be a table containing rows:
+      | term_id | name | slug |
+      | 4       | 2    | 2    |
+
+    When I run `wp post term set 1 post_tag 3 --by=id`
+    Then STDOUT should contain:
+      """
+      Success: Set terms.
+      """
+
+    When I run `wp post term list 1 post_tag --fields=term_id,name,slug`
+    Then STDOUT should be a table containing rows:
+      | term_id | name | slug |
+      | 3       | 4    | 4    |


### PR DESCRIPTION
`wp_set_object_terms()` exhibits ambigious behavior where it will treat
a numeric value as a slug or an id, depending on what it finds in the
database. `--by=id` forces WordPress to explicitly handle the numeric
value as a term id.

Fixes #3716