### PR TITLE
Add caching of WP installs in FeatureContext to speed-up tests.

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -1,12 +1,12 @@
 Feature: Create shortcuts to specific WordPress installs
 
   Scenario: Alias for a path to a specific WP install
-    Given a WP install in 'testdir'
-    And I run `mkdir testdir2`
+    Given a WP install in 'foo'
+    And I run `mkdir bar`
     And a wp-cli.yml file:
       """
-      @testdir:
-        path: testdir
+      @foo:
+        path: foo
       """
 
     When I try `wp core is-installed`
@@ -16,10 +16,10 @@ Feature: Create shortcuts to specific WordPress installs
       """
     And the return code should be 1
 
-    When I run `wp @testdir core is-installed`
+    When I run `wp @foo core is-installed`
     Then the return code should be 0
 
-    When I run `cd testdir2; wp @testdir core is-installed`
+    When I run `cd bar; wp @foo core is-installed`
     Then the return code should be 0
 
   Scenario: Error when invalid alias provided
@@ -36,7 +36,7 @@ Feature: Create shortcuts to specific WordPress installs
     And a wp-cli.yml file:
       """
       @test2:
-        path: testdir
+        path: foo
       """
 
     When I try `wp @test option get home`
@@ -47,20 +47,20 @@ Feature: Create shortcuts to specific WordPress installs
       """
 
   Scenario: Treat global params as local when included in alias
-    Given a WP install in 'testdir'
+    Given a WP install in 'foo'
     And a wp-cli.yml file:
       """
-      @testdir:
-        path: testdir
+      @foo:
+        path: foo
       """
 
-    When I run `wp @testdir option get home`
+    When I run `wp @foo option get home`
     Then STDOUT should be:
       """
       http://example.com
       """
 
-    When I try `wp @testdir option get home --path=testdir`
+    When I try `wp @foo option get home --path=foo`
     Then STDERR should contain:
       """
       Parameter errors:
@@ -70,7 +70,7 @@ Feature: Create shortcuts to specific WordPress installs
       unknown --path parameter
       """
 
-    When I run `wp @testdir eval 'echo get_current_user_id();' --user=admin`
+    When I run `wp @foo eval 'echo get_current_user_id();' --user=admin`
     Then STDOUT should be:
       """
       1
@@ -78,18 +78,18 @@ Feature: Create shortcuts to specific WordPress installs
 
     Given a wp-cli.yml file:
       """
-      @testdir:
-        path: testdir
+      @foo:
+        path: foo
         user: admin
       """
 
-    When I run `wp @testdir eval 'echo get_current_user_id();'`
+    When I run `wp @foo eval 'echo get_current_user_id();'`
     Then STDOUT should be:
       """
       1
       """
 
-    When I try `wp @testdir eval 'echo get_current_user_id();' --user=admin`
+    When I try `wp @foo eval 'echo get_current_user_id();' --user=admin`
     Then STDERR should contain:
       """
       Parameter errors:
@@ -100,15 +100,15 @@ Feature: Create shortcuts to specific WordPress installs
       """
 
   Scenario: Support global params specific to the WordPress install, not WP-CLI generally
-    Given a WP install in 'testdir'
+    Given a WP install in 'foo'
     And a wp-cli.yml file:
       """
-      @testdir:
-        path: testdir
+      @foo:
+        path: foo
         debug: true
       """
 
-    When I run `wp @testdir option get home`
+    When I run `wp @foo option get home`
     Then STDOUT should be:
       """
       http://example.com
@@ -119,8 +119,8 @@ Feature: Create shortcuts to specific WordPress installs
     Given an empty directory
     And a wp-cli.yml file:
       """
-      @testdir:
-        path: testdir
+      @foo:
+        path: foo
       """
 
     When I run `wp eval --skip-wordpress 'echo realpath( getenv( "RUN_DIR" ) );'`
