### PR TITLE
Log command execution right away, instead of waiting for it to complete

### DIFF
--- a/php/WP_CLI/Dispatcher/CommandExecutionLog.php
+++ b/php/WP_CLI/Dispatcher/CommandExecutionLog.php
@@ -41,20 +41,6 @@ final class CommandExecutionLog implements \JsonSerializable {
 	private $assoc_args;
 
 	/**
-	 * Start time for the timer.
-	 *
-	 * @var integer|null
-	 */
-	private $start_time = null;
-
-	/**
-	 * Execution time for the command.
-	 *
-	 * @var integer|null
-	 */
-	private $exec_time = null;
-
-	/**
 	 * Instantiate a CommandExecution object.
 	 *
 	 * @param string $command    Command being run.
@@ -81,22 +67,6 @@ final class CommandExecutionLog implements \JsonSerializable {
 	}
 
 	/**
-	 * Start the execution timer.
-	 */
-	public function start() {
-		$this->start_time = microtime( true );
-	}
-
-	/**
-	 * Stop the execution timer.
-	 */
-	public function stop() {
-		$exec_time = microtime( true ) - $this->start_time;
-		$this->start_time = null;
-		$this->exec_time = round( $exec_time, 3 );
-	}
-
-	/**
 	 * Prepare CommandExecution object for delivery.
 	 *
 	 * @return array
@@ -112,7 +82,6 @@ final class CommandExecutionLog implements \JsonSerializable {
 			'php_version'    => PHP_VERSION,
 			'wp_cli_version' => WP_CLI_VERSION,
 			'wp_cli_type'    => $type,
-			'exec_time'      => $this->exec_time,
 			'is_piped'       => Utils\isPiped() ? '1' : '0',
 		);
 	}

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -410,13 +410,9 @@ class Subcommand extends CompositeCommand {
 			&& ! getenv( 'WP_CLI_DISABLE_USAGE_ANALYTICS' )
 			&& ! getenv( 'BEHAT_RUN' ) ) {
 			$monitored_execution = new CommandExecutionLog( $cmd, $anon_args, $anon_assoc_args );
-			$monitored_execution->start();
-		}
-		call_user_func( $this->when_invoked, $args, array_merge( $extra_args, $assoc_args ) );
-		if ( ! is_null( $monitored_execution ) ) {
-			$monitored_execution->stop();
 			WP_CLI::send_execution_log( $monitored_execution );
 		}
+		call_user_func( $this->when_invoked, $args, array_merge( $extra_args, $assoc_args ) );
 
 		if ( $parent ) {
 			WP_CLI::do_hook( "after_invoke:{$parent}" );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1159,7 +1159,7 @@ class WP_CLI {
 			'cd2'  => $data['wp_version'], // "Custom Dimension 2"
 			'cd3'  => $data['args'], // "Custom Dimension 3"
 			'cd4'  => implode( ', ', $data['assoc_args'] ), // "Custom Dimension 4"
-			'cd5'  => $data['exec_time'],
+			'cd5'  => '', // Was execution time, which we stopped logging
 			'cd6'  => $data['is_piped'],
 		);
 		Utils\http_request( 'POST', 'https://www.google-analytics.com/collect', $post_body, array(), array(


### PR DESCRIPTION
Some commands like `shell` are ended with the user killing the process
(meaning the command execution won't ever be logged).

Other commands kill the process early if there's an error.

I'd prefer we capture as much command execution as we can, and not worry
about execution time.

See #3886