### PR TITLE
Address new sniffs in WPCS 0.12.0

### DIFF
--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -286,7 +286,7 @@ class CompositeCommand {
 
 			$binding['parameters'][] = array(
 				'synopsis' => $synopsis,
-				'desc' => $details['desc']
+				'desc' => $details['desc'],
 			);
 		}
 

--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -47,7 +47,7 @@ class Extractor {
 			$tempdir = implode( DIRECTORY_SEPARATOR, Array (
 				dirname( $zipfile ),
 				Utils\basename( $zipfile, '.zip' ),
-				$zip->getNameIndex( 0 )
+				$zip->getNameIndex( 0 ),
 			) );
 
 			$zip->extractTo( dirname( $tempdir ) );
@@ -76,7 +76,7 @@ class Extractor {
 		$tempdir = implode( DIRECTORY_SEPARATOR, Array (
 			dirname( $tarball ),
 			Utils\basename( $tarball, '.tar.gz' ),
-			$phar->getFileName()
+			$phar->getFileName(),
 		) );
 
 		$phar->extractTo( dirname( $tempdir ), null, true );

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -28,7 +28,7 @@ class Formatter {
 		$format_args = array(
 			'format' => 'table',
 			'fields' => $fields,
-			'field' => null
+			'field' => null,
 		);
 
 		foreach ( array( 'format', 'fields', 'field' ) as $key ) {
@@ -309,7 +309,7 @@ class Formatter {
 
 			$rows[] = (object) array(
 				'Field' => $field,
-				'Value' => $value
+				'Value' => $value,
 			);
 		}
 

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -117,48 +117,48 @@ class Formatter {
 		$fields = $this->args['fields'];
 
 		switch ( $this->args['format'] ) {
-		case 'count':
-			if ( !is_array( $items ) ) {
-				$items = iterator_to_array( $items );
-			}
-			echo count( $items );
-			break;
-
-		case 'ids':
-			if ( !is_array( $items ) ) {
-				$items = iterator_to_array( $items );
-			}
-			echo implode( ' ', $items );
-			break;
-
-		case 'table':
-			self::show_table( $items, $fields );
-			break;
-
-		case 'csv':
-			\WP_CLI\Utils\write_csv( STDOUT, $items, $fields );
-			break;
-
-		case 'json':
-		case 'yaml':
-			$out = array();
-			foreach ( $items as $item ) {
-				$out[] = \WP_CLI\Utils\pick_fields( $item, $fields );
-			}
-
-			if ( 'json' === $this->args['format'] ) {
-				if (defined('JSON_PARTIAL_OUTPUT_ON_ERROR')) {
-					echo json_encode( $out, JSON_PARTIAL_OUTPUT_ON_ERROR );
-				} else {
-					echo json_encode( $out );
+			case 'count':
+				if ( !is_array( $items ) ) {
+					$items = iterator_to_array( $items );
 				}
-			} else if ( 'yaml' === $this->args['format'] ) {
-				echo Spyc::YAMLDump( $out, 2, 0 );
-			}
-			break;
+				echo count( $items );
+				break;
 
-		default:
-			\WP_CLI::error( 'Invalid format: ' . $this->args['format'] );
+			case 'ids':
+				if ( !is_array( $items ) ) {
+					$items = iterator_to_array( $items );
+				}
+				echo implode( ' ', $items );
+				break;
+
+			case 'table':
+				self::show_table( $items, $fields );
+				break;
+
+			case 'csv':
+				\WP_CLI\Utils\write_csv( STDOUT, $items, $fields );
+				break;
+
+			case 'json':
+			case 'yaml':
+				$out = array();
+				foreach ( $items as $item ) {
+					$out[] = \WP_CLI\Utils\pick_fields( $item, $fields );
+				}
+
+				if ( 'json' === $this->args['format'] ) {
+					if (defined('JSON_PARTIAL_OUTPUT_ON_ERROR')) {
+						echo json_encode( $out, JSON_PARTIAL_OUTPUT_ON_ERROR );
+					} else {
+						echo json_encode( $out );
+					}
+				} else if ( 'yaml' === $this->args['format'] ) {
+					echo Spyc::YAMLDump( $out, 2, 0 );
+				}
+				break;
+
+			default:
+				\WP_CLI::error( 'Invalid format: ' . $this->args['format'] );
 		}
 	}
 
@@ -239,25 +239,25 @@ class Formatter {
 
 		switch ( $format ) {
 
-		case 'table':
-		case 'csv':
-			$rows = $this->assoc_array_to_rows( $data );
-			$fields = array( 'Field', 'Value' );
-			if ( 'table' == $format ) {
-				self::show_table( $rows, $fields );
-			} else if ( 'csv' == $format ) {
-				\WP_CLI\Utils\write_csv( STDOUT, $rows, $fields );
-			}
-			break;
+			case 'table':
+			case 'csv':
+				$rows = $this->assoc_array_to_rows( $data );
+				$fields = array( 'Field', 'Value' );
+				if ( 'table' == $format ) {
+					self::show_table( $rows, $fields );
+				} else if ( 'csv' == $format ) {
+					\WP_CLI\Utils\write_csv( STDOUT, $rows, $fields );
+				}
+				break;
 
-		case 'yaml':
-		case 'json':
-			\WP_CLI::print_value( $data, array( 'format' => $format ) );
-			break;
+			case 'yaml':
+			case 'json':
+				\WP_CLI::print_value( $data, array( 'format' => $format ) );
+				break;
 
-		default:
-			\WP_CLI::error( "Invalid format: " . $format );
-			break;
+			default:
+				\WP_CLI::error( "Invalid format: " . $format );
+				break;
 
 		}
 

--- a/php/WP_CLI/Iterators/Table.php
+++ b/php/WP_CLI/Iterators/Table.php
@@ -30,12 +30,12 @@ class Table extends Query {
 	 *
 	 *
 	 * @param array $args Supported arguments:
-	 *		table – the name of the database table
-	 *		fields – an array of columns to get from the table, '*' is a valid value and the default
-	 *		where – conditions for filtering rows. Supports two formats:
-	 *			= string – this will be the where clause
-	 *			= array – each element is treated as a condition if it's positional, or as column => value if
-	 *				it's a key/value pair. In the latter case the value is automatically quoted and escaped
+	 *      table – the name of the database table
+	 *      fields – an array of columns to get from the table, '*' is a valid value and the default
+	 *      where – conditions for filtering rows. Supports two formats:
+	 *              = string – this will be the where clause
+	 *              = array – each element is treated as a condition if it's positional, or as column => value if
+	 *                it's a key/value pair. In the latter case the value is automatically quoted and escaped
 	 *      append - add arbitrary extra SQL
 	 */
 	function __construct( $args = array() ) {

--- a/php/WP_CLI/Iterators/Table.php
+++ b/php/WP_CLI/Iterators/Table.php
@@ -44,7 +44,7 @@ class Table extends Query {
 			'where' => array(),
 			'append' => '',
 			'table' => null,
-			'chunk_size' => 500
+			'chunk_size' => 500,
 		);
 		$table = $args['table'];
 		$args = array_merge( $defaults, $args );

--- a/php/WP_CLI/PackageManagerEventSubscriber.php
+++ b/php/WP_CLI/PackageManagerEventSubscriber.php
@@ -34,7 +34,7 @@ class PackageManagerEventSubscriber implements EventSubscriberInterface {
 
 			switch ( $reason->getReason() ) {
 
-				case Rule::RULE_PACKAGE_CONFLICT;
+				case Rule::RULE_PACKAGE_CONFLICT:
 				case Rule::RULE_PACKAGE_SAME_NAME:
 				case Rule::RULE_PACKAGE_REQUIRES:
 					$composer_error = $reason->getPrettyString( $event->getPool() );

--- a/php/WP_CLI/PackageManagerEventSubscriber.php
+++ b/php/WP_CLI/PackageManagerEventSubscriber.php
@@ -18,7 +18,7 @@ class PackageManagerEventSubscriber implements EventSubscriberInterface {
 		return array(
 			PackageEvents::PRE_PACKAGE_INSTALL => 'pre_install',
 			PackageEvents::POST_PACKAGE_INSTALL => 'post_install',
-			);
+		);
 	}
 
 	public static function pre_install( PackageEvent $event ) {

--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -68,7 +68,7 @@ class Process {
 			'return_code' => proc_close( $proc ),
 			'command' => $this->command,
 			'cwd' => $cwd,
-			'env' => $this->env
+			'env' => $this->env,
 		) );
 	}
 

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -99,7 +99,7 @@ class Runner {
 	public function get_project_config_path() {
 		$config_files = array(
 			'wp-cli.local.yml',
-			'wp-cli.yml'
+			'wp-cli.yml',
 		);
 
 		// Stop looking upward when we find we have emerged from a subdirectory
@@ -464,7 +464,7 @@ class Runner {
 	private static function back_compat_conversions( $args, $assoc_args ) {
 		$top_level_aliases = array(
 			'sql' => 'db',
-			'blog' => 'site'
+			'blog' => 'site',
 		);
 		if ( count( $args ) > 0 ) {
 			foreach ( $top_level_aliases as $old => $new ) {

--- a/php/WP_CLI/SynopsisValidator.php
+++ b/php/WP_CLI/SynopsisValidator.php
@@ -82,7 +82,7 @@ class SynopsisValidator {
 
 		$errors = array(
 			'fatal' => array(),
-			'warning' => array()
+			'warning' => array(),
 		);
 
 		$to_unset = array();

--- a/php/WP_CLI/WpHttpCacheManager.php
+++ b/php/WP_CLI/WpHttpCacheManager.php
@@ -53,7 +53,7 @@ class WpHttpCacheManager {
 				// simulate successful download response
 				return array(
 					'response' => array('code' => ( 200 ), 'message' => 'OK'),
-					'filename' => $args['filename']
+					'filename' => $args['filename'],
 				);
 			} else {
 				WP_CLI::error( sprintf( 'Error copying cached file %s to %s', $filename, $url ) );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -682,8 +682,8 @@ class WP_CLI {
 	 * $status = $this->get_status( $plugin->file );
 	 * // Network-active is the highest level of activation status
 	 * if ( 'active-network' === $status ) {
-	 * 	WP_CLI::warning( "Plugin '{$plugin->name}' is already network active." );
-	 * 	continue;
+	 *   WP_CLI::warning( "Plugin '{$plugin->name}' is already network active." );
+	 *   continue;
 	 * }
 	 * ```
 	 *

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -136,7 +136,7 @@ class Help_Command extends WP_CLI_Command {
 		$descriptorspec = array(
 			0 => $fd,
 			1 => STDOUT,
-			2 => STDERR
+			2 => STDERR,
 		);
 
 		return proc_close( proc_open( $pager, $descriptorspec, $pipes ) );

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -364,7 +364,7 @@ class CLI_Command extends WP_CLI_Command {
 			'major'      => false,
 			'minor'      => false,
 			'patch'      => false,
-			);
+		);
 		foreach ( $release_data as $release ) {
 
 			// Get rid of leading "v" if there is one set.

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -288,7 +288,7 @@ class CLI_Command extends WP_CLI_Command {
 		$headers = array();
 		$options = array(
 			'timeout' => 600,  // 10 minutes ought to be enough for everybody.
-			'filename' => $temp
+			'filename' => $temp,
 		);
 
 		Utils\http_request( 'GET', $download_url, null, $headers, $options );
@@ -346,11 +346,11 @@ class CLI_Command extends WP_CLI_Command {
 		$url = 'https://api.github.com/repos/wp-cli/wp-cli/releases?per_page=100';
 
 		$options = array(
-			'timeout' => 30
+			'timeout' => 30,
 		);
 
 		$headers = array(
-			'Accept' => 'application/json'
+			'Accept' => 'application/json',
 		);
 		$response = Utils\http_request( 'GET', $url, null, $headers, $options );
 
@@ -385,7 +385,7 @@ class CLI_Command extends WP_CLI_Command {
 			$updates[ $update_type ] = array(
 				'version' => $release_version,
 				'update_type' => $update_type,
-				'package_url' => $release->assets[0]->browser_download_url
+				'package_url' => $release->assets[0]->browser_download_url,
 			);
 		}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -606,20 +606,20 @@ function increment_version( $current_version, $new_version ) {
 	switch ( $new_version ) {
 		case 'same':
 			// do nothing
-		break;
+			break;
 
 		case 'patch':
 			$current_version[0][2]++;
 
 			$current_version = array( $current_version[0] ); // drop possible pre-release info
-		break;
+			break;
 
 		case 'minor':
 			$current_version[0][1]++;
 			$current_version[0][2] = 0;
 
 			$current_version = array( $current_version[0] ); // drop possible pre-release info
-		break;
+			break;
 
 		case 'major':
 			$current_version[0][0]++;
@@ -627,11 +627,11 @@ function increment_version( $current_version, $new_version ) {
 			$current_version[0][2] = 0;
 
 			$current_version = array( $current_version[0] ); // drop possible pre-release info
-		break;
+			break;
 
 		default: // not a keyword
 			$current_version = array( array( $new_version ) );
-		break;
+			break;
 	}
 
 	// reconstruct version string

--- a/php/utils.php
+++ b/php/utils.php
@@ -453,7 +453,7 @@ function mustache_render( $template_name, $data = array() ) {
 	$template = file_get_contents( $template_name );
 
 	$m = new \Mustache_Engine( array(
-		'escape' => function ( $val ) { return $val; }
+		'escape' => function ( $val ) { return $val; },
 	) );
 
 	return $m->render( $template, $data );
@@ -522,7 +522,7 @@ function is_windows() {
 function replace_path_consts( $source, $path ) {
 	$replacements = array(
 		'__FILE__' => "'$path'",
-		'__DIR__'  => "'" . dirname( $path ) . "'"
+		'__DIR__'  => "'" . dirname( $path ) . "'",
 	);
 
 	$old = array_keys( $replacements );

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -278,13 +278,13 @@ if ( is_multisite() ) {
 do_action( 'muplugins_loaded' );
 
 if ( is_multisite() )
-	ms_cookie_constants(  );
+	ms_cookie_constants();
 
 // Define constants after multisite is loaded. Cookie-related constants may be overridden in ms_network_cookies().
-wp_cookie_constants( );
+wp_cookie_constants();
 
 // Define and enforce our SSL constants
-wp_ssl_constants( );
+wp_ssl_constants();
 
 // Create common globals.
 require( ABSPATH . WPINC . '/vars.php' );
@@ -319,7 +319,7 @@ if ( WP_CACHE && function_exists( 'wp_cache_postload' ) )
 do_action( 'plugins_loaded' );
 
 // Define constants which affect functionality if not already defined.
-wp_functionality_constants( );
+wp_functionality_constants();
 
 // Add magic quotes and set up $_REQUEST ( $_GET + $_POST )
 wp_magic_quotes();
@@ -372,7 +372,7 @@ $GLOBALS['wp_roles'] = new WP_Roles();
 do_action( 'setup_theme' );
 
 // Define the template related constants.
-wp_templating_constants(  );
+wp_templating_constants();
 
 // Load the default text localization domain.
 load_default_textdomain();

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -58,6 +58,7 @@
 		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceBeforeCloseParenthesis" />
 		<exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter" />
 		<exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore" />
+		<exclude name="WordPress.WP.CapitalPDangit" />
 	</rule>
 
 	<exclude-pattern>*/ci/*</exclude-pattern>


### PR DESCRIPTION
Some new sniffs that shipped in WPCS `0.12.0` raise errors on existing code. This PR updates code so that it will pass checks with PHPCS 0.12.0.

It adds one new sniff to the ignore list in `phpcs.ruleset.xml`: `WordPress.WP.CapitalPDangit`. Otherwise, the following line would raise an error, which seems like a spurious objection:

https://github.com/wp-cli/wp-cli/blob/master/php/utils-wp.php#L299