### PR TITLE
Also process deferred command additions on the `'after_wp_load'` hook.

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -844,3 +844,102 @@ Feature: WP-CLI Commands
       """
       sub-command
       """
+
+  Scenario: Command additions should work as plugins
+    Given a WP install
+    And a wp-content/plugins/test-cli/command.php file:
+      """
+      <?php
+      // Plugin Name: Test CLI Help
+
+      class TestCommand {
+      }
+
+      function test_function() {
+        \WP_CLI::success( 'unknown-parent child-command' );
+      }
+
+      WP_CLI::add_command( 'unknown-parent child-command', 'test_function' );
+
+      WP_CLI::add_command( 'test-command sub-command', function () { \WP_CLI::success( 'test-command sub-command' ); } );
+
+      WP_CLI::add_command( 'test-command', 'TestCommand' );
+      """
+    And I run `wp plugin activate test-cli`
+
+    When I run `wp`
+    Then STDOUT should contain:
+      """
+      test-command
+      """
+    And STDERR should be empty
+
+    When I run `wp help test-command`
+    Then STDOUT should contain:
+      """
+      sub-command
+      """
+    And STDERR should be empty
+
+    When I run `wp test-command sub-command`
+    Then STDOUT should contain:
+      """
+      Success: test-command sub-command
+      """
+    And STDERR should be empty
+
+    When I run `wp unknown-parent child-command`
+    Then STDOUT should contain:
+      """
+      Success: unknown-parent child-command
+      """
+    And STDERR should be empty
+
+  Scenario: Command additions should work as must-use plugins
+    Given a WP install
+    And a wp-content/mu-plugins/test-cli.php file:
+      """
+      <?php
+      // Plugin Name: Test CLI Help
+
+      class TestCommand {
+      }
+
+      function test_function() {
+        \WP_CLI::success( 'unknown-parent child-command' );
+      }
+
+      WP_CLI::add_command( 'unknown-parent child-command', 'test_function' );
+
+      WP_CLI::add_command( 'test-command sub-command', function () { \WP_CLI::success( 'test-command sub-command' ); } );
+
+      WP_CLI::add_command( 'test-command', 'TestCommand' );
+      """
+
+    When I run `wp`
+    Then STDOUT should contain:
+      """
+      test-command
+      """
+    And STDERR should be empty
+
+    When I run `wp help test-command`
+    Then STDOUT should contain:
+      """
+      sub-command
+      """
+    And STDERR should be empty
+
+    When I run `wp test-command sub-command`
+    Then STDOUT should contain:
+      """
+      Success: test-command sub-command
+      """
+    And STDERR should be empty
+
+    When I run `wp unknown-parent child-command`
+    Then STDOUT should contain:
+      """
+      Success: unknown-parent child-command
+      """
+    And STDERR should be empty

--- a/php/WP_CLI/Bootstrap/RegisterDeferredCommands.php
+++ b/php/WP_CLI/Bootstrap/RegisterDeferredCommands.php
@@ -21,6 +21,12 @@ final class RegisterDeferredCommands implements BootstrapStep {
 	 * @return BootstrapState Modified state to pass to the next step.
 	 */
 	public function process( BootstrapState $state ) {
+
+		// Process deferred command additions for external packages.
+		$this->add_deferred_commands();
+
+		// Process deferred command additions for commands added through
+		// plugins.
 		\WP_CLI::add_hook(
 			'after_wp_load',
 			array( $this, 'add_deferred_commands' )

--- a/php/WP_CLI/Bootstrap/RegisterDeferredCommands.php
+++ b/php/WP_CLI/Bootstrap/RegisterDeferredCommands.php
@@ -21,6 +21,18 @@ final class RegisterDeferredCommands implements BootstrapStep {
 	 * @return BootstrapState Modified state to pass to the next step.
 	 */
 	public function process( BootstrapState $state ) {
+		\WP_CLI::add_hook(
+			'after_wp_load',
+			array( $this, 'add_deferred_commands' )
+		);
+
+		return $state;
+	}
+
+	/**
+	 * Add deferred commands that are still waiting to be processed.
+	 */
+	public function add_deferred_commands() {
 		$deferred_additions = \WP_CLI::get_deferred_additions();
 
 		foreach ( $deferred_additions as $name => $addition ) {
@@ -30,7 +42,5 @@ final class RegisterDeferredCommands implements BootstrapStep {
 				$addition['args']
 			);
 		}
-
-		return $state;
 	}
 }


### PR DESCRIPTION
For the command additions within (mu-)plugins to work, they need to be
processed after all plugins have actually been loaded.

Fixes #4122