### PR TITLE
Default to stable if no version options given. Add GITHUB_TOKEN.

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -59,7 +59,6 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 	/**
 	 * Get the environment variables required for launched `wp` processes
-	 * @beforeSuite
 	 */
 	private static function get_process_env_variables() {
 		// Ensure we're using the expected `wp` binary
@@ -81,6 +80,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		}
 		if ( $travis_build_dir = getenv( 'TRAVIS_BUILD_DIR' ) ) {
 			$env['TRAVIS_BUILD_DIR'] = $travis_build_dir;
+		}
+		if ( $github_token = getenv( 'GITHUB_TOKEN' ) ) {
+			$env['GITHUB_TOKEN'] = $github_token;
 		}
 		return $env;
 	}

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -49,7 +49,7 @@ Feature: `wp cli` tasks
       """
     And STDOUT should contain:
     """
-    Success:
+    Success: Updated WP-CLI to the latest stable release.
     """
     And STDERR should be empty
     And the return code should be 0
@@ -101,7 +101,7 @@ Feature: `wp cli` tasks
     When I run `{PHAR_PATH} cli update --no-patch --yes`
     Then STDOUT should contain:
     """
-    Success:
+    Success: Updated WP-CLI to the latest stable release.
     """
     And STDOUT should not contain:
     """


### PR DESCRIPTION
Issue https://github.com/wp-cli/wp-cli/issues/4213

If no version options are given, defaults to stable so as to avoid a `get_updates()` call.

Also (unrelatedly) might as well add the `GITHUB_TOKEN` stuff.

Also removes inappropriate `@beforeSuite` tag on `FeatureContext::get_process_env_variables()`.