### PR TITLE
Add support for globs in `require`

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -112,6 +112,7 @@ Feature: Global flags
       log: called 'error' method
       """
 
+  @flag:require
   Scenario: Using --require
     Given an empty directory
     And a custom-cmd.php file:
@@ -166,6 +167,7 @@ Feature: Global flags
       This is a custom command.
       """
 
+  @flag:require
   Scenario: Using --require with globs
     Given an empty directory
     And a foober/foo.php file:

--- a/features/flags.feature
+++ b/features/flags.feature
@@ -166,6 +166,38 @@ Feature: Global flags
       This is a custom command.
       """
 
+  Scenario: Using --require with globs
+    Given an empty directory
+    And a foober/foo.php file:
+      """
+      <?php echo basename(__FILE__) . "\n";
+      """
+    And a foober/bar.php file:
+      """
+      <?php echo basename(__FILE__) . "\n";
+      """
+    And a doobie/doo.php file:
+      """
+      <?php echo basename(__FILE__) . "\n";
+      """
+
+    And a wp-cli.yml file:
+      """
+      require: foober/*.php
+      """
+
+    When I run `wp`
+    Then STDOUT should contain:
+      """
+      bar.php
+      foo.php
+      """
+    When I run `wp --require=doobie/*.php`
+    Then STDOUT should contain:
+      """
+      doo.php
+      """
+
   Scenario: Enabling/disabling color
     Given a WP install
 

--- a/features/flags.feature
+++ b/features/flags.feature
@@ -112,7 +112,6 @@ Feature: Global flags
       log: called 'error' method
       """
 
-  @flag:require
   Scenario: Using --require
     Given an empty directory
     And a custom-cmd.php file:
@@ -167,7 +166,6 @@ Feature: Global flags
       This is a custom command.
       """
 
-  @flag:require
   Scenario: Using --require with globs
     Given an empty directory
     And a foober/foo.php file:

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -274,6 +274,10 @@ class Configurator {
 			if ( false !== $details['runtime'] && isset( $config[ $key ] ) ) {
 				$value = $config[ $key ];
 
+				if ( 'require' == $key ) {
+					$value = \WP_CLI\Utils\expand_globs( $value );
+				}
+
 				if ( $details['multiple'] ) {
 					self::arrayify( $value );
 					$this->config[ $key ] = array_merge( $this->config[ $key ], $value );
@@ -304,6 +308,7 @@ class Configurator {
 
 		if ( isset( $config['require'] ) ) {
 			self::arrayify( $config['require'] );
+			$config['require'] = \WP_CLI\Utils\expand_globs( $config['require'] );
 			foreach ( $config['require'] as &$path ) {
 				self::absolutize( $path, $yml_file_dir );
 			}

--- a/php/utils.php
+++ b/php/utils.php
@@ -858,3 +858,24 @@ function parse_str_to_argv( $arguments ) {
 function basename( $path, $suffix = '' ) {
 	return urldecode( \basename( str_replace( array( '%2F', '%5C' ), '/', urlencode( $path ) ), $suffix ) );
 }
+
+/**
+ * Expand within paths to their matching paths.
+ *
+ * Has no effect on paths which do not use glob patterns.
+ *
+ * @param string|array $paths Single path as a string, or an array of paths.
+ * @param int          $flags Flags to pass to glob.
+ *
+ * @return array Expanded paths.
+ */
+function expand_globs( $paths, $flags = GLOB_BRACE ) {
+	$expanded = array();
+
+	foreach ( (array) $paths as $path ) {
+		$matching = glob( $path, $flags ) ?: array();
+		$expanded = array_merge( $expanded, $matching );
+	}
+
+	return array_unique( $expanded );
+}

--- a/php/utils.php
+++ b/php/utils.php
@@ -873,7 +873,12 @@ function expand_globs( $paths, $flags = GLOB_BRACE ) {
 	$expanded = array();
 
 	foreach ( (array) $paths as $path ) {
-		$matching = glob( $path, $flags ) ?: array();
+		$matching = array( $path );
+
+		if ( preg_match( '/[' . preg_quote( '*?[]{}!', '/' ) . ']/', $path ) ) {
+			$matching = glob( $path, $flags ) ?: array();
+		}
+
 		$expanded = array_merge( $expanded, $matching );
 	}
 


### PR DESCRIPTION
Sometimes it can be useful to be able to load files with a pattern rather than listing them all out explicitly.

With this PR, you could have something like this in your global config file `~/.wp-cli/config.yml`  for autoloading little one-off commands without any additional configuration:

```yml
require: dropins/*.php
```

It also supports usage with the `--require` flag as well.
This is also backwards compatible because a path that does not use a glob pattern is unaffected.

The utility function added could be useful in other commands as well!