### PR TITLE
Set COLUMNS=80 on wp help wrapping tests to ensure run locally.

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -293,7 +293,7 @@ Feature: Get help about WP-CLI commands
       """
     And I run `wp plugin activate test-cli`
 
-    When I run `wp help test-wordwrap my_command`
+    When I run `COLUMNS=80 wp help test-wordwrap my_command`
     Then STDOUT should contain:
       """
         123456789 123456789 123456789 123456789 123456789 123456789 123456789 12345678
@@ -350,7 +350,7 @@ Feature: Get help about WP-CLI commands
       """
     And STDERR should be empty
 
-    When I run `wp help test-wordwrap my_command | wc -L`
+    When I run `COLUMNS=80 wp help test-wordwrap my_command | wc -L`
     Then STDOUT should be:
       """
       80


### PR DESCRIPTION
After the `Shell::columns()` change in `php-cli-tools` https://github.com/wp-cli/php-cli-tools/pull/118 the tests for default wrapping on help will probably fail locally as the `stty` will probably work, so this changes the 2 cases to explicitly set `COLUMNS` to 80.