### PR TITLE
Introduce `after_wp_config_locate` hook

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -872,6 +872,8 @@ class Runner {
 				"Either create one manually or use `wp config create`." );
 		}
 
+		WP_CLI::do_hook( 'after_wp_config_locate' );
+
 		if ( ( $this->cmd_starts_with( array( 'db' ) ) || $this->cmd_starts_with( array( 'help', 'db' ) ) )
 			&& ! $this->cmd_starts_with( array( 'db', 'tables' ) ) ) {
 			eval( $this->get_wp_config_code() );
@@ -948,6 +950,8 @@ class Runner {
 				"'wp-config.php' not found.\n" .
 				"Either create one manually or use `wp config create`." );
 		}
+
+		WP_CLI::do_hook( 'after_wp_config_locate' );
 
 		WP_CLI::debug( 'wp-config.php path: ' . $wp_config_path, 'bootstrap' );
 		WP_CLI::do_hook( 'before_wp_config_load' );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -207,8 +207,9 @@ class WP_CLI {
 	 * * `after_add_command:<command>` - After the command was added.
 	 * * `before_invoke:<command>` - Just before a command is invoked.
 	 * * `after_invoke:<command>` - Just after a command is involved.
+	 * * `after_wp_config_locate` - After wp-config.php has been located.
 	 * * `before_wp_load` - Just before the WP load process begins.
-	 * * `before_wp_config_load` - After wp-config.php has been located.
+	 * * `before_wp_config_load` - Before wp-config.php has been loaded into scope.
 	 * * `after_wp_config_load` - After wp-config.php has been loaded into scope.
 	 * * `after_wp_load` - Just after the WP load process has completed.
 	 *


### PR DESCRIPTION
This permits commands to hook in to the point after which
`wp-config.php` has been located.

See https://github.com/wp-cli/db-command/issues/15