### PR TITLE
Add help_wp_die_handler. Remove special help treatment for config and db (#4266).

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -63,6 +63,39 @@ Feature: Get help about WP-CLI commands
       wp core install
       """
 
+    When I run `wp help core is-installed`
+    Then STDOUT should contain:
+      """
+      wp core is-installed
+      """
+
+    When I run `wp help core`
+    Then STDOUT should contain:
+      """
+      wp core
+      """
+
+    When I run `wp help config`
+    Then STDOUT should contain:
+      """
+      wp config
+      """
+
+    When I run `wp help db`
+    Then STDOUT should contain:
+      """
+      wp db
+      """
+
+    When I try `wp help non-existent-command`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: Can’t select database. We were able to connect to the database server (which means your username and password is okay) but not able to select the `wp_cli_test` database.
+      Error: 'non-existent-command' is not a registered wp command. See 'wp help' for available commands.
+      """
+    And STDOUT should be empty
+
   Scenario: Help for nonexistent commands
     Given a WP install
 
@@ -242,6 +275,30 @@ Feature: Get help about WP-CLI commands
       """
     And STDOUT should be empty
 
+  Scenario: No WordPress install warning or suggestions for disabled commands
+    Given an empty directory
+    And a wp-cli.yml file:
+      """
+      disabled_commands:
+        db
+      """
+
+    When I try `wp help db`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: The 'db' command has been disabled from the config file.
+      """
+    And STDOUT should be empty
+
+    When I try `wp help db chec`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: The 'db' command has been disabled from the config file.
+      """
+    And STDOUT should be empty
+
   Scenario: Help for third-party commands
     Given a WP install
     And a wp-content/plugins/test-cli/command.php file:
@@ -353,6 +410,84 @@ Feature: Get help about WP-CLI commands
     And I run `wp plugin activate test-cli`
 
     When I run `wp help site`
+    Then STDOUT should contain:
+      """
+      test-extra
+      """
+
+    Given a wp-content/plugins/test-cli/command.php file:
+      """
+      <?php
+      // Plugin Name: Test CLI Extra Config Command
+
+      class Test_CLI_Extra_Config_Command extends WP_CLI_Command {
+
+        /**
+         * A dummy command.
+         *
+         * @subcommand my-command
+         */
+        function my_command() {}
+
+      }
+
+      WP_CLI::add_command( 'config test-extra', 'Test_CLI_Extra_Config_Command' );
+      """
+    And I run `wp plugin activate test-cli`
+
+    When I run `wp help config`
+    Then STDOUT should contain:
+      """
+      test-extra
+      """
+
+    Given a wp-content/plugins/test-cli/command.php file:
+      """
+      <?php
+      // Plugin Name: Test CLI Extra Core Command
+
+      class Test_CLI_Extra_Core_Command extends WP_CLI_Command {
+
+        /**
+         * A dummy command.
+         *
+         * @subcommand my-command
+         */
+        function my_command() {}
+
+      }
+
+      WP_CLI::add_command( 'core test-extra', 'Test_CLI_Extra_Core_Command' );
+      """
+    And I run `wp plugin activate test-cli`
+
+    When I run `wp help core`
+    Then STDOUT should contain:
+      """
+      test-extra
+      """
+
+    Given a wp-content/plugins/test-cli/command.php file:
+      """
+      <?php
+      // Plugin Name: Test CLI Extra DB Command
+
+      class Test_CLI_Extra_DB_Command extends WP_CLI_Command {
+
+        /**
+         * A dummy command.
+         *
+         * @subcommand my-command
+         */
+        function my_command() {}
+
+      }
+
+      WP_CLI::add_command( 'db test-extra', 'Test_CLI_Extra_DB_Command' );
+      """
+    And I run `wp plugin activate test-cli`
+
+    When I run `wp help db`
     Then STDOUT should contain:
       """
       test-extra

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -325,12 +325,15 @@ class Runner {
 		}
 	}
 
