### PR TITLE
make-phar.php: chmod executable & no generated msg if BE_QUIET.

### DIFF
--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -248,4 +248,8 @@ EOB
 
 $phar->stopBuffering();
 
-echo "Generated " . DEST_PATH . "\n";
+chmod( DEST_PATH, 0755 ); // Make executable.
+
+if ( ! BE_QUIET ) {
+	echo "Generated " . DEST_PATH . "\n";
+}


### PR DESCRIPTION
Makes phar executable (handy for local running) and doesn't output generated message if `BE_QUIET` set.