### PR TITLE
Add Utils\canonicalize_path().

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -1005,3 +1005,35 @@ function force_env_on_nix_systems( $command ) {
 	}
 	return $command;
 }
+
+/*
+ * Returns the canonicalized path, with dot and double dot segments resolved.
+ *
+ * Copied from Symfony\Component\DomCrawler\AbstractUriElement::canonicalizePath().
+ * Implements RFC 3986, section 5.2.4.
+ *
+ * @param string $path The path to make canonical.
+ *
+ * @return string The canonicalized path.
+ */
+function canonicalize_path( $path ) {
+	if ( '' === $path || '/' === $path ) {
+		return $path;
+	}
+
+	if ( '.' === substr( $path, -1 ) ) {
+		$path .= '/';
+	}
+
+	$output = array();
+
+	foreach ( explode( '/', $path ) as $segment ) {
+		if ( '..' === $segment ) {
+			array_pop( $output );
+		} elseif ( '.' !== $segment ) {
+			$output[] = $segment;
+		}
+	}
+
+	return implode( '/', $output );
+}

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -154,4 +154,51 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 
 		putenv( 'WP_CLI_TEST_IS_WINDOWS' );
 	}
+
+	/**
+	 *	@dataProvider dataProviderCanonicalizePath
+	 */
+	public function testCanonicalizePath( $path, $expected ) {
+		$this->assertSame( $expected, Utils\canonicalize_path( $path ) );
+	}
+
+	public function dataProviderCanonicalizePath() {
+		return array(
+			array( '', '' ),
+			array( '/', '/' ),
+			array( '//', '//' ),
+
+			array( '.', '' ),
+			array( './', '' ),
+			array( '/.', '/' ),
+			array( '/./', '/' ),
+			array( '/./.', '/' ),
+			array( '/././', '/' ),
+			array( './foo', 'foo' ),
+			array( '/./foo', '/foo' ),
+
+			array( '..', '' ),
+			array( '../', '' ),
+			array( '/..', '' ),
+			array( '/../', '' ),
+			array( '/../..', '' ),
+			array( '/../../', '' ),
+			array( '../foo', 'foo' ),
+			array( '/../foo', 'foo' ),
+
+			array( '/bar/.', '/bar/' ),
+			array( '/bar/./', '/bar/' ),
+			array( '/bar/baz/..', '/bar/' ),
+			array( '/bar/baz/../', '/bar/' ),
+			array( '/bar/baz/../foo', '/bar/foo' ),
+			array( '/bar/baz/../..', '/' ),
+			array( '/foo/bar/baz/../..', '/foo/' ),
+			array( '/bar/baz/../../foo', '/foo' ),
+			array( '/fee/bar/baz/../../foo', '/fee/foo' ),
+			array( '/bar/baz/../bar/./../../foo', '/foo' ),
+			array( '/fee/bar/baz/../bar/./../../foo', '/fee/foo' ),
+			array( '/fee/../bar/./baz/.././../foo/.', '/foo/' ),
+			array( '/fee/fie/../bar/./baz/.././../foo/.', '/fee/foo/' ),
+		);
+	}
 }


### PR DESCRIPTION
Issue https://github.com/wp-cli/scaffold-command/issues/22

As mentioned in https://github.com/wp-cli/scaffold-command/issues/22#issuecomment-307705916 this is a copy of Symfony's [`Symfony\Component\DomCrawler\AbstractUriElement::canonicalizePath`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DomCrawler/AbstractUriElement.php#L137) which has immediate use in `Scaffold_Command::check_target_directory()` and should be generally useful.