### PR TITLE
Permit WP-CLI to be built as a phar when dependency of another project

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -218,9 +218,21 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	public function build_phar( $version = 'same' ) {
 		$this->variables['PHAR_PATH'] = $this->variables['RUN_DIR'] . '/' . uniqid( "wp-cli-build-", TRUE ) . '.phar';
 
+		// Test running against WP-CLI proper
+		$make_phar_path = __DIR__ . '/../../utils/make-phar.php';
+		if ( ! file_exists( $make_phar_path ) ) {
+			// Test running against a package installed as a WP-CLI dependency
+			// WP-CLI installed as a project dependency
+			$make_phar_path = __DIR__ . '/../../../../../utils/make-phar.php';
+			if ( ! file_exists( $make_phar_path ) ) {
+				// WP-CLI as a dependency of this project
+				$make_phar_path = __DIR__ . '/../../vendor/wp-cli/wp-cli/utils/make-phar.php';
+			}
+		}
+
 		$this->proc( Utils\esc_cmd(
 			'php -dphar.readonly=0 %1$s %2$s --version=%3$s && chmod +x %2$s',
-			__DIR__ . '/../../utils/make-phar.php',
+			$make_phar_path,
 			$this->variables['PHAR_PATH'],
 			$version
 		) )->run_check();

--- a/php/boot-phar.php
+++ b/php/boot-phar.php
@@ -1,6 +1,13 @@
 <?php
 
-define( 'WP_CLI_ROOT', 'phar://wp-cli.phar' );
-
-include WP_CLI_ROOT . '/php/wp-cli.php';
+if ( file_exists( 'phar://wp-cli.phar/php/wp-cli.php' ) ) {
+	define( 'WP_CLI_ROOT', 'phar://wp-cli.phar' );
+	include WP_CLI_ROOT . '/php/wp-cli.php';
+} elseif ( file_exists( 'phar://wp-cli.phar/vendor/wp-cli/wp-cli/php/wp-cli.php' ) ) {
+	define( 'WP_CLI_ROOT', 'phar://wp-cli.phar/vendor/wp-cli/wp-cli' );
+	include WP_CLI_ROOT . '/php/wp-cli.php';
+} else {
+	echo "Couldn't find 'php/wp-cli.php'. Was this Phar built correctly?";
+	exit(1);
+}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -35,7 +35,11 @@ function extract_from_phar( $path ) {
 
 function load_dependencies() {
 	if ( inside_phar() ) {
-		require WP_CLI_ROOT . '/vendor/autoload.php';
+		if ( file_exists( WP_CLI_ROOT . '/vendor/autoload.php' ) ) {
+			require WP_CLI_ROOT . '/vendor/autoload.php';
+		} elseif ( file_exists( dirname( dirname( WP_CLI_ROOT ) ) . '/autoload.php' ) ) {
+			require dirname( dirname( WP_CLI_ROOT ) ) . '/autoload.php';
+		}
 		return;
 	}
 


### PR DESCRIPTION
Used in https://github.com/wp-cli/package-command/pull/2

To verify in the `package-command` project:

```
git clone git@github.com:wp-cli/package-command.git
cd package-command
git checkout 1-phar-access
composer install
behat features/package-install.feature
cd vendor/wp-cli/wp-cli
git checkout phar-build-subproject
cd -
```

Here's the current test that fails: https://travis-ci.org/wp-cli/package-command/jobs/214240701