@@ -130,33 +130,33 @@ Feature: Create shortcuts to specific WordPress installs
     Then STDOUT should be YAML containing:
       """
       @all: Run command against every registered alias.
-      @testdir:
-        path: {TEST_DIR}/testdir
+      @foo:
+        path: {TEST_DIR}/foo
       """
 
     When I run `wp cli aliases`
     Then STDOUT should be YAML containing:
       """
       @all: Run command against every registered alias.
-      @testdir:
-        path: {TEST_DIR}/testdir
+      @foo:
+        path: {TEST_DIR}/foo
       """
 
     When I run `wp cli alias --format=json`
     Then STDOUT should be JSON containing:
       """
-      {"@all":"Run command against every registered alias.","@testdir":{"path":"{TEST_DIR}/testdir"}}
+      {"@all":"Run command against every registered alias.","@foo":{"path":"{TEST_DIR}/foo"}}
       """
 
   Scenario: Defining a project alias completely overrides a global alias
-    Given a WP install in 'testdir'
+    Given a WP install in 'foo'
     And a config.yml file:
       """
-      @testdir:
-        path: testdir
+      @foo:
+        path: foo
       """
 
-    When I run `WP_CLI_CONFIG_PATH=config.yml wp @testdir option get home`
+    When I run `WP_CLI_CONFIG_PATH=config.yml wp @foo option get home`
     Then STDOUT should be:
       """
       http://example.com
@@ -164,41 +164,41 @@ Feature: Create shortcuts to specific WordPress installs
 
     Given a wp-cli.yml file:
       """
-      @testdir:
+      @foo:
         path: none-existent-install
       """
-    When I try `WP_CLI_CONFIG_PATH=config.yml wp @testdir option get home`
+    When I try `WP_CLI_CONFIG_PATH=config.yml wp @foo option get home`
     Then STDERR should contain:
       """
       Error: This does not seem to be a WordPress install.
       """
 
   Scenario: Use a group of aliases to run a command against multiple installs
-    Given a WP install in 'subdir1'
-    And a WP install in 'subdir2'
+    Given a WP install in 'foo'
+    And a WP install in 'bar'
     And a wp-cli.yml file:
       """
       @both:
-        - @subdir1
-        - @subdir2
+        - @foo
+        - @bar
       @invalid:
-        - @subdir1
-        - @subdir3
-      @subdir1:
-        path: subdir1
-      @subdir2:
-        path: subdir2
+        - @foo
+        - @baz
+      @foo:
+        path: foo
+      @bar:
+        path: bar
       """
 
-    When I run `wp @subdir1 option update home 'http://apple.com'`
-    And I run `wp @subdir1 option get home`
+    When I run `wp @foo option update home 'http://apple.com'`
+    And I run `wp @foo option get home`
     Then STDOUT should contain:
       """
       http://apple.com
       """
 
-    When I run `wp @subdir2 option update home 'http://google.com'`
-    And I run `wp @subdir2 option get home`
+    When I run `wp @bar option update home 'http://google.com'`
+    And I run `wp @bar option get home`
     Then STDOUT should contain:
       """
       http://google.com
@@ -207,15 +207,15 @@ Feature: Create shortcuts to specific WordPress installs
     When I try `wp @invalid option get home`
     Then STDERR should be:
       """
-      Error: Group '@invalid' contains one or more invalid aliases: @subdir3
+      Error: Group '@invalid' contains one or more invalid aliases: @baz
       """
 
     When I run `wp @both option get home`
     Then STDOUT should be:
       """
-      @subdir1
+      @foo
       http://apple.com
-      @subdir2
+      @bar
       http://google.com
       """
 
@@ -227,25 +227,25 @@ Feature: Create shortcuts to specific WordPress installs
       """
 
   Scenario: Register '@all' alias for running on one or more aliases
-    Given a WP install in 'subdir1'
-    And a WP install in 'subdir2'
+    Given a WP install in 'foo'
+    And a WP install in 'bar'
     And a wp-cli.yml file:
       """
-      @subdir1:
-        path: subdir1
-      @subdir2:
-        path: subdir2
+      @foo:
+        path: foo
+      @bar:
+        path: bar
       """
 
-    When I run `wp @subdir1 option update home 'http://apple.com'`
-    And I run `wp @subdir1 option get home`
+    When I run `wp @foo option update home 'http://apple.com'`
+    And I run `wp @foo option get home`
     Then STDOUT should contain:
       """
       http://apple.com
       """
 
-    When I run `wp @subdir2 option update home 'http://google.com'`
-    And I run `wp @subdir2 option get home`
+    When I run `wp @bar option update home 'http://google.com'`
+    And I run `wp @bar option get home`
     Then STDOUT should contain:
       """
       http://google.com
