### PR TITLE
http_request: add url to error msgs, only re-try if local CACert issue.

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -580,13 +580,17 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 		$request = \Requests::request( $url, $headers, $data, $method, $options );
 		return $request;
 	} catch( \Requests_Exception $ex ) {
+		// CURLE_SSL_CACERT_BADFILE only defined for PHP >= 7.
+		if ( 'curlerror' !== $ex->getType() || ! in_array( curl_errno( $ex->getData() ), array( CURLE_SSL_CONNECT_ERROR, CURLE_SSL_CERTPROBLEM, 77 /*CURLE_SSL_CACERT_BADFILE*/ ), true ) ) {
+			\WP_CLI::error( sprintf( "Failed to get url '%s': %s.", $url, $ex->getMessage() ) );
+		}
 		// Handle SSL certificate issues gracefully
-		\WP_CLI::warning( $ex->getMessage() );
+		\WP_CLI::warning( sprintf( "Re-trying without verify after failing to get verified url '%s' %s.", $url, $ex->getMessage() ) );
 		$options['verify'] = false;
 		try {
 			return \Requests::request( $url, $headers, $data, $method, $options );
 		} catch( \Requests_Exception $ex ) {
-			\WP_CLI::error( $ex->getMessage() );
+			\WP_CLI::error( sprintf( "Failed to get non-verified url '%s' %s.", $url, $ex->getMessage() ) );
 		}
 	}
 }

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -320,6 +320,97 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		}
 	}
 
+	public function testHttpRequestBadAddress() {
+		// Save WP_CLI state.
+		$class_wp_cli_logger = new \ReflectionProperty( 'WP_CLI', 'logger' );
+		$class_wp_cli_logger->setAccessible( true );
+		$class_wp_cli_capture_exit = new \ReflectionProperty( 'WP_CLI', 'capture_exit' );
+		$class_wp_cli_capture_exit->setAccessible( true );
+
+		$prev_logger = $class_wp_cli_logger->getValue();
+		$prev_capture_exit = $class_wp_cli_capture_exit->getValue();
+
+		// Enable exit exception.
+		$class_wp_cli_capture_exit->setValue( true );
+
+		$logger = new \WP_CLI\Loggers\Execution;
+		WP_CLI::set_logger( $logger );
+
+		$exception = null;
+		try {
+			Utils\http_request( 'GET', 'https://nosuchhost_asdf_asdf_asdf.com' );
+		} catch ( \WP_CLI\ExitException $ex ) {
+			$exception = $ex;
+		}
+		$this->assertTrue( null !== $exception );
+		$this->assertTrue( 1 === $exception->getCode() );
+		$this->assertTrue( empty( $logger->stdout ) );
+		$this->assertTrue( false === strpos( $logger->stderr, 'Warning' ) );
+		$this->assertTrue( 0 === strpos( $logger->stderr, 'Error: Failed to get url' ) );
+
+		// Restore.
+		$class_wp_cli_logger->setValue( $prev_logger );
+		$class_wp_cli_capture_exit->setValue( $prev_capture_exit );
+	}
+
+	public function testHttpRequestBadCAcert() {
+		// Save WP_CLI state.
+		$class_wp_cli_logger = new \ReflectionProperty( 'WP_CLI', 'logger' );
+		$class_wp_cli_logger->setAccessible( true );
+
+		$prev_logger = $class_wp_cli_logger->getValue();
+
+		$have_bad_cacert = false;
+		$created_dirs = array();
+
+		// Hack to create bad CAcert, using Utils\get_vendor_paths() preference for a path as part of a Composer-installed larger project.
+		$vendor_dir = WP_CLI_ROOT . '/../../../vendor';
+		$cert_path = '/rmccue/requests/library/Requests/Transport/cacert.pem';
+		$bad_cacert_path = $vendor_dir . $cert_path;
+		if ( ! file_exists( $bad_cacert_path ) ) {
+			// Capture any directories created so can clean up.
+			$dirs = array_merge( array( 'vendor' ), array_filter( explode( '/', dirname( $cert_path ) ) ) );
+			$current_dir = dirname( $vendor_dir );
+			foreach ( $dirs as $dir ) {
+				if ( ! file_exists( $current_dir . '/' . $dir ) ) {
+					if ( ! @mkdir( $current_dir . '/' . $dir ) ) {
+						break;
+					}
+					$created_dirs[] = $current_dir . '/' . $dir;
+				}
+				$current_dir .= '/' . $dir;
+			}
+			if ( $current_dir === dirname( $bad_cacert_path ) && file_put_contents( $bad_cacert_path, "-----BEGIN CERTIFICATE-----\nasdfasdf\n-----END CERTIFICATE-----\n" ) ) {
+				$have_bad_cacert = true;
+			}
+		}
+
+		if ( ! $have_bad_cacert ) {
+			foreach ( array_reverse( $created_dirs ) as $created_dir ) {
+				rmdir( $created_dir );
+			}
+			$this->markTestSkipped( 'Unable to create bad CAcert.' );
+		}
+
+		$logger = new \WP_CLI\Loggers\Execution;
+		WP_CLI::set_logger( $logger );
+
+		Utils\http_request( 'GET', 'https://example.com' );
+
+		// Undo bad CAcert hack before asserting.
+		unlink( $bad_cacert_path );
+		foreach ( array_reverse( $created_dirs ) as $created_dir ) {
+			rmdir( $created_dir );
+		}
+
+		$this->assertTrue( empty( $logger->stdout ) );
+		$this->assertTrue( 0 === strpos( $logger->stderr, 'Warning: Re-trying without verify after failing to get verified url' ) );
+		$this->assertFalse( strpos( $logger->stderr, 'Error' ) );
+
+		// Restore.
+		$class_wp_cli_logger->setValue( $prev_logger );
+	}
+
 	public function testRunMysqlCommandProcDisabled() {
 		$err_msg = 'Error: Cannot do \'run_mysql_command\': The PHP functions `proc_open()` and/or `proc_close()` are disabled';
 

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -2,6 +2,8 @@
 
 use WP_CLI\Utils;
 
+require_once dirname( __DIR__ ) . '/php/class-wp-cli.php';
+
 class UtilsTest extends PHPUnit_Framework_TestCase {
 
 	function testIncrementVersion() {


### PR DESCRIPTION
See https://github.com/wp-cli/export-command/pull/13#issuecomment-324689315

Adds url to `Utils\http_request()` error message as it's helpful to know.

Re-tries without verify only if error is due to a local CAcert issue. (See https://curl.haxx.se/libcurl/c/libcurl-errors.html).

Note adds a test re local CAcert issue but it relies on a hack re `Utils\get_vendor_paths()`, creating a `pem` file outside the current project, so it may be best to leave it out.
