### PR TITLE
Variety of improvements to scaffolded `.travis.yml` and `circle.yml`

### DIFF
--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -110,14 +110,17 @@ Feature: Scaffold plugin unit tests
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
             bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 4.4
             phpunit
+            WP_MULTISITE=1 phpunit
           - |
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
             bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 latest
             phpunit
+            WP_MULTISITE=1 phpunit
           - |
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
             bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 trunk
             phpunit
+            WP_MULTISITE=1 phpunit
       """
 
   Scenario: Scaffold plugin tests with Gitlab as the provider

--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -42,8 +42,34 @@ Feature: Scaffold plugin unit tests
     And the {PLUGIN_DIR}/hello-world/.travis.yml file should contain:
       """
       script:
-        - phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')
-        - phpunit
+        - |
+          if [[ ! -z "$WP_VERSION" ]] ; then
+            phpunit
+            WP_MULTISITE=1 phpunit
+          fi
+        - |
+          if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
+            phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')
+          fi
+      """
+    And the {PLUGIN_DIR}/hello-world/.travis.yml file should contain:
+      """
+      matrix:
+        include:
+          - php: 7.1
+            env: WP_VERSION=latest
+          - php: 7.0
+            env: WP_VERSION=latest
+          - php: 5.6
+            env: WP_VERSION=4.4
+          - php: 5.6
+            env: WP_VERSION=latest
+          - php: 5.6
+            env: WP_VERSION=trunk
+          - php: 5.6
+            env: WP_TRAVISCI=phpcs
+          - php: 5.3
+            env: WP_VERSION=latest
       """
 
     When I run `wp eval "if ( is_executable( '{PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh' ) ) { echo 'executable'; } else { exit( 1 ); }"`

--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -82,7 +82,7 @@ Feature: Scaffold plugin unit tests
       """
           - |
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 3.7
+            bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 4.4
             phpunit
           - |
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR

--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -78,6 +78,21 @@ Feature: Scaffold plugin unit tests
       """
       version: 5.6.22
       """