@@ -254,9 +254,9 @@ Feature: Create shortcuts to specific WordPress installs
     When I run `wp @all option get home`
     Then STDOUT should be:
       """
-      @subdir1
+      @foo
       http://apple.com
-      @subdir2
+      @bar
       http://google.com
       """
 
@@ -268,14 +268,14 @@ Feature: Create shortcuts to specific WordPress installs
       """
 
   Scenario: Don't register '@all' when its already set
-    Given a WP install in 'subdir1'
-    And a WP install in 'subdir2'
+    Given a WP install in 'foo'
+    And a WP install in 'bar'
     And a wp-cli.yml file:
       """
       @all:
-        path: subdir1
-      @subdir2:
-        path: subdir2
+        path: foo
+      @bar:
+        path: bar
       """
 
     When I run `wp @all option get home | wc -l | tr -d ' '`

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -55,6 +55,11 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	private static $cache_dir;
 
 	/**
+	 * The directory that holds the install cache, and which is copied to RUN_DIR during a "Given a WP install" step. Recreated on each suite run.
+	 */
+	private static $install_cache_dir;
+
+	/**
 	 * The directory that the WP-CLI cache (WP_CLI_CACHE_DIR, normally "$HOME/.wp-cli/cache") is set to on a "Given an empty cache" step.
 	 * Variable SUITE_CACHE_DIR. Lives until the end of the scenario (or until another "Given an empty cache" step within the scenario).
 	 */
@@ -152,6 +157,13 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		$result = Process::create( Utils\esc_cmd( 'wp core version --path=%s', self::$cache_dir ) , null, self::get_process_env_variables() )->run_check();
 		echo 'WordPress ' . $result->stdout;
 		echo PHP_EOL;
+
+		// Remove install cache if any (not setting the static var).
+		$wp_version_suffix = ( $wp_version = getenv( 'WP_VERSION' ) ) ? "-$wp_version" : '';
+		$install_cache_dir = sys_get_temp_dir() . '/wp-cli-test-core-install-cache' . $wp_version_suffix;
+		if ( file_exists( $install_cache_dir ) ) {
+			self::remove_dir( $install_cache_dir );
+		}
 	}
 
 	/**
@@ -414,23 +426,33 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		$this->variables['CACHE_DIR'] = $path;
 	}
 
-	private static function run_sql( $sql ) {
-		Utils\run_mysql_command( '/usr/bin/env mysql --no-defaults', array(
-			'execute' => $sql,
+	/**
+	 * Run a MySQL command with `$db_settings`.
+	 *
+	 * @param string $sql_cmd Command to run.
+	 * @param array $assoc_args Optional. Associative array of options. Default empty.
+	 * @param bool $add_database Optional. Whether to add dbname to the $sql_cmd. Default false.
+	 */
+	private static function run_sql( $sql_cmd, $assoc_args = array(), $add_database = false ) {
+		$default_assoc_args = array(
 			'host' => self::$db_settings['dbhost'],
 			'user' => self::$db_settings['dbuser'],
 			'pass' => self::$db_settings['dbpass'],
-		) );
+		);
+		if ( $add_database ) {
+			$sql_cmd .= ' ' . escapeshellarg( self::$db_settings['dbname'] );
+		}
+		Utils\run_mysql_command( $sql_cmd, array_merge( $assoc_args, $default_assoc_args ) );
 	}
 
 	public function create_db() {
 		$dbname = self::$db_settings['dbname'];
-		self::run_sql( "CREATE DATABASE IF NOT EXISTS $dbname" );
+		self::run_sql( 'mysql --no-defaults', array( 'execute' => "CREATE DATABASE IF NOT EXISTS $dbname" ) );
 	}
 
 	public function drop_db() {
 		$dbname = self::$db_settings['dbname'];
-		self::run_sql( "DROP DATABASE IF EXISTS $dbname" );
+		self::run_sql( 'mysql --no-defaults', array( 'execute' => "DROP DATABASE IF EXISTS $dbname" ) );
 	}
 
 	public function proc( $command, $assoc_args = array(), $path = '' ) {
@@ -524,10 +546,29 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 			$params['extra-php'] = $extra_php;
 		}
 
-		$this->proc( 'wp core config', $params, $subdir )->run_check();
+		$config_cache_path = '';
+		if ( self::$install_cache_dir ) {
+			$config_cache_path = self::$install_cache_dir . '/config_' . md5( implode( ':', $params ) . ':subdir=' . $subdir );
+			$run_dir = '' !== $subdir ? ( $this->variables['RUN_DIR'] . "/$subdir" ) : $this->variables['RUN_DIR'];
+		}
+
+		if ( $config_cache_path && file_exists( $config_cache_path ) ) {
+			copy( $config_cache_path, $run_dir . '/wp-config.php' );
+		} else {
+			$this->proc( 'wp config create', $params, $subdir )->run_check();
+			if ( $config_cache_path && file_exists( $run_dir . '/wp-config.php' ) ) {
+				copy( $run_dir . '/wp-config.php', $config_cache_path );
+			}
+		}
 	}
 
 	public function install_wp( $subdir = '' ) {
+		$wp_version_suffix = ( $wp_version = getenv( 'WP_VERSION' ) ) ? "-$wp_version" : '';
+		self::$install_cache_dir = sys_get_temp_dir() . '/wp-cli-test-core-install-cache' . $wp_version_suffix;
+		if ( ! file_exists( self::$install_cache_dir ) ) {
+			mkdir( self::$install_cache_dir );
+		}
+
 		$subdir = $this->replace_variables( $subdir );
 
 		$this->create_db();
@@ -543,7 +584,23 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 			'admin_password' => 'password1'
 		);
 
-		$this->proc( 'wp core install', $install_args, $subdir )->run_check();
+		$install_cache_path = '';
+		if ( self::$install_cache_dir ) {
+			$install_cache_path = self::$install_cache_dir . '/install_' . md5( implode( ':', $install_args ) . ':subdir=' . $subdir );
+			$run_dir = '' !== $subdir ? ( $this->variables['RUN_DIR'] . "/$subdir" ) : $this->variables['RUN_DIR'];
+		}
+
+		if ( $install_cache_path && file_exists( $install_cache_path ) ) {
+			self::copy_dir( $install_cache_path, $run_dir );
+			self::run_sql( 'mysql --no-defaults', array( 'execute' => "source {$install_cache_path}.sql" ), true /*add_database*/ );
+		} else {
+			$this->proc( 'wp core install', $install_args, $subdir )->run_check();
+			if ( $install_cache_path ) {
+				mkdir( $install_cache_path );
+				self::dir_diff_copy( $run_dir, self::$cache_dir, $install_cache_path );
+				self::run_sql( 'mysqldump --no-defaults', array( 'result-file' => "{$install_cache_path}.sql" ), true /*add_database*/ );
+			}
+		}
 	}
 
 	public function install_wp_with_composer( $vendor_directory = 'vendor' ) {
@@ -622,6 +679,42 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 			$this->variables['COMPOSER_PATH'] = exec('which composer');
 		}
 		$this->proc( $this->variables['COMPOSER_PATH'] . ' ' . $cmd )->run_check();
+	}
+
+	/**
+	 * Copy files in updated directory that are not in source directory to copy directory. ("Incremental backup".)
+	 * Note: does not deal with changed files (ie does not compare file contents for changes), for speed reasons.
+	 *
+	 * @param string $upd_dir The directory to search looking for files/directories not in `$src_dir`.
+	 * @param string $src_dir The directory to be compared to `$upd_dir`.
+	 * @param string $cop_dir Where to copy any files/directories in `$upd_dir` but not in `$src_dir` to.
+	 */
+	private static function dir_diff_copy( $upd_dir, $src_dir, $cop_dir ) {
+		if ( false === ( $files = scandir( $upd_dir ) ) ) {
+			$error = error_get_last();
+			throw new \RuntimeException( sprintf( "Failed to open updated directory '%s': %s. " . __FILE__ . ':' . __LINE__, $upd_dir, $error['message'] ) );
+		}
+		foreach ( array_diff( $files, array( '.', '..' ) ) as $file ) {
+			$upd_file = $upd_dir . '/' . $file;
+			$src_file = $src_dir . '/' . $file;
+			$cop_file = $cop_dir . '/' . $file;
+			if ( ! file_exists( $src_file ) ) {
+				if ( is_dir( $upd_file ) ) {
+					if ( ! file_exists( $cop_file ) && ! mkdir( $cop_file, 0777, true /*recursive*/ ) ) {
+						$error = error_get_last();
+						throw new \RuntimeException( sprintf( "Failed to create copy directory '%s': %s. " . __FILE__ . ':' . __LINE__, $cop_file, $error['message'] ) );
+					}
+					self::copy_dir( $upd_file, $cop_file );
+				} else {
+					if ( ! copy( $upd_file, $cop_file ) ) {
+						$error = error_get_last();
+						throw new \RuntimeException( sprintf( "Failed to copy '%s' to '%s': %s. " . __FILE__ . ':' . __LINE__, $upd_file, $cop_file, $error['message'] ) );
+					}
+				}
+			} elseif ( is_dir( $upd_file ) ) {
+				self::dir_diff_copy( $upd_file, $src_file, $cop_file );
+			}
+		}
 	}
 
 }

--- a/features/config.feature
+++ b/features/config.feature
@@ -36,10 +36,10 @@ Feature: Have a config file
     Then STDOUT should not be empty
 
   Scenario: WP in a subdirectory
-    Given a WP install in 'core'
+    Given a WP install in 'foo'
     And a wp-cli.yml file:
       """
