### PR TITLE
Ignore vendor directories when running `phpcs`

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # Run CodeSniffer
-phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')
+phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php' -not -path "./vendor/*" -not -path "./packages/*")
 
 # Run the unit tests
 vendor/bin/phpunit


### PR DESCRIPTION
It's not necessary to scan these files, and adds a huge amount of
unnecessary output to test runs.