### PR TITLE
Add WP_CLI_TEST_LOG_RUN_TIMES run time stats to FeatureContext.

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -93,6 +93,19 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	private static $temp_dir_infix;
 
 	/**
+	 * Settings and variables for WP_CLI_TEST_LOG_RUN_TIMES run time logging.
+	 */
+	private static $log_run_times; // Whether to log run times - WP_CLI_TEST_LOG_RUN_TIMES env var. Set on `@BeforeScenario'.
+	private static $suite_start_time; // When the suite started, set on `@BeforeScenario'.
+	private static $output_to; // Where to output log - error_log|stdout|stderr. Set on `@BeforeSuite`.
+	private static $num_top_processes; // Number of processes/methods to output by longest run times. Set on `@BeforeSuite`.
+	private static $num_top_scenarios; // Number of scenarios to output by longest run times. Set on `@BeforeSuite`.
+
+	private static $scenario_run_times = array(); // Scenario run times (top `self::$num_top_scenarios` only).
+	private static $scenario_count = 0; // Scenario count, incremented on `@AfterScenario`.
+	private static $proc_method_run_times = array(); // Array of run time info for proc methods, keyed by method name and arg, each a 2-element array containing run time and run count.
+
+	/**
 	 * Get the environment variables required for launched `wp` processes
 	 */
 	private static function get_process_env_variables() {
@@ -144,6 +157,11 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	 * @BeforeSuite
 	 */
 	public static function prepare( SuiteEvent $event ) {
+		// Test performance statistics - useful for detecting slow tests.
+		if ( self::$log_run_times = getenv( 'WP_CLI_TEST_LOG_RUN_TIMES' ) ) {
+			self::log_run_times_before_suite( $event );
+		}
+
 		$result = Process::create( 'wp cli info', null, self::get_process_env_variables() )->run_check();
 		echo PHP_EOL;
 		echo $result->stdout;
@@ -162,12 +180,20 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 			self::remove_dir( self::$composer_local_repository );
 			self::$composer_local_repository = null;
 		}
+
+		if ( self::$log_run_times ) {
+			self::log_run_times_after_suite( $event );
+		}
 	}
 
 	/**
 	 * @BeforeScenario
 	 */
 	public function beforeScenario( $event ) {
+		if ( self::$log_run_times ) {
+			self::log_run_times_before_scenario( $event );
+		}
+
 		$this->variables['SRC_DIR'] = realpath( __DIR__ . '/../..' );
 
 		// Used in the names of the RUN_DIR and SUITE_CACHE_DIR directories.
@@ -205,6 +231,10 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		foreach ( $this->running_procs as $proc ) {
 			$status = proc_get_status( $proc );
 			self::terminate_proc( $status['pid'] );
+		}
+
+		if ( self::$log_run_times ) {
+			self::log_run_times_after_scenario( $event );
 		}
 	}
 
@@ -342,6 +372,8 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 			$scenario_feature = $event->getScenario();
 		} elseif ( method_exists( $event, 'getFeature' ) ) {
 			$scenario_feature = $event->getFeature();
+		} elseif ( method_exists( $event, 'getOutline' ) ) {
+			$scenario_feature = $event->getOutline();
 		} else {
 			return null;
 		}
@@ -415,12 +447,18 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	}
 
 	private static function run_sql( $sql ) {
+		$start_time = microtime( true );
+
 		Utils\run_mysql_command( '/usr/bin/env mysql --no-defaults', array(
 			'execute' => $sql,
 			'host' => self::$db_settings['dbhost'],
 			'user' => self::$db_settings['dbuser'],
 			'pass' => self::$db_settings['dbpass'],
 		) );
+
+		if ( self::$log_run_times ) {
+			self::log_proc_method_run_time( 'run_sql ' . $sql, $start_time );
+		}
 	}
 
 	public function create_db() {
@@ -622,6 +660,149 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 			$this->variables['COMPOSER_PATH'] = exec('which composer');
 		}
 		$this->proc( $this->variables['COMPOSER_PATH'] . ' ' . $cmd )->run_check();