-      path: core
+      path: foo
       """
 
     When I run `wp --info`
@@ -51,7 +51,7 @@ Feature: Have a config file
     When I run `wp core is-installed`
     Then STDOUT should be empty
 
-    When I run `wp core is-installed` from 'core/wp-content'
+    When I run `wp core is-installed` from 'foo/wp-content'
     Then STDOUT should be empty
 
     When I run `mkdir -p other/subdir`
@@ -59,18 +59,18 @@ Feature: Have a config file
     Then STDOUT should be empty
 
   Scenario: WP in a subdirectory (autodetected)
-    Given a WP install in 'core'
+    Given a WP install in 'foo'
 
     Given an index.php file:
     """
-    require('./core/wp-blog-header.php');
+    require('./foo/wp-blog-header.php');
     """
     When I run `wp core is-installed`
     Then STDOUT should be empty
 
     Given an index.php file:
     """
-    require dirname(__FILE__) . '/core/wp-blog-header.php';
+    require dirname(__FILE__) . '/foo/wp-blog-header.php';
     """
     When I run `wp core is-installed`
     Then STDOUT should be empty
@@ -82,12 +82,12 @@ Feature: Have a config file
 
   Scenario: Nested installs
     Given a WP install
-    And a WP install in 'subsite'
+    And a WP install in 'foo'
     And a wp-cli.yml file:
       """
       """
 
-    When I run `wp --info` from 'subsite'
+    When I run `wp --info` from 'foo'
     Then STDOUT should not contain:
       """
       wp-cli.yml

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -220,9 +220,9 @@ Feature: Run a WP-CLI command
     | --launch    |
 
   Scenario Outline: Persists global parameters when supplied interactively
