### PR TITLE
Use str_replace instead of preg_replace to normalize doc comment EOLs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform EOL normalization
 * text=auto eol=lf
+tests/data/*-win.php eol=crlf

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -20,7 +20,7 @@ class DocParser {
 	 */
 	public function __construct( $docComment ) {
 		/* Make sure we have a known line ending in document */
-		$docComment = preg_replace( '/\R/', "\n", $docComment );
+		$docComment = str_replace( "\r\n", "\n", $docComment );
 		$this->docComment = self::remove_decorations( $docComment );
 	}
 

--- a/tests/data/commandfactory-doc_comment-class-win.php
+++ b/tests/data/commandfactory-doc_comment-class-win.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Basic class
+ *
+ * ## EXAMPLES
+ *
+ *     # Foo.
+ *     $ wp foo
+ */
+class CommandFactoryTests_Get_Doc_Comment_1_Command_Win extends WP_CLI_Command {
+	/**
+	 * Command1 method
+	 *
+	 * ## OPTIONS
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp foo command1 public
+	 */
+	function command1() {
+	}
+
+	/**
+	 * Command2 function
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--path=<path>]
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp foo command2 --path=/**a/**b/**c/**
+	 */
+
+final
+			protected
+			static
+	function
+			command2() {
+	}
+
+	/**
+	 * Command3 function
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--path=<path>]
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp foo command3 --path=/**a/**b/**c/**
+	 function*/public function command3( $function ) {}
+
+	function command4() {}
+}
+
+/**
+ * Basic class
+ *
+ * ## EXAMPLES
+ *
+ *     # Foo.
+ *     $ wp foo --final abstract
+ class*/abstract class
+  CommandFactoryTests_Get_Doc_Comment_2_Command_Win
+ extends              WP_CLI_Command
+    {
+		function command1() {}
+	}

--- a/tests/data/commandfactory-doc_comment-function-win.php
+++ b/tests/data/commandfactory-doc_comment-function-win.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * foo
+ */
+function commandfactorytests_get_doc_comment_func_1_win( $function = blah ) {
+}
+
+/**
+ * bar
+ function*/function commandfactorytests_get_doc_comment_func_2_win( $function = blah ) {
+}
+
+/**
+ * /** baz
+ */$commandfactorytests_get_doc_comment_func_3_win
+  =
+  	function ( $args ) {
+};

