### PR TITLE
Incorrect table column width calculcations with colorized strings.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,13 @@
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,
+	"repositories": [
+		{
+			"type": "git",
+			"url": "https://github.com/gitlost/php-cli-tools.git"
+		}
+
+	],
 	"require": {
 		"php": ">=5.3.29",
 		"composer/composer": "^1.2.0",
@@ -52,7 +59,7 @@
 		"wp-cli/media-command": "^1.0",
 		"wp-cli/mustangostang-spyc": "^0.6.3",
 		"wp-cli/package-command": "^1.0",
-		"wp-cli/php-cli-tools": "~0.11.2",
+		"wp-cli/php-cli-tools": "dev-issue_106",
 		"wp-cli/rewrite-command": "^1.0",
 		"wp-cli/role-command": "^1.0",
 		"wp-cli/scaffold-command": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,6 @@
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,
-	"repositories": [
-		{
-			"type": "git",
-			"url": "https://github.com/gitlost/php-cli-tools.git"
-		}
-
-	],
 	"require": {
 		"php": ">=5.3.29",
 		"composer/composer": "^1.2.0",
@@ -59,7 +52,7 @@
 		"wp-cli/media-command": "^1.0",
 		"wp-cli/mustangostang-spyc": "^0.6.3",
 		"wp-cli/package-command": "^1.0",
-		"wp-cli/php-cli-tools": "dev-issue_106",
+		"wp-cli/php-cli-tools": "~0.11.2",
 		"wp-cli/rewrite-command": "^1.0",
 		"wp-cli/role-command": "^1.0",
 		"wp-cli/scaffold-command": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd48468393e7ce36d00ed48300479088",
+    "content-hash": "dc335c223a588b1adfc44adc08e608f3",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2219,17 +2219,11 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.3",
+            "version": "dev-issue_106",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "09075e5a5ba804df43e148f887cbf4466bebfa2c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/09075e5a5ba804df43e148f887cbf4466bebfa2c",
-                "reference": "09075e5a5ba804df43e148f887cbf4466bebfa2c",
-                "shasum": ""
+                "url": "https://github.com/gitlost/php-cli-tools.git",
+                "reference": "7466f68a76603d9a1734616aa30fc883724d58cc"
             },
             "require": {
                 "php": ">= 5.3.0"
@@ -2243,20 +2237,19 @@
                     "lib/cli/cli.php"
                 ]
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "authors": [
                 {
-                    "name": "James Logsdon",
-                    "email": "jlogsdon@php.net",
-                    "role": "Developer"
-                },
-                {
                     "name": "Daniel Bachhuber",
                     "email": "daniel@handbuilt.co",
                     "role": "Maintainer"
+                },
+                {
+                    "name": "James Logsdon",
+                    "email": "jlogsdon@php.net",
+                    "role": "Developer"
                 }
             ],
             "description": "Console utilities for PHP",
@@ -2265,7 +2258,7 @@
                 "cli",
                 "console"
             ],
-            "time": "2017-06-08T12:06:09+00:00"
+            "time": "2017-07-25 09:10:02"
         },
         {
             "name": "wp-cli/rewrite-command",
@@ -3344,6 +3337,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "wp-cli/php-cli-tools": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc335c223a588b1adfc44adc08e608f3",
+    "content-hash": "cd48468393e7ce36d00ed48300479088",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2219,11 +2219,17 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "dev-issue_106",
+            "version": "v0.11.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/gitlost/php-cli-tools.git",
-                "reference": "7466f68a76603d9a1734616aa30fc883724d58cc"
+                "url": "https://github.com/wp-cli/php-cli-tools.git",
+                "reference": "2d2b582d79c935f790c4e49e74906859025ffeb3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/2d2b582d79c935f790c4e49e74906859025ffeb3",
+                "reference": "2d2b582d79c935f790c4e49e74906859025ffeb3",
+                "shasum": ""
             },
             "require": {
                 "php": ">= 5.3.0"
@@ -2237,19 +2243,20 @@
                     "lib/cli/cli.php"
                 ]
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "authors": [
                 {
-                    "name": "Daniel Bachhuber",
-                    "email": "daniel@handbuilt.co",
-                    "role": "Maintainer"
-                },
-                {
                     "name": "James Logsdon",
                     "email": "jlogsdon@php.net",
                     "role": "Developer"
+                },
+                {
+                    "name": "Daniel Bachhuber",
+                    "email": "daniel@handbuilt.co",
+                    "role": "Maintainer"
                 }
             ],
             "description": "Console utilities for PHP",
