### PR TITLE
Pass WP_CLI_STRICT_ARGS_MODE on to ssh if set.

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -269,8 +269,8 @@ Feature: Global flags
       """
 
   Scenario: Strict args mode should be passed on to ssh
-    When I try `WP_CLI_STRICT_ARGS_MODE=1 wp --debug --ssh=user@127.0.0.1 --version`
+    When I try `WP_CLI_STRICT_ARGS_MODE=1 wp --debug --ssh=/ --version`
     Then STDERR should contain:
       """
-      Running SSH command: ssh -q user@127.0.0.1 -T WP_CLI_STRICT_ARGS_MODE=1 wp
+      Running SSH command: ssh -q  -T WP_CLI_STRICT_ARGS_MODE=1 wp
       """

--- a/features/flags.feature
+++ b/features/flags.feature
@@ -267,3 +267,10 @@ Feature: Global flags
       """
       Error: RESTful WP-CLI needs to be installed. Try 'wp package install wp-cli/restful'.
       """
+
+  Scenario: Strict args mode should be passed on to ssh
+    When I try `WP_CLI_STRICT_ARGS_MODE=1 wp --debug --ssh=user@127.0.0.1 --version`
+    Then STDERR should contain:
+      """
+      Running SSH command: ssh -q user@127.0.0.1 -T WP_CLI_STRICT_ARGS_MODE=1 wp
+      """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -356,6 +356,12 @@ class Runner {
 		if ( $path ) {
 			$pre_cmd .= "cd {$path}; ";
 		}
+
+		$env_vars = '';
+		if ( getenv( 'WP_CLI_STRICT_ARGS_MODE' ) ) {
+			$env_vars .= 'WP_CLI_STRICT_ARGS_MODE=1 ';
+		}
+
 		$wp_binary = 'wp';
 		$wp_args = array_slice( $GLOBALS['argv'], 1 );
 
@@ -385,7 +391,7 @@ class Runner {
 			$port ? '-p ' . (int) $port . ' ' : '',
 			$host,
 			$is_tty ? '-t' : '-T',
-			$pre_cmd . $wp_binary . ' ' . implode( ' ', array_map( 'escapeshellarg', $wp_args ) )
+			$pre_cmd . $env_vars . $wp_binary . ' ' . implode( ' ', array_map( 'escapeshellarg', $wp_args ) )
 		);
 
 		WP_CLI::debug( 'Running SSH command: ' . $unescaped_command, 'bootstrap' );


### PR DESCRIPTION
Fixes #4206 

Prefixes ssh command with `WP_CLI_STRICT_ARGS_MODE=1` if set locally.