### PR TITLE
Adapt --ssh flag to work with Docker and Docker Compose.

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -275,6 +275,13 @@ Feature: Global flags
       Running SSH command: ssh -q '' -T 'WP_CLI_STRICT_ARGS_MODE=1 wp
       """
 
+  Scenario: SSH flag should support changing directories
+    When I try `wp --debug --ssh=wordpress:/my/path --version`
+    Then STDERR should contain:
+      """
+      Running SSH command: ssh -q 'wordpress' -T 'cd '\''/my/path'\''; wp
+      """
+
   Scenario: SSH flag should support Docker
     When I try `wp --debug --ssh=docker:user@wordpress --version`
     Then STDERR should contain:

--- a/features/flags.feature
+++ b/features/flags.feature
@@ -272,5 +272,12 @@ Feature: Global flags
     When I try `WP_CLI_STRICT_ARGS_MODE=1 wp --debug --ssh=/ --version`
     Then STDERR should contain:
       """
-      Running SSH command: ssh -q  -T WP_CLI_STRICT_ARGS_MODE=1 wp
+      Running SSH command: ssh -q '' -T 'WP_CLI_STRICT_ARGS_MODE=1 wp
+      """
+
+  Scenario: SSH flag should support Docker
+    When I try `wp --debug --ssh=docker:user@wordpress --version`
+    Then STDERR should contain:
+      """
+      Running SSH command: docker exec --user 'user' 'wordpress' sh -c
       """

--- a/features/help.feature
+++ b/features/help.feature
@@ -426,7 +426,7 @@ Feature: Get help about WP-CLI commands
       """
     And STDERR should be empty
 
