### PR TITLE
Generate 18 character password for admin user

### DIFF
--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -545,13 +545,14 @@ class Core_Command extends WP_CLI_Command {
 		}
 
 		$public = true;
+		$password = empty($admin_password) ? wp_generate_password(18) : $admin_password ;
 
 		// @codingStandardsIgnoreStart
 		if ( !is_email( $admin_email ) ) {
 			WP_CLI::error( "The '{$admin_email}' email address is invalid." );
 		}
 
-		$result = wp_install( $title, $admin_user, $admin_email, $public, '', $admin_password );
+		$result = wp_install( $title, $admin_user, $admin_email, $public, '', $password );
 
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( 'Installation failed (' . WP_CLI::error_to_string($result) . ').' );

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -535,7 +535,7 @@ class Core_Command extends WP_CLI_Command {
 			'title' => '',
 			'admin_user' => '',
 			'admin_email' => '',
-			'admin_password' => ''
+			'admin_password' => wp_generate_password(18)
 		) ), EXTR_SKIP );
 
 		// Support prompting for the `--url=<url>`,

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -535,7 +535,7 @@ class Core_Command extends WP_CLI_Command {
 			'title' => '',
 			'admin_user' => '',
 			'admin_email' => '',
-			'admin_password' => wp_generate_password(18)
+			'admin_password' => ''
 		) ), EXTR_SKIP );
 
 		// Support prompting for the `--url=<url>`,

--- a/php/commands/core.php
+++ b/php/commands/core.php
@@ -545,7 +545,7 @@ class Core_Command extends WP_CLI_Command {
 		}
 
 		$public = true;
-		$password = empty($admin_password) ? wp_generate_password(18) : $admin_password ;
+		$password = empty($admin_password) ? wp_generate_password(18) : $admin_password;
 
 		// @codingStandardsIgnoreStart
 		if ( !is_email( $admin_email ) ) {


### PR DESCRIPTION
This matches the default password length for new WP installs.

See also: https://github.com/wp-cli/entity-command/pull/7