### PR TITLE
Bump minimum version for the wp-cli/autoload-splitter package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 		"symfony/process": "^2.1|^3.0",
 		"symfony/translation": "^2.7|^3.0",
 		"symfony/yaml": "^2.7|^3.0",
-		"wp-cli/autoload-splitter": "^0.1",
+		"wp-cli/autoload-splitter": "^0.1.4",
 		"wp-cli/cache-command": "^1.0",
 		"wp-cli/checksum-command": "^1.0",
 		"wp-cli/config-command": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd48468393e7ce36d00ed48300479088",
+    "content-hash": "23211f16642455f042620a340174a14d",
     "packages": [
         {
             "name": "composer/ca-bundle",


### PR DESCRIPTION
See #4234 