### PR TITLE
Better example for WP_CLI::add_command

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -358,8 +358,8 @@ class WP_CLI {
 	 * ```
 	 * # Register a custom 'foo' command to output a supplied positional param.
 	 * #
-	 * # $ wp foo bar
-	 * # Success: bar
+	 * # $ wp foo bar --baz=qux
+	 * # Success: bar qux
 	 *
 	 * /**
 	 *  * My awesome closure command
@@ -369,8 +369,8 @@ class WP_CLI {
 	 *  *
 	 *  * @when before_wp_load
 	 *  *\/
-	 * $foo = function( $args ) {
-	 *     WP_CLI::success( $args[0] );
+	 * $foo = function( $args, $args_assoc ) {
+	 *     WP_CLI::success( $args[0] . ' ' . $args_assoc['baz'] );
 	 * };
 	 * WP_CLI::add_command( 'foo', $foo );
 	 * ```

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -358,7 +358,7 @@ class WP_CLI {
 	 * ```
 	 * # Register a custom 'foo' command to output a supplied positional param.
 	 * #
-	 * # $ wp foo bar --baz=qux
+	 * # $ wp foo bar --append=qux
 	 * # Success: bar qux
 	 *
 	 * /**
@@ -367,10 +367,13 @@ class WP_CLI {
 	 *  * <message>
 	 *  * : An awesome message to display
 	 *  *
+	 *  * --append=<message>
+	 *  * : An awesome message to append to the original message.
+	 *  *
 	 *  * @when before_wp_load
 	 *  *\/
-	 * $foo = function( $args, $args_assoc ) {
-	 *     WP_CLI::success( $args[0] . ' ' . $args_assoc['baz'] );
+	 * $foo = function( $args, $assoc_args ) {
+	 *     WP_CLI::success( $args[0] . ' ' . $assoc_args['append'] );
 	 * };
 	 * WP_CLI::add_command( 'foo', $foo );
 	 * ```


### PR DESCRIPTION
Make the example better by adding an associative argument parameter to illustrate its usage.

Original PR: https://github.com/wp-cli/handbook/pull/77