### PR TITLE
Fix help wordwrapping (subcommands especially). Use Shell:columns(). Export TERM.

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -73,6 +73,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		if ( $config_path = getenv( 'WP_CLI_CONFIG_PATH' ) ) {
 			$env['WP_CLI_CONFIG_PATH'] = $config_path;
 		}
+		if ( $term = getenv( 'TERM' ) ) {
+			$env['TERM'] = $term;
+		}
 		return $env;
 	}
 

--- a/features/help.feature
+++ b/features/help.feature
@@ -5,27 +5,38 @@ Feature: Get help about WP-CLI commands
 
     When I run `wp help`
     Then STDOUT should not be empty
+    And STDOUT should contain:
+      """
+        Run 'wp help <command>' to get more information on a specific command.
+
+      """
+    And STDERR should be empty
 
     When I run `wp help core`
     Then STDOUT should not be empty
+    And STDERR should be empty
 
     When I run `wp help core download`
     Then STDOUT should not be empty
+    And STDERR should be empty
 
     When I run `wp help help`
     Then STDOUT should not be empty
+    And STDERR should be empty
 
     When I run `wp help help`
     Then STDOUT should contain:
       """
       GLOBAL PARAMETERS
       """
+    And STDERR should be empty
 
     When I run `wp post list --post_type=post --posts_per_page=5 --help`
     Then STDOUT should contain:
       """
       wp post list
       """
+    And STDERR should be empty
 
   Scenario: Help when WordPress is downloaded but not installed
     Given an empty directory
@@ -84,12 +95,14 @@ Feature: Get help about WP-CLI commands
       """
       A dummy command.
       """
+    And STDERR should be empty
 
     When I run `wp help test-help`
     Then STDOUT should contain:
       """
       wp test-help
       """
+    And STDERR should be empty
 
   Scenario: Help for incomplete commands
     Given an empty directory
@@ -234,12 +247,24 @@ Feature: Get help about WP-CLI commands
 
       class Test_Wordwrap extends WP_CLI_Command {
         /**
-         * A dummy command.
+         * 123456789 123456789 123456789 123456789 123456789 123456789 123456789 12345678
          *
          * ## OPTIONS
          *
          * [--skip-delete]
          * : Skip deletion of the original thumbnails. If your thumbnails are linked from sources outside your control, it's likely best to leave them around. Defaults to false.
+         *
+         * [--eighty=<four initial spaces>]
+         * : 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456
+         *
+         * [--eighty-one=<four initial spaces>]
+         * : 123456789 123456789 123456789 123456789 123456789 123456789 123456789 1234567
+         *
+         * [--forty=<four initial spaces>]
+         * : 123456789 123456789 123456789 123456
+         *
+         * [--forty-one=<four initial spaces>]
+         * : 123456789 123456789 123456789 1234567
          *
          * ## EXAMPLES
          *
@@ -252,6 +277,14 @@ Feature: Get help about WP-CLI commands
          *     3/3 Regenerated "large" thumbnail for "Even Yooger than the Yoogest Image Ever, Really" (ID 9997).
          *     Success: Regenerated 3 of 3 images.
          *
+         *     # 6 initial spaces + 74 = 80; 6 + 75 = 81
+         *     # 123456789 123456789 123456789 123456789 123456789 123456789 123456789 1234
+         *     # 123456789 123456789 123456789 123456789 123456789 123456789 123456789 12345
+         *
+         *     # 6 initial spaces + 34 = 40; 6 + 35 = 41
+         *     # 123456789 123456789 123456789 1234
+         *     # 123456789 123456789 123456789 12345
+         *
          */
         function my_command() {}
       }
@@ -263,10 +296,28 @@ Feature: Get help about WP-CLI commands
     When I run `wp help test-wordwrap my_command`
     Then STDOUT should contain:
       """
+        123456789 123456789 123456789 123456789 123456789 123456789 123456789 12345678
+
+      """
+    And STDOUT should contain:
+      """
         [--skip-delete]
           Skip deletion of the original thumbnails. If your thumbnails are linked from
-          sources outside your control, it's likely best to leave them around. Defaults to
-          false.
+          sources outside your control, it's likely best to leave them around.
+          Defaults to false.
+
+      """
+    And STDOUT should contain:
+      """
+        [--eighty=<four initial spaces>]
+          123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456
+
+      """
+    And STDOUT should contain:
+      """
+        [--eighty-one=<four initial spaces>]
+          123456789 123456789 123456789 123456789 123456789 123456789 123456789
+          1234567
 
       """
     And STDOUT should contain:
