### PR TITLE
Check for xdebug before disabling in ci/prepare.sh.

### DIFF
--- a/ci/prepare.sh
+++ b/ci/prepare.sh
@@ -7,7 +7,11 @@ set -ex
 WP_CLI_BIN_DIR=${WP_CLI_BIN_DIR-/tmp/wp-cli-phar}
 
 # Disable XDebug to speed up Composer and test suites.
-phpenv config-rm xdebug.ini
+if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
+  phpenv config-rm xdebug.ini
+else
+  echo "xdebug.ini does not exist"
+fi
 
 composer install --no-interaction --prefer-source
 


### PR DESCRIPTION
See issue https://github.com/wp-cli/scaffold-package-command/issues/142, PR https://github.com/wp-cli/scaffold-command/pull/49 and https://core.trac.wordpress.org/changeset/41177

Checks that xdebug is installed before disabling in `ci/prepare.sh`, otherwise will get error. (Currently the Travis PHP 7.2 beta doesn't install xdebug by default.)