### PR TITLE
Add GITHUB_TOKEN to CLI_Command::get_updates and get_process_env_variables.

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -116,6 +116,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		if ( $travis_build_dir = getenv( 'TRAVIS_BUILD_DIR' ) ) {
 			$env['TRAVIS_BUILD_DIR'] = $travis_build_dir;
 		}
+		if ( $github_token = getenv( 'GITHUB_TOKEN' ) ) {
+			$env['GITHUB_TOKEN'] = $github_token;
+		}
 		return $env;
 	}
 

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -352,6 +352,10 @@ class CLI_Command extends WP_CLI_Command {
 		$headers = array(
 			'Accept' => 'application/json',
 		);
+		if ( $github_token = getenv( 'GITHUB_TOKEN' ) ) {
+			$headers['Authorization'] = 'token ' . $github_token;
+		}
+
 		$response = Utils\http_request( 'GET', $url, null, $headers, $options );
 
 		if ( ! $response->success || 200 !== $response->status_code ) {


### PR DESCRIPTION
Related https://github.com/wp-cli/wp-cli/pull/4187.

See also https://github.com/wp-cli/wp-cli/blob/master/utils/contrib-list.php#L193

Adds `GITHUB_TOKEN` to `CLI_Command::get_updates()` and passes through in `FeatureContext::get_process_env_variables()` to avoid github request rate limiting - useful in itself and also needed for when `github-api` tests are enabled on Travis.