### PR TITLE
Replace /tmp with sys_get_temp_dir() in get_process_env_variables().

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -102,7 +102,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		$env = array(
 			'PATH' =>  $bin_dir . ':' . $vendor_dir . ':' . getenv( 'PATH' ),
 			'BEHAT_RUN' => 1,
-			'HOME' => '/tmp/wp-cli-home',
+			'HOME' => sys_get_temp_dir() . '/wp-cli-home',
 		);
 		if ( $config_path = getenv( 'WP_CLI_CONFIG_PATH' ) ) {
 			$env['WP_CLI_CONFIG_PATH'] = $config_path;

--- a/features/cli-info.feature
+++ b/features/cli-info.feature
@@ -20,7 +20,7 @@ Feature: Review CLI information
     When I run `wp cli info --format=json`
     Then STDOUT should be JSON containing:
       """
-      {"wp_cli_packages_dir_path":"/tmp/wp-cli-home/.wp-cli/packages/"}
+      {"wp_cli_packages_dir_path":"{PACKAGE_PATH}"}
       """
 
     When I run `wp cli info`


### PR DESCRIPTION
Replaces hard-coded `/tmp` with `sys_get_temp_dir()` in setting `HOME` in `FeatureContext::get_process_env_variables()`.

Also replaces hard-coded `/tmp` in `features/cli-info.feature` with `{PACKAGE_PATH}`.