+	}
+
+	/**
+	 * Initialize run time logging.
+	 */
+	private static function log_run_times_before_suite( $event ) {
+		self::$suite_start_time = microtime( true );
+
+		$travis = getenv( 'TRAVIS' );
+
+		// Default output settings.
+		self::$output_to = $travis ? 'stdout' : 'error_log';
+		self::$num_top_processes = $travis ? 10 : 40;
+		self::$num_top_scenarios = $travis ? 10 : 20;
+
+		// Allow setting of above with "WP_CLI_TEST_LOG_RUN_TIMES=<output_to>[,<num_top_processes>][,<num_top_scenarios>]" formatted env var.
+		if ( preg_match( '/^(error_log|stdout|stderr)?(,[0-9]+)?(,[0-9]+)?$/i', self::$log_run_times, $matches ) ) {
+			if ( isset( $matches[1] ) ) {
+				self::$output_to = strtolower( $matches[1] );
+			}
+			if ( isset( $matches[2] ) ) {
+				self::$num_top_processes = max( (int) substr( $matches[2], 1 ), 1 );
+			}
+			if ( isset( $matches[3] ) ) {
+				self::$num_top_scenarios = max( (int) substr( $matches[3], 1 ), 1 );
+			}
+		}
+	}
+
+	/**
+	 * Record the start time of the scenario into the `$scenario_run_times` array.
+	 */
+	private static function log_run_times_before_scenario( $event ) {
+		if ( $scenario_key = self::get_scenario_key( $event ) ) {
+			self::$scenario_run_times[ $scenario_key ] = -microtime( true );
+		}
+	}
+
+	/**
+	 * Save the run time of the scenario into the `$scenario_run_times` array. Only the top `self::$num_top_scenarios` are kept.
+	 */
+	private static function log_run_times_after_scenario( $event ) {
+		if ( $scenario_key = self::get_scenario_key( $event ) ) {
+			self::$scenario_run_times[ $scenario_key ] += microtime( true );
+			self::$scenario_count++;
+			if ( count( self::$scenario_run_times ) > self::$num_top_scenarios ) {
+				arsort( self::$scenario_run_times );
+				array_pop( self::$scenario_run_times );
+			}
+		}
+	}
+
+	/**
+	 * Get the scenario key used for `$scenario_run_times` array.
+	 * Format "<grandparent-dir> <feature-file>:<line-number>", eg "core-command core-update.feature:221".
+	 */
+	private static function get_scenario_key( $event ) {
+		$scenario_key = '';
+		if ( $file = self::get_event_file( $event, $line ) ) {
+			$scenario_grandparent = Utils\basename( dirname( dirname( $file ) ) );
+			$scenario_key = $scenario_grandparent . ' ' . Utils\basename( $file ) . ':' . $line;
+		}
+		return $scenario_key;
+	}
+
+	/**
+	 * Print out stats on the run times of processes and scenarios.
+	 */
+	private static function log_run_times_after_suite( $event ) {
+
+		$suite = '';
+		if ( self::$scenario_run_times ) {
+			// Grandparent directory is first part of key.
+			$keys = array_keys( self::$scenario_run_times );
+			$suite = substr( $keys[0], 0, strpos( $keys[0], ' ' ) );
+		}
+
+		$run_from = Utils\basename( dirname( dirname( __DIR__ ) ) );
+
+		// Format same as Behat, if have minutes.
+		$fmt = function ( $time ) {
+			$mins = floor( $time / 60 );
+			return round( $time, 3 ) . ( $mins ? ( ' (' . $mins . 'm' . round( $time - ( $mins * 60 ), 3 ) . 's)' ) : '' );
+		};
+
+		$time = microtime( true ) - self::$suite_start_time;
+
+		$log = "\n" . str_repeat( '(', 80 ) . "\n";
+
+		// Process and proc method run times.
+		$run_times = array_merge( Process::$run_times, self::$proc_method_run_times );
+
+		list( $ptime, $calls ) = array_reduce( $run_times, function ( $carry, $item ) {
+			return array( $carry[0] + $item[0], $carry[1] + $item[1] );
+		}, array( 0, 0 ) );
+
+		$overhead = $time - $ptime;
+		$pct = round( ( $overhead / $time ) * 100 );
+		$unique = count( $run_times );
+
+		$log .= sprintf(
+			"\nTotal process run time %s (tests %s, overhead %.3f %d%%), calls %d (%d unique) for '%s' run from '%s'\n",
+			$fmt( $ptime ), $fmt( $time ), $overhead, $pct, $calls, $unique, $suite, $run_from
+		);
+
+		uasort( $run_times, function ( $a, $b ) {
+			return $a[0] === $b[0] ? 0 : ( $a[0] < $b[0] ? 1 : -1 ); // Reverse sort.
+		} );
+
+		$tops = array_slice( $run_times, 0, self::$num_top_processes, true );
+
+		$log .= "\nTop " . self::$num_top_processes . " process run times for '$suite'\n" . implode( "\n", array_map( function ( $k, $v, $i ) {
+			return sprintf( ' %3d. %7.3f %3d %s', $i + 1, round( $v[0], 3 ), $v[1], $k );
+		}, array_keys( $tops ), $tops, array_keys( array_keys( $tops ) ) ) ) . "\n";
+
+		// Scenario run times.
+		arsort( self::$scenario_run_times );
+
+		$tops = array_slice( self::$scenario_run_times, 0, self::$num_top_scenarios, true );
+
+		$log .= "\nTop " . self::$num_top_scenarios . " (of " . self::$scenario_count . ") scenario run times for '$suite'\n" . implode( "\n", array_map( function ( $k, $v, $i ) {
+			return sprintf( ' %3d. %7.3f %s', $i + 1, round( $v, 3 ), substr( $k, strpos( $k, ' ' ) + 1 ) );
+		}, array_keys( $tops ), $tops, array_keys( array_keys( $tops ) ) ) ) . "\n";
+
+		$log .= "\n" . str_repeat( ')', 80 );
+
+		if ( 'error_log' === self::$output_to ) {
+			error_log( $log );
+		} else {
+			fwrite( 'stderr' === self::$output_to ? STDERR : STDOUT, "\n" . $log );
+		}
+	}
+
+	/**
+	 * Log the run time of a proc method (one that doesn't use Process but does (use a function that does) a `proc_open()`).
+	 */
+	private static function log_proc_method_run_time( $key, $start_time ) {
+		$run_time = microtime( true ) - $start_time;
+		if ( ! isset( self::$proc_method_run_times[ $key ] ) ) {
+			self::$proc_method_run_times[ $key ] = array( 0, 0 );
+		}
+		self::$proc_method_run_times[ $key ][0] += $run_time;
+		self::$proc_method_run_times[ $key ][1]++;
 	}
 
 }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -458,21 +458,6 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		$this->variables['CACHE_DIR'] = $path;
 	}
 
