### PR TITLE
Give suggestions when exiting early on `wp help`

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -102,7 +102,7 @@ Feature: WP-CLI Commands
     When I try `wp --require=custom-cmd.php command invalid`
     Then STDERR should contain:
       """
-      Error: 'invalid' is not a registered subcommand of 'command'. See 'wp help command'.
+      Error: 'invalid' is not a registered subcommand of 'command'. See 'wp help command' for available subcommands.
       """
 
   Scenario: Use a closure as a command

--- a/features/flags.feature
+++ b/features/flags.feature
@@ -40,7 +40,7 @@ Feature: Global flags
     Then the return code should be 1
     And STDERR should be:
       """
-      Error: 'non-existing-command' is not a registered wp command. See 'wp help'.
+      Error: 'non-existing-command' is not a registered wp command. See 'wp help' for available commands.
       """
 
   Scenario: Debug run
@@ -204,7 +204,7 @@ Feature: Global flags
     When I try `wp --no-color non-existent-command`
     Then STDERR should be:
       """
-      Error: 'non-existent-command' is not a registered wp command. See 'wp help'.
+      Error: 'non-existent-command' is not a registered wp command. See 'wp help' for available commands.
       """
 
     When I try `wp --color non-existent-command`

--- a/features/help.feature
+++ b/features/help.feature
@@ -147,6 +147,19 @@ Feature: Get help about WP-CLI commands
       """
     And STDOUT should be empty
 
+    # Bug: if `WP_DEBUG` (or `WP_DEBUG_DISPLAY') are defined falsey than a db error won't be trapped.
+    Given a define-wp-debug-false.php file:
+      """
+      <?php define( 'WP_DEBUG', false );
+      """
+
+    When I try `wp help core --require=define-wp-debug-false.php`
+    Then STDOUT should be empty
+    And STDERR should be:
+      """
+      Error: Can’t select database. We were able to connect to the database server (which means your username and password is okay) but not able to select the `wp_cli_test` database.
+      """
+
   Scenario: Help for nonexistent commands
     Given a WP install
 

--- a/features/help.feature
+++ b/features/help.feature
@@ -4,8 +4,7 @@ Feature: Get help about WP-CLI commands
     Given an empty directory
 
     When I run `wp help`
-    Then STDOUT should not be empty
-    And STDOUT should contain:
+    Then STDOUT should contain:
       """
         Run 'wp help <command>' to get more information on a specific command.
 
@@ -13,15 +12,24 @@ Feature: Get help about WP-CLI commands
     And STDERR should be empty
 
     When I run `wp help core`
-    Then STDOUT should not be empty
+    Then STDOUT should contain:
+      """
+        wp core
+      """
     And STDERR should be empty
 
     When I run `wp help core download`
-    Then STDOUT should not be empty
+    Then STDOUT should contain:
+      """
+        wp core download
+      """
     And STDERR should be empty
 
     When I run `wp help help`
-    Then STDOUT should not be empty
+    Then STDOUT should contain:
+      """
+        wp help
+      """
     And STDERR should be empty
 
     When I run `wp help help`
