### PR TITLE
Replicate sanitization WordPress normally performs when fetching

### DIFF
--- a/features/option.feature
+++ b/features/option.feature
@@ -201,3 +201,18 @@ Feature: Manage WordPress options
       | wp_autoload_1 | disabled       | no       |
       | wp_autoload_2 | implicit2      | yes      |
       | wp_autoload_3 | enabled        | yes      |
+
+  Scenario: Extra removetrailingslash sanitization for whitelisted options
+    Given a WP install
+
+    When I run `wp option update home 'http://localhost/'`
+    Then STDOUT should be:
+      """
+      Success: Updated 'home' option.
+      """
+
+    When I run `wp option update home 'http://localhost/'`
+    Then STDOUT should be:
+      """
+      Success: Value passed for 'home' option is unchanged.
+      """

--- a/php/commands/option.php
+++ b/php/commands/option.php
@@ -328,6 +328,10 @@ class Option_Command extends WP_CLI_Command {
 		}
 
 		$value = sanitize_option( $key, $value );
+		// Sanitization WordPress normally performs when getting an option
+		if ( in_array( $key, array('siteurl', 'home', 'category_base', 'tag_base') ) ) {
+			$value = untrailingslashit( $value );
+		}
 		$old_value = sanitize_option( $key, get_option( $key ) );
 
 		if ( $value === $old_value && is_null( $autoload ) ) {


### PR DESCRIPTION
Doing so means our comparison conditional checks the correct value.

Fixes #3967