### PR TITLE
Fetch as many WP-CLI releases as we can

### DIFF
--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -343,7 +343,7 @@ class CLI_Command extends WP_CLI_Command {
 	 * Returns update information.
 	 */
 	private function get_updates( $assoc_args ) {
-		$url = 'https://api.github.com/repos/wp-cli/wp-cli/releases';
+		$url = 'https://api.github.com/repos/wp-cli/wp-cli/releases?per_page=100';
 
 		$options = array(
 			'timeout' => 30


### PR DESCRIPTION
We currently have 34 releases. If we continue to release 4x per year, it
will take us another 15 years to get to 100

See #4186