### PR TITLE
Update license file's name in wp-cli-updatedeb

### DIFF
--- a/utils/wp-cli-updatedeb.sh
+++ b/utils/wp-cli-updatedeb.sh
@@ -3,8 +3,8 @@
 # Package wp-cli to be installed in Debian-compatible systems.
 # Only the phar file is included.
 #
-# VERSION       :0.2.2
-# DATE          :2016-10-26
+# VERSION       :0.2.3
+# DATE          :2017-05-31
 # AUTHOR        :Viktor Szépe <viktor@szepe.net>
 # LICENSE       :The MIT License (MIT)
 # URL           :https://github.com/wp-cli/wp-cli/tree/master/utils
@@ -40,6 +40,8 @@ Description: wp-cli is a set of command-line tools for managing
 EOF
 }
 
+set -e
+
 # deb's dir
 if ! [ -d "$DIR" ]; then
     mkdir "$DIR" || die 1 "Cannot create directory here: ${PWD}"
@@ -54,20 +56,20 @@ if ! [ -r DEBIAN/control ]; then
 fi
 
 # copyright
-if ! [ -r usr/share/doc/php-wpcli/copyright ];then
+if ! [ -r usr/share/doc/php-wpcli/copyright ]; then
     mkdir -p usr/share/doc/php-wpcli &> /dev/null
-    wget -nv -O usr/share/doc/php-wpcli/copyright https://github.com/wp-cli/wp-cli/raw/master/LICENSE.txt
+    wget -nv -O usr/share/doc/php-wpcli/copyright https://github.com/wp-cli/wp-cli/raw/master/LICENSE
 fi
 
 # changelog
-if ! [ -r usr/share/doc/php-wpcli/changelog.gz ];then
+if ! [ -r usr/share/doc/php-wpcli/changelog.gz ]; then
     mkdir -p usr/share/doc/php-wpcli &> /dev/null
     echo "Changelog can be found in the blog: http://wp-cli.org/blog/" \
         | gzip -n -9 > usr/share/doc/php-wpcli/changelog.gz
 fi
 
 # minimal man page
-if ! [ -r usr/share/man/man1/wp.1.gz ];then
+if ! [ -r usr/share/man/man1/wp.1.gz ]; then
     mkdir -p usr/share/man/man1 &> /dev/null
     {
         echo '.TH "WP" "1"'
@@ -86,15 +88,15 @@ wget -nv -O usr/bin/wp "$PHAR" || die 3 "Phar download failure"
 chmod +x usr/bin/wp || die 4 "chmod failure"
 
 # get version
-WPCLI_VER="$(usr/bin/wp cli version|cut -d" " -f2)"
+WPCLI_VER="$(usr/bin/wp cli version | cut -d " " -f 2)"
 [ -z "$WPCLI_VER" ] && die 5 "Cannot get wp-cli version"
 echo "Current version: ${WPCLI_VER}"
 
 # update version
-sed -i "s/^Version: .*$/Version: ${WPCLI_VER}/" DEBIAN/control || die 6 "Version update failure"
+sed -i -e "s/^Version: .*$/Version: ${WPCLI_VER}/" DEBIAN/control || die 6 "Version update failure"
 
 # update MD5-s
-find usr -type f -exec md5sum \{\} \; > DEBIAN/md5sums || die 7 "md5sum creation failure"
+find usr -type f -exec md5sum "{}" ";" > DEBIAN/md5sums || die 7 "md5sum creation failure"
 
 popd
 
@@ -106,6 +108,6 @@ fakeroot dpkg-deb --build "$DIR" "$WPCLI_PKG" || die 8 "Packaging failed"
 lintian --display-info --display-experimental --pedantic --show-overrides php-wpcli_*_all.deb
 
 # optional steps
-echo "sign it:               dpkg-sig -k YOUR-KEY -s builder \"${WPCLI_PKG}\""
+echo "sign it:               dpkg-sig -k SIGNING-KEY -s builder \"${WPCLI_PKG}\""
 echo "include in your repo:  pushd /var/www/REPO-DIR"
 echo "                       reprepro includedeb jessie \"${WPCLI_PKG}\" && popd"


### PR DESCRIPTION
Plus make it more error prone and readable

@danielbachhuber It came out during building 1.2.0