### PR TITLE
Ignore `*.sql` in scaffolded `.gitignore` and `.distignore`

### DIFF
--- a/templates/plugin-distignore.mustache
+++ b/templates/plugin-distignore.mustache
@@ -24,5 +24,6 @@ wp-cli.local.yml
 tests
 vendor
 node_modules
-*.zip
+*.sql
 *.tar.gz
+*.zip

--- a/templates/plugin-gitignore.mustache
+++ b/templates/plugin-gitignore.mustache
@@ -2,5 +2,6 @@
 Thumbs.db
 wp-cli.local.yml
 node_modules/
-*.zip
+*.sql
 *.tar.gz
+*.zip


### PR DESCRIPTION
SQL dumps shouldn't be committed to repos, nor included in distribution archives.