### PR TITLE
Make unit tests PHPUnit 6 compat.

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -6,7 +6,7 @@ set -ex
 phpcs
 
 # Run the unit tests
-vendor/bin/phpunit
+phpunit
 
 BEHAT_TAGS=$(php ci/behat-tags.php)
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,13 @@
 
 define( 'WP_CLI_ROOT', dirname( __DIR__ ) );
 
+/**
+ * Compatibility with PHPUnit 6+
+ */
+if ( class_exists( 'PHPUnit\Runner\Version' ) ) {
+	require_once __DIR__ . '/phpunit6-compat.php';
+}
+
 if ( file_exists( WP_CLI_ROOT . '/vendor/autoload.php' ) ) {
 	define( 'WP_CLI_VENDOR_DIR' , WP_CLI_ROOT . '/vendor' );
 } elseif ( file_exists( dirname( dirname( WP_CLI_ROOT ) ) . '/autoload.php' ) ) {

--- a/tests/phpunit6-compat.php
+++ b/tests/phpunit6-compat.php
@@ -1,0 +1,19 @@
+<?php
+// From core "tests/phpunit/includes/phpunit6-compat.php" without `getTickets()` (see https://core.trac.wordpress.org/ticket/39822).
+
+if ( class_exists( 'PHPUnit\Runner\Version' ) && version_compare( PHPUnit\Runner\Version::id(), '6.0', '>=' ) ) {
+
+	class_alias( 'PHPUnit\Framework\TestCase',                   'PHPUnit_Framework_TestCase' );
+	class_alias( 'PHPUnit\Framework\Exception',                  'PHPUnit_Framework_Exception' );
+	class_alias( 'PHPUnit\Framework\ExpectationFailedException', 'PHPUnit_Framework_ExpectationFailedException' );
+	class_alias( 'PHPUnit\Framework\Error\Notice',               'PHPUnit_Framework_Error_Notice' );
+	class_alias( 'PHPUnit\Framework\Error\Warning',              'PHPUnit_Framework_Error_Warning' );
+	class_alias( 'PHPUnit\Framework\Test',                       'PHPUnit_Framework_Test' );
+	class_alias( 'PHPUnit\Framework\Warning',                    'PHPUnit_Framework_Warning' );
+	class_alias( 'PHPUnit\Framework\AssertionFailedError',       'PHPUnit_Framework_AssertionFailedError' );
+	class_alias( 'PHPUnit\Framework\TestSuite',                  'PHPUnit_Framework_TestSuite' );
+	class_alias( 'PHPUnit\Framework\TestListener',               'PHPUnit_Framework_TestListener' );
+	class_alias( 'PHPUnit\Util\GlobalState',                     'PHPUnit_Util_GlobalState' );
+	class_alias( 'PHPUnit\Util\Getopt',                          'PHPUnit_Util_Getopt' );
+
+}


### PR DESCRIPTION
Related https://github.com/wp-cli/php-cli-tools/pull/118 and https://core.trac.wordpress.org/ticket/39822

Makes unit tests PHPUnit 6 compatible, and runs the default `phpunit` on Travis.

`phpunit6-compat.php` is the same as core's version, without the core-specific `PHPUnit_Util_Test::getTickets()`.

(Have left the `composer.json` phpunit requirement alone, not sure what to do there.) 