### PR TITLE
Add `phar_safe_path()` function.

### DIFF
--- a/php/boot-phar.php
+++ b/php/boot-phar.php
@@ -1,5 +1,8 @@
 <?php
 
+// Store the path to the Phar early on for `Utils\phar-safe-path()` function.
+define( 'WP_CLI_PHAR_PATH', getcwd() );
+
 if ( file_exists( 'phar://wp-cli.phar/php/wp-cli.php' ) ) {
 	define( 'WP_CLI_ROOT', 'phar://wp-cli.phar' );
 	include WP_CLI_ROOT . '/php/wp-cli.php';

--- a/php/utils.php
+++ b/php/utils.php
@@ -10,8 +10,10 @@ use \WP_CLI;
 use \WP_CLI\Dispatcher;
 use \WP_CLI\Iterators\Transform;
 
+const PHAR_STREAM_PREFIX = 'phar://';
+
 function inside_phar() {
-	return 0 === strpos( WP_CLI_ROOT, 'phar://' );
+	return 0 === strpos( WP_CLI_ROOT, PHAR_STREAM_PREFIX );
 }
 
 // Files that need to be read by external programs have to be extracted from the Phar archive.
@@ -459,7 +461,7 @@ function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
  */
 function mustache_render( $template_name, $data = array() ) {
 	// Transform absolute path to relative path inside of Phar
-	if ( inside_phar() && 0 === stripos( $template_name, 'phar://' ) ) {
+	if ( inside_phar() && 0 === stripos( $template_name, PHAR_STREAM_PREFIX ) ) {
 		$search = '';
 		$replace = '';
 		if ( file_exists( WP_CLI_ROOT . '/vendor/autoload.php' ) ) {
@@ -883,4 +885,29 @@ function expand_globs( $paths, $flags = GLOB_BRACE ) {
 	}
 
 	return array_unique( $expanded );
+}
+
+/**
+ * Get a Phar-safe version of a path.
+ *
+ * For paths inside a Phar, this strips the outer filesystem's location to
+ * reduce the path to what it needs to be within the Phar archive.
+ *
+ * Use the __FILE__ or __DIR__ constants as a starting point.
+ *
+ * @param string $path An absolute path that might be within a Phar.
+ *
+ * @return string A Phar-safe version of the path.
+ */
+function phar_safe_path( $path ) {
+
+	if ( ! inside_phar() ) {
+		return $path;
+	}
+
+	return str_replace(
+		PHAR_STREAM_PREFIX . getcwd() . '/',
+		PHAR_STREAM_PREFIX,
+		$path
+	);
 }

--- a/php/utils.php
+++ b/php/utils.php
@@ -906,7 +906,7 @@ function phar_safe_path( $path ) {
 	}
 
 	return str_replace(
-		PHAR_STREAM_PREFIX . getcwd() . '/',
+		PHAR_STREAM_PREFIX . WP_CLI_PHAR_PATH . '/',
 		PHAR_STREAM_PREFIX,
 		$path
 	);


### PR DESCRIPTION
This function allows to retrieve a path by making sure it is adapted when used within a Phar archive.

This is meant to solve issues like https://github.com/wp-cli/scaffold-command/pull/10

Fixes #3987