### PR TITLE
Fix quotes on ini_set( error_log, null ).

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -52,7 +52,7 @@ Feature: Global flags
       CONST_WITHOUT_QUOTES
       """
 
-    When I try `wp eval 'ini_set( 'error_log', null ); echo CONST_WITHOUT_QUOTES;' --debug`
+    When I try `wp eval 'ini_set( "error_log", null ); echo CONST_WITHOUT_QUOTES;' --debug`
     Then the return code should be 0
     And STDOUT should be:
       """

--- a/features/skip-plugins.feature
+++ b/features/skip-plugins.feature
@@ -32,7 +32,7 @@ Feature: Skipping plugins
       """
 
     # Can specify multiple plugins to skip
-    When I try `wp eval --skip-plugins=hello,akismet 'ini_set( 'error_log', null ); echo hello_dolly();'`
+    When I try `wp eval --skip-plugins=hello,akismet 'ini_set( "error_log", null ); echo hello_dolly();'`
     Then STDERR should contain:
       """
       Call to undefined function hello_dolly()
@@ -55,7 +55,7 @@ Feature: Skipping plugins
       """
 
     When I run `wp plugin activate hello`
-    And I try `wp eval 'ini_set( 'error_log', null ); echo hello_dolly();'`
+    And I try `wp eval 'ini_set( "error_log", null ); echo hello_dolly();'`
     Then STDERR should contain:
       """
       Call to undefined function hello_dolly()
@@ -69,7 +69,7 @@ Feature: Skipping plugins
       """
 
     When I run `wp plugin activate hello`
-    And I try `wp eval 'ini_set( 'error_log', null ); echo hello_dolly();'`
+    And I try `wp eval 'ini_set( "error_log", null ); echo hello_dolly();'`
     Then STDERR should contain:
       """
       Call to undefined function hello_dolly()


### PR DESCRIPTION
Replaces single quotes with double on "error_log" param.

(Introduced by me  https://github.com/wp-cli/wp-cli/pull/4148)