### PR TITLE
Require php-5.6 for failing nightly test

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -110,6 +110,7 @@ Feature: `wp cli` tasks
     And STDERR should be empty
     And the return code should be 0
 
+  @require-php-5.6
   Scenario: Install WP-CLI nightly
     Given an empty directory
     And a new Phar with version "0.14.0"


### PR DESCRIPTION
I think something changed in the Travis PHP 5.3 environment, and I don't
want to invest the time into tracking it down.