### PR TITLE
Behat: Allow test DB user + pass to be set by env vars

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -196,7 +196,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 			self::$db_settings['dbuser'] = getenv( 'WP_CLI_TEST_DBUSER' );
 		}
 
-		if ( getenv( 'WP_CLI_TEST_DBPASS' ) !== false ) {
+		if ( false !== getenv( 'WP_CLI_TEST_DBPASS' ) ) {
 			self::$db_settings['dbpass'] = getenv( 'WP_CLI_TEST_DBPASS' );
 		}
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -192,9 +192,18 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	 * @param array $parameters context parameters (set them up through behat.yml)
 	 */
 	public function __construct( array $parameters ) {
+		if ( getenv( 'WP_CLI_TEST_DBUSER' ) ) {
+			self::$db_settings['dbuser'] = getenv( 'WP_CLI_TEST_DBUSER' );
+		}
+
+		if ( getenv( 'WP_CLI_TEST_DBPASS' ) !== false ) {
+			self::$db_settings['dbpass'] = getenv( 'WP_CLI_TEST_DBPASS' );
+		}
+
 		if ( getenv( 'WP_CLI_TEST_DBHOST' ) ) {
 			self::$db_settings['dbhost'] = getenv( 'WP_CLI_TEST_DBHOST' );
 		}
+
 		$this->drop_db();
 		$this->set_cache_dir();
 		$this->variables['CORE_CONFIG_SETTINGS'] = Utils\assoc_args_to_str( self::$db_settings );


### PR DESCRIPTION
This is something that I added for the `valet` command because I needed to be able to test creation and deletion of databases other than `wp_cli_test`. Rather than granting more permissions, I felt it would be much easier to just use different credentials. I think this could be useful in other situations as well.

In case you're wondering the ` !== false` check on the password var is to allow for an empty password to be set with `WP_CLI_TEST_DBPASS=""`, where the others cannot be empty.

E.g. https://github.com/aaemnnosttv/wp-cli-valet-command/blob/af1ee1123c3d2fa991a5d4a6ba982db14b966397/.travis.yml#L8-L11