### PR TITLE
Bail early on `add_command()`.

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -396,6 +396,11 @@ class WP_CLI {
 	 * @return true True on success, false if deferred, hard error if registration failed.
 	 */
 	public static function add_command( $name, $callable, $args = array() ) {
+		// Bail immediately if the WP-CLI executable has not been run.
+		if ( ! defined( 'WP_CLI' ) ) {
+			return false;
+		}
+
 		$valid = false;
 		if ( is_callable( $callable ) ) {
 			$valid = true;


### PR DESCRIPTION
As Composer will use a fixed require for any package files included in the Composer autoloader's `"files"` directive, we need to bail early in the `WP_CLI::add_command()` method so that WP-CLI is not executed from web-requests where it was included in the same `composer.json` file than the WP code itself.

See #4124