### PR TITLE
Don't send core's email notifications during user import-csv

### DIFF
--- a/features/user-import-csv.feature
+++ b/features/user-import-csv.feature
@@ -18,6 +18,7 @@ Feature: Import users from CSV
 
     When I run `wp user import-csv users.csv`
     Then STDOUT should not be empty
+    And an email should not be sent
 
     When I run `wp user list --format=count`
     Then STDOUT should be:
@@ -57,6 +58,7 @@ Feature: Import users from CSV
 
     When I run `wp user import-csv user-valid.csv`
     Then STDOUT should not be empty
+    And an email should not be sent
 
     When I run `wp user get bobjones --field=display_name`
     Then STDOUT should be:
@@ -77,8 +79,9 @@ Feature: Import users from CSV
     When I run `wp user create bobjones bobjones@example.com --display_name="Robert Jones" --role=administrator`
     Then STDOUT should not be empty
 
-    When I run `wp user import-csv users.csv --skip-update`
+    When I run `wp user import-csv users.csv --skip-update --send-email`
     Then STDOUT should not be empty
+    And an email should be sent
 
     When I run `wp user list --format=count`
     Then STDOUT should be:

--- a/php/commands/user.php
+++ b/php/commands/user.php
@@ -808,6 +808,10 @@ class User_Command extends \WP_CLI\CommandWithDBObject {
 			WP_CLI::error( sprintf( "Missing file: %s", $filename ) );
 		}
 
+		// Don't send core's emails during the creation / update process
+		add_filter( 'send_password_change_email', '__return_false' );
+		add_filter( 'send_email_change_email', '__return_false' );
+
 		foreach ( new \WP_CLI\Iterators\CSV( $filename ) as $i => $new_user ) {
 			$defaults = array(
 				'role' => get_option('default_role'),


### PR DESCRIPTION
`wp user import-csv` includes a `--send-email` flag, which gives the
user control over when the email notification is sent. We should always
defer to this flag, which calls `wp_new_user_notification()`
independently.

Fixes #3903