### PR TITLE
spelling fixes

### DIFF
--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -131,7 +131,7 @@ class CompositeCommand {
 	}
 
 	/**
-	 * Set the long description for this composite commmand
+	 * Set the long description for this composite command
 	 *
 	 * @param string
 	 */

--- a/php/WP_CLI/SynopsisValidator.php
+++ b/php/WP_CLI/SynopsisValidator.php
@@ -20,7 +20,7 @@ class SynopsisValidator {
 	}
 
 	/**
-	 * Get any unknown arugments.
+	 * Get any unknown arguments.
 	 *
 	 * @return array
 	 */

--- a/php/commands/option.php
+++ b/php/commands/option.php
@@ -185,7 +185,7 @@ class Option_Command extends WP_CLI_Command {
 	 *     _site_transient_update_core 808
 	 *     _site_transient_update_plugins  6645
 	 *
-	 *     # List all options begining with "i2f_".
+	 *     # List all options beginning with "i2f_".
 	 *     $ wp option list --search="i2f_*"
 	 *     +-------------+--------------+
 	 *     | option_name | option_value |
@@ -193,7 +193,7 @@ class Option_Command extends WP_CLI_Command {
 	 *     | i2f_version | 0.1.0        |
 	 *     +-------------+--------------+
 	 *
-	 *     # Delete all options begining with "theme_mods_".
+	 *     # Delete all options beginning with "theme_mods_".
 	 *     $ wp option list --search="theme_mods_*" --field=option_name | xargs -I % wp option delete %
 	 *     Success: Deleted 'theme_mods_twentysixteen' option.
 	 *     Success: Deleted 'theme_mods_twentyfifteen' option.


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.