@@ -286,61 +337,102 @@ Feature: Get help about WP-CLI commands
       """
     And STDOUT should contain:
       """
+          # 123456789 123456789 123456789 123456789 123456789 123456789 123456789 1234
+          # 123456789 123456789 123456789 123456789 123456789 123456789 123456789
+          12345
+      """
+    And STDOUT should contain:
+      """
         --url=<url>
             Pretend request came from given URL. In multisite, this argument is how
             the target site is specified.
 
       """
+    And STDERR should be empty
 
-    When I run `WP_CLI_HELP_WORDWRAP_WIDTH=30 wp help test-wordwrap my_command`
+    When I run `wp help test-wordwrap my_command | wc -L`
+    Then STDOUT should be:
+      """
+      80
+      """
+
+    When I run `TERM=vt100 COLUMNS=40 wp help test-wordwrap my_command`
     Then STDOUT should contain:
       """
-        [--skip-delete]
-          Skip deletion of the
-          original thumbnails. If your
-          thumbnails are linked from
-          sources outside your control,
-          it's likely best to leave them
-          around. Defaults to false.
+        123456789 123456789 123456789
+        123456789 123456789 123456789
+        123456789 12345678
 
       """
     And STDOUT should contain:
       """
-          # Re-generate only the
-          thumbnails of "large" image
-          size for all images.
+        [--skip-delete]
+          Skip deletion of the original
+          thumbnails. If your thumbnails are
+          linked from sources outside your
+          control, it's likely best to leave
+          them around. Defaults to false.
+
+      """
+    And STDOUT should contain:
+      """
+        [--forty=<four initial spaces>]
+          123456789 123456789 123456789 123456
+
+      """
+    And STDOUT should contain:
+      """
+        [--forty-one=<four initial spaces>]
+          123456789 123456789 123456789
+          1234567
+
+      """
+    And STDOUT should contain:
+      """
+          # Re-generate only the thumbnails of
+          "large" image size for all images.
           $ wp media regenerate
           --image_size=large
-          Do you really want to
-          regenerate the "large" image
-          size for all images? [y/n] y
-          Found 3 images to
-          regenerate.
-          1/3 Regenerated "large"
-          thumbnail for "Yoogest Image
-          Ever, Really" (ID 9999).
+          Do you really want to regenerate the
+          "large" image size for all images?
+          [y/n] y
+          Found 3 images to regenerate.
+          1/3 Regenerated "large" thumbnail
+          for "Yoogest Image Ever, Really" (ID
+          9999).
           2/3 No "large" thumbnail
-          regeneration needed for
-          "Snowflake" (ID 9998).
-          3/3 Regenerated "large"
-          thumbnail for "Even Yooger
-          than the Yoogest Image Ever,
-          Really" (ID 9997).
-          Success: Regenerated 3 of
-          3 images.
+          regeneration needed for "Snowflake"
+          (ID 9998).
+          3/3 Regenerated "large" thumbnail
+          for "Even Yooger than the Yoogest
+          Image Ever, Really" (ID 9997).
+          Success: Regenerated 3 of 3 images.
 
+      """
+    And STDOUT should contain:
+      """
+          # 123456789 123456789 123456789 1234
+          # 123456789 123456789 123456789
+          12345
       """
     And STDOUT should contain:
       """
         --url=<url>
-            Pretend request came
-            from given URL. In multisite,
-            this argument is how the
-            target site is specified.
+            Pretend request came from given
+            URL. In multisite, this argument
+            is how the target site is
+            specified.
 
       """
+    And STDERR should be empty
 
-    When I run `WP_CLI_HELP_WORDWRAP_WIDTH=0 wp help test-wordwrap my_command`
+    When I run `TERM=vt100 COLUMNS=40 wp help test-wordwrap my_command | wc -L`
+    Then STDOUT should be:
+      """
+      40
+      """
+
+    When I run `TERM=vt100 COLUMNS=1000 wp help test-wordwrap my_command`
     Then STDOUT should contain:
       """
         [--skip-delete]
