### PR TITLE
Travis CI : lock wp-coding-standards/wpcs version to 0.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - |
-    composer global require wp-coding-standards/wpcs
+    composer global require wp-coding-standards/wpcs:0.11.0
     phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
   - ./ci/prepare.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - |
-    composer global require wp-coding-standards/wpcs:0.11.0
+    composer global require wp-coding-standards/wpcs:0.12.0
     phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
   - ./ci/prepare.sh
 


### PR DESCRIPTION
Travis CI : lock wp-coding-standards/wpcs version to 0.11.0