### PR TITLE
`wp help` should be fired before wp load

### DIFF
--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -20,6 +20,8 @@ class Help_Command extends WP_CLI_Command {
 	 *
 	 *     # get help for `core download` subcommand
 	 *     wp help core download
+	 *
+	 * @when before_wp_load
 	 */
 	function __invoke( $args, $assoc_args ) {
 		$command = self::find_subcommand( $args );
@@ -199,4 +201,3 @@ class Help_Command extends WP_CLI_Command {
 }
 
 WP_CLI::add_command( 'help', 'Help_Command' );
-


### PR DESCRIPTION
`wp help` always try to connect to WordPress.

```
$ ~/wp-cli/wp-cli/bin/wp help core download
PHP Warning:  mysqli_real_connect(): (HY000/2002): Operation timed out in /Users/miyauchi/www/nightly.dev/wordpress/wp-includes/wp-db.php on line 1536
```