### PR TITLE
Ignore `InvalidClassFileName` for `*/tests/*`

### DIFF
--- a/templates/phpcs.ruleset.xml
+++ b/templates/phpcs.ruleset.xml
@@ -7,4 +7,8 @@
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
+
+	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
 </ruleset>


### PR DESCRIPTION
Otherwise, WPCS v0.11.0 starts throwing errors

See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/882