### PR TITLE
Allow root use of `wp cli info`, in addition to `wp cli update`

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -711,7 +711,7 @@ class Runner {
 		if ( $this->config['allow-root'] ) {
 			return; # they're aware of the risks!
 		}
-		if ( count( $this->arguments ) >= 2 && 'cli' === $this->arguments[0] && 'update' === $this->arguments[1] ) {
+		if ( count( $this->arguments ) >= 2 && 'cli' === $this->arguments[0] && in_array( $this->arguments[1], array( 'update', 'info' ), true ) ) {
 			return; # make it easier to update root-owned copies
 		}
 		if ( !function_exists( 'posix_geteuid') ) {


### PR DESCRIPTION
Prevents situations like this:

![image](https://user-images.githubusercontent.com/36432/27409557-e4863192-5696-11e7-8e02-9ff5a376c222.png)

Because I've run `sudo wp cli update`, I shouldn't also need to include `--allow-root`.