### PR TITLE
Fix Runner.php when ABSPATH is already defined

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -203,8 +203,12 @@ class Runner {
 	 * @param string $path
 	 */
 	private static function set_wp_root( $path ) {
-		define( 'ABSPATH', rtrim( $path, '/' ) . '/' );
-		WP_CLI::debug( 'ABSPATH defined: ' . ABSPATH, 'bootstrap' );
+		if (!defined('ABSPATH')) {
+			define( 'ABSPATH', rtrim( $path, '/' ) . '/' );
+			WP_CLI::debug( 'ABSPATH defined: ' . ABSPATH, 'bootstrap' );
+		} else {
+			WP_CLI::warning( 'cannot set ABSPATH (already defined) : ' . ABSPATH);
+		}
 
 		$_SERVER['DOCUMENT_ROOT'] = realpath( $path );
 	}
@@ -852,8 +856,12 @@ class Runner {
 			}
 		}
 
-		// Handle --path parameter
-		self::set_wp_root( $this->find_wp_root() );
+		// Handle --path parameter if ABSPATH is not defined yet
+		if (!defined('ABSPATH')) {
+			self::set_wp_root( $this->find_wp_root() );
+		} else if ( !empty( $this->config['path'] ) ) {
+			WP_CLI::warning( '--path parameter detected but ABSPATH is already defined');
+		}
 
 		// First try at showing man page
 		if ( ! empty( $this->arguments[0] )

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -647,8 +647,12 @@ class WP_CLI {
 	 * ```
 	 * # Called in `WP_CLI\Runner::set_wp_root()`.
 	 * private static function set_wp_root( $path ) {
-	 *     define( 'ABSPATH', rtrim( $path, '/' ) . '/' );
-	 *     WP_CLI::debug( 'ABSPATH defined: ' . ABSPATH );
+	 *     if (!defined('ABSPATH')) {
+	 *         define( 'ABSPATH', rtrim( $path, '/' ) . '/' );
+	 *         WP_CLI::debug( 'ABSPATH defined: ' . ABSPATH );
+	 *     } else {
+	 *         WP_CLI::warning( 'ABSPATH already defined: ' . ABSPATH );
+	 *     }
 	 *     $_SERVER['DOCUMENT_ROOT'] = realpath( $path );
 	 * }
 	 *


### PR DESCRIPTION
This happens when wp-config.php has been generated and `ABSPATH` is defined.

`wp-cli` show a php notice in the terminal.

```
PHP Notice:  Constant ABSPATH already defined in phar:///usr/local/bin/wp/php/WP_CLI/Runner.php(964) : eval()'d code on line 71
```
