### PR TITLE
Replace variables for subdirectory install path

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -365,10 +365,11 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	}
 
 	public function install_wp( $subdir = '' ) {
+		$subdir = $this->replace_variables( $subdir );
+
 		$this->create_db();
 		$this->create_run_dir();
 		$this->download_wp( $subdir );
-
 		$this->create_config( $subdir );
 
 		$install_args = array(


### PR DESCRIPTION
Allow for dynamic values when creating a subdirectory install in a Behat scenario.

E.g. https://github.com/aaemnnosttv/wp-cli-valet-command/blob/5637efca1c1efd8ccc52adc7c01bc4774b0b043b/features/valet-destroy.feature#L5

Added in my command a while ago https://github.com/aaemnnosttv/wp-cli-valet-command/commit/4af4028cb3a16f1e4731ccb16141935284aa8179 but I think it would be useful to have in core as well.