@@ -38,6 +46,51 @@ Feature: Get help about WP-CLI commands
       """
     And STDERR should be empty
 
+  # Prior to WP 4.3 widgets & others used PHP 4 style constructors and prior to WP 3.9 wpdb used the mysql extension which can all lead (depending on PHP version) to PHP Deprecated notices.
+  @require-wp-4.3
+  Scenario: Help for internal commands with WP
+    Given a WP install
+    And a stderr-error-log.php file:
+      """
+      <?php define( 'WP_DEBUG', true ); define( 'WP_DEBUG_DISPLAY', null ); define( 'WP_DEBUG_LOG', false ); ini_set( "error_log", '' ); ini_set( 'display_errors', 'STDERR' );
+      """
+
+    When I run `wp --require=stderr-error-log.php help`
+    Then STDOUT should contain:
+      """
+        Run 'wp help <command>' to get more information on a specific command.
+
+      """
+    And STDERR should be empty
+
+    When I run `wp --require=stderr-error-log.php help core`
+    Then STDOUT should contain:
+      """
+        wp core
+      """
+    And STDERR should be empty
+
+    When I run `wp --require=stderr-error-log.php help core download`
+    Then STDOUT should contain:
+      """
+        wp core download
+      """
+    And STDERR should be empty
+
+    When I run `wp --require=stderr-error-log.php help help`
+    Then STDOUT should contain:
+      """
+        wp help
+      """
+    And STDERR should be empty
+
+    When I run `wp --require=stderr-error-log.php help help`
+    Then STDOUT should contain:
+      """
+      GLOBAL PARAMETERS
+      """
+    And STDERR should be empty
+
   Scenario: Help when WordPress is downloaded but not installed
     Given an empty directory
 
@@ -47,13 +100,52 @@ Feature: Get help about WP-CLI commands
       """
       wp config create
       """
+    And STDERR should be empty
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS}`
+    When I run `wp config create {CORE_CONFIG_SETTINGS}`
     And I run `wp help core install`
     Then STDOUT should contain:
       """
       wp core install
       """
+    And STDERR should be empty
+
+    When I run `wp help core is-installed`
+    Then STDOUT should contain:
+      """
+      wp core is-installed
+      """
+    And STDERR should be empty
+
+    When I run `wp help core`
+    Then STDOUT should contain:
+      """
+      wp core
+      """
+    And STDERR should be empty
+
+    When I run `wp help config`
+    Then STDOUT should contain:
+      """
+      wp config
+      """
+    And STDERR should be empty
+
+    When I run `wp help db`
+    Then STDOUT should contain:
+      """
+      wp db
+      """
+    And STDERR should be empty
+
+    When I try `wp help non-existent-command`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: Can’t select database. We were able to connect to the database server (which means your username and password is okay) but not able to select the `wp_cli_test` database.
+      Error: 'non-existent-command' is not a registered wp command. See 'wp help' for available commands.
+      """
+    And STDOUT should be empty
 
   Scenario: Help for nonexistent commands
     Given a WP install
@@ -62,15 +154,201 @@ Feature: Get help about WP-CLI commands
     Then the return code should be 1
     And STDERR should be:
       """
-      Error: 'non-existent-command' is not a registered wp command.
+      Error: 'non-existent-command' is not a registered wp command. See 'wp help' for available commands.
       """
+    And STDOUT should be empty
+
+    When I try `wp help non-existent-command --path=/nowhere`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: No WordPress install found. If the command 'non-existent-command' is in a plugin or theme, pass --path=`path/to/wordpress`.
+      Error: 'non-existent-command' is not a registered wp command. See 'wp help' for available commands.
+      """
+    And STDOUT should be empty
 
     When I try `wp help non-existent-command non-existent-subcommand`
     Then the return code should be 1
     And STDERR should be:
       """
