### PR TITLE
Fix autoload file names for `$custom_vendor` condition

### DIFF
--- a/php/WP_CLI/Bootstrap/IncludeFallbackAutoloader.php
+++ b/php/WP_CLI/Bootstrap/IncludeFallbackAutoloader.php
@@ -26,7 +26,7 @@ final class IncludeFallbackAutoloader extends AutoloaderStep {
 		if ( $custom_vendor = $this->get_custom_vendor_folder() ) {
 			array_unshift(
 				$autoloader_paths,
-				WP_CLI_ROOT . '/../../../' . $custom_vendor . '/autoload_commands.php'
+				WP_CLI_ROOT . '/../../../' . $custom_vendor . '/autoload.php'
 			);
 		}
 

--- a/php/WP_CLI/Bootstrap/IncludeFrameworkAutoloader.php
+++ b/php/WP_CLI/Bootstrap/IncludeFrameworkAutoloader.php
@@ -28,7 +28,7 @@ final class IncludeFrameworkAutoloader extends AutoloaderStep {
 		if ( $custom_vendor = $this->get_custom_vendor_folder() ) {
 			array_unshift(
 				$autoloader_paths,
-				WP_CLI_ROOT . '/../../../' . $custom_vendor . '/autoload_commands.php'
+				WP_CLI_ROOT . '/../../../' . $custom_vendor . '/autoload_framework.php'
 			);
 		}
 


### PR DESCRIPTION
These should always the respective targeted autoloader filenames:

- Bundle: `autoload_commands.php`
- Framework: `autoload_framework.php`
- Fallback: `autoload.php`

Props @gitlost