### PR TITLE
Add test that cli update on stable gives at latest version message.

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -64,6 +64,12 @@ Feature: `wp cli` tasks
       0.0.0
       """
 
+    When I run `{PHAR_PATH} cli update`
+    Then STDOUT should be:
+      """
+      Success: WP-CLI is at the latest version.
+      """
+
   @github-api
   Scenario: Patch update from 0.14.0 to 0.14.1
     Given an empty directory


### PR DESCRIPTION
Adds test that `wp cli update` when on latest stable returns "WP-CLI is at the latest version." (there's one for `check-update`).