### PR TITLE
Fix broken tests by removing platform-specific indentation from `wc` output.

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -263,7 +263,7 @@ Feature: Create shortcuts to specific WordPress installs
         path: subdir2
       """
 
-    When I run `wp @all option get home | wc -l`
+    When I run `wp @all option get home | wc -l | tr -d ' '`
     Then STDOUT should be:
       """
       1

--- a/features/post.feature
+++ b/features/post.feature
@@ -66,7 +66,7 @@ Feature: Manage WordPress posts
       | post_name  |           |
       | post_type  | post      |
 
-    When I run `wp post get {POST_ID} --format=csv --fields=post_title,type | wc -l`
+    When I run `wp post get {POST_ID} --format=csv --fields=post_title,type | wc -l | tr -d ' '`
     Then STDOUT should be:
       """
       3

--- a/features/user-import-csv.feature
+++ b/features/user-import-csv.feature
@@ -109,7 +109,7 @@ Feature: Import users from CSV
     And I run `wp user add-role billjones author`
     Then STDOUT should not be empty
 
-    When I run `wp user list --field=user_login | wc -l`
+    When I run `wp user list --field=user_login | wc -l | tr -d ' '`
     Then STDOUT should be:
       """
       2
@@ -121,7 +121,7 @@ Feature: Import users from CSV
     When I run `wp user delete $(wp user list --format=ids) --yes`
     Then STDOUT should not be empty
 
-    When I run `wp user list --field=user_login | wc -l`
+    When I run `wp user list --field=user_login | wc -l | tr -d ' '`
     Then STDOUT should be:
       """
       0


### PR DESCRIPTION
Pipe `wc` output through `tr` to delete the indentation, so that the output is consistent across all platforms and the tests all behave in the same way.

Fixes #3925