-	private static function run_sql( $sql ) {
-		$start_time = microtime( true );
-
-		Utils\run_mysql_command( '/usr/bin/env mysql --no-defaults', array(
-			'execute' => $sql,
-			'host' => self::$db_settings['dbhost'],
-			'user' => self::$db_settings['dbuser'],
-			'pass' => self::$db_settings['dbpass'],
-		) );
-
-		if ( self::$log_run_times ) {
-			self::log_proc_method_run_time( 'run_sql ' . $sql, $start_time );
-		}
-	}
-
 	/**
 	 * Run a MySQL command with `$db_settings`.
 	 *
@@ -489,7 +474,11 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		if ( $add_database ) {
 			$sql_cmd .= ' ' . escapeshellarg( self::$db_settings['dbname'] );
 		}
+		$start_time = microtime( true );
 		Utils\run_mysql_command( $sql_cmd, array_merge( $assoc_args, $default_assoc_args ) );
+		if ( self::$log_run_times ) {
+			self::log_proc_method_run_time( 'run_sql ' . $sql_cmd, $start_time );
+		}
 	}
 
 	public function create_db() {

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -97,7 +97,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	 */
 	private static $log_run_times; // Whether to log run times - WP_CLI_TEST_LOG_RUN_TIMES env var. Set on `@BeforeScenario'.
 	private static $suite_start_time; // When the suite started, set on `@BeforeScenario'.
-	private static $output_to; // Where to output log - error_log|stdout|stderr. Set on `@BeforeSuite`.
+	private static $output_to; // Where to output log - stdout|error_log. Set on `@BeforeSuite`.
 	private static $num_top_processes; // Number of processes/methods to output by longest run times. Set on `@BeforeSuite`.
 	private static $num_top_scenarios; // Number of scenarios to output by longest run times. Set on `@BeforeSuite`.
 