-    When I run `TERM=vt100 COLUMNS=40 wp help test-wordwrap my_command | wc -L`
+    When I run `TERM=vt100 COLUMNS=40 wp help test-wordwrap my_command | sed '/\-\-ssh/d' | wc -L`
     Then STDOUT should be:
       """
       40

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -331,23 +331,15 @@ class Runner {
 	}
 
 	/**
-	 * Perform a command against a remote server over SSH
+	 * Perform a command against a remote server over SSH (or a container using
+	 * scheme of "docker" or "docker-compose").
+	 *
+	 * @param string $connection_string Passed connection string.
+	 * @return void
 	 */
-	private function run_ssh_command( $ssh ) {
+	private function run_ssh_command( $connection_string ) {
 
 		WP_CLI::do_hook( 'before_ssh' );
-
-		// host OR host/path/to/wordpress OR host:port/path/to/wordpress
-		$bits = Utils\parse_ssh_url( $ssh );
-		$host = isset( $bits['host'] ) ? $bits['host'] : null;
-		$port = isset( $bits['port'] ) ? $bits['port'] : null;
-		$path = isset( $bits['path'] ) ? $bits['path'] : null;
-
-		WP_CLI::debug( 'SSH host: ' . $host, 'bootstrap' );
-		WP_CLI::debug( 'SSH port: ' . $port, 'bootstrap' );
-		WP_CLI::debug( 'SSH path: ' . $path, 'bootstrap' );
-
-		$is_tty = function_exists( 'posix_isatty' ) && posix_isatty( STDOUT );
 
 		$pre_cmd = getenv( 'WP_CLI_SSH_PRE_CMD' );
 		if ( $pre_cmd ) {
@@ -386,23 +378,8 @@ class Runner {
 			}
 		}
 
-		$unescaped_command = sprintf(
-			'ssh -q %s%s %s %s',
-			$port ? '-p ' . (int) $port . ' ' : '',
-			$host,
-			$is_tty ? '-t' : '-T',
-			$pre_cmd . $env_vars . $wp_binary . ' ' . implode( ' ', array_map( 'escapeshellarg', $wp_args ) )
-		);
-
-		WP_CLI::debug( 'Running SSH command: ' . $unescaped_command, 'bootstrap' );
-
-		$escaped_command = sprintf(
-			'ssh -q %s%s %s %s',
-			$port ? '-p ' . (int) $port . ' ' : '',
-			escapeshellarg( $host ),
-			$is_tty ? '-t' : '-T',
-			escapeshellarg( $pre_cmd . $wp_binary . ' ' . implode( ' ', array_map( 'escapeshellarg', $wp_args ) ) )
-		);
+		$wp_command = $pre_cmd . $env_vars . $wp_binary . ' ' . implode( ' ', array_map( 'escapeshellarg', $wp_args ) );
+		$escaped_command = $this->generate_ssh_command( $connection_string, $wp_command );
 
 		passthru( $escaped_command, $exit_code );
 		if ( 255 === $exit_code ) {
@@ -410,6 +387,74 @@ class Runner {
 		} else {
 			exit( $exit_code );
 		}
+	}
+
+	/**
+	 * Generate a shell command from the passed connection string.
+	 *
+	 * @param string $connection_string Passed connection string.
+	 * @param string $wp_command        WP-CLI command to run.
+	 * @return string
+	 */
+	private function generate_ssh_command( $connection_string, $wp_command ) {
+		$bits = Utils\parse_ssh_url( $connection_string );
+		$escaped_command = '';
+
+		// Set default values.
+		foreach ( array( 'scheme', 'user', 'host', 'port', 'path' ) as $bit ) {
+			if ( ! isset( $bits[ $bit ] ) ) {
+				$bits[ $bit ] = null;
+			}
+
+			WP_CLI::debug( 'SSH ' . $bit . ': ' . $bits[ $bit ], 'bootstrap' );
+		}
+
+		$is_tty = function_exists( 'posix_isatty' ) && posix_isatty( STDOUT );
+
+		if ( 'docker' === $bits['scheme'] ) {
+			$command = 'docker exec %s%s%s sh -c %s';
+
+			$escaped_command = sprintf(
+				$command,
+				$bits['user'] ? '--user ' . escapeshellarg( $bits['user'] ) . ' ' : '',
+				$is_tty ? '-t ' : '',
+				escapeshellarg( $bits['host'] ),
+				escapeshellarg( $wp_command )
+			);
+		}
+
+		if ( 'docker-compose' === $bits['scheme'] ) {
+			$command = 'docker-compose exec %s%s%s sh -c %s';
+
+			$escaped_command = sprintf(
+				$command,
+				$bits['user'] ? '--user ' . escapeshellarg( $bits['user'] ) . ' ' : '',
+				$is_tty ? '' : '-T ',
+				escapeshellarg( $bits['host'] ),
+				escapeshellarg( $wp_command )
+			);
+		}
+
+		// Default scheme is SSH.
+		if ( 'ssh' === $bits['scheme'] || null === $bits['scheme'] ) {
+			$command = 'ssh -q %s%s %s %s';
+
+			if ( $bits['user'] ) {
+				$bits['host'] = $bits['user'] . '@' . $bits['host'];
+			}
+
+			$escaped_command = sprintf(
+				$command,
+				$bits['port'] ? '-p ' . (int) $bits['port'] . ' ' : '',
+				escapeshellarg( $bits['host'] ),
+				$is_tty ? '-t' : '-T',
+				escapeshellarg( $wp_command )
+			);
+		}
+
+		WP_CLI::debug( 'Running SSH command: ' . $escaped_command, 'bootstrap' );
+
+		return $escaped_command;
 	}
 
 	/**

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -486,7 +486,7 @@ class CLI_Command extends WP_CLI_Command {
 	 *
 	 *     # Dump the list of installed commands.
 	 *     $ wp cli cmd-dump
-	 *     {"name":"wp","description":"Manage WordPress through the command-line.","longdesc":"\n\n## GLOBAL PARAMETERS\n\n  --path=<path>\n      Path to the WordPress files.\n\n  --ssh=<ssh>\n      Perform operation against a remote server over SSH.\n\n  --url=<url>\n      Pretend request came from given URL. In multisite, this argument is how the target site is specified. \n\n  --user=<id|login|email>\n
+	 *     {"name":"wp","description":"Manage WordPress through the command-line.","longdesc":"\n\n## GLOBAL PARAMETERS\n\n  --path=<path>\n      Path to the WordPress files.\n\n  --ssh=<ssh>\n      Perform operation against a remote server over SSH (or a container using scheme of "docker" or "docker-compose").\n\n  --url=<url>\n      Pretend request came from given URL. In multisite, this argument is how the target site is specified. \n\n  --user=<id|login|email>\n
 	 *
 	 * @subcommand cmd-dump
 	 */

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -8,9 +8,9 @@ return array(
 	),
 
 	'ssh' => array(
-		'runtime' => '=[<user>@]<host>[:<port>][<path>]',
-		'file' => '[<user>@]<host>[:<port>][<path>]',
-		'desc' => 'Perform operation against a remote server over SSH.',
+		'runtime' => '=[<scheme>:][<user>@]<host|container>[:<port>][<path>]',
+		'file' => '[<scheme>:][<user>@]<host|container>[:<port>][<path>]',
+		'desc' => 'Perform operation against a remote server over SSH (or a container using scheme of "docker" or "docker-compose").',
 	),
 
 	'http' => array(

--- a/php/utils.php
+++ b/php/utils.php
@@ -770,18 +770,24 @@ function get_temp_dir() {
  * @return mixed
  */
 function parse_ssh_url( $url, $component = -1 ) {
-	preg_match( '#^([^:/~]+)(:([\d]*))?((/|~)(.+))?$#', $url, $matches );
+	preg_match( '#^((docker|docker\-compose|ssh):)?(([^@:]+)@)?([^:/~]+)(:([\d]*))?((/|~)(.+))?$#', $url, $matches );
 	$bits = array();
 	foreach( array(
-		1 => 'host',
-		3 => 'port',
-		4 => 'path',
+		2 => 'scheme',
+		4 => 'user',
+		5 => 'host',
+		7 => 'port',
+		8 => 'path',
 	) as $i => $key ) {
 		if ( ! empty( $matches[ $i ] ) ) {
 			$bits[ $key ] = $matches[ $i ];
 		}
 	}
 	switch ( $component ) {
+		case PHP_URL_SCHEME:
+			return isset( $bits['scheme'] ) ? $bits['scheme'] : null;
+		case PHP_URL_USER:
+			return isset( $bits['user'] ) ? $bits['user'] : null;
 		case PHP_URL_HOST:
 			return isset( $bits['host'] ) ? $bits['host'] : null;
 		case PHP_URL_PATH:

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -60,6 +60,8 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( array(
 			'host' => 'foo',
 		), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
 		$this->assertEquals( 'foo', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
@@ -68,6 +70,8 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( array(
 			'host' => 'foo.com',
 		), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
 		$this->assertEquals( 'foo.com', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
@@ -77,6 +81,8 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			'host' => 'foo.com',
 			'port' => 2222,
 		), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
 		$this->assertEquals( 'foo.com', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
 		$this->assertEquals( 2222, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
@@ -87,6 +93,8 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			'port' => 2222,
 			'path' => '/path/to/dir',
 		), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
 		$this->assertEquals( 'foo.com', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
 		$this->assertEquals( 2222, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( '/path/to/dir', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
@@ -96,6 +104,8 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			'host' => 'foo.com',
 			'path' => '~/path/to/dir',
 		), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
 		$this->assertEquals( 'foo.com', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( '~/path/to/dir', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
@@ -103,6 +113,8 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		// No host
 		$testcase = '~/path/to/dir';
 		$this->assertEquals( array(), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
@@ -113,6 +125,8 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			'host' => 'foo.com',
 			'path' => '~/path/to/dir',
 		), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
 		$this->assertEquals( 'foo.com', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( '~/path/to/dir', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
@@ -123,9 +137,73 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			'path' => '~/path/to/dir',
 			'port' => '2222'
 		), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
 		$this->assertEquals( 'foo.com', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
 		$this->assertEquals( '2222', Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( '~/path/to/dir', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
+
+		// explicit scheme, user, host, path, no port
+		$testcase = 'ssh:bar@foo.com:~/path/to/dir';
+		$this->assertEquals( array(
+			'scheme' => 'ssh',
+			'user' => 'bar',
+			'host' => 'foo.com',
+			'path' => '~/path/to/dir',
+		), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( 'ssh', Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( 'bar', Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
+		$this->assertEquals( 'foo.com', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
+		$this->assertEquals( '~/path/to/dir', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
+
+		// container scheme
+		$testcase = 'docker:wordpress';
+		$this->assertEquals( array(
+			'scheme' => 'docker',
+			'host' => 'wordpress',
+		), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( 'docker', Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
+		$this->assertEquals( 'wordpress', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
+
+		// container scheme with user, and host
+		$testcase = 'docker:bar@wordpress';
+		$this->assertEquals( array(
+			'scheme' => 'docker',
+			'user' => 'bar',
+			'host' => 'wordpress',
+		), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( 'docker', Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( 'bar', Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
+		$this->assertEquals( 'wordpress', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
+
+		// container scheme with user, host, and path
+		$testcase = 'docker-compose:bar@wordpress:~/path/to/dir';
+		$this->assertEquals( array(
+			'scheme' => 'docker-compose',
+			'user' => 'bar',
+			'host' => 'wordpress',
+			'path' => '~/path/to/dir',
+		), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( 'docker-compose', Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( 'bar', Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
+		$this->assertEquals( 'wordpress', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
+		$this->assertEquals( '~/path/to/dir', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
+
+		// unsupported scheme, should not match
+		$testcase = 'foo:bar';
+		$this->assertEquals( array(), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 	}
 
 	public function testParseStrToArgv() {


### PR DESCRIPTION
- Introduce a new `<scheme>:` prefix to the connection string provided to `--ssh`. Current accepted values are `docker:`, `docker-compose:`, and `ssh:`. This prefix can be omitted and a default of `ssh:` will be assumed.

- Additionally make the `<user>@` option an explicit value separate from `<host>` so that it can be passed via CLI flag to Docker processes.

- Refactor the `Runner#run_ssh_command` method to respond to different schemes.

- Update existing functional test to accept escaped output. (Debug output of the unescaped command was removed during refactor to simplify the implementation.)

- Add unit tests for updated `parse_ssh_url`.

- Add functional test for `docker:` prefix.

- Remove `--ssh` global flag from 40-column wrap test. The help text for the `--ssh` flag is now an unwrappable 61 characters long, leads to a failed functional test in `help.feature`. Strip out the `--ssh` global flag before passing to `wc -L`. Not sure what the best solution is here; this seemed like the most straightforward to me.