-	private function _run_command_and_exit() {
+	private function _run_command_and_exit( $help_exit_warning = '' ) {
 		$this->run_command( $this->arguments, $this->assoc_args );
 		if ( $this->cmd_starts_with( array( 'help' ) ) ) {
 			// Help couldn't find the command so exit with suggestion.
 			$suggestion_or_disabled = $this->find_command_to_run( array_slice( $this->arguments, 1 ) );
 			if ( is_string( $suggestion_or_disabled ) ) {
+				if ( $help_exit_warning ) {
+					WP_CLI::warning( $help_exit_warning );
+				}
 				WP_CLI::error( $suggestion_or_disabled );
 			}
 			// Should never get here.
@@ -919,13 +922,11 @@ class Runner {
 		// Handle --path parameter
 		self::set_wp_root( $this->find_wp_root() );
 
-		// First try at showing man page
-		if ( ! empty( $this->arguments[0] )
-			&& 'help' === $this->arguments[0]
+		// First try at showing man page - if help command and either haven't found 'version.php' or 'wp-config.php' (so won't be loading WP & adding commands) or help on subcommand.
+		if ( $this->cmd_starts_with( array( 'help' ) )
 			&& ( ! $this->wp_exists()
 				|| ! Utils\locate_wp_config()
-				|| ( ! empty( $this->arguments[1] ) && ! empty( $this->arguments[2] ) && 'core' === $this->arguments[1] && in_array( $this->arguments[2], array( 'install', 'multisite-install', 'verify-checksums', 'version' ) ) )
-				|| ( ! empty( $this->arguments[1] ) && 'config' === $this->arguments[1] )
+				|| count( $this->arguments ) > 2
 			) ) {
 			$this->auto_check_update();
 			$this->run_command( $this->arguments, $this->assoc_args );
@@ -951,8 +952,7 @@ class Runner {
 				"Either create one manually or use `wp config create`." );
 		}
 
-		if ( ( $this->cmd_starts_with( array( 'db' ) ) || $this->cmd_starts_with( array( 'help', 'db' ) ) )
-			&& ! $this->cmd_starts_with( array( 'db', 'tables' ) ) ) {
+		if ( $this->cmd_starts_with( array( 'db' ) ) && ! $this->cmd_starts_with( array( 'db', 'tables' ) ) ) {
 			eval( $this->get_wp_config_code() );
 			$this->_run_command_and_exit();
 		}
@@ -1136,7 +1136,15 @@ class Runner {
 			WP_CLI::add_wp_hook( 'setup_theme', array( $this, 'action_setup_theme_wp_cli_skip_themes' ), 999 );
 		}
 
-		WP_CLI::add_wp_hook( 'wp_die_handler', function() { return '\WP_CLI\Utils\wp_die_handler'; } );
+		if ( $this->cmd_starts_with( array( 'help' ) ) ) {
+			// Try to trap errors on help.
+			$help_handler = array( $this, 'help_wp_die_handler' ); // Avoid any cross PHP version issues by not using $this in anon function.
+			WP_CLI::add_wp_hook( 'wp_die_handler', function () use ( $help_handler ) { return $help_handler; } );
+			// Hack: define WP_ADMIN to cause `dead_db()` in "wp-includes/functions.php" to use `wp_die()` instead of `die()`.
+			define( 'WP_ADMIN', true );
+		} else {
+			WP_CLI::add_wp_hook( 'wp_die_handler', function() { return '\WP_CLI\Utils\wp_die_handler'; } );
+		}
 
 		// Prevent code from performing a redirect
 		WP_CLI::add_wp_hook( 'wp_redirect', 'WP_CLI\\Utils\\wp_redirect_handler' );
@@ -1356,6 +1364,17 @@ class Runner {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Error handler for `wp_die()` when the command is help to try to trap errors (db connection failure in particular) during WordPress load.
+	 */
+	public function help_wp_die_handler( $message ) {
+		$help_exit_warning = 'Error during WordPress load.';
+		if ( $message instanceof \WP_Error ) {
+			$help_exit_warning = WP_CLI\Utils\wp_clean_error_message( $message->get_error_message() );
+		}
+		$this->_run_command_and_exit( $help_exit_warning );
 	}
 
 	/**

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -54,6 +54,15 @@ function wp_die_handler( $message ) {
 		$message = $message->get_error_message();
 	}
 
+	$message = wp_clean_error_message( $message );
+
+	\WP_CLI::error( $message );
+}
+
+/**
+ * Clean HTML error message so suitable for text display.
+ */
+function wp_clean_error_message( $message ) {
 	$original_message = $message = trim( $message );
 	if ( preg_match( '|^\<h1>(.+?)</h1>|', $original_message, $matches ) ) {
 		$message = $matches[1] . '.';
@@ -70,7 +79,7 @@ function wp_die_handler( $message ) {
 	$message = strip_tags( $message );
 	$message = html_entity_decode( $message, ENT_COMPAT, 'UTF-8' );
 
-	\WP_CLI::error( $message );
+	return $message;
 }
 
 function wp_redirect_handler( $url ) {


### PR DESCRIPTION
PR https://github.com/wp-cli/wp-cli/pull/4266 and issue https://github.com/wp-cli/wp-cli/issues/4265

Adds a `help_wp_die_handler` to try to trap errors during WP load, especially db select fails when have a partial WP install. (See https://github.com/wp-cli/wp-cli/blob/master/features/help.feature#L49).

(It could also be used to get `wp core is-installed` to work in this situation if a check were added to that command to see if WP function `wp_cache_get()` exists before calling `is_blog_installed()` but don't know if it's worth it?)

Removes the special handling for `help config` and `help db`, but expands the special handling for `help core install/multisite-install/verify-checksum/version` to all `help command subcommand`s on "First try at showing man page" as if they exist the help will be correct (unlike in the `help command` case where extra subcommands could be added).

Adds some extra tests to cover these situations, and also to cover help on disabled command.
