### PR TITLE
Add more tests to declare explicit behavior of `WP_CLI::add_hook()`

### DIFF
--- a/features/hook.feature
+++ b/features/hook.feature
@@ -10,8 +10,6 @@ Feature: Tests `WP_CLI::add_hook()`
       };
 
       WP_CLI::add_hook( 'before_invoke:plugin list', $callback );
-      WP_CLI::add_hook( 'before_invoke:theme list', $callback );
-      WP_CLI::add_hook( 'before_invoke:db check', $callback );
       """
 
     When I run `wp plugin list`
@@ -21,14 +19,38 @@ Feature: Tests `WP_CLI::add_hook()`
       """
     And the return code should be 0
 
-    When I run `wp theme list`
+  Scenario: Add callback to the `before_invoke`
+    Given a WP install
+    And a wp-content/mu-plugins/test-harness.php file:
+      """
+      <?php
+      $callback = function() {
+        WP_CLI::log( '`add_hook()` to the `before_invoke` is working.');
+      };
+
+      WP_CLI::add_hook( 'before_invoke:db check', $callback );
+      """
+
+    When I run `wp db check`
     Then STDOUT should contain:
       """
       `add_hook()` to the `before_invoke` is working.
       """
     And the return code should be 0
 
-    When I run `wp db check`
+  Scenario: Add callback to the `before_invoke`
+    Given a WP install
+    And a wp-content/mu-plugins/test-harness.php file:
+      """
+      <?php
+      $callback = function() {
+        WP_CLI::log( '`add_hook()` to the `before_invoke` is working.');
+      };
+
+      WP_CLI::add_hook( 'before_invoke:core version', $callback );
+      """
+
+    When I run `wp core version`
     Then STDOUT should contain:
       """
       `add_hook()` to the `before_invoke` is working.

--- a/features/hook.feature
+++ b/features/hook.feature
@@ -2,7 +2,7 @@ Feature: Tests `WP_CLI::add_hook()`
 
   Scenario: Add callback to the `before_invoke`
     Given a WP install
-    And a wp-content/mu-plugins/test-harness.php file:
+    And a before-invoke.php file:
       """
       <?php
       $callback = function() {
@@ -10,6 +10,11 @@ Feature: Tests `WP_CLI::add_hook()`
       };
 
       WP_CLI::add_hook( 'before_invoke:plugin list', $callback );
+      """
+    And a wp-cli.yml file:
+      """
+      require:
+        - before-invoke.php
       """
 
     When I run `wp plugin list`
@@ -21,7 +26,7 @@ Feature: Tests `WP_CLI::add_hook()`
 
   Scenario: Add callback to the `before_invoke`
     Given a WP install
-    And a wp-content/mu-plugins/test-harness.php file:
+    And a before-invoke.php file:
       """
       <?php
       $callback = function() {
@@ -29,6 +34,11 @@ Feature: Tests `WP_CLI::add_hook()`
       };
 
       WP_CLI::add_hook( 'before_invoke:db check', $callback );
+      """
+    And a wp-cli.yml file:
+      """
+      require:
+        - before-invoke.php
       """
 
     When I run `wp db check`
@@ -40,7 +50,7 @@ Feature: Tests `WP_CLI::add_hook()`
 
   Scenario: Add callback to the `before_invoke`
     Given a WP install
-    And a wp-content/mu-plugins/test-harness.php file:
+    And a before-invoke.php file:
       """
       <?php
       $callback = function() {
@@ -48,6 +58,11 @@ Feature: Tests `WP_CLI::add_hook()`
       };
 
       WP_CLI::add_hook( 'before_invoke:core version', $callback );
+      """
+    And a wp-cli.yml file:
+      """
+      require:
+        - before-invoke.php
       """
 
     When I run `wp core version`

--- a/features/hook.feature
+++ b/features/hook.feature
@@ -1,0 +1,36 @@
+Feature: Tests `WP_CLI::add_hook()`
+
+  Scenario: Add callback to the `before_invoke`
+    Given a WP install
+    And a wp-content/mu-plugins/test-harness.php file:
+      """
+      <?php
+      $callback = function() {
+        WP_CLI::log( '`add_hook()` to the `before_invoke` is working.');
+      };
+
+      WP_CLI::add_hook( 'before_invoke:plugin list', $callback );
+      WP_CLI::add_hook( 'before_invoke:theme list', $callback );
+      WP_CLI::add_hook( 'before_invoke:db check', $callback );
+      """
+
+    When I run `wp plugin list`
+    Then STDOUT should contain:
+      """
+      `add_hook()` to the `before_invoke` is working.
+      """
+    And the return code should be 0
+
+    When I run `wp theme list`
+    Then STDOUT should contain:
+      """
+      `add_hook()` to the `before_invoke` is working.
+      """
+    And the return code should be 0
+
+    When I run `wp db check`
+    Then STDOUT should contain:
+      """
+      `add_hook()` to the `before_invoke` is working.
+      """
+    And the return code should be 0

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1010,7 +1010,7 @@ class WP_CLI {
 
 		if ( defined( 'PHP_BINARY' ) )
 			return PHP_BINARY;
-		
+
 		return 'php';
 	}
 


### PR DESCRIPTION
I added `WP_CLI::add_hook( 'before_invoke:<command>', $callback );` to some command.
Then I found the some commands doesn't fire some hooks.
For example, `wp plugin *` fires the `before_invoke` hook, but `wp db *` and `wp core *` don't fire the same hook.

Is it problem that should be solved or we need to improve the documentation?