### PR TITLE
Allow annotations to whitelist method

### DIFF
--- a/php/WP_CLI/Dispatcher/CommandFactory.php
+++ b/php/WP_CLI/Dispatcher/CommandFactory.php
@@ -116,8 +116,8 @@ class CommandFactory {
 		}
 
 		return $method->isPublic()
-		       && ! $method->isStatic()
-		       && 0 !== strpos( $method->getName(), '__' );
+			&& ! $method->isStatic()
+			&& 0 !== strpos( $method->getName(), '__' );
 	}
 }
 

--- a/php/WP_CLI/Dispatcher/CommandFactory.php
+++ b/php/WP_CLI/Dispatcher/CommandFactory.php
@@ -104,11 +104,20 @@ class CommandFactory {
 	/**
 	 * Check whether a method is actually callable.
 	 *
-	 * @param ReflectionMethod $method
+	 * @param \ReflectionMethod $method
+	 *
 	 * @return bool
 	 */
 	private static function is_good_method( $method ) {
-		return $method->isPublic() && !$method->isStatic() && 0 !== strpos( $method->getName(), '__' );
+		$doc_block = new \WP_CLI\DocParser( $method->getDocComment() );
+
+		if ( $doc_block->get_tag( 'subcommand' ) || 'public' == $doc_block->get_tag( 'access' ) ) {
+			return true;
+		}
+
+		return $method->isPublic()
+		       && ! $method->isStatic()
+		       && 0 !== strpos( $method->getName(), '__' );
 	}
 }
 


### PR DESCRIPTION
This PR changes the way `\WP_CLI\Dispatcher\CommandFactory::is_good_method` decides if a given method should be considered usable for a sub command.

Until now, only public non-static instance methods are allowed to be used. However this limitation unnecessarily restricts the usage of a powerful feature of protected methods - the magic `__call()` method.

By making the sub-command's method protected or private, but whitelisting it using an annotation as allowed for here, the developer can use the `__call()` method to do any "preflight" handling, checks, or abort before the actual method is invoked.

Why not just use `before_invoke:{cmd}` hook?
1. Does not pass command arguments to the callback (yet)
1. `__call()` gives you object context within the command to be able to call other protected methods or access/set/modify instance state.

In a way, this is similar to what I would like to be able to do in #3354. The only change requested here is that WP-CLI trusts the developer that these annotations mean the method is ok to use.

This PR considers two annotations in this decision: WP-CLI's `@subcommand` and the standard `@access`. The method will be whitelisted for any value for `@subcommand` or if `@access public`.

Consider this example command:

```php
<?php

/**
 * Does foo.
 */
class WP_CLI_FooCommand
{
    protected $args;

    /**
     * Do bar.
     *
     * [<extra>...]
     * : Positional args
     *
     * [--asdf=<arggg>]
     * : Non-sensical assoc arg
     *
     * @access public
     */
    protected function bar() {
        echo __METHOD__;
        var_dump($this->args);
    }

    /**
     * Do baz.
     *
     * [<extra>...]
     * : Positional args
     *
     * [--asdf=<arggg>]
     * : Non-sensical assoc arg
     * 
     * @subcommand baz
     */
    protected function blah() {
        echo __METHOD__;
        var_dump($this->args);
    }

    /**
     * This method will not show in the list
     */
    protected function not_a_command() {
        echo __METHOD__;
    }

    /**
     * Handle calls to protected methods.
     * 
     * @param  string $method
     * @param  string $args  
     */
    public function __call($method, $args) {
        var_dump("calling $method");

        $this->args = $args;

        $this->$method();
    }
}

WP_CLI::add_command('foo', WP_CLI_FooCommand::class);
```

```
NAME

  wp foo

DESCRIPTION

  Does foo.

SYNOPSIS

  wp foo <command>

SUBCOMMANDS

  bar      Do bar.
  baz      Do baz.

```

```
➜ wp foo bar lorem ipsum dolor --asdf=yo
/Users/aaemnnosttv/.wp-cli/commands/foo-command.php:58:
string(11) "calling bar"
WP_CLI_FooCommand::bar/Users/aaemnnosttv/.wp-cli/commands/foo-command.php:24:
array(2) {
  [0] =>
  array(3) {
    [0] =>
    string(5) "lorem"
    [1] =>
    string(5) "ipsum"
    [2] =>
    string(5) "dolor"
  }
  [1] =>
  array(1) {
    'asdf' =>
    string(2) "yo"
  }
}
```
