### PR TITLE
Save runtime config so can pass as args to Runner::run_alias_group() invocation.

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -323,3 +323,57 @@ Feature: Create shortcuts to specific WordPress installs
       Error: Parameter errors:
        unknown --url parameter
       """
+
+  Scenario: Global parameters should be passed to grouped aliases
+    Given a WP install in 'foo'
+    And a WP install in 'bar'
+    And a wp-cli.yml file:
+      """
+      @foo:
+        path: foo
+      @bar:
+        path: bar
+      @foobar:
+        - @foo
+        - @bar
+      """
+
+    When I try `wp core is-installed --allow-root --debug`
+    Then STDERR should contain:
+      """
+      Error: This does not seem to be a WordPress install.
+      """
+    And STDERR should contain:
+      """
+      core is-installed --allow-root --debug
+      """
+    And the return code should be 1
+
+    When I run `wp @foo core is-installed --allow-root --debug`
+    Then the return code should be 0
+    And STDERR should contain:
+      """
+      @foo core is-installed --allow-root --debug
+      """
+
+    When I run `cd bar; wp @bar core is-installed --allow-root --debug`
+    Then the return code should be 0
+    And STDERR should contain:
+      """
+      @bar core is-installed --allow-root --debug
+      """
+
+    When I run `wp @foobar core is-installed --allow-root --debug`
+    Then the return code should be 0
+    And STDERR should contain:
+      """
+      @foobar core is-installed --allow-root --debug
+      """
+    And STDERR should contain:
+      """
+      @foo core is-installed --allow-root --debug
+      """
+    And STDERR should contain:
+      """
+      @bar core is-installed --allow-root --debug
+      """

--- a/features/flags.feature
+++ b/features/flags.feature
@@ -52,7 +52,7 @@ Feature: Global flags
       CONST_WITHOUT_QUOTES
       """
 
-    When I try `wp eval 'echo CONST_WITHOUT_QUOTES;' --debug`
+    When I try `wp eval 'ini_set( 'error_log', null ); echo CONST_WITHOUT_QUOTES;' --debug`
     Then the return code should be 0
     And STDOUT should be:
       """

--- a/features/skip-plugins.feature
+++ b/features/skip-plugins.feature
@@ -32,7 +32,7 @@ Feature: Skipping plugins
       """
 
     # Can specify multiple plugins to skip
-    When I try `wp eval --skip-plugins=hello,akismet 'echo hello_dolly();'`
+    When I try `wp eval --skip-plugins=hello,akismet 'ini_set( 'error_log', null ); echo hello_dolly();'`
     Then STDERR should contain:
       """
       Call to undefined function hello_dolly()
@@ -55,7 +55,7 @@ Feature: Skipping plugins
       """
 
     When I run `wp plugin activate hello`
-    And I try `wp eval 'echo hello_dolly();'`
+    And I try `wp eval 'ini_set( 'error_log', null ); echo hello_dolly();'`
     Then STDERR should contain:
       """
       Call to undefined function hello_dolly()
@@ -69,7 +69,7 @@ Feature: Skipping plugins
       """
 
     When I run `wp plugin activate hello`
-    And I try `wp eval 'echo hello_dolly();'`
+    And I try `wp eval 'ini_set( 'error_log', null ); echo hello_dolly();'`
     Then STDERR should contain:
       """
       Call to undefined function hello_dolly()

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -22,7 +22,7 @@ class Runner {
 
 	private $aliases;
 
-	private $arguments, $assoc_args;
+	private $arguments, $assoc_args, $runtime_config;
 
 	private $_early_invoke = array();
 
@@ -689,12 +689,12 @@ class Runner {
 
 		// Runtime config and args
 		{
-			list( $args, $assoc_args, $runtime_config ) = $configurator->parse_args( $argv );
+			list( $args, $assoc_args, $this->runtime_config ) = $configurator->parse_args( $argv );
 
 			list( $this->arguments, $this->assoc_args ) = self::back_compat_conversions(
 				$args, $assoc_args );
 
-			$configurator->merge_array( $runtime_config );
+			$configurator->merge_array( $this->runtime_config );
 		}
 
 		list( $this->config, $this->extra_config ) = $configurator->to_array();
@@ -756,7 +756,8 @@ class Runner {
 			WP_CLI::log( $alias );
 			$args = implode( ' ', array_map( 'escapeshellarg', $this->arguments ) );
 			$assoc_args = Utils\assoc_args_to_str( $this->assoc_args );
-			$full_command = "WP_CLI_CONFIG_PATH={$config_path} {$php_bin} {$script_path} {$alias} {$args} {$assoc_args}";
+			$runtime_config = Utils\assoc_args_to_str( $this->runtime_config );
+			$full_command = "WP_CLI_CONFIG_PATH={$config_path} {$php_bin} {$script_path} {$alias} {$args}{$assoc_args}{$runtime_config}";
 			$proc = proc_open( $full_command, array( STDIN, STDOUT, STDERR ), $pipes );
 			proc_close( $proc );
 		}
@@ -777,6 +778,7 @@ class Runner {
 
 		WP_CLI::debug( $this->_global_config_path_debug, 'bootstrap' );
 		WP_CLI::debug( $this->_project_config_path_debug, 'bootstrap' );
+		WP_CLI::debug( 'argv: ' . implode( ' ', $GLOBALS['argv'] ), 'bootstrap' );
 
 		$this->check_root();
 		if ( $this->alias ) {


### PR DESCRIPTION
Issue https://github.com/wp-cli/wp-cli/issues/4146

Saves runtime config to new class var `runtime_config` (rather than local) which is then used in `Runner::run_alias_group()` to pass as args to sub-alias invocations.

Adds new debug message dumping `argv()` to make it easy to test that the args are being passed.

Also unrelatedly makes PHP erroring tests more local-testing friendly by setting any `error_log` to null before calling them so that the errors do actually end up in `behat`'s STDERR.