### PR TITLE
Declare fields for properties of Process and ProcessRun

### DIFF
--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -25,6 +25,8 @@ class Process {
 	 * @param string $command Command to execute.
 	 * @param string $cwd Directory to execute the command in.
 	 * @param array $env Environment variables to set when running the command.
+	 *
+	 * @return Process
 	 */
 	public static function create( $command, $cwd = null, $env = array() ) {
 		$proc = new self;

--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -80,7 +80,8 @@ class Process {
 	public function run_check() {
 		$r = $this->run();
 
-		if ( $r->return_code || !empty( $r->stderr ) ) {
+		// $r->STDERR is incorrect, but kept incorrect for backwards-compat
+		if ( $r->return_code || !empty( $r->STDERR ) ) {
 			throw new \RuntimeException( $r );
 		}
 

--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -80,7 +80,7 @@ class Process {
 	public function run_check() {
 		$r = $this->run();
 
-		if ( $r->return_code || !empty( $r->STDERR ) ) {
+		if ( $r->return_code || !empty( $r->stderr ) ) {
 			throw new \RuntimeException( $r );
 		}
 

--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -6,6 +6,20 @@ namespace WP_CLI;
  * Run a system process, and learn what happened.
  */
 class Process {
+	/**
+	 * @var string The full command to execute by the system.
+	 */
+	private $command;
+
+	/**
+	 * @var string|null The path of the working directory for the process or NULL if not specified (defaults to current working directory).
+	 */
+	private $cwd;
+
+	/**
+	 * @var array Environment variables to set when running the command.
+	 */
+	private $env;
 
 	/**
 	 * @param string $command Command to execute.
@@ -21,8 +35,6 @@ class Process {
 
 		return $proc;
 	}
-
-	private $command, $cwd, $env;
 
 	private function __construct() {}
 

--- a/php/WP_CLI/ProcessRun.php
+++ b/php/WP_CLI/ProcessRun.php
@@ -6,6 +6,35 @@ namespace WP_CLI;
  * Results of an executed command.
  */
 class ProcessRun {
+	/**
+	 * @var string The full command executed by the system.
+	 */
+	public $command;
+
+	/**
+	 * @var string Captured output from the process' STDOUT.
+	 */
+	public $stdout;
+
+	/**
+	 * @var string Captured output from the process' STDERR.
+	 */
+	public $stderr;
+
+	/**
+	 * @var string|null The path of the working directory for the process or NULL if not specified (defaults to current working directory).
+	 */
+	public $cwd;
+
+	/**
+	 * @var array Environment variables set for this process.
+	 */
+	public $env;
+
+	/**
+	 * @var int Exit code of the process.
+	 */
+	public $return_code;
 
 	/**
 	 * @var array $props Properties of executed command.


### PR DESCRIPTION
This PR primarily adds/corrects inline documentation for the `WP_CLI\Process` and `\WP_CLI\ProcessRun` classes.

These properties should be defined on the classes for better documentation and inspectability.