+    And the {PLUGIN_DIR}/circle.yml file should contain:
+      """
+          - |
+            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+            bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 3.7
+            phpunit
+          - |
+            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+            bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 latest
+            phpunit
+          - |
+            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+            bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 trunk
+            phpunit
+      """
 
   Scenario: Scaffold plugin tests with Gitlab as the provider
     Given a WP install

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -39,8 +39,32 @@ Feature: Scaffold theme unit tests
     And the {THEME_DIR}/p2child/.travis.yml file should contain:
       """
       script:
-        - phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')
-        - phpunit
+        - |
+          if [[ ! -z "$WP_VERSION" ]] ; then
+            phpunit
+            WP_MULTISITE=1 phpunit
+          fi
+        - |
+          if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
+            phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')
+          fi
+      """
+    And the {THEME_DIR}/p2child/.travis.yml file should contain:
+      """
+      matrix:
+        include:
+          - php: 7.1
+            env: WP_VERSION=latest
+          - php: 7.0
+            env: WP_VERSION=latest
+          - php: 5.6
+            env: WP_VERSION=latest
+          - php: 5.6
+            env: WP_VERSION=trunk
+          - php: 5.6
+            env: WP_TRAVISCI=phpcs
+          - php: 5.3
+            env: WP_VERSION=latest
       """
 
     When I run `wp eval "if ( is_executable( '{THEME_DIR}/p2child/bin/install-wp-tests.sh' ) ) { echo 'executable'; } else { exit( 1 ); }"`

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -412,10 +412,22 @@ Feature: WordPress code scaffolding
     And the {PLUGIN_DIR}/hello-world/.travis.yml file should exist
     And the {PLUGIN_DIR}/hello-world/.travis.yml file should contain:
       """
-      env:
-        - WP_VERSION=latest WP_MULTISITE=0
-        - WP_VERSION=3.7 WP_MULTISITE=0
-        - WP_VERSION={WP_VERSION} WP_MULTISITE=0
+      matrix:
+        include:
+          - php: 7.1
+            env: WP_VERSION=latest
+          - php: 7.0
+            env: WP_VERSION=latest
+          - php: 5.6
+            env: WP_VERSION=4.4
+          - php: 5.6
+            env: WP_VERSION=latest
+          - php: 5.6
+            env: WP_VERSION=trunk
+          - php: 5.6
+            env: WP_TRAVISCI=phpcs
+          - php: 5.3
+            env: WP_VERSION=latest
       """
 
   Scenario: Scaffold starter code for a theme and network enable it

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -752,7 +752,7 @@ class Scaffold_Command extends WP_CLI_Command {
 		if ( 'travis' === $assoc_args['ci'] ) {
 			$files_to_create["{$target_dir}/.travis.yml"] = Utils\mustache_render( 'plugin-travis.mustache', compact( 'wp_versions_to_test' ) );
 		} else if ( 'circle' === $assoc_args['ci'] ) {
-			$files_to_create["{$target_dir}/circle.yml"] = Utils\mustache_render( 'plugin-circle.mustache' );
+			$files_to_create["{$target_dir}/circle.yml"] = Utils\mustache_render( 'plugin-circle.mustache', compact( 'wp_versions_to_test' ) );
 		} else if ( 'gitlab' === $assoc_args['ci'] ) {
 			$files_to_create["{$target_dir}/.gitlab-ci.yml"] = Utils\mustache_render( 'plugin-gitlab.mustache' );
 		}

--- a/php/commands/scaffold.php
+++ b/php/commands/scaffold.php
@@ -726,7 +726,7 @@ class Scaffold_Command extends WP_CLI_Command {
 		$wp_filesystem->mkdir( $tests_dir );
 		$wp_filesystem->mkdir( $bin_dir );
 
-		$wp_versions_to_test = array('latest');
+		$wp_versions_to_test = array();
 		// Parse plugin readme.txt
 		if ( file_exists( $target_dir . '/readme.txt' ) ) {
 			$readme_content = file_get_contents( $target_dir . '/readme.txt' );
@@ -735,11 +735,9 @@ class Scaffold_Command extends WP_CLI_Command {
 			if ( isset( $matches[1] ) && $matches[1] ) {
 				$wp_versions_to_test[] = trim( $matches[1] );
 			}
-			preg_match( '/Tested up to\:(.*)\n/m', $readme_content, $matches );
-			if ( isset( $matches[1] ) && $matches[1] ) {
-				$wp_versions_to_test[] = trim( $matches[1] );
-			}
 		}
+		$wp_versions_to_test[] = 'latest';
+		$wp_versions_to_test[] = 'trunk';
 
 		$template_data = array(
 			"{$type}_slug"    => $slug,

--- a/templates/plugin-circle.mustache
+++ b/templates/plugin-circle.mustache
@@ -22,4 +22,5 @@ test:
       rm -rf $WP_TESTS_DIR $WP_CORE_DIR
       bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 {{.}}
       phpunit
+      WP_MULTISITE=1 phpunit
     {{/wp_versions_to_test}}

--- a/templates/plugin-circle.mustache
+++ b/templates/plugin-circle.mustache
@@ -2,6 +2,8 @@ machine:
   php:
     version: 5.6.22
   environment:
+    WP_TESTS_DIR: /tmp/wordpress-tests-lib
+    WP_CORE_DIR: /tmp/wordpress/
     PATH: $HOME/.composer/vendor/bin:$PATH
 
 dependencies:
@@ -10,10 +12,14 @@ dependencies:
 
 test:
   pre:
-    - bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 latest
     - |
       composer global require wp-coding-standards/wpcs
       phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
   override:
     - phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')
-    - phpunit
+    {{#wp_versions_to_test}}
+    - |
+      rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+      bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 {{.}}
+      phpunit
+    {{/wp_versions_to_test}}

--- a/templates/plugin-readme.mustache
+++ b/templates/plugin-readme.mustache
@@ -2,7 +2,7 @@
 Contributors: (this should be a list of wordpress.org userid's)
 Donate link: http://example.com/
 Tags: comments, spam
-Requires at least: 3.7
+Requires at least: 4.4
 Tested up to: {{plugin_tested_up_to}}
 Stable tag: 0.1.0
 License: GPLv2 or later

--- a/templates/plugin-travis.mustache
+++ b/templates/plugin-travis.mustache
@@ -15,33 +15,45 @@ cache:
   - composer
   - $HOME/.composer/cache
 
-php:
-  - 5.3
-  - 5.6
-
-env:
-{{#wp_versions_to_test}}
-  - WP_VERSION={{.}} WP_MULTISITE=0
-{{/wp_versions_to_test}}
-
 matrix:
   include:
+    - php: 7.1
+      env: WP_VERSION=latest
+    - php: 7.0
+      env: WP_VERSION=latest
+    {{#wp_versions_to_test}}
+    - php: 5.6
+      env: WP_VERSION={{.}}
+    {{/wp_versions_to_test}}
+    - php: 5.6
+      env: WP_TRAVISCI=phpcs
     - php: 5.3
-      env: WP_VERSION=latest WP_MULTISITE=1
+      env: WP_VERSION=latest
 
 before_script:
-  - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - |
-    if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
-      composer global require "phpunit/phpunit=5.7.*"
-    else
-      composer global require "phpunit/phpunit=4.8.*"
+    if [[ ! -z "$WP_VERSION" ]] ; then
+      bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+      if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
+        composer global require "phpunit/phpunit=5.7.*"
+      else
+        composer global require "phpunit/phpunit=4.8.*"
+      fi
     fi
   - |
-    composer global require wp-coding-standards/wpcs
-    phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+    if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
+      composer global require wp-coding-standards/wpcs
+      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+    fi
 
 script:
-  - phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')
-  - phpunit
+  - |
+    if [[ ! -z "$WP_VERSION" ]] ; then
+      phpunit
+      WP_MULTISITE=1 phpunit
+    fi
+  - |
+    if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
+      phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')
+    fi


### PR DESCRIPTION
* Rebuilds `.travis.yml` file:
  * Explicitly identify each job in the build matrix
  * Run tests against PHP 7.1 and 7.0
  * Only run `phpcs` once, instead of with every job
  * Run multisite tests on each job
  * Tested in https://github.com/wp-cli/sample-plugin/pull/6
* Scaffolds `circle.yml` to run against range of supported WP versions
  * Also runs multisite tests for each job
  * Tested in https://github.com/wp-cli/sample-plugin/pull/5 and https://github.com/wp-cli/sample-plugin/pull/7
* In default `readme.txt`, uses WP 4.4 as the minimum supported WP version

Fixes #3784
Fixes #3785