--- a/tests/test-commandfactory.php
+++ b/tests/test-commandfactory.php
@@ -10,6 +10,10 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 	 * @dataProvider dataProviderExtractLastDocComment
 	 */
 	function testExtractLastDocComment( $content, $expected ) {
+		// Save and set test env var.
+		$is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
+		putenv( 'WP_CLI_TEST_IS_WINDOWS=0' );
+
 		static $extract_last_doc_comment = null;
 		if ( null === $extract_last_doc_comment ) {
 			$extract_last_doc_comment = new \ReflectionMethod( 'WP_CLI\Dispatcher\CommandFactory', 'extract_last_doc_comment' );
@@ -18,6 +22,30 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 
 		$actual = $extract_last_doc_comment->invoke( null, $content );
 		$this->assertSame( $expected, $actual );
+
+		// Restore.
+		putenv( false === $is_windows ? 'WP_CLI_TEST_IS_WINDOWS' : "WP_CLI_TEST_IS_WINDOWS=$is_windows" );
+	}
+
+	/**
+	 * @dataProvider dataProviderExtractLastDocComment
+	 */
+	function testExtractLastDocCommentWin( $content, $expected ) {
+		// Save and set test env var.
+		$is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
+		putenv( 'WP_CLI_TEST_IS_WINDOWS=1' );
+
+		static $extract_last_doc_comment = null;
+		if ( null === $extract_last_doc_comment ) {
+			$extract_last_doc_comment = new \ReflectionMethod( 'WP_CLI\Dispatcher\CommandFactory', 'extract_last_doc_comment' );
+			$extract_last_doc_comment->setAccessible( true );
+		}
+
+		$actual = $extract_last_doc_comment->invoke( null, $content );
+		$this->assertSame( $expected, $actual );
+
+		// Restore.
+		putenv( false === $is_windows ? 'WP_CLI_TEST_IS_WINDOWS' : "WP_CLI_TEST_IS_WINDOWS=$is_windows" );
 	}
 
 	function dataProviderExtractLastDocComment() {
@@ -29,6 +57,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 			array( "/***/ */", false ),
 			array( "/***/", "/***/" ),
 			array( "\n /**\n  \n  \t\n  */ \t\n \n ", "/**\n  \n  \t\n  */" ),
+			array( "\r\n /**\r\n  \r\n  \t\r\n  */ \t\r\n \r\n ", "/**\r\n  \r\n  \t\r\n  */" ),
 			array( "/**/ /***/ /***/", "/***/" ),
 			array( "asdfasdf/** /** */", "/** /** */" ),
 			array( "*//** /** */", "/** /** */" ),
@@ -39,11 +68,13 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 			array( "/** */class qwer", "/** */" ),
 			array( "/**1*/class qwer{}/**2*/class asdf", "/**2*/" ),
 			array( "/** */class qwer {}\nclass asdf", false ),
+			array( "/** */class qwer {}\r\nclass asdf", false ),
 
 			array( "/** */function qwer", "/** */" ),
 			array( "/** */function qwer( \$function ) {}", "/** */" ),
 			array( "/**1*/function qwer() {}/**2*/function asdf()", "/**2*/" ),
 			array( "/** */function qwer() {}\nfunction asdf()", false ),
+			array( "/** */function qwer() {}\r\nfunction asdf()", false ),
 			array( "/** */function qwer() {}function asdf()", false ),
 			array( "/** */function qwer() {};function asdf( \$function )", false ),
 		);
@@ -51,14 +82,22 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 
 	function testGetDocComment() {
 		// Save and set test env var.
-		$prev_test_get_doc_comment = getenv( 'WP_CLI_TEST_GET_DOC_COMMENT' );
+		$get_doc_comment = getenv( 'WP_CLI_TEST_GET_DOC_COMMENT' );
+		$is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
+
 		putenv( 'WP_CLI_TEST_GET_DOC_COMMENT=1' );
+		putenv( 'WP_CLI_TEST_IS_WINDOWS=0' );
 
 		// Make private function accessible.
 		$get_doc_comment = new \ReflectionMethod( 'WP_CLI\Dispatcher\CommandFactory', 'get_doc_comment' );
 		$get_doc_comment->setAccessible( true );
 
-		require __DIR__ . '/data/commandfactory-doc_comment-class.php';
+		if ( ! class_exists( 'CommandFactoryTests_Get_Doc_Comment_1_Command', false ) ) {
+			require __DIR__ . '/data/commandfactory-doc_comment-class.php';
+		}
+		if ( ! class_exists( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', false ) ) {
+			require __DIR__ . '/data/commandfactory-doc_comment-class-win.php';
+		}
 
 		// Class 1
 
@@ -101,6 +140,47 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		$this->assertSame( $expected, $actual );
 		$this->assertFalse( $actual );
 
+		// Class 1 Windows
+
+		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 1
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command1' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 2
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command2' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 3
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command3' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 4
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command4' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+		$this->assertFalse( $actual );
+
 		// Class 2
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_2_Command' );
@@ -112,6 +192,23 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 1
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_2_Command', 'command1' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+		$this->assertFalse( $actual );
+
+		// Class 2 Windows
+
+		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_2_Command_Win' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 1
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_2_Command_Win', 'command1' );
 		$expected = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
@@ -147,8 +244,175 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		$this->assertSame( $expected, $actual );
 
 		// Restore.
+		putenv( false === $get_doc_comment ? 'WP_CLI_TEST_GET_DOC_COMMENT' : "WP_CLI_TEST_GET_DOC_COMMENT=$get_doc_comment" );
+		putenv( false === $is_windows ? 'WP_CLI_TEST_IS_WINDOWS' : "WP_CLI_TEST_IS_WINDOWS=$is_windows" );
+	}
 
-		putenv( false === $prev_test_get_doc_comment ? 'WP_CLI_TEST_GET_DOC_COMMENT' : "WP_CLI_TEST_GET_DOC_COMMENT=$prev_test_get_doc_comment" );
-		$this->assertTrue( true );
+	function testGetDocCommentWin() {
+		// Save and set test env var.
+		$get_doc_comment = getenv( 'WP_CLI_TEST_GET_DOC_COMMENT' );
+		$is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
+
+		putenv( 'WP_CLI_TEST_GET_DOC_COMMENT=1' );
+		putenv( 'WP_CLI_TEST_IS_WINDOWS=1' );
+
+		// Make private function accessible.
+		$get_doc_comment = new \ReflectionMethod( 'WP_CLI\Dispatcher\CommandFactory', 'get_doc_comment' );
+		$get_doc_comment->setAccessible( true );
+
+		if ( ! class_exists( 'CommandFactoryTests_Get_Doc_Comment_1_Command', false ) ) {
+			require __DIR__ . '/data/commandfactory-doc_comment-class.php';
+		}
+		if ( ! class_exists( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', false ) ) {
+			require __DIR__ . '/data/commandfactory-doc_comment-class-win.php';
+		}
+
+		// Class 1
+
+		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_1_Command' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 1
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command1' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 2
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command2' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 3
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command3' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 4
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command4' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+		$this->assertFalse( $actual );
+
+		// Class 1 Windows
+
+		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 1
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command1' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 2
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command2' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 3
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command3' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 4
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command4' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+		$this->assertFalse( $actual );
+
+		// Class 2
+
+		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_2_Command' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 1
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_2_Command', 'command1' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+		$this->assertFalse( $actual );
+
+		// Class 2 Windows
+
+		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_2_Command_Win' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Class method 1
+
+		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_2_Command_Win', 'command1' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+		$this->assertFalse( $actual );
+
+		// Functions
+
+		require __DIR__ . '/data/commandfactory-doc_comment-function-win.php';
+
+		// Function 1 Windows
+
+		$reflection = new \ReflectionFunction( 'commandfactorytests_get_doc_comment_func_1_win' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Function 2
+
+		$reflection = new \ReflectionFunction( 'commandfactorytests_get_doc_comment_func_2_win' );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Function 3
+
+		$reflection = new \ReflectionFunction( $commandfactorytests_get_doc_comment_func_3_win );
+		$expected = $reflection->getDocComment();
+
+		$actual = $get_doc_comment->invoke( null, $reflection );
+		$this->assertSame( $expected, $actual );
+
+		// Restore.
+		putenv( false === $get_doc_comment ? 'WP_CLI_TEST_GET_DOC_COMMENT' : "WP_CLI_TEST_GET_DOC_COMMENT=$get_doc_comment" );
+		putenv( false === $is_windows ? 'WP_CLI_TEST_IS_WINDOWS' : "WP_CLI_TEST_IS_WINDOWS=$is_windows" );
 	}
 }


### PR DESCRIPTION
Issue https://github.com/wp-cli/wp-cli/issues/4220 and PR https://github.com/wp-cli/wp-cli/pull/4221.

Uses `str_replace()` instead of `preg_replace()`.

Adds Windows tests to `CommandFactoryTests`, including DOS formatted test files.

