### PR TITLE
Add command hooks mechanism for simple dependency resolution.

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -752,3 +752,53 @@ Feature: WP-CLI Commands
       """
       Did you mean
       """
+
+  Scenario: Adding a command can be aborted through the hooks system
+    Given an empty directory
+    And a abort-add-command.php file:
+      """
+      <?php
+      WP_CLI::add_hook( 'before_add_command:test-command-2', function ( $addition ) {
+        $addition->abort( 'Testing hooks.' );
+      } );
+
+      WP_CLI::add_command( 'test-command-1', function () {} );
+      WP_CLI::add_command( 'test-command-2', function () {} );
+      """
+
+    When I run `wp --require=abort-add-command.php`
+    Then STDOUT should contain:
+      """
+      test-command-1
+      """
+    And STDOUT should not contain:
+      """
+      test-command-2
+      """
+
+  Scenario: Adding a command can depend on a previous command having been added before
+    Given an empty directory
+    And a add-dependent-command.php file:
+      """
+      <?php
+      class TestCommand {
+      }
+
+      WP_CLI::add_hook( 'after_add_command:test-command', function () {
+        WP_CLI::add_command( 'test-command sub-command', function () {} );
+      } );
+
+      WP_CLI::add_command( 'test-command', 'TestCommand' );
+      """
+
+    When I run `wp --require=add-dependent-command.php`
+    Then STDOUT should contain:
+      """
+      test-command
+      """
+
+    When I run `wp --require=add-dependent-command.php help test-command`
+    Then STDOUT should contain:
+      """
+      sub-command
+      """

--- a/php/WP_CLI/Dispatcher/CommandAddition.php
+++ b/php/WP_CLI/Dispatcher/CommandAddition.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace WP_CLI\Dispatcher;
+
+use WP_CLI;
+
+/**
+ * Controls whether adding of a command should be completed or not.
+ *
+ * This is needed because we can't reliably pass scalar values by reference
+ * through the hooks mechanism. An object is always passed by reference.
+ *
+ * @package WP_CLI
+ */
+final class CommandAddition {
+
+	/**
+	 * Whether the command addition was aborted or not.
+	 *
+	 * @var bool
+	 */
+	private $abort = false;
+
+	/**
+	 * Reason for which the addition was aborted.
+	 *
+	 * @var string
+	 */
+	private $reason = '';
+
+	/**
+	 * Abort the current command addition.
+	 *
+	 * @param string $reason Reason as to why the addition was aborted.
+	 */
+	public function abort( $reason = '' ) {
+		$this->abort = true;
+		$this->reason = (string) $reason;
+	}
+
+	/**
+	 * Check whether the command addition was aborted.
+	 *
+	 * @return bool
+	 */
+	public function was_aborted() {
+		return $this->abort;
+	}
+
+	/**
+	 * Get the reason as to why the addition was aborted.
+	 *
+	 * @return string
+	 */
+	public function get_reason() {
+		return $this->reason;
+	}
+}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -202,6 +202,8 @@ class WP_CLI {
 	 *
 	 * WP-CLI hooks include:
 	 *
+	 * * `before_add_command:<command>` - Before the command is added.
+	 * * `after_add_command:<command>` - After the command was added.
 	 * * `before_invoke:<command>` - Just before a command is invoked.
 	 * * `after_invoke:<command>` - Just after a command is involved.
 	 * * `before_wp_load` - Just before the WP load process begins.

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -405,6 +405,14 @@ class WP_CLI {
 			WP_CLI::error( sprintf( "Callable %s does not exist, and cannot be registered as `wp %s`.", json_encode( $callable ), $name ) );
 		}
 
+		$addition = new Dispatcher\CommandAddition();
+		self::do_hook( "before_add_command:{$name}", $addition );
+
+		if ( $addition->was_aborted() ) {
+			WP_CLI::warning( "Aborting the addition of the command '{$name}' with reason: {$addition->get_reason()}." );
+			return false;
+		}
+
 		foreach( array( 'before_invoke', 'after_invoke' ) as $when ) {
 			if ( isset( $args[ $when ] ) ) {
 				self::add_hook( "{$when}:{$name}", $args[ $when ] );
@@ -481,6 +489,8 @@ class WP_CLI {
 		}
 
 		$command->add_subcommand( $leaf_name, $leaf_command );
+
+		self::do_hook( "after_add_command:{$name}" );
 		return true;
 	}
 


### PR DESCRIPTION
The following hooks have been added:

    1. `before_add_command:<command>` - Called before WP_CLI tries to add the
    command `<command>` to its known vocabulary.

    The callback that is being called by this hook will receive an instance of
    a `WP_CLI\Dispatcher\CommandAddition` object, which allows the callback to
    control whether WP_CLI should proceed with the addition or not. On
    aborting, the callback can provide a reason.

    This can be used to let the addition of a command depend on some prior
    requirement to be met.

    2. `after_add_command:<command>` - Called after the command `<command>` has
    been added to the known vocabulary.

    This can be used for let the addition of the command depend on other
    commands being added first. In this way, the addition of commands can be
    rendered independent of loading order.

    Note: Introducing the class `WP_CLI\Dispatcher\CommandAddition` was
    necessary in order to get around the fact that arguments cannot be reliably
    passed across the flow `do_hook()` -> `call_user_func_array()` ->
    `add_hook()`.

Fixes #3835