### PR TITLE
Only apply @require-wp tags when WP_VERSION isn't 'latest' or 'nightly'

### DIFF
--- a/ci/behat-tags.php
+++ b/ci/behat-tags.php
@@ -31,8 +31,15 @@ function version_tags( $prefix, $current, $operator = '<' ) {
 	return $skip_tags;
 }
 
+$wp_version_reqs = array();
+// Only apply @require-wp tags when WP_VERSION isn't 'latest' or 'nightly'
+// 'latest' and 'nightly' are expected to work with all features
+if ( ! in_array( getenv( 'WP_VERSION' ), array( 'latest', 'nightly', 'trunk' ), true ) ) {
+	$wp_version_reqs = version_tags( 'require-wp', getenv( 'WP_VERSION' ), '<' );
+}
+
 $skip_tags = array_merge(
-	version_tags( 'require-wp', getenv( 'WP_VERSION' ), '<' ),
+	$wp_version_reqs,
 	version_tags( 'require-php', PHP_VERSION, '<' ),
 	version_tags( 'less-than-php', PHP_VERSION, '>' )
 );


### PR DESCRIPTION
The approach of skipping this tag avoids needing a HTTP request to
resolve the latest version, and is functionally equivalent.

Fixes #3956