-      Error: 'non-existent-command non-existent-subcommand' is not a registered wp command.
+      Error: 'non-existent-command' is not a registered wp command. See 'wp help' for available commands.
       """
+    And STDOUT should be empty
+
+    When I try `wp help non-existent-command non-existent-subcommand --path=/nowhere`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: No WordPress install found. If the command 'non-existent-command non-existent-subcommand' is in a plugin or theme, pass --path=`path/to/wordpress`.
+      Error: 'non-existent-command' is not a registered wp command. See 'wp help' for available commands.
+      """
+    And STDOUT should be empty
+
+  Scenario: Help for nonexistent commands without a WP install
+    Given an empty directory
+
+    When I try `wp help non-existent-command`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: No WordPress install found. If the command 'non-existent-command' is in a plugin or theme, pass --path=`path/to/wordpress`.
+      Error: 'non-existent-command' is not a registered wp command. See 'wp help' for available commands.
+      """
+    And STDOUT should be empty
+
+  Scenario: Help for specially treated commands with nonexistent subcommands
+    Given a WP install
+
+    When I try `wp help config non-existent-subcommand`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: 'non-existent-subcommand' is not a registered subcommand of 'config'. See 'wp help config' for available subcommands.
+      """
+    And STDOUT should be empty
+
+    When I try `wp help config non-existent-subcommand --path=/nowhere`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: No WordPress install found. If the command 'config non-existent-subcommand' is in a plugin or theme, pass --path=`path/to/wordpress`.
+      Error: 'non-existent-subcommand' is not a registered subcommand of 'config'. See 'wp help config' for available subcommands.
+      """
+    And STDOUT should be empty
+
+    When I try `wp help core non-existent-subcommand`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: 'non-existent-subcommand' is not a registered subcommand of 'core'. See 'wp help core' for available subcommands.
+      """
+    And STDOUT should be empty
+
+    When I try `wp help core non-existent-subcommand --path=/nowhere`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: No WordPress install found. If the command 'core non-existent-subcommand' is in a plugin or theme, pass --path=`path/to/wordpress`.
+      Error: 'non-existent-subcommand' is not a registered subcommand of 'core'. See 'wp help core' for available subcommands.
+      """
+    And STDOUT should be empty
+
+    When I try `wp help db non-existent-subcommand`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: 'non-existent-subcommand' is not a registered subcommand of 'db'. See 'wp help db' for available subcommands.
+      """
+    And STDOUT should be empty
+
+    When I try `wp help db non-existent-subcommand --path=/nowhere`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: No WordPress install found. If the command 'db non-existent-subcommand' is in a plugin or theme, pass --path=`path/to/wordpress`.
+      Error: 'non-existent-subcommand' is not a registered subcommand of 'db'. See 'wp help db' for available subcommands.
+      """
+    And STDOUT should be empty
+
+  Scenario: Suggestions for command typos in help
+    Given an empty directory
+
+    When I try `wp help confi`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: No WordPress install found. If the command 'confi' is in a plugin or theme, pass --path=`path/to/wordpress`.
+      Error: 'confi' is not a registered wp command. See 'wp help' for available commands.
+      Did you mean 'config'?
+      """
+    And STDOUT should be empty
+
+    When I try `wp help cor`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: No WordPress install found. If the command 'cor' is in a plugin or theme, pass --path=`path/to/wordpress`.
+      Error: 'cor' is not a registered wp command. See 'wp help' for available commands.
+      Did you mean 'core'?
+      """
+    And STDOUT should be empty
+
+    When I try `wp help d`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: No WordPress install found. If the command 'd' is in a plugin or theme, pass --path=`path/to/wordpress`.
+      Error: 'd' is not a registered wp command. See 'wp help' for available commands.
+      Did you mean 'db'?
+      """
+    And STDOUT should be empty
+
+    When I try `wp help packag`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: No WordPress install found. If the command 'packag' is in a plugin or theme, pass --path=`path/to/wordpress`.
+      Error: 'packag' is not a registered wp command. See 'wp help' for available commands.
+      Did you mean 'package'?
+      """
+    And STDOUT should be empty
+
+  Scenario: Suggestions for subcommand typos in help of specially treated commands
+    Given an empty directory
+
+    When I try `wp help config creat`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: No WordPress install found. If the command 'config creat' is in a plugin or theme, pass --path=`path/to/wordpress`.
+      Error: 'creat' is not a registered subcommand of 'config'. See 'wp help config' for available subcommands.
+      Did you mean 'create'?
+      """
+    And STDOUT should be empty
+
+    When I try `wp help core versio`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: No WordPress install found. If the command 'core versio' is in a plugin or theme, pass --path=`path/to/wordpress`.
+      Error: 'versio' is not a registered subcommand of 'core'. See 'wp help core' for available subcommands.
+      Did you mean 'version'?
+      """
+    And STDOUT should be empty
+
+    When I try `wp help db chec`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Warning: No WordPress install found. If the command 'db chec' is in a plugin or theme, pass --path=`path/to/wordpress`.
+      Error: 'chec' is not a registered subcommand of 'db'. See 'wp help db' for available subcommands.
+      Did you mean 'check'?
+      """
+    And STDOUT should be empty
+
+  Scenario: No WordPress install warning or suggestions for disabled commands
+    Given an empty directory
+    And a wp-cli.yml file:
+      """
+      disabled_commands:
+        db
+      """
+
+    When I try `wp help db`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: The 'db' command has been disabled from the config file.
+      """
+    And STDOUT should be empty
+
+    When I try `wp help db chec`
+    Then the return code should be 1
+    And STDERR should be:
+      """
+      Error: The 'db' command has been disabled from the config file.
+      """
+    And STDOUT should be empty
 
   Scenario: Help for third-party commands
     Given a WP install
@@ -183,6 +461,84 @@ Feature: Get help about WP-CLI commands
     And I run `wp plugin activate test-cli`
 
     When I run `wp help site`
+    Then STDOUT should contain:
+      """
+      test-extra
+      """
+
+    Given a wp-content/plugins/test-cli/command.php file:
+      """
+      <?php
+      // Plugin Name: Test CLI Extra Config Command
+
+      class Test_CLI_Extra_Config_Command extends WP_CLI_Command {
+
+        /**
+         * A dummy command.
+         *
+         * @subcommand my-command
+         */
+        function my_command() {}
+
+      }
+
+      WP_CLI::add_command( 'config test-extra', 'Test_CLI_Extra_Config_Command' );
+      """
+    And I run `wp plugin activate test-cli`
+
+    When I run `wp help config`
+    Then STDOUT should contain:
+      """
+      test-extra
+      """
+
+    Given a wp-content/plugins/test-cli/command.php file:
+      """
+      <?php
+      // Plugin Name: Test CLI Extra Core Command
+
+      class Test_CLI_Extra_Core_Command extends WP_CLI_Command {
+
+        /**
+         * A dummy command.
+         *
+         * @subcommand my-command
+         */
+        function my_command() {}
+
+      }
+
+      WP_CLI::add_command( 'core test-extra', 'Test_CLI_Extra_Core_Command' );
+      """
+    And I run `wp plugin activate test-cli`
+
+    When I run `wp help core`
+    Then STDOUT should contain:
+      """
+      test-extra
+      """
+
+    Given a wp-content/plugins/test-cli/command.php file:
+      """
+      <?php
+      // Plugin Name: Test CLI Extra DB Command
+
+      class Test_CLI_Extra_DB_Command extends WP_CLI_Command {
+
+        /**
+         * A dummy command.
+         *
+         * @subcommand my-command
+         */
+        function my_command() {}
+
+      }
+
+      WP_CLI::add_command( 'db test-extra', 'Test_CLI_Extra_DB_Command' );
+      """
+    And I run `wp plugin activate test-cli`
+
+    When I run `wp help db`
     Then STDOUT should contain:
       """
       test-extra

