### PR TITLE
Add Utils\trailingslashit() and use it.

### DIFF
--- a/features/cli-info.feature
+++ b/features/cli-info.feature
@@ -28,3 +28,22 @@ Feature: Review CLI information
       """
       WP-CLI packages dir:
       """
+
+  Scenario: Packages directory path should be slashed correctly
+    When I run `WP_CLI_PACKAGES_DIR=/foo wp package path`
+    Then STDOUT should be:
+      """
+      /foo/
+      """
+
+    When I run `WP_CLI_PACKAGES_DIR=/foo/ wp package path`
+    Then STDOUT should be:
+      """
+      /foo/
+      """
+
+    When I run `WP_CLI_PACKAGES_DIR=/foo\\ wp package path`
+    Then STDOUT should be:
+      """
+      /foo/
+      """

--- a/features/runner.feature
+++ b/features/runner.feature
@@ -1,0 +1,21 @@
+Feature: Runner WP-CLI
+
+  Scenario: Path argument should be slashed correctly
+  When I try `wp no-such-command --path=/foo --debug`
+  Then STDERR should contain:
+    """
+    ABSPATH defined: /foo/
+    """
+
+  When I try `wp no-such-command --path=/foo/ --debug`
+  Then STDERR should contain:
+    """
+    ABSPATH defined: /foo/
+    """
+
+  When I try `wp no-such-command --path=/foo\\ --debug`
+  Then STDERR should contain:
+    """
+    ABSPATH defined: /foo/
+    """
+

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -48,7 +48,7 @@ class FileCache {
 	 * @param string $whitelist  List of characters that are allowed in path names (used in a regex character class)
 	 */
 	public function __construct( $cacheDir, $ttl, $maxSize, $whitelist = 'a-z0-9._-' ) {
-		$this->root = rtrim( $cacheDir, '/\\' ) . '/';
+		$this->root = Utils\trailingslashit( $cacheDir );
 		$this->ttl = (int) $ttl;
 		$this->maxSize = (int) $maxSize;
 		$this->whitelist = $whitelist;

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -127,7 +127,7 @@ class Runner {
 	 */
 	public function get_packages_dir_path() {
 		if ( getenv( 'WP_CLI_PACKAGES_DIR' ) ) {
-			$packages_dir = rtrim( getenv( 'WP_CLI_PACKAGES_DIR' ), '/' ) . '/';
+			$packages_dir = Utils\trailingslashit( getenv( 'WP_CLI_PACKAGES_DIR' ) );
 		} else {
 			$packages_dir = Utils\get_home_dir() . '/.wp-cli/packages/';
 		}
@@ -203,7 +203,7 @@ class Runner {
 	 * @param string $path
 	 */
 	private static function set_wp_root( $path ) {
-		define( 'ABSPATH', rtrim( $path, '/' ) . '/' );
+		define( 'ABSPATH', Utils\trailingslashit( $path ) );
 		WP_CLI::debug( 'ABSPATH defined: ' . ABSPATH, 'bootstrap' );
 
 		$_SERVER['DOCUMENT_ROOT'] = realpath( $path );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -647,7 +647,7 @@ class WP_CLI {
 	 * ```
 	 * # Called in `WP_CLI\Runner::set_wp_root()`.
 	 * private static function set_wp_root( $path ) {
-	 *     define( 'ABSPATH', rtrim( $path, '/' ) . '/' );
+	 *     define( 'ABSPATH', Utils\trailingslashit( $path ) );
 	 *     WP_CLI::debug( 'ABSPATH defined: ' . ABSPATH );
 	 *     $_SERVER['DOCUMENT_ROOT'] = realpath( $path );
 	 * }

--- a/php/utils.php
+++ b/php/utils.php
@@ -713,6 +713,19 @@ function get_home_dir() {
 }
 
 /**
+ * Appends a trailing slash.
+ *
+ * @access public
+ * @category System
+ *
+ * @param string $string What to add the trailing slash to.
+ * @return string String with trailing slash added.
+ */
+function trailingslashit( $string ) {
+	return rtrim( $string, '/\\' ) . '/';
+}
+
+/**
  * Get the system's temp directory. Warns user if it isn't writable.
  *
  * @access public
@@ -723,17 +736,15 @@ function get_home_dir() {
 function get_temp_dir() {
 	static $temp = '';
 
-	$trailingslashit = function( $path ) {
-		return rtrim( $path ) . '/';
-	};
+	if ( $temp ) {
+		return $temp;
+	}
 
-	if ( $temp )
-		return $trailingslashit( $temp );
-
-	if ( function_exists( 'sys_get_temp_dir' ) ) {
-		$temp = sys_get_temp_dir();
-	} else if ( ini_get( 'upload_tmp_dir' ) ) {
-		$temp = ini_get( 'upload_tmp_dir' );
+	// `sys_get_temp_dir()` introduced PHP 5.2.1.
+	if ( $try = sys_get_temp_dir() ) {
+		$temp = trailingslashit( $try );
+	} elseif ( $try = ini_get( 'upload_tmp_dir' ) ) {
+		$temp = trailingslashit( $try );
 	} else {
 		$temp = '/tmp/';
 	}
@@ -742,7 +753,7 @@ function get_temp_dir() {
 		\WP_CLI::warning( "Temp directory isn't writable: {$temp}" );
 	}
 
-	return $trailingslashit( $temp );
+	return $temp;
 }
 
 /**

--- a/tests/test-file-cache.php
+++ b/tests/test-file-cache.php
@@ -1,0 +1,32 @@
+<?php
+
+use WP_CLI\FileCache;
+use WP_CLI\Utils;
+
+class FileCacheTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * Test get_root() deals with backslashed directory.
+	 */
+	public function testGetRoot() {
+		$max_size = 32;
+		$ttl = 60;
+
+		$cache_dir = Utils\get_temp_dir() . uniqid( 'wp-cli-test-file-cache', true );
+		error_log( "cache_dir=$cache_dir" );
+
+		$cache = new FileCache( $cache_dir, $ttl, $max_size );
+		$this->assertSame( $cache_dir . '/', $cache->get_root() );
+		unset( $cache );
+
+		$cache = new FileCache( $cache_dir . '/', $ttl, $max_size );
+		$this->assertSame( $cache_dir . '/', $cache->get_root() );
+		unset( $cache );
+
+		$cache = new FileCache( $cache_dir . '\\', $ttl, $max_size );
+		$this->assertSame( $cache_dir . '/', $cache->get_root() );
+		unset( $cache );
+
+		rmdir( $cache_dir );
+	}
+}


### PR DESCRIPTION
As mentioned in https://github.com/wp-cli/core-command/pull/22, adds `Utils\trailingslashit()` from WP core.

Uses it, in particular in `Utils\get_temp_dir()` (its version was wrong) and also couldn't resist simplifying that function so that it saves the slashed version to the static, saving vital microcycles.