### PR TITLE
Absolutize 'path' defined in an alias

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -2,6 +2,7 @@ Feature: Create shortcuts to specific WordPress installs
 
   Scenario: Alias for a path to a specific WP install
     Given a WP install in 'testdir'
+    And I run `mkdir testdir2`
     And a wp-cli.yml file:
       """
       @testdir:
@@ -16,6 +17,9 @@ Feature: Create shortcuts to specific WordPress installs
     And the return code should be 1
 
     When I run `wp @testdir core is-installed`
+    Then the return code should be 0
+
+    When I run `cd testdir2; wp @testdir core is-installed`
     Then the return code should be 0
 
   Scenario: Error when invalid alias provided

--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -108,12 +108,15 @@ Feature: Create shortcuts to specific WordPress installs
         path: testdir
       """
 
+    When I run `wp eval --skip-wordpress 'echo realpath( getenv( "RUN_DIR" ) );'`
+    Then save STDOUT as {TEST_DIR}
+
     When I run `wp cli alias`
     Then STDOUT should be YAML containing:
       """
       @all: Run command against every registered alias.
       @testdir:
-        path: testdir
+        path: {TEST_DIR}/testdir
       """
 
     When I run `wp cli aliases`
@@ -121,13 +124,13 @@ Feature: Create shortcuts to specific WordPress installs
       """
       @all: Run command against every registered alias.
       @testdir:
-        path: testdir
+        path: {TEST_DIR}/testdir
       """
 
     When I run `wp cli alias --format=json`
     Then STDOUT should be JSON containing:
       """
-      {"@all":"Run command against every registered alias.","@testdir":{"path":"testdir"}}
+      {"@all":"Run command against every registered alias.","@testdir":{"path":"{TEST_DIR}/testdir"}}
       """
 
   Scenario: Defining a project alias completely overrides a global alias

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -218,12 +218,17 @@ class Configurator {
 		if ( ! empty( $yaml['_']['inherit'] ) ) {
 			$this->merge_yml( $yaml['_']['inherit'], $current_alias );
 		}
+		// Prepare the base path for absolutized alias paths
+		$yml_file_dir = $path ? dirname( $path ) : false;
 		foreach ( $yaml as $key => $value ) {
 			if ( preg_match( '#' . self::ALIAS_REGEX . '#', $key ) ) {
 				$this->aliases[ $key ] = array();
 				$is_alias = false;
 				foreach( self::$alias_spec as $i ) {
 					if ( isset( $value[ $i ] ) ) {
+						if ( 'path' === $i && ! isset( $value['ssh'] ) ) {
+							self::absolutize( $value[ $i ], $yml_file_dir );
+						}
 						$this->aliases[ $key ][ $i ] = $value[ $i ];
 						$is_alias = true;
 					}


### PR DESCRIPTION
From this example:

```
Given a wp-cli.yml file:
  """
  path: testdir
  @testdir:
    path: testdir
  """
```

Both instances of 'path' should be made absolute. However, prior to this
changeset, only 'path' as a default value was made absolute. The 'path'
defined by the `@testdir` alias was relative.