### PR TITLE
Fixed line endings

### DIFF
--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -276,7 +276,7 @@ class Subcommand extends CompositeCommand {
 		$i = 0;
 		$errors = array( 'fatal' => array(), 'warning' => array() );
 		$mock_doc = array( $this->get_shortdesc(), '' );
-		$mock_doc = array_merge( $mock_doc, explode( PHP_EOL, $this->get_longdesc() ) );
+		$mock_doc = array_merge( $mock_doc, explode( "\n", $this->get_longdesc() ) );
 		$mock_doc = '/**' . PHP_EOL . '* ' . implode( PHP_EOL . '* ', $mock_doc ) . PHP_EOL . '*/';
 		$docparser = new \WP_CLI\DocParser( $mock_doc );
 		foreach( $synopsis_spec as $spec ) {

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -19,6 +19,8 @@ class DocParser {
 	 * @param string $docComment
 	 */
 	public function __construct( $docComment ) {
+		/* Make sure we have a known line ending in document */
+		$docComment = preg_replace( '/\R/', "\n", $docComment );
 		$this->docComment = self::remove_decorations( $docComment );
 	}
 


### PR DESCRIPTION
For issue #4220 
This isn't tested, except in my home environment. The super-critical parts are
php/WP_CLI/Dispatcher/CommandFactory.php
php/WP_CLI/Dispatcher/Subcommand.php:30 `preg_match_all( '/(.+?)\R+:/', $longdesc, $matches );`
php/WP_CLI/DocParser.php:73

This also fixes the wp help command, which screwed up indentation on win systems, regardless of line endings in file.