--- a/features/help.feature
+++ b/features/help.feature
@@ -147,18 +147,19 @@ Feature: Get help about WP-CLI commands
       """
     And STDOUT should be empty
 
-    # Bug: if `WP_DEBUG` (or `WP_DEBUG_DISPLAY') are defined falsey than a db error won't be trapped.
+    # Bug: if `WP_DEBUG` (or `WP_DEBUG_DISPLAY') is defined falsey than a db error won't be trapped.
     Given a define-wp-debug-false.php file:
       """
       <?php define( 'WP_DEBUG', false );
       """
 
     When I try `wp help core --require=define-wp-debug-false.php`
-    Then STDOUT should be empty
+    Then the return code should be 1
     And STDERR should be:
       """
       Error: Can’t select database. We were able to connect to the database server (which means your username and password is okay) but not able to select the `wp_cli_test` database.
       """
+    And STDOUT should be empty
 
   Scenario: Help for nonexistent commands
     Given a WP install

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -60,8 +60,7 @@ class Runner {
 
 		foreach ( $this->_early_invoke[ $when ] as $path ) {
 			if ( $this->cmd_starts_with( $path ) ) {
-				$this->_run_command();
-				exit;
+				$this->_run_command_and_exit();
 			}
 		}
 	}
@@ -263,7 +262,7 @@ class Runner {
 					$parent_name = implode( ' ', $cmd_path );
 					$suggestion = $this->get_subcommand_suggestion( $child, $command );
 					return sprintf(
-						"'%s' is not a registered subcommand of '%s'. See 'wp help %s'.%s",
+						"'%s' is not a registered subcommand of '%s'. See 'wp help %s' for available subcommands.%s",
 						$child,
 						$parent_name,
 						$parent_name,
@@ -272,7 +271,7 @@ class Runner {
 				} else {
 					$suggestion = $this->get_subcommand_suggestion( $full_name, $command );
 					return sprintf(
-						"'%s' is not a registered wp command. See 'wp help'.%s",
+						"'%s' is not a registered wp command. See 'wp help' for available commands.%s",
 						$full_name,
 						! empty( $suggestion ) ? PHP_EOL . "Did you mean '{$suggestion}'?" : ''
 					);
@@ -326,8 +325,20 @@ class Runner {
 		}
 	}
 
-	private function _run_command() {
+	private function _run_command_and_exit( $help_exit_warning = '' ) {
 		$this->run_command( $this->arguments, $this->assoc_args );
+		if ( $this->cmd_starts_with( array( 'help' ) ) ) {
+			// Help couldn't find the command so exit with suggestion.
+			$suggestion_or_disabled = $this->find_command_to_run( array_slice( $this->arguments, 1 ) );
+			if ( is_string( $suggestion_or_disabled ) ) {
+				if ( $help_exit_warning ) {
+					WP_CLI::warning( $help_exit_warning );
+				}
+				WP_CLI::error( $suggestion_or_disabled );
+			}
+			// Should never get here.
+		}
+		exit;
 	}
 
 	/**
@@ -694,6 +705,15 @@ class Runner {
 
 	private function check_wp_version() {
 		if ( !$this->wp_exists() ) {
+			// If the command doesn't exist use as error.
+			$args = $this->cmd_starts_with( array( 'help' ) ) ? array_slice( $this->arguments, 1 ) : $this->arguments;
+			$suggestion_or_disabled = $this->find_command_to_run( $args );
+			if ( is_string( $suggestion_or_disabled ) ) {
+				if ( ! preg_match( '/disabled from the config file.$/', $suggestion_or_disabled ) ) {
+					WP_CLI::warning( "No WordPress install found. If the command '" . implode( ' ', $args ) . "' is in a plugin or theme, pass --path=`path/to/wordpress`." );
+				}
+				WP_CLI::error( $suggestion_or_disabled );
+			}
 			WP_CLI::error(
 				"This does not seem to be a WordPress install.\n" .
 				"Pass --path=`path/to/wordpress` or run `wp core download`." );
@@ -876,8 +896,7 @@ class Runner {
 		// Protect 'cli info' from most of the runtime,
 		// except when the command will be run over SSH
 		if ( 'cli' === $this->arguments[0] && ! empty( $this->arguments[1] ) && 'info' === $this->arguments[1] && ! $this->config['ssh'] ) {
-			$this->_run_command();
-			exit;
+			$this->_run_command_and_exit();
 		}
 
 		if ( isset( $this->config['http'] ) && ! class_exists( '\WP_REST_CLI\Runner' ) ) {
@@ -903,16 +922,15 @@ class Runner {
 		// Handle --path parameter
 		self::set_wp_root( $this->find_wp_root() );
 
-		// First try at showing man page
-		if ( ! empty( $this->arguments[0] )
-			&& 'help' === $this->arguments[0]
+		// First try at showing man page - if help command and either haven't found 'version.php' or 'wp-config.php' (so won't be loading WP & adding commands) or help on subcommand.
+		if ( $this->cmd_starts_with( array( 'help' ) )
 			&& ( ! $this->wp_exists()
 				|| ! Utils\locate_wp_config()
-				|| ( ! empty( $this->arguments[1] ) && ! empty( $this->arguments[2] ) && 'core' === $this->arguments[1] && in_array( $this->arguments[2], array( 'install', 'multisite-install', 'verify-checksums', 'version' ) ) )
-				|| ( ! empty( $this->arguments[1] ) && 'config' === $this->arguments[1] )
+				|| count( $this->arguments ) > 2
 			) ) {
 			$this->auto_check_update();
-			$this->_run_command();
+			$this->run_command( $this->arguments, $this->assoc_args );
+			// Help didn't exit so failed to find the command at this stage.
 		}
 
 		// Handle --url parameter
@@ -925,8 +943,7 @@ class Runner {
 		$this->check_wp_version();
 
 		if ( $this->cmd_starts_with( array( 'config', 'create' ) ) ) {
-			$this->_run_command();
-			exit;
+			$this->_run_command_and_exit();
 		}
 
 		if ( !Utils\locate_wp_config() ) {
@@ -935,11 +952,9 @@ class Runner {
 				"Either create one manually or use `wp config create`." );
 		}
 
-		if ( ( $this->cmd_starts_with( array( 'db' ) ) || $this->cmd_starts_with( array( 'help', 'db' ) ) )
-			&& ! $this->cmd_starts_with( array( 'db', 'tables' ) ) ) {
+		if ( $this->cmd_starts_with( array( 'db' ) ) && ! $this->cmd_starts_with( array( 'db', 'tables' ) ) ) {
 			eval( $this->get_wp_config_code() );
-			$this->_run_command();
-			exit;
+			$this->_run_command_and_exit();
 		}
 
 		if ( $this->cmd_starts_with( array( 'core', 'is-installed' ) )
@@ -982,7 +997,7 @@ class Runner {
 
 		$this->load_wordpress();
 
-		$this->_run_command();
+		$this->_run_command_and_exit();
 
 	}
 
@@ -1043,6 +1058,15 @@ class Runner {
 
 		// Load Core, mu-plugins, plugins, themes etc.
 		if ( Utils\wp_version_compare( '4.6-alpha-37575', '>=' ) ) {
+			if ( $this->cmd_starts_with( array( 'help' ) ) ) {
+				// Hack: define `WP_DEBUG` and `WP_DEBUG_DISPLAY` to get `wpdb::bail()` to `wp_die()`.
+				if ( ! defined( 'WP_DEBUG' ) ) {
+					define( 'WP_DEBUG', true );
+				}
+				if ( ! defined( 'WP_DEBUG_DISPLAY' ) ) {
+					define( 'WP_DEBUG_DISPLAY', true );
+				}
+			}
 			require ABSPATH . 'wp-settings.php';
 		} else {
 			require WP_CLI_ROOT . '/php/wp-settings-cli.php';
@@ -1121,7 +1145,13 @@ class Runner {
 			WP_CLI::add_wp_hook( 'setup_theme', array( $this, 'action_setup_theme_wp_cli_skip_themes' ), 999 );
 		}
 
-		WP_CLI::add_wp_hook( 'wp_die_handler', function() { return '\WP_CLI\Utils\wp_die_handler'; } );
+		if ( $this->cmd_starts_with( array( 'help' ) ) ) {
+			// Try to trap errors on help.
+			$help_handler = array( $this, 'help_wp_die_handler' ); // Avoid any cross PHP version issues by not using $this in anon function.
+			WP_CLI::add_wp_hook( 'wp_die_handler', function () use ( $help_handler ) { return $help_handler; } );
+		} else {
+			WP_CLI::add_wp_hook( 'wp_die_handler', function() { return '\WP_CLI\Utils\wp_die_handler'; } );
+		}
 
 		// Prevent code from performing a redirect
 		WP_CLI::add_wp_hook( 'wp_redirect', 'WP_CLI\\Utils\\wp_redirect_handler' );
@@ -1344,6 +1374,19 @@ class Runner {
 	}
 
 	/**
+	 * Error handler for `wp_die()` when the command is help to try to trap errors (db connection failure in particular) during WordPress load.
+	 */
+	public function help_wp_die_handler( $message ) {
+		$help_exit_warning = 'Error during WordPress load.';
+		if ( $message instanceof \WP_Error ) {
+			$help_exit_warning = WP_CLI\Utils\wp_clean_error_message( $message->get_error_message() );
+		} elseif ( is_string( $message ) ) {
+			$help_exit_warning = WP_CLI\Utils\wp_clean_error_message( $message );
+		}
+		$this->_run_command_and_exit( $help_exit_warning );
+	}
+
+	/**
 	 * Check whether there's a WP-CLI update available, and suggest update if so.
 	 */
 	private function auto_check_update() {
@@ -1444,4 +1487,3 @@ class Runner {
 		}
 	}
 }
-

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -22,37 +22,14 @@ class Help_Command extends WP_CLI_Command {
 	 *     wp help core download
 	 */
 	function __invoke( $args, $assoc_args ) {
-		$command = self::find_subcommand( $args );
+		$r = WP_CLI::get_runner()->find_command_to_run( $args );
 
-		if ( $command ) {
-
-			if ( WP_CLI::get_runner()->is_command_disabled( $command ) ) {
-				$path = implode( ' ', array_slice( \WP_CLI\Dispatcher\get_path( $command ), 1 ) );
-				WP_CLI::error( sprintf(
-					"The '%s' command has been disabled from the config file.",
-					$path
-				) );
-			}
+		if ( is_array( $r ) ) {
+			list( $command ) = $r;
 
 			self::show_help( $command );
 			exit;
 		}
-
-		// WordPress is already loaded, so there's no chance we'll find the command
-		if ( function_exists( 'add_filter' ) ) {
-			$command_string = implode( ' ', $args );
-			\WP_CLI::error( sprintf( "'%s' is not a registered wp command.", $command_string ) );
-		}
-	}
-
-	private static function find_subcommand( $args ) {
-		$command = \WP_CLI::get_root_command();
-
-		while ( !empty( $args ) && $command && $command->can_have_subcommands() ) {
-			$command = $command->find_subcommand( $args );
-		}
-
-		return $command;
 	}
 
 	private static function show_help( $command ) {

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -54,6 +54,15 @@ function wp_die_handler( $message ) {
 		$message = $message->get_error_message();
 	}
 
+	$message = wp_clean_error_message( $message );
+
+	\WP_CLI::error( $message );
+}
+
+/**
+ * Clean HTML error message so suitable for text display.
+ */
+function wp_clean_error_message( $message ) {
 	$original_message = $message = trim( $message );
 	if ( preg_match( '|^\<h1>(.+?)</h1>|', $original_message, $matches ) ) {
 		$message = $matches[1] . '.';
@@ -70,7 +79,7 @@ function wp_die_handler( $message ) {
 	$message = strip_tags( $message );
 	$message = html_entity_decode( $message, ENT_COMPAT, 'UTF-8' );
 
-	\WP_CLI::error( $message );
+	return $message;
 }
 
 function wp_redirect_handler( $url ) {


### PR DESCRIPTION
Issue https://github.com/wp-cli/wp-cli/issues/4265 and PR https://github.com/wp-cli/wp-cli/pull/4291

This is the same PR as the original PRs https://github.com/wp-cli/wp-cli/pull/4266 and https://github.com/wp-cli/wp-cli/pull/4285 but defining `WP_DEBUG` (and `WP_DEBUG_DISPLAY`) instead of `WP_ADMIN` on `help` to get WP to use `wp_die()` so its error message can be trapped. 

It differs from the original try https://github.com/wp-cli/wp-cli/pull/4291/commits/571de94fc8ba3cc2dd0cede69835666c175381ea in that the define is only done when WP's "wp-settings.php" is loaded instead of "wp-settings-cli.php", as the latter checks for a db error immediately after `require_wp_db()` and uses `wp_die()` - added in https://github.com/wp-cli/wp-cli/pull/352 and for the same reason i.e. that `dead_db()` uses `die()` when `WP_ADMIN` is not defined. This avoids the PHP Deprecated notices being triggered for old PHPs/WPs which caused the original try to fail.

Having `WP_DEBUG` and `WP_DEBUG_DISPLAY` defined causes `wpdb::__construct()` to set `wpdb::$show_errors` which in turn causes `wpdb::bail()` to use `wp_die()` rather than return, so `dead_db()` is by-passed.

This makes the hack less robust than defining `WP_ADMIN`, as a `wp-config.php` could define `WP_DEBUG` or `WP_DEBUG_DISPLAY` to be falsey and thus trigger the `die()` if the database is unavailable, but still much preferable in view of https://github.com/wp-cli/wp-cli/pull/674 as mentioned in https://github.com/wp-cli/wp-cli/pull/4291#issuecomment-322183302.

With reference to https://github.com/wp-cli/wp-cli/pull/4291#issuecomment-322239193

> It's also another hack that's likely to have unintended consequences.

Although it's regrettable that a hack like this is needed, defining `WP_DEBUG` is unlikely to have unintended consequences as all reasonable WP code should run the same whether it's defined or not. Also this execution path is only for `help` and only to get any packages/plugins/themes to add their commands (not run them).

(As an aside I think a case could be made for defining `WP_DEBUG` always when running under behat, at least for modern PHPs and WPs, as PHP notices are currently invisible in Travis.)