@@ -364,4 +456,117 @@ Feature: Get help about WP-CLI commands
         --url=<url>
             Pretend request came from given URL. In multisite, this argument is how the target site is specified.
 
+      """
+    And STDERR should be empty
+
+  Scenario: Help for commands with subcommands should wordwrap well
+    Given a WP install
+    And a wp-content/plugins/test-cli/command.php file:
+      """
+      <?php
+      // Plugin Name: Test CLI Help
+
+      class Test_Wordwrap extends WP_CLI_Command {
+        /**
+         * Generate PHP code for registering a custom post type.
+         *
+         * @subcommand post-type
+         *
+         * @alias      cpt
+         */
+        public function post_type( $args, $assoc_args ) {}
+
+        /**
+         * Generate starter code for a theme based on _s.
+         *
+         * See the [Underscores website](http://underscores.me/) for more details.
+         */
+        public function _s( $args, $assoc_args ) {}
+
+        /**
+         * Generate GitHub configuration files for your command.
+         *
+         * @when       before_wp_load
+         * @subcommand package-github
+         */
+        public function package_github( $args, $assoc_args ) {}
+
+        /**
+         * Generate files needed for writing Behat tests for your command.
+         *
+         * @when       before_wp_load
+         * @subcommand package-tests
+         */
+        public function package_tests( $args, $assoc_args ) {}
+
+        /**
+         * Generate files needed for running PHPUnit tests in a plugin.
+         *
+         * @subcommand plugin-tests
+         */
+        public function plugin_tests( $args, $assoc_args ) {}
+
+        /**
+         * Generate files needed for running PHPUnit tests in a theme.
+         *
+         * @subcommand theme-tests
+         */
+        public function theme_tests( $args, $assoc_args ) {}
+
+        /**
+         * 2 chars initial + 20 padded command + 58 these = 80 chars.
+         *
+         * @subcommand eighty
+         */
+        public function eighty( $args, $assoc_args ) {}
+
+        /**
+         * 2 chars initial + 20 padded command + 59 these = 81 chars..
+         *
+         * @subcommand eighty-one
+         */
+        public function eighty_one( $args, $assoc_args ) {}
+
+        /**
+         * A very long description a very longgggggggggg description a very longgggg description a very long description a very longgggggggggggggggg description a very long description a very long description a very long description a very longgg description.
+         *
+         * @subcommand very-long
+         */
+        public function very_long( $args, $assoc_args ) {}
+      }
+
+      WP_CLI::add_command( 'test-wordwrap', 'Test_Wordwrap' );
+      """
+    And I run `wp plugin activate test-cli`
+
+    When I run `TERM=vt100 COLUMNS=80 wp help test-wordwrap`
+    Then STDOUT should contain:
+      """
+      SUBCOMMANDS
+
+        _s                  Generate starter code for a theme based on _s.
+        eighty              2 chars initial + 20 padded command + 58 these = 80 chars.
+        eighty-one          2 chars initial + 20 padded command + 59 these = 81
+                            chars..
+        package-github      Generate GitHub configuration files for your command.
+        package-tests       Generate files needed for writing Behat tests for your
+                            command.
+        plugin-tests        Generate files needed for running PHPUnit tests in a
+                            plugin.
+        post-type           Generate PHP code for registering a custom post type.
+        theme-tests         Generate files needed for running PHPUnit tests in a
+                            theme.
+        very-long           A very long description a very longgggggggggg description
+                            a very longgggg description a very long description a very
+                            longgggggggggggggggg description a very long description a
+                            very long description a very long description a very
+                            longgg description.
+
+      """
+    And STDERR should be empty
+
+    When I run `TERM=vt100 COLUMNS=80 wp help test-wordwrap | wc -L`
+    Then STDOUT should be:
+      """
+      80
       """

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -58,6 +58,15 @@ class Help_Command extends WP_CLI_Command {
 	private static function show_help( $command ) {
 		$out = self::get_initial_markdown( $command );
 
+		// Remove subcommands if in columns - will wordwrap separately.
+		$subcommands = '';
+		$column_subpattern = '[ \t]+[^\t]+\t+';
+		if ( preg_match( '/(^## SUBCOMMANDS[^\n]*\n+' . $column_subpattern . '.+?)(?:^##|\z)/ms', $out, $matches, PREG_OFFSET_CAPTURE ) ) {
+			$subcommands = $matches[1][0];
+			$subcommands_header = "## SUBCOMMANDS\n";
+			$out = substr_replace( $out, $subcommands_header, $matches[1][1], strlen( $subcommands ) );
+		}
+
 		$out .= $command->get_longdesc();
 
 		// definition lists
@@ -66,21 +75,35 @@ class Help_Command extends WP_CLI_Command {
 		// Ensure all non-section headers are indented.
 		$out = preg_replace( '#^([^\s^\#])#m', "\t$1", $out );
 
+		$tab = str_repeat( ' ', 2 );
+
+		// Need to de-tab for wordwrapping to work properly.
+		$out = str_replace( "\t", $tab, $out );
+
+		$wordwrap_width = \cli\Shell::columns();
+
 		// Wordwrap with indent.
-		$wordwrap_width = 80;
-		if ( false !== ( $env_wordwrap_width = getenv( 'WP_CLI_HELP_WORDWRAP_WIDTH' ) ) ) {
-			$wordwrap_width = (int) $env_wordwrap_width;
-		}
-		if ( $wordwrap_width > 0 ) {
-			$out = preg_replace_callback( '/([ \t]*)[^\n]+\n/', function ( $matches ) use ( $wordwrap_width ) {
-				return wordwrap( $matches[0], $wordwrap_width, "\n{$matches[1]}" );
-			}, $out );
+		$out = preg_replace_callback( '/^( *)([^\n]+)\n/m', function ( $matches ) use ( $wordwrap_width ) {
+			return $matches[1] . str_replace( "\n", "\n{$matches[1]}", wordwrap( $matches[2], $wordwrap_width - strlen( $matches[1] ) ) ) . "\n";
+		}, $out );
+
+		if ( $subcommands ) {
+			// Wordwrap with column indent.
+			$subcommands = preg_replace_callback( '/^(' . $column_subpattern . ')([^\n]+)\n/m', function ( $matches ) use ( $wordwrap_width, $tab ) {
+				// Need to de-tab for wordwrapping to work properly.
+				$matches[1] = str_replace( "\t", $tab, $matches[1] );
+				$matches[2] = str_replace( "\t", $tab, $matches[2] );
+				$padding_len = strlen( $matches[1] );
+				$padding = str_repeat( ' ', $padding_len );
+				return $matches[1] . str_replace( "\n", "\n$padding", wordwrap( $matches[2], $wordwrap_width - $padding_len ) ) . "\n";
+			}, $subcommands );
+
+			// Put subcommands back.
+			$out = str_replace( $subcommands_header, $subcommands, $out );
 		}
 
 		// section headers
 		$out = preg_replace( '/^## ([A-Z ]+)/m', WP_CLI::colorize( '%9\1%n' ), $out );
-
-		$out = str_replace( "\t", '  ', $out );
 
 		self::pass_through_pager( $out );
 	}

--- a/templates/man-params.mustache
+++ b/templates/man-params.mustache
@@ -15,4 +15,5 @@
 {{/parameters}}
 {{#root_command}}
   Run 'wp help <command>' to get more information on a specific command.
+
 {{/root_command}}


### PR DESCRIPTION
Fixes #4127

Fixes wordwrapping for help, treating subcommand list separately.

Uses Shell::columns() instead of WP_CLI_HELP_WORDWRAP_WIDTH.

Exports TERM in FeatureContext::get_process_env_variables() so that Shell::columns() doesn't throw errors in tests (a separate PR will make Shell:columns() check TERM and work better in Windows).

Adds blank line after root_command in `man-params.mustache` to compensate for its loss with the new wordwrapping in 1.2.0.

Better tests so that this sort of thing is less likely in the future.