### PR TITLE
Add `WP_CLI\Utils\is_bundled_command( $command )` function.

### DIFF
--- a/php/boot-fs.php
+++ b/php/boot-fs.php
@@ -14,5 +14,11 @@ if ( version_compare( PHP_VERSION, '5.3.0', '<' ) ) {
 
 define( 'WP_CLI_ROOT', dirname( __DIR__ ) );
 
+if ( file_exists( WP_CLI_ROOT . '/vendor/autoload.php' ) ) {
+	define( 'WP_CLI_VENDOR_DIR' , WP_CLI_ROOT . '/vendor' );
+} elseif ( file_exists( dirname( dirname( WP_CLI_ROOT ) ) . '/autoload.php' ) ) {
+	define( 'WP_CLI_VENDOR_DIR' , dirname( dirname( WP_CLI_ROOT ) ) );
+}
+
 include_once WP_CLI_ROOT . '/php/wp-cli.php';
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -924,3 +924,34 @@ function phar_safe_path( $path ) {
 		$path
 	);
 }
+
+/**
+ * Check whether a given Command object is part of the bundled set of
+ * commands.
+ *
+ * This function accepts both a fully qualified class name as a string as
+ * well as an object that extends `WP_CLI\Dispatcher\CompositeCommand`.
+ *
+ * @param \WP_CLI\Dispatcher\CompositeCommand|string $command
+ *
+ * @return bool
+ */
+function is_bundled_command( $command ) {
+	static $classes;
+
+	if ( null === $classes ) {
+		$classes = array();
+		$class_map = WP_CLI_VENDOR_DIR . '/composer/autoload_commands_classmap.php';
+		if ( file_exists( WP_CLI_VENDOR_DIR . '/composer/') ) {
+			$classes = include $class_map;
+		}
+	}
+
+	if ( is_object( $command ) ) {
+		$command = get_class( $command );
+	}
+
+	return is_string( $command )
+		? array_key_exists( $command, $classes )
+		: false;
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,13 @@
 <?php
 
-require_once getcwd() . '/vendor/autoload.php';
-require_once getcwd() . '/php/utils.php';
+define( 'WP_CLI_ROOT', dirname( __DIR__ ) );
+
+if ( file_exists( WP_CLI_ROOT . '/vendor/autoload.php' ) ) {
+	define( 'WP_CLI_VENDOR_DIR' , WP_CLI_ROOT . '/vendor' );
+} elseif ( file_exists( dirname( dirname( WP_CLI_ROOT ) ) . '/autoload.php' ) ) {
+	define( 'WP_CLI_VENDOR_DIR' , dirname( dirname( WP_CLI_ROOT ) ) );
+}
+
+require_once WP_CLI_VENDOR_DIR . '/autoload.php';
+require_once WP_CLI_ROOT . '/php/utils.php';
 

--- a/tests/test-bundled-commands.php
+++ b/tests/test-bundled-commands.php
@@ -1,0 +1,43 @@
+<?php
+
+use WP_CLI\Utils;
+use WP_CLI\Dispatcher\CompositeCommand;
+
+// Mock class to test whether `CLI_Command` will be found.
+class CLI_Command extends CompositeCommand {
+
+	public function __construct() { }
+}
+
+// Mock class to test whether `Random_Unknown_Command` will be found.
+class Random_Unknown_Command extends CompositeCommand {
+
+	public function __construct() { }
+}
+
+class BundledCommandTest extends PHPUnit_Framework_TestCase {
+
+	/** @dataProvider dataProviderIsBundledCommands */
+	public function testIsBundledCommand( $command, $expected_result ) {
+		$result = Utils\is_bundled_command( $command );
+		$this->assertEquals( $expected_result, $result );
+	}
+
+	public function dataProviderIsBundledCommands() {
+		return array(
+			// Bundled commands.
+			array( 'CLI_Command', true ),
+			array( new CLI_Command(), true ),
+
+			// Commands not bundled.
+			array( 'Random_Unknown_Command', false ),
+			array( new Random_Unknown_Command(), false ),
+
+			// Wrong data types.
+			array( array( 'CLI_Command' ), false ),
+			array( new stdClass(), false ),
+			array( 42, false ),
+			array( null, false ),
+		);
+	}
+}


### PR DESCRIPTION
This function loads the Composer classmap we've built through the autoloader splitting functionality, and checks whether a given class is contained within that classmap.

It accepts both a fully qualified class name as a string, as well as an object that should be a subtype of `WP_CLI\Dispatcher\CompositeCommand`.

See #3886