### PR TITLE
Fix double slash in boot-phar.php path. 

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -568,7 +568,7 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 			}
 		}
 		if ( empty( $options['verify'] ) ){
-			WP_CLI::error_log( "Cannot find SSL certificate." );
+			WP_CLI::error( "Cannot find SSL certificate." );
 		}
 	}
 

--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -63,6 +63,9 @@ function set_file_contents( $phar, $path, $content ) {
 	$phar[ $key ] = $content;
 }
 
+if ( file_exists( DEST_PATH ) ) {
+	unlink( DEST_PATH );
+}
 $phar = new Phar( DEST_PATH, 0, 'wp-cli.phar' );
 
 $phar->startBuffering();
@@ -168,7 +171,7 @@ $phar->setStub( <<<EOB
 #!/usr/bin/env php
 <?php
 Phar::mapPhar();
-include 'phar://wp-cli.phar/{$phar_boot}';
+include 'phar://wp-cli.phar{$phar_boot}';
 __HALT_COMPILER();
 ?>
 EOB


### PR DESCRIPTION
Issue https://github.com/wp-cli/wp-cli/issues/4168

Removes unneeded slash in "boot-phar.php" path.

Also removes any existing phar before populating - handy when using locally.

Also fixes typo error_log -> error in `Utiils::http_request()`.