### PR TITLE
Make tests runnable locally without errors or noise.

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -8,9 +8,6 @@ use Behat\Behat\Context\ClosuredContextInterface,
 use \WP_CLI\Process;
 use \WP_CLI\Utils;
 
-use Symfony\Component\Filesystem\Filesystem,
-	Symfony\Component\Filesystem\Exception\IOExceptionInterface;
-
 // Inside a community package
 if ( file_exists( __DIR__ . '/utils.php' ) ) {
 	require_once __DIR__ . '/utils.php';
@@ -47,7 +44,7 @@ if ( file_exists( __DIR__ . '/utils.php' ) ) {
  */
 class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
-	private static $cache_dir, $suite_cache_dir, $fs;
+	private static $cache_dir, $suite_cache_dir;
 
 	private static $db_settings = array(
 		'dbname' => 'wp_cli_test',
@@ -210,9 +207,6 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		$this->drop_db();
 		$this->set_cache_dir();
 		$this->variables['CORE_CONFIG_SETTINGS'] = Utils\assoc_args_to_str( self::$db_settings );
-		if ( ! self::$fs ) {
-			self::$fs = new FileSystem;
-		}
 	}
 
 	public function getStepDefinitionResources() {
@@ -394,13 +388,6 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 	public function move_files( $src, $dest ) {
 		rename( $this->variables['RUN_DIR'] . "/$src", $this->variables['RUN_DIR'] . "/$dest" );
-	}
-
-	/**
-	 * Remove a directory (recursive).
-	 */
-	public function remove_dir( $dir ) {
-		self::$fs->remove( $dir );
 	}
 
 	public function add_line_to_wp_config( &$wp_config_code, $line ) {

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -8,6 +8,9 @@ use Behat\Behat\Context\ClosuredContextInterface,
 use \WP_CLI\Process;
 use \WP_CLI\Utils;
 
+use Symfony\Component\Filesystem\Filesystem,
+	Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+
 // Inside a community package
 if ( file_exists( __DIR__ . '/utils.php' ) ) {
 	require_once __DIR__ . '/utils.php';
@@ -44,7 +47,7 @@ if ( file_exists( __DIR__ . '/utils.php' ) ) {
  */
 class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
-	private static $cache_dir, $suite_cache_dir;
+	private static $cache_dir, $suite_cache_dir, $fs;
 
 	private static $db_settings = array(
 		'dbname' => 'wp_cli_test',
@@ -207,6 +210,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		$this->drop_db();
 		$this->set_cache_dir();
 		$this->variables['CORE_CONFIG_SETTINGS'] = Utils\assoc_args_to_str( self::$db_settings );
+		if ( ! self::$fs ) {
+			self::$fs = new FileSystem;
+		}
 	}
 
 	public function getStepDefinitionResources() {
@@ -388,6 +394,13 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 	public function move_files( $src, $dest ) {
 		rename( $this->variables['RUN_DIR'] . "/$src", $this->variables['RUN_DIR'] . "/$dest" );
+	}
+
+	/**
+	 * Remove a directory (recursive).
+	 */
+	public function remove_dir( $dir ) {
+		self::$fs->remove( $dir );
 	}
 
 	public function add_line_to_wp_config( &$wp_config_code, $line ) {

--- a/features/cli-info.feature
+++ b/features/cli-info.feature
@@ -1,7 +1,12 @@
 Feature: Review CLI information
 
+  Background:
+    When I run `wp package path`
+    Then save STDOUT as {PACKAGE_PATH}
+
   Scenario: Get the path to the packages directory
     Given an empty directory
+	And an empty {PACKAGE_PATH} directory
 
     When I run `wp cli info --format=json`
     Then STDOUT should be JSON containing:

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -137,7 +137,7 @@ Feature: `wp cli` tasks
       y
       """
 
-    When I run `{PHAR_PATH} cli check-update --minor --field=version`
+    When I run `{PHAR_PATH} cli check-update --field=version | head -1`
     Then STDOUT should not be empty
     And save STDOUT as {UPDATE_VERSION}
 

--- a/features/framework.feature
+++ b/features/framework.feature
@@ -181,14 +181,10 @@ Feature: Load WP-CLI
 
   Scenario: Handle error when WordPress cannot connect to the database host
     Given a WP install
-    And a wp-debug.php file:
-      """
-      <?php
-      define( 'WP_DEBUG', true );
-      """
     And a invalid-host.php file:
       """
       <?php
+	  error_reporting( error_reporting() & ~E_NOTICE );
       define( 'DB_HOST', 'localghost' );
       """
 
@@ -198,7 +194,7 @@ Feature: Load WP-CLI
       Error: Error establishing a database connection.
       """
 
-    When I try `wp --require=invalid-host.php --require=wp-debug.php option get home`
+    When I try `wp --require=invalid-host.php option get home`
     Then STDERR should contain:
       """
       Error: Error establishing a database connection.

--- a/features/framework.feature
+++ b/features/framework.feature
@@ -184,7 +184,7 @@ Feature: Load WP-CLI
     And a invalid-host.php file:
       """
       <?php
-	  error_reporting( error_reporting() & ~E_NOTICE );
+      error_reporting( error_reporting() & ~E_NOTICE );
       define( 'DB_HOST', 'localghost' );
       """
 

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -12,7 +12,11 @@ $steps->Given( '/^an empty directory$/',
 
 $steps->Given( '/^an empty ([^\s]+) directory$/',
 	function ( $world, $dir ) {
-		$world->remove_dir( $world->replace_variables( $dir ) );
+		$dir = $world->replace_variables( $dir );
+		if ( '/' === $dir ) {
+			throw new Exception( 'Attempted to delete the entire filesystem.' );
+		}
+		$world->proc( WP_CLI\Utils\esc_cmd( 'rm -r %s', $dir ) )->run();
 	}
 );
 

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -10,6 +10,12 @@ $steps->Given( '/^an empty directory$/',
 	}
 );
 
+$steps->Given( '/^an empty ([^\s]+) directory$/',
+	function ( $world, $dir ) {
+		$world->remove_dir( $world->replace_variables( $dir ) );
+	}
+);
+
 $steps->Given( '/^an empty cache/',
 	function ( $world ) {
 		$world->variables['SUITE_CACHE_DIR'] = FeatureContext::create_cache_dir();


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/4210

Adds "Given an empty XXX directory" for use by `cli-info.feature` to clear `PACKAGE_PATH` so it's re-runnable.

Fixes `UPDATE_VERSION` in `cli.feature` to get the correct latest version.

Suppresses PHP notices in `framework.feature` thrown by `wp-db.php`.

(Also needs https://github.com/wp-cli/wp-cli/pull/4208 to remove noise completely.)