### PR TITLE
Use a more helpful description for `wp cli *`

### DIFF
--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -4,7 +4,7 @@ use \Composer\Semver\Comparator;
 use \WP_CLI\Utils;
 
 /**
- * Manage WP-CLI itself.
+ * Review current WP-CLI info, check for updates, or see defined aliases.
  *
  * ## EXAMPLES
  *


### PR DESCRIPTION
From:

> Manage WP-CLI itself.

To:

> Review current WP-CLI info, check for updates, or see defined aliases.