@@ -2258,7 +2265,7 @@
                 "cli",
                 "console"
             ],
-            "time": "2017-07-25 09:10:02"
+            "time": "2017-07-25T21:46:43+00:00"
         },
         {
             "name": "wp-cli/rewrite-command",
@@ -3337,7 +3344,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "wp-cli/php-cli-tools": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,

--- a/features/formatter.feature
+++ b/features/formatter.feature
@@ -115,41 +115,41 @@ Feature: Format output
     Given an empty directory
     And a file.php file:
       """
-	  <?php
-	  use cli\Colors;
-	  /**
-	   * Fake command.
-	   *
-	   * ## OPTIONS
-	   *
-	   * [--format=<format>]
-	   * : Render output in a particular format.
-	   * ---
-	   * default: table
-	   * options:
-	   *   - table
-	   * ---
+      <?php
+      use cli\Colors;
+      /**
+       * Fake command.
+       *
+       * ## OPTIONS
+       *
+       * [--format=<format>]
+       * : Render output in a particular format.
+       * ---
+       * default: table
+       * options:
+       *   - table
+       * ---
        *
        * @when before_wp_load
-	   */
-	  $fake_command = function( $args, $assoc_args ) {
-		  Colors::enable( true );
-		  $items = array(
-			  array( 'package' => Colors::colorize( '%ygaa/gaa-kabes%n' ), 'version' => 'dev-master', 'result' => Colors::colorize( "%r\xf0\x9f\x9b\x87%n" ) ),
-			  array( 'package' => Colors::colorize( '%ygaa/gaa-log%n' ), 'version' => '*', 'result' => Colors::colorize( "%g\xe2\x9c\x94%n" ) ),
-			  array( 'package' => Colors::colorize( '%ygaa/gaa-nonsense%n' ), 'version' => 'v3.0.11', 'result' => Colors::colorize( "%r\xf0\x9f\x9b\x87%n" ) ),
-			  array( 'package' => Colors::colorize( '%ygaa/gaa-100%%new%n' ), 'version' => 'v100%new', 'result' => Colors::colorize( "%g\xe2\x9c\x94%n" ) ),
-		  );
-		  $formatter = new \WP_CLI\Formatter( $assoc_args, array( 'package', 'version', 'result' ) );
-		  $formatter->display_items( $items, array( true, false, true ) );
-	  };
-	  WP_CLI::add_command( 'fake', $fake_command );
+       */
+      $fake_command = function( $args, $assoc_args ) {
+          Colors::enable( true );
+          $items = array(
+              array( 'package' => Colors::colorize( '%ygaa/gaa-kabes%n' ), 'version' => 'dev-master', 'result' => Colors::colorize( "%r\xf0\x9f\x9b\x87%n" ) ),
+              array( 'package' => Colors::colorize( '%ygaa/gaa-log%n' ), 'version' => '*', 'result' => Colors::colorize( "%g\xe2\x9c\x94%n" ) ),
+              array( 'package' => Colors::colorize( '%ygaa/gaa-nonsense%n' ), 'version' => 'v3.0.11', 'result' => Colors::colorize( "%r\xf0\x9f\x9b\x87%n" ) ),
+              array( 'package' => Colors::colorize( '%ygaa/gaa-100%%new%n' ), 'version' => 'v100%new', 'result' => Colors::colorize( "%g\xe2\x9c\x94%n" ) ),
+          );
+          $formatter = new \WP_CLI\Formatter( $assoc_args, array( 'package', 'version', 'result' ) );
+          $formatter->display_items( $items, array( true, false, true ) );
+      };
+      WP_CLI::add_command( 'fake', $fake_command );
       """
 
     When I run `wp --require=file.php fake`
     Then STDOUT should be a table containing rows:
       | package          | version    | result |
-	  | [33mgaa/gaa-kabes[0m    | dev-master | [31m🛇[0m      |
-	  | [33mgaa/gaa-log[0m      | *          | [32m✔[0m      |
-	  | [33mgaa/gaa-nonsense[0m | v3.0.11    | [31m🛇[0m      |
-	  | [33mgaa/gaa-100%new[0m  | v100%new   | [32m✔[0m      |
+      | [33mgaa/gaa-kabes[0m    | dev-master | [31m🛇[0m      |
+      | [33mgaa/gaa-log[0m      | *          | [32m✔[0m      |
+      | [33mgaa/gaa-nonsense[0m | v3.0.11    | [31m🛇[0m      |
+      | [33mgaa/gaa-100%new[0m  | v100%new   | [32m✔[0m      |

--- a/features/formatter.feature
+++ b/features/formatter.feature
@@ -110,3 +110,46 @@ Feature: Format output
       | 1  | Afrikaans     | 0      |
       | 2  | العَرَبِيَّة‎‎  | 1      |
       | 3  | English       | 0      |
+
+  Scenario: Padding for pre-colorized tables
+    Given an empty directory
+    And a file.php file:
+      """
+	  <?php
+	  use cli\Colors;
+	  /**
+	   * Fake command.
+	   *
+	   * ## OPTIONS
+	   *
+	   * [--format=<format>]
+	   * : Render output in a particular format.
+	   * ---
+	   * default: table
+	   * options:
+	   *   - table
+	   * ---
+       *
+       * @when before_wp_load
+	   */
+	  $fake_command = function( $args, $assoc_args ) {
+		  Colors::enable( true );
+		  $items = array(
+			  array( 'package' => Colors::colorize( '%ygaa/gaa-kabes%n' ), 'version' => 'dev-master', 'result' => Colors::colorize( "%r\xf0\x9f\x9b\x87%n" ) ),
+			  array( 'package' => Colors::colorize( '%ygaa/gaa-log%n' ), 'version' => '*', 'result' => Colors::colorize( "%g\xe2\x9c\x94%n" ) ),
+			  array( 'package' => Colors::colorize( '%ygaa/gaa-nonsense%n' ), 'version' => 'v3.0.11', 'result' => Colors::colorize( "%r\xf0\x9f\x9b\x87%n" ) ),
+			  array( 'package' => Colors::colorize( '%ygaa/gaa-100%%new%n' ), 'version' => 'v100%new', 'result' => Colors::colorize( "%g\xe2\x9c\x94%n" ) ),
+		  );
+		  $formatter = new \WP_CLI\Formatter( $assoc_args, array( 'package', 'version', 'result' ) );
+		  $formatter->display_items( $items, array( true, false, true ) );
+	  };
+	  WP_CLI::add_command( 'fake', $fake_command );
+      """
+
+    When I run `wp --require=file.php fake`
+    Then STDOUT should be a table containing rows:
+      | package          | version    | result |
+	  | [33mgaa/gaa-kabes[0m    | dev-master | [31m🛇[0m      |
+	  | [33mgaa/gaa-log[0m      | *          | [32m✔[0m      |
+	  | [33mgaa/gaa-nonsense[0m | v3.0.11    | [31m🛇[0m      |
+	  | [33mgaa/gaa-100%new[0m  | v100%new   | [32m✔[0m      |

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -61,9 +61,10 @@ class Formatter {
 	/**
 	 * Display multiple items according to the output arguments.
 	 *
-	 * @param array $items
+	 * @param array      $items
+	 * @param bool|array $ascii_pre_colorized Optional. A boolean or an array of booleans to pass to `format()` if items in the table are pre-colorized. Default false.
 	 */
-	public function display_items( $items ) {
+	public function display_items( $items, $ascii_pre_colorized = false ) {
 		if ( $this->args['field'] ) {
 			$this->show_single_field( $items, $this->args['field'] );
 		} else {
@@ -85,16 +86,17 @@ class Formatter {
 				}
 			}
 
-			$this->format( $items );
+			$this->format( $items, $ascii_pre_colorized );
 		}
 	}
 
 	/**
 	 * Display a single item according to the output arguments.
 	 *
-	 * @param mixed $item
+	 * @param mixed      $item
+	 * @param bool|array $ascii_pre_colorized Optional. A boolean or an array of booleans to pass to `show_multiple_fields()` if the item in the table is pre-colorized. Default false.
 	 */
-	public function display_item( $item ) {
+	public function display_item( $item, $ascii_pre_colorized = false ) {
 		if ( isset( $this->args['field'] ) ) {
 			$item = (object) $item;
 			$key = $this->find_item_key( $item, $this->args['field'] );
@@ -104,16 +106,17 @@ class Formatter {
 			}
 			\WP_CLI::print_value( $value, array( 'format' => $this->args['format'] ) );
 		} else {
-			$this->show_multiple_fields( $item, $this->args['format'] );
+			$this->show_multiple_fields( $item, $this->args['format'], $ascii_pre_colorized );
 		}
 	}
 
 	/**
 	 * Format items according to arguments.
 	 *
-	 * @param array $items
+	 * @param array      $items
+	 * @param bool|array $ascii_pre_colorized Optional. A boolean or an array of booleans to pass to `show_table()` if items in the table are pre-colorized. Default false.
 	 */
-	private function format( $items ) {
+	private function format( $items, $ascii_pre_colorized = false ) {
 		$fields = $this->args['fields'];
 
 		switch ( $this->args['format'] ) {
@@ -132,7 +135,7 @@ class Formatter {
 				break;
 
 			case 'table':
-				self::show_table( $items, $fields );
+				self::show_table( $items, $fields, $ascii_pre_colorized );
 				break;
 
 			case 'csv':
@@ -217,10 +220,11 @@ class Formatter {
 	/**
 	 * Show multiple fields of an object.
 	 *
-	 * @param object|array Data to display
-	 * @param string Format to display the data in
+	 * @param object|array $data                Data to display
+	 * @param string       $format              Format to display the data in
+	 * @param bool|array   $ascii_pre_colorized Optional. A boolean or an array of booleans to pass to `show_table()` if the item in the table is pre-colorized. Default false.
 	 */
-	private function show_multiple_fields( $data, $format ) {
+	private function show_multiple_fields( $data, $format, $ascii_pre_colorized = false ) {
 
 		$true_fields = array();
 		foreach( $this->args['fields'] as $field ) {
@@ -244,7 +248,7 @@ class Formatter {
 				$rows = $this->assoc_array_to_rows( $data );
 				$fields = array( 'Field', 'Value' );
 				if ( 'table' == $format ) {
-					self::show_table( $rows, $fields );
+					self::show_table( $rows, $fields, $ascii_pre_colorized );
 				} else if ( 'csv' == $format ) {
 					\WP_CLI\Utils\write_csv( STDOUT, $rows, $fields );
 				}
@@ -266,10 +270,11 @@ class Formatter {
 	/**
 	 * Show items in a \cli\Table.
 	 *
-	 * @param array $items
-	 * @param array $fields
+	 * @param array      $items
+	 * @param array      $fields
+	 * @param bool|array $ascii_pre_colorized Optional. A boolean or an array of booleans to pass to `Table::setAsciiPreColorized()` if items in the table are pre-colorized. Default false.
 	 */
-	private static function show_table( $items, $fields ) {
+	private static function show_table( $items, $fields, $ascii_pre_colorized = false ) {
 		$table = new \cli\Table();
 
 		$enabled = \cli\Colors::shouldColorize();
@@ -277,6 +282,7 @@ class Formatter {
 			\cli\Colors::disable( true );
 		}
 
+		$table->setAsciiPreColorized( $ascii_pre_colorized );
 		$table->setHeaders( $fields );
 
 		foreach ( $items as $item ) {


### PR DESCRIPTION
Issue https://github.com/wp-cli/php-cli-tools/issues/106

This uses the pre-colorized stuff added in https://github.com/wp-cli/php-cli-tools/pull/111. Adds `ascii_pre_colorized` arg to the various display functions in `Formatter` which eventually gets passed to `show_table()` which just calls `Table::setAsciiPreColorized()` with it. 

So if you have an Ascii table with some pre-colorized columns you can do eg `$table->display_items( $items, array( true, false, true ) )` to indicate that the padding should be adjusted for them.