@@ -668,15 +668,17 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	private static function log_run_times_before_suite( $event ) {
 		self::$suite_start_time = microtime( true );
 
+		Process::$log_run_times = true;
+
 		$travis = getenv( 'TRAVIS' );
 
 		// Default output settings.
-		self::$output_to = $travis ? 'stdout' : 'error_log';
+		self::$output_to = 'stdout';
 		self::$num_top_processes = $travis ? 10 : 40;
 		self::$num_top_scenarios = $travis ? 10 : 20;
 
 		// Allow setting of above with "WP_CLI_TEST_LOG_RUN_TIMES=<output_to>[,<num_top_processes>][,<num_top_scenarios>]" formatted env var.
-		if ( preg_match( '/^(error_log|stdout|stderr)?(,[0-9]+)?(,[0-9]+)?$/i', self::$log_run_times, $matches ) ) {
+		if ( preg_match( '/^(stdout|error_log)?(,[0-9]+)?(,[0-9]+)?$/i', self::$log_run_times, $matches ) ) {
 			if ( isset( $matches[1] ) ) {
 				self::$output_to = strtolower( $matches[1] );
 			}
@@ -747,7 +749,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 		$time = microtime( true ) - self::$suite_start_time;
 
-		$log = "\n" . str_repeat( '(', 80 ) . "\n";
+		$log = PHP_EOL . str_repeat( '(', 80 ) . PHP_EOL;
 
 		// Process and proc method run times.
 		$run_times = array_merge( Process::$run_times, self::$proc_method_run_times );
@@ -761,7 +763,7 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		$unique = count( $run_times );
 
 		$log .= sprintf(
-			"\nTotal process run time %s (tests %s, overhead %.3f %d%%), calls %d (%d unique) for '%s' run from '%s'\n",
+			PHP_EOL . "Total process run time %s (tests %s, overhead %.3f %d%%), calls %d (%d unique) for '%s' run from '%s'" . PHP_EOL,
 			$fmt( $ptime ), $fmt( $time ), $overhead, $pct, $calls, $unique, $suite, $run_from
 		);
 
@@ -771,25 +773,27 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 		$tops = array_slice( $run_times, 0, self::$num_top_processes, true );
 
-		$log .= "\nTop " . self::$num_top_processes . " process run times for '$suite'\n" . implode( "\n", array_map( function ( $k, $v, $i ) {
+		$log .= PHP_EOL . "Top " . self::$num_top_processes . " process run times for '$suite'";
+		$log .= PHP_EOL . implode( PHP_EOL, array_map( function ( $k, $v, $i ) {
 			return sprintf( ' %3d. %7.3f %3d %s', $i + 1, round( $v[0], 3 ), $v[1], $k );
-		}, array_keys( $tops ), $tops, array_keys( array_keys( $tops ) ) ) ) . "\n";
+		}, array_keys( $tops ), $tops, array_keys( array_keys( $tops ) ) ) ) . PHP_EOL;
 
 		// Scenario run times.
 		arsort( self::$scenario_run_times );
 
 		$tops = array_slice( self::$scenario_run_times, 0, self::$num_top_scenarios, true );
 
-		$log .= "\nTop " . self::$num_top_scenarios . " (of " . self::$scenario_count . ") scenario run times for '$suite'\n" . implode( "\n", array_map( function ( $k, $v, $i ) {
+		$log .= PHP_EOL . "Top " . self::$num_top_scenarios . " (of " . self::$scenario_count . ") scenario run times for '$suite'";
+		$log .= PHP_EOL . implode( PHP_EOL, array_map( function ( $k, $v, $i ) {
 			return sprintf( ' %3d. %7.3f %s', $i + 1, round( $v, 3 ), substr( $k, strpos( $k, ' ' ) + 1 ) );
-		}, array_keys( $tops ), $tops, array_keys( array_keys( $tops ) ) ) ) . "\n";
+		}, array_keys( $tops ), $tops, array_keys( array_keys( $tops ) ) ) ) . PHP_EOL;
 
-		$log .= "\n" . str_repeat( ')', 80 );
+		$log .= PHP_EOL . str_repeat( ')', 80 );
 
 		if ( 'error_log' === self::$output_to ) {
 			error_log( $log );
 		} else {
-			fwrite( 'stderr' === self::$output_to ? STDERR : STDOUT, "\n" . $log );
+			echo PHP_EOL . $log;
 		}
 	}
 

--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -22,6 +22,20 @@ class Process {
 	private $env;
 
 	/**
+	 * @var array Descriptor spec for `proc_open()`.
+	 */
+	private static $descriptors = array(
+		0 => STDIN,
+		1 => array( 'pipe', 'w' ),
+		2 => array( 'pipe', 'w' ),
+	);
+
+	/**
+	 * @var array Array of process run time info, keyed by process command, each a 2-element array containing run time and run count.
+	 */
+	public static $run_times = array();
+
+	/**
 	 * @param string $command Command to execute.
 	 * @param string $cwd Directory to execute the command in.
 	 * @param array $env Environment variables to set when running the command.
@@ -46,15 +60,9 @@ class Process {
 	 * @return ProcessRun
 	 */
 	public function run() {
-		$cwd = $this->cwd;
+		$start_time = microtime( true );
 
-		$descriptors = array(
-			0 => STDIN,
-			1 => array( 'pipe', 'w' ),
-			2 => array( 'pipe', 'w' ),
-		);
-
-		$proc = proc_open( $this->command, $descriptors, $pipes, $cwd, $this->env );
+		$proc = proc_open( $this->command, self::$descriptors, $pipes, $this->cwd, $this->env );
 
 		$stdout = stream_get_contents( $pipes[1] );
 		fclose( $pipes[1] );
@@ -62,13 +70,26 @@ class Process {
 		$stderr = stream_get_contents( $pipes[2] );
 		fclose( $pipes[2] );
 
+		$return_code = proc_close( $proc );
+
+		$run_time = microtime( true ) - $start_time;
+
+		if ( getenv( 'WP_CLI_TEST_LOG_RUN_TIMES' ) ) {
+			if ( ! isset( self::$run_times[ $this->command ] ) ) {
+				self::$run_times[ $this->command ] = array( 0, 0 );
+			}
+			self::$run_times[ $this->command ][0] += $run_time;
+			self::$run_times[ $this->command ][1]++;
+		}
+
 		return new ProcessRun( array(
 			'stdout' => $stdout,
 			'stderr' => $stderr,
-			'return_code' => proc_close( $proc ),
+			'return_code' => $return_code,
 			'command' => $this->command,
-			'cwd' => $cwd,
+			'cwd' => $this->cwd,
 			'env' => $this->env,
+			'run_time' => $run_time,
 		) );
 	}
 

--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -31,6 +31,11 @@ class Process {
 	);
 
 	/**
+	 * @var bool Whether to log run time info or not.
+	 */
+	public static $log_run_times = false;
+
+	/**
 	 * @var array Array of process run time info, keyed by process command, each a 2-element array containing run time and run count.
 	 */
 	public static $run_times = array();
@@ -74,7 +79,7 @@ class Process {
 
 		$run_time = microtime( true ) - $start_time;
 
-		if ( getenv( 'WP_CLI_TEST_LOG_RUN_TIMES' ) ) {
+		if ( self::$log_run_times ) {
 			if ( ! isset( self::$run_times[ $this->command ] ) ) {
 				self::$run_times[ $this->command ] = array( 0, 0 );
 			}

--- a/php/WP_CLI/ProcessRun.php
+++ b/php/WP_CLI/ProcessRun.php
@@ -37,6 +37,11 @@ class ProcessRun {
 	public $return_code;
 
 	/**
+	 * @var float The run time of the process.
+	 */
+	public $run_time;
+
+	/**
 	 * @var array $props Properties of executed command.
 	 */
 	public function __construct( $props ) {
@@ -54,6 +59,7 @@ class ProcessRun {
 		$out  = "$ $this->command\n";
 		$out .= "$this->stdout\n$this->stderr";
 		$out .= "cwd: $this->cwd\n";
+		$out .= "run time: $this->run_time\n";
 		$out .= "exit status: $this->return_code";
 
 		return $out;


### PR DESCRIPTION
Adds logging of process run times to `FeatureContext`, useful for detecting slow tests and suggesting where things could be speeded up.

The logging is triggered by setting the `WP_CLI_TEST_LOG_RUN_TIMES` environment variable, which can take a formatted value setting some output options (where to output to, no. of slowest processes to show, no. of slowest scenarios to show).

By default it logs to `error_log` for local testing, and `STDOUT` on Travis.

Adds run time info to `Process` (whose `run()` is changed a bit) and `ProcessRun`.

Also fixes a bug in `FeatureContext::get_event_file()` where it wasn't allowing for Scenario Outlines.