-    Given a WP install in 'subdir'
+    Given a WP install in 'foo'
 
-    When I run `wp <flag> --path=subdir run 'rewrite structure "archives/%post_id%/" --path=subdir'`
+    When I run `wp <flag> --path=foo run 'rewrite structure "archives/%post_id%/" --path=foo'`
     Then STDOUT should be:
       """
       Success: Rewrite rules flushed.


### PR DESCRIPTION
For consideration/discussion.

Adds caching of single-site installs of WP in tests for performance reasons.

The basic algorithm is to save `wp-config.php`, any files/directories added during install, and a `mysqldump` of the database, to an install cache, keyed by options and sub-directory, and then use them to do a WP install rather than calling `wp core install` each time.

It assumes that the only file whose contents change is `wp-config.php`, which is true now and back to WP 3.7.11, but obviously may change. Currently the only other files added are `wp-content/mu-plugins/no-mail.php` and a blank `wp-content/uploads/<year>/<month>/` directory.

Also standardizes the names of sub-directory installs to `foo` and `bar` (instead of the various `testdir`, `subdir`, `core` etc used in `aliases.features`, `config.features` and `runcommand.features`) to maximize reusage.

The speed up is pleasant, if not spectacular (`mysqldump` and `mysql source` are not fast), but is especially noticeable locally.
