### PR TITLE
Address some code standards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 	"config": {
 		"platform": {
 			"php": "5.3.29"
-		}
+		},
+        "sort-packages": true
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,
@@ -63,9 +64,11 @@
 		"wp-cli/widget-command": "^1.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "3.7.*",
 		"behat/behat": "2.5.*",
-		"roave/security-advisories": "dev-master"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.2",
+		"phpunit/phpunit": "3.7.*",
+		"roave/security-advisories": "dev-master",
+		"wp-coding-standards/wpcs": "^0.13.1"
 	},
 	"suggest": {
 		"psy/psysh": "Enhanced `wp shell` functionality"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "af81682689ad61c9aa1b67539da5823c",
+    "content-hash": "8fbcffae89db750c42aa54d691f7248d",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2842,6 +2842,72 @@
             "time": "2013-10-15T11:22:17+00:00"
         },
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DealerDirect/phpcodesniffer-composer-installer.git",
+                "reference": "17130f536db62570bcfc5cce59464b36e82eb092"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DealerDirect/phpcodesniffer-composer-installer/zipball/17130f536db62570bcfc5cce59464b36e82eb092",
+                "reference": "17130f536db62570bcfc5cce59464b36e82eb092",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "require-dev": {
+                "composer/composer": "*"
+            },
+            "suggest": {
+                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "f.nijhof@dealerdirect.nl",
+                    "homepage": "http://workingatdealerdirect.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://workingatdealerdirect.eu",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2017-08-16T10:25:17+00:00"
+        },
+        {
             "name": "phpunit/php-code-coverage",
             "version": "1.2.18",
             "source": {
@@ -3347,6 +3413,124 @@
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
             "time": "2017-08-17T12:55:16+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-05-22T02:43:20+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "0.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
+                "reference": "1f64b1a0b5b789822d0303436ee4e30e0135e4dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/1f64b1a0b5b789822d0303436ee4e30e0135e4dc",
+                "reference": "1f64b1a0b5b789822d0303436ee4e30e0135e4dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2017-08-05T16:08:58+00:00"
         }
     ],
     "aliases": [],

--- a/php/WP_CLI/Bootstrap/DefineProtectedCommands.php
+++ b/php/WP_CLI/Bootstrap/DefineProtectedCommands.php
@@ -40,7 +40,7 @@ final class DefineProtectedCommands implements BootstrapStep {
 	private function get_protected_commands() {
 		return array(
 			'cli info',
-		    'package',
+			'package',
 		);
 	}
 

--- a/php/WP_CLI/Completions.php
+++ b/php/WP_CLI/Completions.php
@@ -16,13 +16,13 @@ class Completions {
 
 		// last word is either empty or an incomplete subcommand
 		$this->cur_word = end( $this->words );
-		if ( "" !== $this->cur_word && ! preg_match( "/^\-/", $this->cur_word ) ) {
+		if ( '' !== $this->cur_word && ! preg_match( '/^\-/', $this->cur_word ) ) {
 			array_pop( $this->words );
 		}
 
 		$is_alias = false;
 		$is_help = false;
-		if ( ! empty( $this->words[0] ) && preg_match( "/^@/", $this->words[0] ) ) {
+		if ( ! empty( $this->words[0] ) && preg_match( '/^@/', $this->words[0] ) ) {
 			array_shift( $this->words );
 			// `wp @al` is false, but `wp @all ` is true.
 			if ( count( $this->words ) ) {
@@ -34,7 +34,7 @@ class Completions {
 		}
 
 		$r = $this->get_command( $this->words );
-		if ( !is_array( $r ) ) {
+		if ( ! is_array( $r ) ) {
 			return;
 		}
 
@@ -51,7 +51,7 @@ class Completions {
 
 		if ( $command->can_have_subcommands() ) {
 			// add completion when command is `wp` and alias isn't set.
-			if ( "wp" === $command->get_name() && false === $is_alias && false == $is_help ) {
+			if ( 'wp' === $command->get_name() && false === $is_alias && false == $is_help ) {
 				$aliases = \WP_CLI::get_configurator()->get_aliases();
 				foreach ( $aliases as $name => $_ ) {
 					$this->add( "$name " );
@@ -71,7 +71,7 @@ class Completions {
 
 					if ( $arg['type'] == 'flag' ) {
 						$opt .= ' ';
-					} elseif ( !$arg['value']['optional'] ) {
+					} elseif ( ! $arg['value']['optional'] ) {
 						$opt .= '=';
 					}
 
@@ -86,7 +86,7 @@ class Completions {
 
 				$opt = "--{$param}";
 
-				if ( "" === $runtime || ! is_string( $runtime ) ) {
+				if ( '' === $runtime || ! is_string( $runtime ) ) {
 					$opt .= ' ';
 				} else {
 					$opt .= '=';
@@ -110,11 +110,11 @@ class Completions {
 		}
 
 		$r = \WP_CLI::get_runner()->find_command_to_run( $positional_args );
-		if ( !is_array( $r ) && array_pop( $positional_args ) == $this->cur_word ) {
+		if ( ! is_array( $r ) && array_pop( $positional_args ) == $this->cur_word ) {
 			$r = \WP_CLI::get_runner()->find_command_to_run( $positional_args );
 		}
 
-		if ( !is_array( $r ) ) {
+		if ( ! is_array( $r ) ) {
 			return $r;
 		}
 
@@ -133,11 +133,11 @@ class Completions {
 			} elseif ( isset( $details['hidden'] ) ) {
 				continue;
 			}
-			$params[ $key ] = $details["runtime"];
+			$params[ $key ] = $details['runtime'];
 
 			// Add additional option like `--[no-]color`.
-			if ( true === $details["runtime"] ) {
-				$params[ "no-" . $key ] = '';
+			if ( true === $details['runtime'] ) {
+				$params[ 'no-' . $key ] = '';
 			}
 		}
 

--- a/php/WP_CLI/Completions.php
+++ b/php/WP_CLI/Completions.php
@@ -43,7 +43,7 @@ class Completions {
 		$spec = SynopsisParser::parse( $command->get_synopsis() );
 
 		foreach ( $spec as $arg ) {
-			if ( $arg['type'] == 'positional' && $arg['name'] == 'file' ) {
+			if ( 'positional' == $arg['type'] && 'file' == $arg['name'] ) {
 				$this->add( '<file> ' );
 				return;
 			}
@@ -69,7 +69,7 @@ class Completions {
 
 					$opt = "--{$arg['name']}";
 
-					if ( $arg['type'] == 'flag' ) {
+					if ( 'flag' == $arg['type'] ) {
 						$opt .= ' ';
 					} elseif ( ! $arg['value']['optional'] ) {
 						$opt .= '=';
@@ -145,7 +145,7 @@ class Completions {
 	}
 
 	private function add( $opt ) {
-		if ( $this->cur_word !== '' ) {
+		if ( '' !== $this->cur_word ) {
 			if ( strpos( $opt, $this->cur_word ) !== 0 ) {
 				return;
 			}

--- a/php/WP_CLI/ComposerIO.php
+++ b/php/WP_CLI/ComposerIO.php
@@ -18,8 +18,8 @@ class ComposerIO extends NullIO {
 	}
 
 	/**
-     * {@inheritDoc}
-     */
+	 * {@inheritDoc}
+	 */
 	public function write( $messages, $newline = true, $verbosity = self::NORMAL ) {
 		self::output_clean_message( $messages );
 	}

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -171,7 +171,7 @@ class Configurator {
 		if ( getenv( 'WP_CLI_STRICT_ARGS_MODE' ) ) {
 			foreach ( $global_assoc as $tmp ) {
 				list( $key, $value ) = $tmp;
-				if ( isset( $this->spec[ $key ] ) && $this->spec[ $key ]['runtime'] !== false ) {
+				if ( isset( $this->spec[ $key ] ) && false !== $this->spec[ $key ]['runtime'] ) {
 					$this->assoc_arg_to_runtime_config( $key, $value, $runtime_config );
 				}
 			}
@@ -182,7 +182,7 @@ class Configurator {
 			foreach ( $mixed_args as $tmp ) {
 				list( $key, $value ) = $tmp;
 
-				if ( isset( $this->spec[ $key ] ) && $this->spec[ $key ]['runtime'] !== false ) {
+				if ( isset( $this->spec[ $key ] ) && false !== $this->spec[ $key ]['runtime'] ) {
 					$this->assoc_arg_to_runtime_config( $key, $value, $runtime_config );
 				} else {
 					$assoc_args[ $key ] = $value;

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -94,10 +94,10 @@ class Configurator {
 	function get_aliases() {
 		if ( $runtime_alias = getenv( 'WP_CLI_RUNTIME_ALIAS' ) ) {
 			$returned_aliases = array();
-			foreach( json_decode( $runtime_alias, true ) as $key => $value ) {
+			foreach ( json_decode( $runtime_alias, true ) as $key => $value ) {
 				if ( preg_match( '#' . self::ALIAS_REGEX . '#', $key ) ) {
 					$returned_aliases[ $key ] = array();
-					foreach( self::$alias_spec as $i ) {
+					foreach ( self::$alias_spec as $i ) {
 						if ( isset( $value[ $i ] ) ) {
 							$returned_aliases[ $key ][ $i ] = $value[ $i ];
 						}
@@ -151,10 +151,9 @@ class Configurator {
 				} else {
 					$global_assoc[] = $assoc_arg;
 				}
-			} else if ( ! is_null( $positional ) ) {
+			} elseif ( ! is_null( $positional ) ) {
 				$positional_args[] = $positional;
 			}
-
 		}
 
 		return array( $positional_args, $assoc_args, $global_assoc, $local_assoc );
@@ -170,13 +169,13 @@ class Configurator {
 		$assoc_args = $runtime_config = array();
 
 		if ( getenv( 'WP_CLI_STRICT_ARGS_MODE' ) ) {
-			foreach( $global_assoc as $tmp ) {
+			foreach ( $global_assoc as $tmp ) {
 				list( $key, $value ) = $tmp;
 				if ( isset( $this->spec[ $key ] ) && $this->spec[ $key ]['runtime'] !== false ) {
 					$this->assoc_arg_to_runtime_config( $key, $value, $runtime_config );
 				}
 			}
-			foreach( $local_assoc as $tmp ) {
+			foreach ( $local_assoc as $tmp ) {
 				$assoc_args[ $tmp[0] ] = $tmp[1];
 			}
 		} else {
@@ -226,7 +225,7 @@ class Configurator {
 			if ( preg_match( '#' . self::ALIAS_REGEX . '#', $key ) ) {
 				$this->aliases[ $key ] = array();
 				$is_alias = false;
-				foreach( self::$alias_spec as $i ) {
+				foreach ( self::$alias_spec as $i ) {
 					if ( isset( $value[ $i ] ) ) {
 						if ( 'path' === $i && ! isset( $value['ssh'] ) ) {
 							self::absolutize( $value[ $i ], $yml_file_dir );
@@ -238,14 +237,14 @@ class Configurator {
 				// If it's not an alias, it might be a group of aliases
 				if ( ! $is_alias && is_array( $value ) ) {
 					$alias_group = array();
-					foreach( $value as $i => $k ) {
+					foreach ( $value as $i => $k ) {
 						if ( preg_match( '#' . self::ALIAS_REGEX . '#', $k ) ) {
 							$alias_group[] = $k;
 						}
 					}
 					$this->aliases[ $key ] = $alias_group;
 				}
-			} elseif ( !isset( $this->spec[ $key ] ) || false === $this->spec[ $key ]['file'] ) {
+			} elseif ( ! isset( $this->spec[ $key ] ) || false === $this->spec[ $key ]['file'] ) {
 				if ( isset( $this->extra_config[ $key ] )
 					&& ! empty( $yaml['_']['merge'] )
 					&& is_array( $this->extra_config[ $key ] )
@@ -297,16 +296,18 @@ class Configurator {
 	 * @return array $config Declared configuration values
 	 */
 	private static function load_yml( $yml_file ) {
-		if ( !$yml_file )
+		if ( ! $yml_file ) {
 			return array();
+		}
 
 		$config = Spyc::YAMLLoad( $yml_file );
 
 		// Make sure config-file-relative paths are made absolute.
 		$yml_file_dir = dirname( $yml_file );
 
-		if ( isset( $config['path'] ) )
+		if ( isset( $config['path'] ) ) {
 			self::absolutize( $config['path'], $yml_file_dir );
+		}
 
 		if ( isset( $config['require'] ) ) {
 			self::arrayify( $config['require'] );
@@ -337,7 +338,7 @@ class Configurator {
 	 * @param mixed $val A string or an array
 	 */
 	private static function arrayify( &$val ) {
-		if ( !is_array( $val ) ) {
+		if ( ! is_array( $val ) ) {
 			$val = array( $val );
 		}
 	}
@@ -349,7 +350,7 @@ class Configurator {
 	 * @param string $base Base path to prepend.
 	 */
 	private static function absolutize( &$path, $base ) {
-		if ( !empty( $path ) && !\WP_CLI\Utils\is_path_absolute( $path ) ) {
+		if ( ! empty( $path ) && ! \WP_CLI\Utils\is_path_absolute( $path ) ) {
 			$path = $base . DIRECTORY_SEPARATOR . $path;
 		}
 	}

--- a/php/WP_CLI/Dispatcher/CommandFactory.php
+++ b/php/WP_CLI/Dispatcher/CommandFactory.php
@@ -25,16 +25,20 @@ class CommandFactory {
 			|| ( is_string( $callable ) && function_exists( $callable ) ) ) {
 			$reflection = new \ReflectionFunction( $callable );
 			$command = self::create_subcommand( $parent, $name, $callable, $reflection );
-		} else if ( is_array( $callable ) && is_callable( $callable ) ) {
+		} elseif ( is_array( $callable ) && is_callable( $callable ) ) {
 			$reflection = new \ReflectionClass( $callable[0] );
-			$command = self::create_subcommand( $parent, $name, array( $callable[0], $callable[1] ),
-					$reflection->getMethod( $callable[1] ) );
+			$command = self::create_subcommand(
+				$parent, $name, array( $callable[0], $callable[1] ),
+				$reflection->getMethod( $callable[1] )
+			);
 		} else {
 			$reflection = new \ReflectionClass( $callable );
 			if ( $reflection->hasMethod( '__invoke' ) ) {
 				$class = is_object( $callable ) ? $callable : $reflection->name;
-				$command = self::create_subcommand( $parent, $name, array( $class, '__invoke' ),
-					$reflection->getMethod( '__invoke' ) );
+				$command = self::create_subcommand(
+					$parent, $name, array( $class, '__invoke' ),
+					$reflection->getMethod( '__invoke' )
+				);
 			} else {
 				$command = self::create_composite_command( $parent, $name, $callable );
 			}
@@ -65,11 +69,13 @@ class CommandFactory {
 		$docparser = new \WP_CLI\DocParser( $doc_comment );
 
 		if ( is_array( $callable ) ) {
-			if ( !$name )
+			if ( ! $name ) {
 				$name = $docparser->get_tag( 'subcommand' );
+			}
 
-			if ( !$name )
+			if ( ! $name ) {
 				$name = $reflection->name;
+			}
 		}
 		if ( ! $doc_comment ) {
 			\WP_CLI::debug( null === $doc_comment ? "Failed to get doc comment for {$name}." : "No doc comment for {$name}.", 'commandfactory' );
@@ -105,8 +111,9 @@ class CommandFactory {
 		$container = new CompositeCommand( $parent, $name, $docparser );
 
 		foreach ( $reflection->getMethods() as $method ) {
-			if ( !self::is_good_method( $method ) )
+			if ( ! self::is_good_method( $method ) ) {
 				continue;
+			}
 
 			$class = is_object( $callable ) ? $callable : $reflection->name;
 			$subcommand = self::create_subcommand( $container, false, array( $class, $method->name ), $method );
@@ -126,7 +133,7 @@ class CommandFactory {
 	 * @return bool
 	 */
 	private static function is_good_method( $method ) {
-		return $method->isPublic() && !$method->isStatic() && 0 !== strpos( $method->getName(), '__' );
+		return $method->isPublic() && ! $method->isStatic() && 0 !== strpos( $method->getName(), '__' );
 	}
 
 	/**

--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -157,7 +157,8 @@ class CompositeCommand {
 	 * @return string
 	 */
 	public function get_usage( $prefix ) {
-		return sprintf( "%s%s %s",
+		return sprintf(
+			'%s%s %s',
 			$prefix,
 			implode( ' ', get_path( $this ) ),
 			$this->get_synopsis()
@@ -213,7 +214,7 @@ class CompositeCommand {
 
 		$subcommands = $this->get_subcommands();
 
-		if ( !isset( $subcommands[ $name ] ) ) {
+		if ( ! isset( $subcommands[ $name ] ) ) {
 			$aliases = self::get_aliases( $subcommands );
 
 			if ( isset( $aliases[ $name ] ) ) {
@@ -221,8 +222,9 @@ class CompositeCommand {
 			}
 		}
 
-		if ( !isset( $subcommands[ $name ] ) )
+		if ( ! isset( $subcommands[ $name ] ) ) {
 			return false;
+		}
 
 		return $subcommands[ $name ];
 	}
@@ -239,8 +241,9 @@ class CompositeCommand {
 
 		foreach ( $subcommands as $name => $subcommand ) {
 			$alias = $subcommand->get_alias();
-			if ( $alias )
+			if ( $alias ) {
 				$aliases[ $alias ] = $name;
+			}
 		}
 
 		return $aliases;
@@ -265,24 +268,28 @@ class CompositeCommand {
 		$binding = array();
 		$binding['root_command'] = $root_command;
 
-		if (! $this->can_have_subcommands() || ( is_object( $this->parent ) && get_class( $this->parent ) == 'WP_CLI\Dispatcher\CompositeCommand' )) {
+		if ( ! $this->can_have_subcommands() || ( is_object( $this->parent ) && get_class( $this->parent ) == 'WP_CLI\Dispatcher\CompositeCommand' ) ) {
 			$binding['is_subcommand'] = true;
 		}
 
 		foreach ( \WP_CLI::get_configurator()->get_spec() as $key => $details ) {
-			if ( false === $details['runtime'] )
+			if ( false === $details['runtime'] ) {
 				continue;
+			}
 
-			if ( isset( $details['deprecated'] ) )
+			if ( isset( $details['deprecated'] ) ) {
 				continue;
+			}
 
-			if ( isset( $details['hidden'] ) )
+			if ( isset( $details['hidden'] ) ) {
 				continue;
+			}
 
-			if ( true === $details['runtime'] )
+			if ( true === $details['runtime'] ) {
 				$synopsis = "--[no-]$key";
-			else
+			} else {
 				$synopsis = "--$key" . $details['runtime'];
+			}
 
 			$binding['parameters'][] = array(
 				'synopsis' => $synopsis,

--- a/php/WP_CLI/Dispatcher/RootCommand.php
+++ b/php/WP_CLI/Dispatcher/RootCommand.php
@@ -40,7 +40,7 @@ class RootCommand extends CompositeCommand {
 
 		Utils\load_command( $command );
 
-		if ( !isset( $this->subcommands[ $command ] ) ) {
+		if ( ! isset( $this->subcommands[ $command ] ) ) {
 			return false;
 		}
 

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -340,7 +340,7 @@ class Subcommand extends CompositeCommand {
 			$errors[ $error_type ] = array_merge( $errors[ $error_type ], $returned_errors[ $error_type ] );
 		}
 
-		if ( $this->name != 'help' ) {
+		if ( 'help' != $this->name ) {
 			foreach ( $validator->unknown_assoc( $assoc_args ) as $key ) {
 				$suggestion = Utils\get_suggestion(
 					$key,

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -24,7 +24,7 @@ class Subcommand extends CompositeCommand {
 		$this->alias = $docparser->get_tag( 'alias' );
 
 		$this->synopsis = $docparser->get_synopsis();
-		if ( !$this->synopsis && $this->longdesc ) {
+		if ( ! $this->synopsis && $this->longdesc ) {
 			$this->synopsis = self::extract_synopsis( $this->longdesc );
 		}
 	}
@@ -97,7 +97,8 @@ class Subcommand extends CompositeCommand {
 	 * @return string
 	 */
 	function get_usage( $prefix ) {
-		return sprintf( "%s%s %s",
+		return sprintf(
+			'%s%s %s',
 			$prefix,
 			implode( ' ', get_path( $this ) ),
 			$this->get_synopsis()
@@ -134,12 +135,15 @@ class Subcommand extends CompositeCommand {
 
 		$synopsis = $this->get_synopsis();
 
-		if ( ! $synopsis )
+		if ( ! $synopsis ) {
 			return array( $args, $assoc_args );
+		}
 
-		$spec = array_filter( \WP_CLI\SynopsisParser::parse( $synopsis ), function( $spec_arg ) {
-			return in_array( $spec_arg['type'], array( 'generic', 'positional', 'assoc', 'flag' ) );
-		});
+		$spec = array_filter(
+			\WP_CLI\SynopsisParser::parse( $synopsis ), function( $spec_arg ) {
+				return in_array( $spec_arg['type'], array( 'generic', 'positional', 'assoc', 'flag' ) );
+			}
+		);
 
 		$spec = array_values( $spec );
 
@@ -151,7 +155,7 @@ class Subcommand extends CompositeCommand {
 		// 'positional' arguments are positional (aka zero-indexed)
 		// so $args needs to be reset before prompting for new arguments
 		$args = array();
-		foreach( $spec as $key => $spec_arg ) {
+		foreach ( $spec as $key => $spec_arg ) {
 
 			// When prompting for specific arguments (e.g. --prompt=user_pass),
 			// ignore all arguments that don't match
@@ -174,57 +178,63 @@ class Subcommand extends CompositeCommand {
 
 				$repeat = false;
 				do {
-					if ( ! $repeat )
+					if ( ! $repeat ) {
 						$key_prompt = $current_prompt . $key_token;
-					else
-						$key_prompt = str_repeat( " ", strlen( $current_prompt ) ) . $key_token;
+					} else {
+						$key_prompt = str_repeat( ' ', strlen( $current_prompt ) ) . $key_token;
+					}
 
 					$key = $this->prompt( $key_prompt, $default );
-					if ( false === $key )
+					if ( false === $key ) {
 						return array( $args, $assoc_args );
+					}
 
 					if ( $key ) {
 						$key_prompt_count = strlen( $key_prompt ) - strlen( $value_token ) - 1;
-						$value_prompt = str_repeat( " ", $key_prompt_count ) . '=' . $value_token;
+						$value_prompt = str_repeat( ' ', $key_prompt_count ) . '=' . $value_token;
 
 						$value = $this->prompt( $value_prompt, $default );
-						if ( false === $value )
+						if ( false === $value ) {
 							return array( $args, $assoc_args );
+						}
 
-						$assoc_args[$key] = $value;
+						$assoc_args[ $key ] = $value;
 
 						$repeat = true;
 					} else {
 						$repeat = false;
 					}
-
-				} while( $repeat );
+				} while ( $repeat );
 
 			} else {
 
 				$prompt = $current_prompt . $spec_arg['token'];
-				if ( 'flag' == $spec_arg['type'] )
+				if ( 'flag' == $spec_arg['type'] ) {
 					$prompt .= ' (Y/n)';
+				}
 
 				$response = $this->prompt( $prompt, $default );
-				if ( false === $response )
+				if ( false === $response ) {
 					return array( $args, $assoc_args );
+				}
 
 				if ( $response ) {
 					switch ( $spec_arg['type'] ) {
 						case 'positional':
-							if ( $spec_arg['repeating'] )
+							if ( $spec_arg['repeating'] ) {
 								$response = explode( ' ', $response );
-							else
+							} else {
 								$response = array( $response );
+							}
 							$args = array_merge( $args, $response );
 							break;
 						case 'assoc':
-							$assoc_args[$spec_arg['name']] = $response;
+							$assoc_args[ $spec_arg['name'] ] = $response;
 							break;
 						case 'flag':
-							if ( 'Y' == strtoupper( $response ) )
-								$assoc_args[$spec_arg['name']] = true;
+							if ( 'Y' == strtoupper( $response ) ) {
+								$assoc_args[ $spec_arg['name'] ] = true;
+							}
 							break;
 					}
 				}
@@ -246,7 +256,7 @@ class Subcommand extends CompositeCommand {
 	 */
 	private function validate_args( $args, $assoc_args, $extra_args ) {
 		$synopsis = $this->get_synopsis();
-		if ( !$synopsis ) {
+		if ( ! $synopsis ) {
 			return array( array(), $args, $assoc_args, $extra_args );
 		}
 
@@ -254,31 +264,38 @@ class Subcommand extends CompositeCommand {
 
 		$cmd_path = implode( ' ', get_path( $this ) );
 		foreach ( $validator->get_unknown() as $token ) {
-			\WP_CLI::warning( sprintf(
-				"The `%s` command has an invalid synopsis part: %s",
-				$cmd_path, $token
-			) );
+			\WP_CLI::warning(
+				sprintf(
+					'The `%s` command has an invalid synopsis part: %s',
+					$cmd_path, $token
+				)
+			);
 		}
 
-		if ( !$validator->enough_positionals( $args ) ) {
+		if ( ! $validator->enough_positionals( $args ) ) {
 			$this->show_usage();
-			exit(1);
+			exit( 1 );
 		}
 
 		$unknown_positionals = $validator->unknown_positionals( $args );
-		if ( !empty( $unknown_positionals ) ) {
-			\WP_CLI::error( 'Too many positional arguments: ' .
-				implode( ' ', $unknown_positionals ) );
+		if ( ! empty( $unknown_positionals ) ) {
+			\WP_CLI::error(
+				'Too many positional arguments: ' .
+				implode( ' ', $unknown_positionals )
+			);
 		}
 
 		$synopsis_spec = \WP_CLI\SynopsisParser::parse( $synopsis );
 		$i = 0;
-		$errors = array( 'fatal' => array(), 'warning' => array() );
+		$errors = array(
+			'fatal' => array(),
+			'warning' => array(),
+		);
 		$mock_doc = array( $this->get_shortdesc(), '' );
 		$mock_doc = array_merge( $mock_doc, explode( "\n", $this->get_longdesc() ) );
 		$mock_doc = '/**' . PHP_EOL . '* ' . implode( PHP_EOL . '* ', $mock_doc ) . PHP_EOL . '*/';
 		$docparser = new \WP_CLI\DocParser( $mock_doc );
-		foreach( $synopsis_spec as $spec ) {
+		foreach ( $synopsis_spec as $spec ) {
 			if ( 'positional' === $spec['type'] ) {
 				$spec_args = $docparser->get_arg_args( $spec['name'] );
 				if ( ! isset( $args[ $i ] ) ) {
@@ -301,7 +318,7 @@ class Subcommand extends CompositeCommand {
 					}
 				}
 				$i++;
-			} else if ( 'assoc' === $spec['type'] ) {
+			} elseif ( 'assoc' === $spec['type'] ) {
 				$spec_args = $docparser->get_param_args( $spec['name'] );
 				if ( ! isset( $assoc_args[ $spec['name'] ] ) && ! isset( $extra_args[ $spec['name'] ] ) ) {
 					if ( isset( $spec_args['default'] ) ) {
@@ -319,7 +336,7 @@ class Subcommand extends CompositeCommand {
 		list( $returned_errors, $to_unset ) = $validator->validate_assoc(
 			array_merge( \WP_CLI::get_config(), $extra_args, $assoc_args )
 		);
-		foreach( array( 'fatal', 'warning' ) as $error_type ) {
+		foreach ( array( 'fatal', 'warning' ) as $error_type ) {
 			$errors[ $error_type ] = array_merge( $errors[ $error_type ], $returned_errors[ $error_type ] );
 		}
 
@@ -339,7 +356,7 @@ class Subcommand extends CompositeCommand {
 			}
 		}
 
-		if ( !empty( $errors['fatal'] ) ) {
+		if ( ! empty( $errors['fatal'] ) ) {
 			$out = 'Parameter errors:';
 			foreach ( $errors['fatal'] as $key => $error ) {
 				$out .= "\n {$error}";
@@ -372,7 +389,7 @@ class Subcommand extends CompositeCommand {
 		}
 
 		$extra_positionals = array();
-		foreach( $extra_args as $k => $v ) {
+		foreach ( $extra_args as $k => $v ) {
 			if ( is_numeric( $k ) ) {
 				if ( ! isset( $args[ $k ] ) ) {
 					$extra_positionals[ $k ] = $v;

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -44,8 +44,9 @@ class DocParser {
 	 * @return string
 	 */
 	public function get_shortdesc() {
-		if ( !preg_match( '|^([^@][^\n]+)\n*|', $this->docComment, $matches ) )
+		if ( ! preg_match( '|^([^@][^\n]+)\n*|', $this->docComment, $matches ) ) {
 			return '';
+		}
 
 		return $matches[1];
 	}
@@ -57,15 +58,17 @@ class DocParser {
 	 */
 	public function get_longdesc() {
 		$shortdesc = $this->get_shortdesc();
-		if ( !$shortdesc )
+		if ( ! $shortdesc ) {
 			return '';
+		}
 
 		$longdesc = substr( $this->docComment, strlen( $shortdesc ) );
 
 		$lines = array();
 		foreach ( explode( "\n", $longdesc ) as $line ) {
-			if ( 0 === strpos( $line, '@' ) )
+			if ( 0 === strpos( $line, '@' ) ) {
 				break;
+			}
 
 			$lines[] = $line;
 		}
@@ -81,8 +84,9 @@ class DocParser {
 	 * @return string
 	 */
 	public function get_tag( $name ) {
-		if ( preg_match( '|^@' . $name . '\s+([a-z-_0-9]+)|m', $this->docComment, $matches ) )
+		if ( preg_match( '|^@' . $name . '\s+([a-z-_0-9]+)|m', $this->docComment, $matches ) ) {
 			return $matches[1];
+		}
 
 		return '';
 	}
@@ -93,8 +97,9 @@ class DocParser {
 	 * @return string
 	 */
 	public function get_synopsis() {
-		if ( !preg_match( '|^@synopsis\s+(.+)|m', $this->docComment, $matches ) )
+		if ( ! preg_match( '|^@synopsis\s+(.+)|m', $this->docComment, $matches ) ) {
 			return '';
+		}
 
 		return $matches[1];
 	}
@@ -160,7 +165,7 @@ class DocParser {
 		$bits = explode( PHP_EOL, $this->docComment );
 		$within_arg = $within_doc = false;
 		$document = array();
-		foreach( $bits as $bit ) {
+		foreach ( $bits as $bit ) {
 			if ( preg_match( $regex, $bit ) ) {
 				$within_arg = true;
 			}

--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -44,7 +44,7 @@ class Extractor {
 		$zip = new ZipArchive();
 		$res = $zip->open( $zipfile );
 		if ( true === $res ) {
-			$tempdir = implode( DIRECTORY_SEPARATOR, Array (
+			$tempdir = implode( DIRECTORY_SEPARATOR, array(
 				dirname( $zipfile ),
 				Utils\basename( $zipfile, '.zip' ),
 				$zip->getNameIndex( 0 ),
@@ -73,7 +73,7 @@ class Extractor {
 			return;
 		}
 		$phar = new PharData( $tarball );
-		$tempdir = implode( DIRECTORY_SEPARATOR, Array (
+		$tempdir = implode( DIRECTORY_SEPARATOR, array(
 			dirname( $tarball ),
 			Utils\basename( $tarball, '.tar.gz' ),
 			$phar->getFileName(),

--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -44,11 +44,13 @@ class Extractor {
 		$zip = new ZipArchive();
 		$res = $zip->open( $zipfile );
 		if ( true === $res ) {
-			$tempdir = implode( DIRECTORY_SEPARATOR, array(
-				dirname( $zipfile ),
-				Utils\basename( $zipfile, '.zip' ),
-				$zip->getNameIndex( 0 ),
-			) );
+			$tempdir = implode(
+				DIRECTORY_SEPARATOR, array(
+					dirname( $zipfile ),
+					Utils\basename( $zipfile, '.zip' ),
+					$zip->getNameIndex( 0 ),
+				)
+			);
 
 			$zip->extractTo( dirname( $tempdir ) );
 			$zip->close();
@@ -73,11 +75,13 @@ class Extractor {
 			return;
 		}
 		$phar = new PharData( $tarball );
-		$tempdir = implode( DIRECTORY_SEPARATOR, array(
-			dirname( $tarball ),
-			Utils\basename( $tarball, '.tar.gz' ),
-			$phar->getFileName(),
-		) );
+		$tempdir = implode(
+			DIRECTORY_SEPARATOR, array(
+				dirname( $tarball ),
+				Utils\basename( $tarball, '.tar.gz' ),
+				$phar->getFileName(),
+			)
+		);
 
 		$phar->extractTo( dirname( $tempdir ), null, true );
 
@@ -89,7 +93,8 @@ class Extractor {
 	public static function copy_overwrite_files( $source, $dest ) {
 		$iterator = new RecursiveIteratorIterator(
 			new RecursiveDirectoryIterator( $source, RecursiveDirectoryIterator::SKIP_DOTS ),
-			RecursiveIteratorIterator::SELF_FIRST);
+			RecursiveIteratorIterator::SELF_FIRST
+		);
 
 		$error = 0;
 
@@ -102,7 +107,7 @@ class Extractor {
 			$dest_path = $dest . DIRECTORY_SEPARATOR . $iterator->getSubPathName();
 
 			if ( $item->isDir() ) {
-				if ( !is_dir( $dest_path ) ) {
+				if ( ! is_dir( $dest_path ) ) {
 					mkdir( $dest_path );
 				}
 			} else {

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -53,7 +53,7 @@ class FileCache {
 		$this->maxSize = (int) $maxSize;
 		$this->whitelist = $whitelist;
 
-		if ( !$this->ensure_dir_exists( $this->root ) ) {
+		if ( ! $this->ensure_dir_exists( $this->root ) ) {
 			$this->enabled = false;
 		}
 
@@ -86,13 +86,13 @@ class FileCache {
 	 * @return bool|string filename or false
 	 */
 	public function has( $key, $ttl = null ) {
-		if ( !$this->enabled ) {
+		if ( ! $this->enabled ) {
 			return false;
 		}
 
 		$filename = $this->filename( $key );
 
-		if ( !file_exists( $filename ) ) {
+		if ( ! file_exists( $filename ) ) {
 			return false;
 		}
 
@@ -192,7 +192,7 @@ class FileCache {
 	 * @return bool
 	 */
 	public function remove( $key ) {
-		if ( !$this->enabled ) {
+		if ( ! $this->enabled ) {
 			return false;
 		}
 
@@ -211,7 +211,7 @@ class FileCache {
 	 * @return bool
 	 */
 	public function clean() {
-		if ( !$this->enabled ) {
+		if ( ! $this->enabled ) {
 			return false;
 		}
 
@@ -257,12 +257,12 @@ class FileCache {
 	 * @return bool
 	 */
 	protected function ensure_dir_exists( $dir ) {
-		if ( !is_dir( $dir ) ) {
+		if ( ! is_dir( $dir ) ) {
 			if ( file_exists( $dir ) ) {
 				// exists and not a dir
 				return false;
 			}
-			if ( !@mkdir( $dir, 0777, true ) ) {
+			if ( ! @mkdir( $dir, 0777, true ) ) {
 				return false;
 			}
 		}
@@ -277,13 +277,13 @@ class FileCache {
 	 * @return bool|string filename or false
 	 */
 	protected function prepare_write( $key ) {
-		if ( !$this->enabled ) {
+		if ( ! $this->enabled ) {
 			return false;
 		}
 
 		$filename = $this->filename( $key );
 
-		if ( !$this->ensure_dir_exists( dirname( $filename ) ) ) {
+		if ( ! $this->ensure_dir_exists( dirname( $filename ) ) ) {
 			return false;
 		}
 
@@ -298,11 +298,11 @@ class FileCache {
 	 */
 	protected function validate_key( $key ) {
 		$url_parts = parse_url( $key );
-		if ( ! empty($url_parts['scheme']) ) { // is url
-			$parts = array('misc');
+		if ( ! empty( $url_parts['scheme'] ) ) { // is url
+			$parts = array( 'misc' );
 			$parts[] = $url_parts['scheme'] . '-' . $url_parts['host'] .
 				( empty( $url_parts['port'] ) ? '' : '-' . $url_parts['port'] );
-			$parts[] = substr($url_parts['path'], 1) .
+			$parts[] = substr( $url_parts['path'], 1 ) .
 				( empty( $url_parts['query'] ) ? '' : '-' . $url_parts['query'] );
 		} else {
 			$key = str_replace( '\\', '/', $key );
@@ -320,7 +320,7 @@ class FileCache {
 	 * @param string $key
 	 * @return string filename
 	 */
-	protected function filename( $key ){
+	protected function filename( $key ) {
 		return $this->root . $this->validate_key( $key );
 	}
 

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -97,7 +97,7 @@ class FileCache {
 		}
 
 		// use ttl param or global ttl
-		if ( $ttl === null ) {
+		if ( null === $ttl ) {
 			$ttl = $this->ttl;
 		} elseif ( $this->ttl > 0 ) {
 			$ttl = min( (int) $ttl, $this->ttl );

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -71,7 +71,7 @@ class Formatter {
 			if ( in_array( $this->args['format'], array( 'csv', 'json', 'table' ) ) ) {
 				$item = is_array( $items ) && ! empty( $items ) ? array_shift( $items ) : false;
 				if ( $item && ! empty( $this->args['fields'] ) ) {
-					foreach( $this->args['fields'] as &$field ) {
+					foreach ( $this->args['fields'] as &$field ) {
 						$field = $this->find_item_key( $item, $field );
 					}
 					array_unshift( $items, $item );
@@ -104,7 +104,11 @@ class Formatter {
 			if ( in_array( $this->args['format'], array( 'table', 'csv' ) ) && ( is_object( $value ) || is_array( $value ) ) ) {
 				$value = json_encode( $value );
 			}
-			\WP_CLI::print_value( $value, array( 'format' => $this->args['format'] ) );
+			\WP_CLI::print_value(
+				$value, array(
+					'format' => $this->args['format'],
+				)
+			);
 		} else {
 			$this->show_multiple_fields( $item, $this->args['format'], $ascii_pre_colorized );
 		}
@@ -121,14 +125,14 @@ class Formatter {
 
 		switch ( $this->args['format'] ) {
 			case 'count':
-				if ( !is_array( $items ) ) {
+				if ( ! is_array( $items ) ) {
 					$items = iterator_to_array( $items );
 				}
 				echo count( $items );
 				break;
 
 			case 'ids':
-				if ( !is_array( $items ) ) {
+				if ( ! is_array( $items ) ) {
 					$items = iterator_to_array( $items );
 				}
 				echo implode( ' ', $items );
@@ -150,12 +154,12 @@ class Formatter {
 				}
 
 				if ( 'json' === $this->args['format'] ) {
-					if (defined('JSON_PARTIAL_OUTPUT_ON_ERROR')) {
+					if ( defined( 'JSON_PARTIAL_OUTPUT_ON_ERROR' ) ) {
 						echo json_encode( $out, JSON_PARTIAL_OUTPUT_ON_ERROR );
 					} else {
 						echo json_encode( $out );
 					}
-				} else if ( 'yaml' === $this->args['format'] ) {
+				} elseif ( 'yaml' === $this->args['format'] ) {
 					echo Spyc::YAMLDump( $out, 2, 0 );
 				}
 				break;
@@ -185,7 +189,11 @@ class Formatter {
 			if ( 'json' == $this->args['format'] ) {
 				$values[] = $item->$key;
 			} else {
-				\WP_CLI::print_value( $item->$key, array( 'format' => $this->args['format'] ) );
+				\WP_CLI::print_value(
+					$item->$key, array(
+						'format' => $this->args['format'],
+					)
+				);
 			}
 		}
 
@@ -227,15 +235,15 @@ class Formatter {
 	private function show_multiple_fields( $data, $format, $ascii_pre_colorized = false ) {
 
 		$true_fields = array();
-		foreach( $this->args['fields'] as $field ) {
+		foreach ( $this->args['fields'] as $field ) {
 			$true_fields[] = $this->find_item_key( $data, $field );
 		}
 
-		foreach( $data as $key => $value ) {
+		foreach ( $data as $key => $value ) {
 			if ( ! in_array( $key, $true_fields ) ) {
 				if ( is_array( $data ) ) {
 					unset( $data[ $key ] );
-				} else if ( is_object( $data ) ) {
+				} elseif ( is_object( $data ) ) {
 					unset( $data->$key );
 				}
 			}
@@ -249,18 +257,22 @@ class Formatter {
 				$fields = array( 'Field', 'Value' );
 				if ( 'table' == $format ) {
 					self::show_table( $rows, $fields, $ascii_pre_colorized );
-				} else if ( 'csv' == $format ) {
+				} elseif ( 'csv' == $format ) {
 					\WP_CLI\Utils\write_csv( STDOUT, $rows, $fields );
 				}
 				break;
 
 			case 'yaml':
 			case 'json':
-				\WP_CLI::print_value( $data, array( 'format' => $format ) );
+				\WP_CLI::print_value(
+					$data, array(
+						'format' => $format,
+					)
+				);
 				break;
 
 			default:
-				\WP_CLI::error( "Invalid format: " . $format );
+				\WP_CLI::error( 'Invalid format: ' . $format );
 				break;
 
 		}
@@ -289,7 +301,7 @@ class Formatter {
 			$table->addRow( array_values( \WP_CLI\Utils\pick_fields( $item, $fields ) ) );
 		}
 
-		foreach( $table->getDisplayLines() as $line ) {
+		foreach ( $table->getDisplayLines() as $line ) {
 			\WP_CLI::line( $line );
 		}
 
@@ -329,13 +341,13 @@ class Formatter {
 	 * @return mixed
 	 */
 	public function transform_item_values_to_json( $item ) {
-		foreach( $this->args['fields'] as $field ) {
+		foreach ( $this->args['fields'] as $field ) {
 			$true_field = $this->find_item_key( $item, $field );
 			$value = is_object( $item ) ? $item->$true_field : $item[ $true_field ];
 			if ( is_array( $value ) || is_object( $value ) ) {
 				if ( is_object( $item ) ) {
 					$item->$true_field = json_encode( $value );
-				} else if ( is_array( $item ) ) {
+				} elseif ( is_array( $item ) ) {
 					$item[ $true_field ] = json_encode( $value );
 				}
 			}

--- a/php/WP_CLI/Iterators/CSV.php
+++ b/php/WP_CLI/Iterators/CSV.php
@@ -19,7 +19,7 @@ class CSV implements \Iterator {
 
 	public function __construct( $filename, $delimiter = ',' ) {
 		$this->filePointer = fopen( $filename, 'r' );
-		if ( !$this->filePointer ) {
+		if ( ! $this->filePointer ) {
 			\WP_CLI::error( sprintf( 'Could not open file: %s', $filename ) );
 		}
 
@@ -49,18 +49,20 @@ class CSV implements \Iterator {
 		while ( true ) {
 			$str = fgets( $this->filePointer );
 
-			if ( false === $str )
+			if ( false === $str ) {
 				break;
+			}
 
 			$row = str_getcsv( $str, $this->delimiter );
 
 			$element = array();
 			foreach ( $this->columns as $i => $key ) {
-				if ( isset( $row[ $i ] ) )
+				if ( isset( $row[ $i ] ) ) {
 					$element[ $key ] = $row[ $i ];
+				}
 			}
 
-			if ( !empty( $element ) ) {
+			if ( ! empty( $element ) ) {
 				$this->currentElement = $element;
 				$this->currentIndex++;
 

--- a/php/WP_CLI/Iterators/Query.php
+++ b/php/WP_CLI/Iterators/Query.php
@@ -38,8 +38,9 @@ class Query implements \Iterator {
 		$this->query = $query;
 
 		$this->count_query = preg_replace( '/^.*? FROM /', 'SELECT COUNT(*) FROM ', $query, 1, $replacements );
-		if ( $replacements != 1 )
+		if ( $replacements != 1 ) {
 			$this->count_query = '';
+		}
 
 		$this->chunk_size = $chunk_size;
 
@@ -48,19 +49,21 @@ class Query implements \Iterator {
 
 	/**
 	 * Reduces the offset when the query row count shrinks
-	 * 
-	 * In cases where the iterated rows are being updated such that they will no 
+	 *
+	 * In cases where the iterated rows are being updated such that they will no
 	 * longer be returned by the original query, the offset must be reduced to
 	 * iterate over all remaining rows.
 	 */
 	private function adjust_offset_for_shrinking_result_set() {
-		if ( empty( $this->count_query ) )
+		if ( empty( $this->count_query ) ) {
 			return;
+		}
 
 		$row_count = $this->db->get_var( $this->count_query );
 
-		if ( $row_count < $this->row_count )
+		if ( $row_count < $this->row_count ) {
 			$this->offset -= $this->row_count - $row_count;
+		}
 
 		$this->row_count = $row_count;
 	}
@@ -71,7 +74,7 @@ class Query implements \Iterator {
 		$query = $this->query . sprintf( ' LIMIT %d OFFSET %d', $this->chunk_size, $this->offset );
 		$this->results = $this->db->get_results( $query );
 
-		if ( !$this->results ) {
+		if ( ! $this->results ) {
 			if ( $this->db->last_error ) {
 				throw new Exception( 'Database error: ' . $this->db->last_error );
 			} else {
@@ -109,10 +112,10 @@ class Query implements \Iterator {
 			return false;
 		}
 
-		if ( !isset( $this->results[ $this->index_in_results ] ) ) {
+		if ( ! isset( $this->results[ $this->index_in_results ] ) ) {
 			$items_loaded = $this->load_items_from_db();
 
-			if ( !$items_loaded ) {
+			if ( ! $items_loaded ) {
 				$this->rewind();
 				$this->depleted = true;
 				return false;

--- a/php/WP_CLI/Iterators/Query.php
+++ b/php/WP_CLI/Iterators/Query.php
@@ -38,7 +38,7 @@ class Query implements \Iterator {
 		$this->query = $query;
 
 		$this->count_query = preg_replace( '/^.*? FROM /', 'SELECT COUNT(*) FROM ', $query, 1, $replacements );
-		if ( $replacements != 1 ) {
+		if ( 1 != $replacements ) {
 			$this->count_query = '';
 		}
 

--- a/php/WP_CLI/Iterators/Table.php
+++ b/php/WP_CLI/Iterators/Table.php
@@ -58,20 +58,27 @@ class Table extends Query {
 	}
 
 	private static function build_fields( $fields ) {
-		if ( '*' === $fields )
+		if ( '*' === $fields ) {
 			return $fields;
+		}
 
-		return implode( ', ', array_map( function ($v) { return "`$v`"; }, $fields ) );
+		return implode(
+			', ', array_map(
+				function ( $v ) {
+						return "`$v`";
+				}, $fields
+			)
+		);
 	}
 
 	private static function build_where_conditions( $where ) {
 		global $wpdb;
 		if ( is_array( $where ) ) {
 			$conditions = array();
-			foreach( $where as $key => $value ) {
+			foreach ( $where as $key => $value ) {
 				if ( is_array( $value ) ) {
 					$conditions[]  = $key . ' IN (' . esc_sql( implode( ',', $value ) ) . ')';
-				} else if ( is_numeric( $key ) ) {
+				} elseif ( is_numeric( $key ) ) {
 					$conditions[] = $value;
 				} else {
 					$conditions[] = $key . $wpdb->prepare( ' = %s', $value );

--- a/php/WP_CLI/Loggers/Execution.php
+++ b/php/WP_CLI/Loggers/Execution.php
@@ -72,7 +72,7 @@ class Execution extends Base {
 	 * @param string $str Message to write.
 	 */
 	protected function write( $handle, $str ) {
-		switch( $handle ) {
+		switch ( $handle ) {
 			case 'STDOUT':
 				$this->stdout .= $str;
 				break;

--- a/php/WP_CLI/Loggers/Regular.php
+++ b/php/WP_CLI/Loggers/Regular.php
@@ -57,9 +57,11 @@ class Regular extends Base {
 	 */
 	public function error_multi_line( $message_lines ) {
 		// convert tabs to four spaces, as some shells will output the tabs as variable-length
-		$message_lines = array_map( function( $line ) {
-			return str_replace( "\t", '    ', $line );
-		} , $message_lines );
+		$message_lines = array_map(
+			function( $line ) {
+					 return str_replace( "\t", '    ', $line );
+			} , $message_lines
+		);
 
 		$longest = max( array_map( 'strlen', $message_lines ) );
 

--- a/php/WP_CLI/PackageManagerEventSubscriber.php
+++ b/php/WP_CLI/PackageManagerEventSubscriber.php
@@ -43,7 +43,7 @@ class PackageManagerEventSubscriber implements EventSubscriberInterface {
 			}
 
 			if ( ! empty( $composer_error ) ) {
-				WP_CLI::log( sprintf( " - Warning: %s", $composer_error ) );
+				WP_CLI::log( sprintf( ' - Warning: %s', $composer_error ) );
 			}
 		}
 

--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -87,15 +87,17 @@ class Process {
 			self::$run_times[ $this->command ][1]++;
 		}
 
-		return new ProcessRun( array(
-			'stdout' => $stdout,
-			'stderr' => $stderr,
-			'return_code' => $return_code,
-			'command' => $this->command,
-			'cwd' => $this->cwd,
-			'env' => $this->env,
-			'run_time' => $run_time,
-		) );
+		return new ProcessRun(
+			array(
+				'stdout' => $stdout,
+				'stderr' => $stderr,
+				'return_code' => $return_code,
+				'command' => $this->command,
+				'cwd' => $this->cwd,
+				'env' => $this->env,
+				'run_time' => $run_time,
+			)
+		);
 	}
 
 	/**
@@ -107,7 +109,7 @@ class Process {
 		$r = $this->run();
 
 		// $r->STDERR is incorrect, but kept incorrect for backwards-compat
-		if ( $r->return_code || !empty( $r->STDERR ) ) {
+		if ( $r->return_code || ! empty( $r->STDERR ) ) {
 			throw new \RuntimeException( $r );
 		}
 

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -240,7 +240,7 @@ class Runner {
 	}
 
 	private function cmd_starts_with( $prefix ) {
-		return $prefix == array_slice( $this->arguments, 0, count( $prefix ) );
+		return array_slice( $this->arguments, 0, count( $prefix ) ) == $prefix;
 	}
 
 	/**
@@ -577,7 +577,7 @@ class Runner {
 
 		// {plugin|theme} update-all  ->  {plugin|theme} update --all
 		if ( count( $args ) > 1 && in_array( $args[0], array( 'plugin', 'theme' ) )
-			&& $args[1] == 'update-all'
+			&& 'update-all' == $args[1]
 		) {
 			$args[1] = 'update';
 			$assoc_args['all'] = true;
@@ -608,7 +608,7 @@ class Runner {
 
 		// {post|user} list --ids  ->  {post|user} list --format=ids
 		if ( count( $args ) > 1 && in_array( $args[0], array( 'post', 'user' ) )
-			&& $args[1] == 'list'
+			&& 'list' == $args[1]
 			&& isset( $assoc_args['ids'] )
 		) {
 			$assoc_args['format'] = 'ids';
@@ -980,7 +980,7 @@ class Runner {
 
 		if (
 			count( $this->arguments ) >= 2 &&
-			$this->arguments[0] == 'core' &&
+			'core' == $this->arguments[0] &&
 			in_array( $this->arguments[1], array( 'install', 'multisite-install' ) )
 		) {
 			define( 'WP_INSTALLING', true );

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -33,8 +33,9 @@ class Runner {
 	private $_required_files;
 
 	public function __get( $key ) {
-		if ( '_' === $key[0] )
+		if ( '_' === $key[0] ) {
 			return null;
+		}
 
 		return $this->$key;
 	}
@@ -55,8 +56,9 @@ class Runner {
 	 * @param string $when Named execution hook
 	 */
 	private function do_early_invoke( $when ) {
-		if ( !isset( $this->_early_invoke[ $when ] ) )
+		if ( ! isset( $this->_early_invoke[ $when ] ) ) {
 			return;
+		}
 
 		foreach ( $this->_early_invoke[ $when ] as $path ) {
 			if ( $this->cmd_starts_with( $path ) ) {
@@ -103,14 +105,16 @@ class Runner {
 
 		// Stop looking upward when we find we have emerged from a subdirectory
 		// install into a parent install
-		$project_config_path = Utils\find_file_upward( $config_files, getcwd(), function ( $dir ) {
-			static $wp_load_count = 0;
-			$wp_load_path = $dir . DIRECTORY_SEPARATOR . 'wp-load.php';
-			if ( file_exists( $wp_load_path ) ) {
-				$wp_load_count += 1;
+		$project_config_path = Utils\find_file_upward(
+			$config_files, getcwd(), function ( $dir ) {
+				static $wp_load_count = 0;
+				$wp_load_path = $dir . DIRECTORY_SEPARATOR . 'wp-load.php';
+				if ( file_exists( $wp_load_path ) ) {
+					$wp_load_count += 1;
+				}
+				return $wp_load_count > 1;
 			}
-			return $wp_load_count > 1;
-		} );
+		);
 		if ( ! empty( $project_config_path ) ) {
 			$this->_project_config_path_debug = 'Using project config: ' . $project_config_path;
 		} else {
@@ -142,7 +146,7 @@ class Runner {
 	private static function extract_subdir_path( $index_path ) {
 		$index_code = file_get_contents( $index_path );
 
-		if ( !preg_match( '|^\s*require\s*\(?\s*(.+?)/wp-blog-header\.php([\'"])|m', $index_code, $matches ) ) {
+		if ( ! preg_match( '|^\s*require\s*\(?\s*(.+?)/wp-blog-header\.php([\'"])|m', $index_code, $matches ) ) {
 			return false;
 		}
 
@@ -150,7 +154,7 @@ class Runner {
 		$wp_path_src = Utils\replace_path_consts( $wp_path_src, $index_path );
 		$wp_path = eval( "return $wp_path_src;" );
 
-		if ( !Utils\is_path_absolute( $wp_path ) ) {
+		if ( ! Utils\is_path_absolute( $wp_path ) ) {
 			$wp_path = dirname( $index_path ) . "/$wp_path";
 		}
 
@@ -164,10 +168,11 @@ class Runner {
 	 * @return string An absolute path
 	 */
 	private function find_wp_root() {
-		if ( !empty( $this->config['path'] ) ) {
+		if ( ! empty( $this->config['path'] ) ) {
 			$path = $this->config['path'];
-			if ( !Utils\is_path_absolute( $path ) )
+			if ( ! Utils\is_path_absolute( $path ) ) {
 				$path = getcwd() . '/' . $path;
+			}
 
 			return $path;
 		}
@@ -184,12 +189,13 @@ class Runner {
 			}
 
 			if ( file_exists( "$dir/index.php" ) ) {
-				if ( $path = self::extract_subdir_path( "$dir/index.php" ) )
+				if ( $path = self::extract_subdir_path( "$dir/index.php" ) ) {
 					return $path;
+				}
 			}
 
 			$parent_dir = dirname( $dir );
-			if ( empty($parent_dir) || $parent_dir === $dir ) {
+			if ( empty( $parent_dir ) || $parent_dir === $dir ) {
 				break;
 			}
 			$dir = $parent_dir;
@@ -250,13 +256,13 @@ class Runner {
 
 		$cmd_path = array();
 
-		while ( !empty( $args ) && $command->can_have_subcommands() ) {
+		while ( ! empty( $args ) && $command->can_have_subcommands() ) {
 			$cmd_path[] = $args[0];
 			$full_name = implode( ' ', $cmd_path );
 
 			$subcommand = $command->find_subcommand( $args );
 
-			if ( !$subcommand ) {
+			if ( ! $subcommand ) {
 				if ( count( $cmd_path ) > 1 ) {
 					$child = array_pop( $cmd_path );
 					$parent_name = implode( ' ', $cmd_path );
@@ -373,19 +379,23 @@ class Runner {
 		if ( $this->alias && ! empty( $wp_args[0] ) && $this->alias === $wp_args[0] ) {
 			array_shift( $wp_args );
 			$runtime_alias = array();
-			foreach( $this->aliases[ $this->alias ] as $key => $value ) {
+			foreach ( $this->aliases[ $this->alias ] as $key => $value ) {
 				if ( 'ssh' === $key ) {
 					continue;
 				}
 				$runtime_alias[ $key ] = $value;
 			}
 			if ( ! empty( $runtime_alias ) ) {
-				$encoded_alias = json_encode( array( $this->alias => $runtime_alias ) );
+				$encoded_alias = json_encode(
+					array(
+						$this->alias => $runtime_alias,
+					)
+				);
 				$wp_binary = "WP_CLI_RUNTIME_ALIAS='{$encoded_alias}' {$wp_binary} {$this->alias}";
 			}
 		}
 
-		foreach( $wp_args as $k => $v ) {
+		foreach ( $wp_args as $k => $v ) {
 			if ( preg_match( '#--ssh=#', $v ) ) {
 				unset( $wp_args[ $k ] );
 			}
@@ -502,7 +512,7 @@ class Runner {
 			$lines_to_run[] = $line;
 		}
 
-		if ( !$found_wp_settings ) {
+		if ( ! $found_wp_settings ) {
 			WP_CLI::error( 'Strange wp-config.php file: wp-settings.php is not loaded directly.' );
 		}
 
@@ -533,7 +543,7 @@ class Runner {
 		}
 
 		// *-meta  ->  * meta
-		if ( !empty( $args ) && preg_match( '/(post|comment|user|network)-meta/', $args[0], $matches ) ) {
+		if ( ! empty( $args ) && preg_match( '/(post|comment|user|network)-meta/', $args[0], $matches ) ) {
 			array_shift( $args );
 			array_unshift( $args, 'meta' );
 			array_unshift( $args, $matches[1] );
@@ -675,17 +685,18 @@ class Runner {
 
 	public function init_colorization() {
 		if ( 'auto' === $this->config['color'] ) {
-			$this->colorize = ( !\WP_CLI\Utils\isPiped() && !\WP_CLI\Utils\is_windows() );
+			$this->colorize = ( ! \WP_CLI\Utils\isPiped() && ! \WP_CLI\Utils\is_windows() );
 		} else {
 			$this->colorize = $this->config['color'];
 		}
 	}
 
 	public function init_logger() {
-		if ( $this->config['quiet'] )
+		if ( $this->config['quiet'] ) {
 			$logger = new \WP_CLI\Loggers\Quiet;
-		else
+		} else {
 			$logger = new \WP_CLI\Loggers\Regular( $this->in_color() );
+		}
 
 		WP_CLI::set_logger( $logger );
 	}
@@ -704,7 +715,7 @@ class Runner {
 	}
 
 	private function check_wp_version() {
-		if ( !$this->wp_exists() ) {
+		if ( ! $this->wp_exists() ) {
 			// If the command doesn't exist use as error.
 			$args = $this->cmd_starts_with( array( 'help' ) ) ? array_slice( $this->arguments, 1 ) : $this->arguments;
 			$suggestion_or_disabled = $this->find_command_to_run( $args );
@@ -716,7 +727,8 @@ class Runner {
 			}
 			WP_CLI::error(
 				"This does not seem to be a WordPress install.\n" .
-				"Pass --path=`path/to/wordpress` or run `wp core download`." );
+				'Pass --path=`path/to/wordpress` or run `wp core download`.'
+			);
 		}
 
 		global $wp_version;
@@ -764,7 +776,8 @@ class Runner {
 			list( $args, $assoc_args, $this->runtime_config ) = $configurator->parse_args( $argv );
 
 			list( $this->arguments, $this->assoc_args ) = self::back_compat_conversions(
-				$args, $assoc_args );
+				$args, $assoc_args
+			);
 
 			$configurator->merge_array( $this->runtime_config );
 		}
@@ -786,7 +799,7 @@ class Runner {
 		if ( count( $this->arguments ) >= 2 && 'cli' === $this->arguments[0] && in_array( $this->arguments[1], array( 'update', 'info' ), true ) ) {
 			return; # make it easier to update root-owned copies
 		}
-		if ( !function_exists( 'posix_geteuid') ) {
+		if ( ! function_exists( 'posix_geteuid' ) ) {
 			return; # posix functions not available
 		}
 		if ( posix_geteuid() !== 0 ) {
@@ -798,7 +811,7 @@ class Runner {
 			"run this as the user that your WordPress install exists under.\n" .
 			"\n" .
 			"If you REALLY mean to run this as root, we won't stop you, but just " .
-			"bear in mind that any code on this site will then have full control of " .
+			'bear in mind that any code on this site will then have full control of ' .
 			"your server, making it quite DANGEROUS.\n" .
 			"\n" .
 			"If you'd like to continue as root, please run this again, adding this " .
@@ -826,7 +839,7 @@ class Runner {
 		}
 		$config_path = escapeshellarg( $config_path );
 
-		foreach( $aliases as $alias ) {
+		foreach ( $aliases as $alias ) {
 			WP_CLI::log( $alias );
 			$args = implode( ' ', array_map( 'escapeshellarg', $this->arguments ) );
 			$assoc_args = Utils\assoc_args_to_str( $this->assoc_args );
@@ -841,7 +854,7 @@ class Runner {
 		$orig_config = $this->config;
 		$alias_config = $this->aliases[ $this->alias ];
 		$this->config = array_merge( $orig_config, $alias_config );
-		foreach( $alias_config as $key => $_ ) {
+		foreach ( $alias_config as $key => $_ ) {
 			if ( isset( $orig_config[ $key ] ) && ! is_null( $orig_config[ $key ] ) ) {
 				$this->assoc_args[ $key ] = $orig_config[ $key ];
 			}
@@ -890,8 +903,9 @@ class Runner {
 			}
 		}
 
-		if ( empty( $this->arguments ) )
+		if ( empty( $this->arguments ) ) {
 			$this->arguments[] = 'help';
+		}
 
 		// Protect 'cli info' from most of the runtime,
 		// except when the command will be run over SSH
@@ -935,8 +949,9 @@ class Runner {
 
 		// Handle --url parameter
 		$url = self::guess_url( $this->config );
-		if ( $url )
+		if ( $url ) {
 			\WP_CLI::set_url( $url );
+		}
 
 		$this->do_early_invoke( 'before_wp_load' );
 
@@ -946,10 +961,11 @@ class Runner {
 			$this->_run_command_and_exit();
 		}
 
-		if ( !Utils\locate_wp_config() ) {
+		if ( ! Utils\locate_wp_config() ) {
 			WP_CLI::error(
 				"'wp-config.php' not found.\n" .
-				"Either create one manually or use `wp config create`." );
+				'Either create one manually or use `wp config create`.'
+			);
 		}
 
 		if ( $this->cmd_starts_with( array( 'db' ) ) && ! $this->cmd_starts_with( array( 'db', 'tables' ) ) ) {
@@ -970,7 +986,7 @@ class Runner {
 			define( 'WP_INSTALLING', true );
 
 			// We really need a URL here
-			if ( !isset( $_SERVER['HTTP_HOST'] ) ) {
+			if ( ! isset( $_SERVER['HTTP_HOST'] ) ) {
 				$url = 'http://example.com';
 				\WP_CLI::set_url( $url );
 			}
@@ -980,13 +996,13 @@ class Runner {
 				$url_parts = Utils\parse_url( $url );
 				self::fake_current_site_blog( $url_parts );
 
-				if ( !defined( 'COOKIEHASH' ) ) {
+				if ( ! defined( 'COOKIEHASH' ) ) {
 					define( 'COOKIEHASH', md5( $url_parts['host'] ) );
 				}
 			}
 		}
 
-		if ( $this->cmd_starts_with( array( 'import') ) ) {
+		if ( $this->cmd_starts_with( array( 'import' ) ) ) {
 			define( 'WP_LOAD_IMPORTERS', true );
 			define( 'WP_IMPORTING', true );
 		}
@@ -1024,7 +1040,8 @@ class Runner {
 		if ( ! $wp_config_path ) {
 			WP_CLI::error(
 				"'wp-config.php' not found.\n" .
-				"Either create one manually or use `wp config create`." );
+				'Either create one manually or use `wp config create`.'
+			);
 		}
 
 		WP_CLI::debug( 'wp-config.php path: ' . $wp_config_path, 'bootstrap' );
@@ -1033,7 +1050,7 @@ class Runner {
 		// Load wp-config.php code, in the global scope
 		$wp_cli_original_defined_vars = get_defined_vars();
 		eval( $this->get_wp_config_code() );
-		foreach( get_defined_vars() as $key => $var ) {
+		foreach ( get_defined_vars() as $key => $var ) {
 			if ( array_key_exists( $key, $wp_cli_original_defined_vars ) || 'wp_cli_original_defined_vars' === $key ) {
 				continue;
 			}
@@ -1078,7 +1095,11 @@ class Runner {
 		// Load all the admin APIs, for convenience
 		require ABSPATH . 'wp-admin/includes/admin.php';
 
-		add_filter( 'filesystem_method', function() { return 'direct'; }, 99 );
+		add_filter(
+			'filesystem_method', function() {
+				return 'direct';
+			}, 99
+		);
 
 		WP_CLI::debug( 'Loaded WordPress', 'bootstrap' );
 		WP_CLI::do_hook( 'after_wp_load' );
@@ -1088,7 +1109,7 @@ class Runner {
 	private static function fake_current_site_blog( $url_parts ) {
 		global $current_site, $current_blog;
 
-		if ( !isset( $url_parts['path'] ) ) {
+		if ( ! isset( $url_parts['path'] ) ) {
 			$url_parts['path'] = '/';
 		}
 
@@ -1148,30 +1169,42 @@ class Runner {
 		if ( $this->cmd_starts_with( array( 'help' ) ) ) {
 			// Try to trap errors on help.
 			$help_handler = array( $this, 'help_wp_die_handler' ); // Avoid any cross PHP version issues by not using $this in anon function.
-			WP_CLI::add_wp_hook( 'wp_die_handler', function () use ( $help_handler ) { return $help_handler; } );
+			WP_CLI::add_wp_hook(
+				'wp_die_handler', function () use ( $help_handler ) {
+					return $help_handler;
+				}
+			);
 		} else {
-			WP_CLI::add_wp_hook( 'wp_die_handler', function() { return '\WP_CLI\Utils\wp_die_handler'; } );
+			WP_CLI::add_wp_hook(
+				'wp_die_handler', function() {
+					return '\WP_CLI\Utils\wp_die_handler';
+				}
+			);
 		}
 
 		// Prevent code from performing a redirect
 		WP_CLI::add_wp_hook( 'wp_redirect', 'WP_CLI\\Utils\\wp_redirect_handler' );
 
-		WP_CLI::add_wp_hook( 'nocache_headers', function( $headers ){
-			// WordPress might be calling nocache_headers() because of a dead db
-			global $wpdb;
-			if ( ! empty( $wpdb->error ) ) {
-				Utils\wp_die_handler( $wpdb->error );
+		WP_CLI::add_wp_hook(
+			'nocache_headers', function( $headers ) {
+				// WordPress might be calling nocache_headers() because of a dead db
+				global $wpdb;
+				if ( ! empty( $wpdb->error ) ) {
+					Utils\wp_die_handler( $wpdb->error );
+				}
+				// Otherwise, WP might be calling nocache_headers() because WP isn't installed
+				Utils\wp_not_installed();
+				return $headers;
 			}
-			// Otherwise, WP might be calling nocache_headers() because WP isn't installed
-			Utils\wp_not_installed();
-			return $headers;
-		});
+		);
 
 		// ALTERNATE_WP_CRON might trigger a redirect, which we can't handle
 		if ( defined( 'ALTERNATE_WP_CRON' ) && ALTERNATE_WP_CRON ) {
-			WP_CLI::add_wp_hook( 'muplugins_loaded', function() {
-				remove_action( 'init', 'wp_cron' );
-			});
+			WP_CLI::add_wp_hook(
+				'muplugins_loaded', function() {
+					remove_action( 'init', 'wp_cron' );
+				}
+			);
 		}
 
 		// Get rid of warnings when converting single site to multisite
@@ -1185,9 +1218,11 @@ class Runner {
 				'WPLANG' => '',
 			);
 			foreach ( $values as $key => $value ) {
-				WP_CLI::add_wp_hook( "pre_site_option_$key", function () use ( $values, $key ) {
-					return $values[ $key ];
-				} );
+				WP_CLI::add_wp_hook(
+					"pre_site_option_$key", function () use ( $values, $key ) {
+						return $values[ $key ];
+					}
+				);
 			}
 		}
 
@@ -1195,78 +1230,92 @@ class Runner {
 		WP_CLI::add_wp_hook( 'ms_site_check', '__return_true' );
 
 		// Always permit operations against WordPress, regardless of maintenance mode
-		WP_CLI::add_wp_hook( 'enable_maintenance_mode', function() {
-			return false;
-		});
+		WP_CLI::add_wp_hook(
+			'enable_maintenance_mode', function() {
+				return false;
+			}
+		);
 
 		// Use our own debug mode handling instead of WP core
-		WP_CLI::add_wp_hook( 'enable_wp_debug_mode_checks', function( $ret ) {
-			Utils\wp_debug_mode();
-			return false;
-		});
+		WP_CLI::add_wp_hook(
+			'enable_wp_debug_mode_checks', function( $ret ) {
+				Utils\wp_debug_mode();
+				return false;
+			}
+		);
 
 		// Never load advanced-cache.php drop-in when WP-CLI is operating
-		WP_CLI::add_wp_hook( 'enable_loading_advanced_cache_dropin', function() {
-			return false;
-		});
+		WP_CLI::add_wp_hook(
+			'enable_loading_advanced_cache_dropin', function() {
+				return false;
+			}
+		);
 
 		// In a multisite install, die if unable to find site given in --url parameter
 		if ( $this->is_multisite() ) {
-			WP_CLI::add_wp_hook( 'ms_site_not_found', function( $current_site, $domain, $path ) {
-				$url = $domain . $path;
-				$message = $url ? "Site '{$url}' not found." : 'Site not found.';
-				$has_param = isset( WP_CLI::get_runner()->config['url'] );
-				$has_const = defined( 'DOMAIN_CURRENT_SITE' );
-				$explanation = '';
-				if ( $has_param ) {
-					$explanation = 'Verify `--url=<url>` matches an existing site.';
-				} else {
-					if ( $has_const ) {
-						$explanation = 'Verify DOMAIN_CURRENT_SITE matches an existing site or use `--url=<url>` to override.';
+			WP_CLI::add_wp_hook(
+				'ms_site_not_found', function( $current_site, $domain, $path ) {
+					$url = $domain . $path;
+					$message = $url ? "Site '{$url}' not found." : 'Site not found.';
+					$has_param = isset( WP_CLI::get_runner()->config['url'] );
+					$has_const = defined( 'DOMAIN_CURRENT_SITE' );
+					$explanation = '';
+					if ( $has_param ) {
+						$explanation = 'Verify `--url=<url>` matches an existing site.';
 					} else {
-						$explanation = "Define DOMAIN_CURRENT_SITE in 'wp-config.php' or use `--url=<url>` to override.";
+						if ( $has_const ) {
+							$explanation = 'Verify DOMAIN_CURRENT_SITE matches an existing site or use `--url=<url>` to override.';
+						} else {
+							$explanation = "Define DOMAIN_CURRENT_SITE in 'wp-config.php' or use `--url=<url>` to override.";
+						}
 					}
-				}
-				if ( $explanation ) {
-					$message .= ' ' . $explanation;
-				}
-				WP_CLI::error( $message );
-			}, 10, 3 );
+					if ( $explanation ) {
+						$message .= ' ' . $explanation;
+					}
+					WP_CLI::error( $message );
+				}, 10, 3
+			);
 		}
 
 		// The APC cache is not available on the command-line, so bail, to prevent cache poisoning
-		WP_CLI::add_wp_hook( 'muplugins_loaded', function() {
-			if ( $GLOBALS['_wp_using_ext_object_cache'] && class_exists( 'APC_Object_Cache' ) ) {
-				WP_CLI::warning( 'Running WP-CLI while the APC object cache is activated can result in cache corruption.' );
-				WP_CLI::confirm( 'Given the consequences, do you wish to continue?' );
-			}
-		}, 0 );
+		WP_CLI::add_wp_hook(
+			'muplugins_loaded', function() {
+				if ( $GLOBALS['_wp_using_ext_object_cache'] && class_exists( 'APC_Object_Cache' ) ) {
+					WP_CLI::warning( 'Running WP-CLI while the APC object cache is activated can result in cache corruption.' );
+					WP_CLI::confirm( 'Given the consequences, do you wish to continue?' );
+				}
+			}, 0
+		);
 
 		// Handle --user parameter
 		if ( ! defined( 'WP_INSTALLING' ) ) {
 			$config = $this->config;
-			WP_CLI::add_wp_hook( 'init', function() use ( $config ) {
-				if ( isset( $config['user'] ) ) {
-					$fetcher = new \WP_CLI\Fetchers\User;
-					$user = $fetcher->get_check( $config['user']  );
-					wp_set_current_user( $user->ID );
-				} else {
-					add_action( 'init', 'kses_remove_filters', 11 );
-				}
-			}, 0 );
+			WP_CLI::add_wp_hook(
+				'init', function() use ( $config ) {
+					if ( isset( $config['user'] ) ) {
+						$fetcher = new \WP_CLI\Fetchers\User;
+						$user = $fetcher->get_check( $config['user'] );
+						wp_set_current_user( $user->ID );
+					} else {
+						add_action( 'init', 'kses_remove_filters', 11 );
+					}
+				}, 0
+			);
 		}
 
 		// Avoid uncaught exception when using wp_mail() without defined $_SERVER['SERVER_NAME']
-		WP_CLI::add_wp_hook( 'wp_mail_from', function( $from_email ){
-			if ( 'wordpress@' === $from_email ) {
-				$sitename = strtolower( parse_url( site_url(), PHP_URL_HOST ) );
-				if ( substr( $sitename, 0, 4 ) == 'www.' ) {
-					$sitename = substr( $sitename, 4 );
+		WP_CLI::add_wp_hook(
+			'wp_mail_from', function( $from_email ) {
+				if ( 'wordpress@' === $from_email ) {
+					$sitename = strtolower( parse_url( site_url(), PHP_URL_HOST ) );
+					if ( substr( $sitename, 0, 4 ) == 'www.' ) {
+						$sitename = substr( $sitename, 4 );
+					}
+					$from_email = 'wordpress@' . $sitename;
 				}
-				$from_email = 'wordpress@' . $sitename;
+				return $from_email;
 			}
-			return $from_email;
-		});
+		);
 
 	}
 
@@ -1282,12 +1331,12 @@ class Runner {
 			if ( ! is_array( $plugins ) ) {
 				return $plugins;
 			}
-			foreach( $plugins as $a => $b ) {
+			foreach ( $plugins as $a => $b ) {
 				// active_sitewide_plugins stores plugin name as the key
 				if ( false !== strpos( current_filter(), 'active_sitewide_plugins' ) && Utils\is_plugin_skipped( $a ) ) {
 					unset( $plugins[ $a ] );
-				// active_plugins stores plugin name as the value
-				} else if ( false !== strpos( current_filter(), 'active_plugins' ) && Utils\is_plugin_skipped( $b ) ) {
+					// active_plugins stores plugin name as the value
+				} elseif ( false !== strpos( current_filter(), 'active_plugins' ) && Utils\is_plugin_skipped( $b ) ) {
 					unset( $plugins[ $a ] );
 				}
 			}
@@ -1304,14 +1353,16 @@ class Runner {
 			'pre_option_active_plugins',
 			'option_active_plugins',
 		);
-		foreach( $hooks as $hook ) {
+		foreach ( $hooks as $hook ) {
 			WP_CLI::add_wp_hook( $hook, $wp_cli_filter_active_plugins, 999 );
 		}
-		WP_CLI::add_wp_hook( 'plugins_loaded', function() use ( $hooks, $wp_cli_filter_active_plugins ) {
-			foreach( $hooks as $hook ) {
-				remove_filter( $hook, $wp_cli_filter_active_plugins, 999 );
-			}
-		}, 0 );
+		WP_CLI::add_wp_hook(
+			'plugins_loaded', function() use ( $hooks, $wp_cli_filter_active_plugins ) {
+				foreach ( $hooks as $hook ) {
+					remove_filter( $hook, $wp_cli_filter_active_plugins, 999 );
+				}
+			}, 0
+		);
 	}
 
 	/**
@@ -1344,15 +1395,17 @@ class Runner {
 			'pre_option_stylesheet',
 			'option_stylesheet',
 		);
-		foreach( $hooks as $hook ) {
+		foreach ( $hooks as $hook ) {
 			add_filter( $hook, $wp_cli_filter_active_theme, 999 );
 		}
 		// Clean up after the TEMPLATEPATH and STYLESHEETPATH constants are defined
-		WP_CLI::add_wp_hook( 'after_setup_theme', function() use ( $hooks, $wp_cli_filter_active_theme ) {
-			foreach( $hooks as $hook ) {
-				remove_filter( $hook, $wp_cli_filter_active_theme, 999 );
-			}
-		}, 0 );
+		WP_CLI::add_wp_hook(
+			'after_setup_theme', function() use ( $hooks, $wp_cli_filter_active_theme ) {
+				foreach ( $hooks as $hook ) {
+					remove_filter( $hook, $wp_cli_filter_active_theme, 999 );
+				}
+			}, 0
+		);
 	}
 
 	/**
@@ -1437,7 +1490,11 @@ class Runner {
 
 		// Check whether any updates are available.
 		ob_start();
-		WP_CLI::run_command( array( 'cli', 'check-update' ), array( 'format' => 'count' ) );
+		WP_CLI::run_command(
+			array( 'cli', 'check-update' ), array(
+				'format' => 'count',
+			)
+		);
 		$count = ob_get_clean();
 		if ( ! $count ) {
 			return;

--- a/php/WP_CLI/SynopsisParser.php
+++ b/php/WP_CLI/SynopsisParser.php
@@ -21,7 +21,7 @@ class SynopsisParser {
 			$param = self::classify_token( $token );
 
 			// Some types of parameters shouldn't be mandatory
-			if ( isset( $param['optional'] ) && !$param['optional'] ) {
+			if ( isset( $param['optional'] ) && ! $param['optional'] ) {
 				if ( 'flag' === $param['type'] || ( 'assoc' === $param['type'] && $param['value']['optional'] ) ) {
 					$param['type'] = 'unknown';
 				}
@@ -42,9 +42,14 @@ class SynopsisParser {
 		if ( ! is_array( $synopsis ) ) {
 			return '';
 		}
-		$bits = array( 'positional' => '', 'assoc' => '', 'generic' => '', 'flag' => '' );
-		foreach( $bits as $key => &$value ) {
-			foreach( $synopsis as $arg ) {
+		$bits = array(
+			'positional' => '',
+			'assoc' => '',
+			'generic' => '',
+			'flag' => '',
+		);
+		foreach ( $bits as $key => &$value ) {
+			foreach ( $synopsis as $arg ) {
 				if ( empty( $arg['type'] )
 					|| $key !== $arg['type'] ) {
 					continue;
@@ -56,12 +61,12 @@ class SynopsisParser {
 
 				if ( 'positional' === $key ) {
 					$rendered_arg = "<{$arg['name']}>";
-				} else if ( 'assoc' === $key ) {
+				} elseif ( 'assoc' === $key ) {
 					$arg_value = isset( $arg['value']['name'] ) ? $arg['value']['name'] : $arg['name'];
 					$rendered_arg = "--{$arg['name']}=<{$arg_value}>";
-				} else if ( 'generic' === $key ) {
-					$rendered_arg = "--<field>=<value>";
-				} else if ( 'flag' === $key ) {
+				} elseif ( 'generic' === $key ) {
+					$rendered_arg = '--<field>=<value>';
+				} elseif ( 'flag' === $key ) {
 					$rendered_arg = "--{$arg['name']}";
 				}
 				if ( ! empty( $arg['repeating'] ) ) {
@@ -74,7 +79,7 @@ class SynopsisParser {
 			}
 		}
 		$rendered = '';
-		foreach( $bits as $v ) {
+		foreach ( $bits as $v ) {
 			if ( ! empty( $v ) ) {
 				$rendered .= $v;
 			}
@@ -118,7 +123,9 @@ class SynopsisParser {
 				if ( preg_match( "/^=<$p_value>$/", $value, $matches ) ) {
 					$param['value']['name'] = $matches[1];
 				} else {
-					$param = array( 'type' => 'unknown' );
+					$param = array(
+						'type' => 'unknown',
+					);
 				}
 			}
 		} else {

--- a/php/WP_CLI/SynopsisValidator.php
+++ b/php/WP_CLI/SynopsisValidator.php
@@ -25,9 +25,13 @@ class SynopsisValidator {
 	 * @return array
 	 */
 	public function get_unknown() {
-		return array_column( $this->query_spec( array(
-			'type' => 'unknown',
-		) ), 'token' );
+		return array_column(
+			$this->query_spec(
+				array(
+					'type' => 'unknown',
+				)
+			), 'token'
+		);
 	}
 
 	/**
@@ -37,10 +41,12 @@ class SynopsisValidator {
 	 * @return bool
 	 */
 	public function enough_positionals( $args ) {
-		$positional = $this->query_spec( array(
-			'type' => 'positional',
-			'optional' => false,
-		) );
+		$positional = $this->query_spec(
+			array(
+				'type' => 'positional',
+				'optional' => false,
+			)
+		);
 
 		return count( $args ) >= count( $positional );
 	}
@@ -52,19 +58,24 @@ class SynopsisValidator {
 	 * @return array
 	 */
 	public function unknown_positionals( $args ) {
-		$positional_repeating = $this->query_spec( array(
-			'type' => 'positional',
-			'repeating' => true,
-		) );
+		$positional_repeating = $this->query_spec(
+			array(
+				'type' => 'positional',
+				'repeating' => true,
+			)
+		);
 
 		// At least one positional supports as many as possible.
-		if ( !empty( $positional_repeating ) )
+		if ( ! empty( $positional_repeating ) ) {
 			return array();
+		}
 
-		$positional = $this->query_spec( array(
-			'type' => 'positional',
-			'repeating' => false,
-		) );
+		$positional = $this->query_spec(
+			array(
+				'type' => 'positional',
+				'repeating' => false,
+			)
+		);
 
 		return array_slice( $args, count( $positional ) );
 	}
@@ -76,9 +87,11 @@ class SynopsisValidator {
 	 * @return array
 	 */
 	public function validate_assoc( $assoc_args ) {
-		$assoc_spec = $this->query_spec( array(
-			'type' => 'assoc',
-		) );
+		$assoc_spec = $this->query_spec(
+			array(
+				'type' => 'assoc',
+			)
+		);
 
 		$errors = array(
 			'fatal' => array(),
@@ -90,14 +103,14 @@ class SynopsisValidator {
 		foreach ( $assoc_spec as $param ) {
 			$key = $param['name'];
 
-			if ( !isset( $assoc_args[ $key ] ) ) {
-				if ( !$param['optional'] ) {
-					$errors['fatal'][$key] = "missing --$key parameter";
+			if ( ! isset( $assoc_args[ $key ] ) ) {
+				if ( ! $param['optional'] ) {
+					$errors['fatal'][ $key ] = "missing --$key parameter";
 				}
 			} else {
-				if ( true === $assoc_args[ $key ] && !$param['value']['optional'] ) {
-					$error_type = ( !$param['optional'] ) ? 'fatal' : 'warning';
-					$errors[ $error_type ][$key] = "--$key parameter needs a value";
+				if ( true === $assoc_args[ $key ] && ! $param['value']['optional'] ) {
+					$error_type = ( ! $param['optional'] ) ? 'fatal' : 'warning';
+					$errors[ $error_type ][ $key ] = "--$key parameter needs a value";
 
 					$to_unset[] = $key;
 				}
@@ -114,18 +127,22 @@ class SynopsisValidator {
 	 * @return array|false
 	 */
 	public function unknown_assoc( $assoc_args ) {
-		$generic = $this->query_spec( array(
-			'type' => 'generic',
-		) );
+		$generic = $this->query_spec(
+			array(
+				'type' => 'generic',
+			)
+		);
 
-		if ( count( $generic ) )
+		if ( count( $generic ) ) {
 			return array();
+		}
 
 		$known_assoc = array();
 
 		foreach ( $this->spec as $param ) {
-			if ( in_array( $param['type'], array( 'assoc', 'flag' ) ) )
+			if ( in_array( $param['type'], array( 'assoc', 'flag' ) ) ) {
 				$known_assoc[] = $param['name'];
+			}
 		}
 
 		return array_diff( array_keys( $assoc_args ), $known_assoc );
@@ -146,15 +163,16 @@ class SynopsisValidator {
 		foreach ( $this->spec as $key => $to_match ) {
 			$matched = 0;
 			foreach ( $args as $m_key => $m_value ) {
-				if ( array_key_exists( $m_key, $to_match ) && $m_value == $to_match[ $m_key ] )
+				if ( array_key_exists( $m_key, $to_match ) && $m_value == $to_match[ $m_key ] ) {
 					$matched++;
+				}
 			}
 
-			if (   ( 'AND' == $operator && $matched == $count )
+			if ( ( 'AND' == $operator && $matched == $count )
 				|| ( 'OR' == $operator && $matched > 0 )
 				|| ( 'NOT' == $operator && 0 == $matched ) ) {
-					$filtered[$key] = $to_match;
-				}
+					$filtered[ $key ] = $to_match;
+			}
 		}
 
 		return $filtered;

--- a/php/WP_CLI/UpgraderSkin.php
+++ b/php/WP_CLI/UpgraderSkin.php
@@ -17,11 +17,13 @@ class UpgraderSkin extends \WP_Upgrader_Skin {
 	function bulk_footer() {}
 
 	function error( $error ) {
-		if ( !$error )
+		if ( ! $error ) {
 			return;
+		}
 
-		if ( is_string( $error ) && isset( $this->upgrader->strings[ $error ] ) )
+		if ( is_string( $error ) && isset( $this->upgrader->strings[ $error ] ) ) {
 			$error = $this->upgrader->strings[ $error ];
+		}
 
 		// TODO: show all errors, not just the first one
 		\WP_CLI::warning( $error );
@@ -33,18 +35,21 @@ class UpgraderSkin extends \WP_Upgrader_Skin {
 			\WP_CLI::get_http_cache_manager()->whitelist_package( $this->api->download_link, 'theme', $this->api->slug, $this->api->version );
 		}
 
-		if ( isset( $this->upgrader->strings[$string] ) )
-			$string = $this->upgrader->strings[$string];
-
-		if ( strpos($string, '%') !== false ) {
-			$args = func_get_args();
-			$args = array_splice($args, 1);
-			if ( !empty($args) )
-				$string = vsprintf($string, $args);
+		if ( isset( $this->upgrader->strings[ $string ] ) ) {
+			$string = $this->upgrader->strings[ $string ];
 		}
 
-		if ( empty($string) )
+		if ( strpos( $string, '%' ) !== false ) {
+			$args = func_get_args();
+			$args = array_splice( $args, 1 );
+			if ( ! empty( $args ) ) {
+				$string = vsprintf( $string, $args );
+			}
+		}
+
+		if ( empty( $string ) ) {
 			return;
+		}
 
 		$string = str_replace( '&#8230;', '...', strip_tags( $string ) );
 		$string = html_entity_decode( $string, ENT_QUOTES, get_bloginfo( 'charset' ) );

--- a/php/WP_CLI/WpHttpCacheManager.php
+++ b/php/WP_CLI/WpHttpCacheManager.php
@@ -29,8 +29,8 @@ class WpHttpCacheManager {
 		$this->cache = $cache;
 
 		// hook into wp http api
-		add_filter( 'pre_http_request', array($this, 'filter_pre_http_request'), 10, 3 );
-		add_filter( 'http_response', array($this, 'filter_http_response'), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'filter_pre_http_request' ), 10, 3 );
+		add_filter( 'http_response', array( $this, 'filter_http_response' ), 10, 3 );
 	}
 
 	/**
@@ -38,7 +38,7 @@ class WpHttpCacheManager {
 	 */
 	public function filter_pre_http_request( $response, $args, $url ) {
 		// check if whitelisted
-		if ( !isset( $this->whitelist[$url] ) ) {
+		if ( ! isset( $this->whitelist[ $url ] ) ) {
 			return $response;
 		}
 		// check if downloading
@@ -46,13 +46,16 @@ class WpHttpCacheManager {
 			return $response;
 		}
 		// check cache and export to designated location
-		$filename = $this->cache->has( $this->whitelist[$url]['key'], $this->whitelist[$url]['ttl'] );
+		$filename = $this->cache->has( $this->whitelist[ $url ]['key'], $this->whitelist[ $url ]['ttl'] );
 		if ( $filename ) {
 			WP_CLI::log( sprintf( 'Using cached file \'%s\'...', $filename, $url ) );
 			if ( copy( $filename, $args['filename'] ) ) {
 				// simulate successful download response
 				return array(
-					'response' => array('code' => ( 200 ), 'message' => 'OK'),
+					'response' => array(
+						'code' => ( 200 ),
+						'message' => 'OK',
+					),
 					'filename' => $args['filename'],
 				);
 			} else {
@@ -72,7 +75,7 @@ class WpHttpCacheManager {
 	 */
 	public function filter_http_response( $response, $args, $url ) {
 		// check if whitelisted
-		if ( !isset( $this->whitelist[$url] ) ) {
+		if ( ! isset( $this->whitelist[ $url ] ) ) {
 			return $response;
 		}
 		// check if downloading
@@ -84,7 +87,7 @@ class WpHttpCacheManager {
 			return $response;
 		}
 		// cache downloaded file
-		$this->cache->import( $this->whitelist[$url]['key'], $response['filename']);
+		$this->cache->import( $this->whitelist[ $url ]['key'], $response['filename'] );
 		return $response;
 	}
 
@@ -113,7 +116,7 @@ class WpHttpCacheManager {
 	 */
 	public function whitelist_url( $url, $key = null, $ttl = null ) {
 		$key = $key ? : $url;
-		$this->whitelist[$url] = compact( 'key', 'ttl' );
+		$this->whitelist[ $url ] = compact( 'key', 'ttl' );
 	}
 
 	/**
@@ -123,7 +126,7 @@ class WpHttpCacheManager {
 	 * @return bool
 	 */
 	public function is_whitelisted( $url ) {
-		return isset( $this->whitelist[$url] );
+		return isset( $this->whitelist[ $url ] );
 	}
 
 }

--- a/php/boot-fs.php
+++ b/php/boot-fs.php
@@ -4,12 +4,12 @@
 
 if ( 'cli' !== PHP_SAPI ) {
 	echo "Only CLI access.\n";
-	die(-1);
+	die( -1 );
 }
 
 if ( version_compare( PHP_VERSION, '5.3.0', '<' ) ) {
 	printf( "Error: WP-CLI requires PHP %s or newer. You are running version %s.\n", '5.3.0', PHP_VERSION );
-	die(-1);
+	die( -1 );
 }
 
 define( 'WP_CLI_ROOT', dirname( __DIR__ ) );

--- a/php/boot-phar.php
+++ b/php/boot-phar.php
@@ -11,5 +11,5 @@ if ( file_exists( 'phar://wp-cli.phar/php/wp-cli.php' ) ) {
 	include WP_CLI_ROOT . '/php/wp-cli.php';
 } else {
 	echo "Couldn't find 'php/wp-cli.php'. Was this Phar built correctly?";
-	exit(1);
+	exit( 1 );
 }

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -40,7 +40,7 @@ class WP_CLI {
 	public static function get_configurator() {
 		static $configurator;
 
-		if ( !$configurator ) {
+		if ( ! $configurator ) {
 			$configurator = new WP_CLI\Configurator( WP_CLI_ROOT . '/php/config-spec.php' );
 		}
 
@@ -50,7 +50,7 @@ class WP_CLI {
 	public static function get_root_command() {
 		static $root;
 
-		if ( !$root ) {
+		if ( ! $root ) {
 			$root = new Dispatcher\RootCommand;
 		}
 
@@ -60,7 +60,7 @@ class WP_CLI {
 	public static function get_runner() {
 		static $runner;
 
-		if ( !$runner ) {
+		if ( ! $runner ) {
 			$runner = new WP_CLI\Runner;
 		}
 
@@ -73,7 +73,7 @@ class WP_CLI {
 	public static function get_cache() {
 		static $cache;
 
-		if ( !$cache ) {
+		if ( ! $cache ) {
 			$home = Utils\get_home_dir();
 			$dir = getenv( 'WP_CLI_CACHE_DIR' ) ? : "$home/.wp-cli/cache";
 
@@ -82,9 +82,11 @@ class WP_CLI {
 
 			// clean older files on shutdown with 1/50 probability
 			if ( 0 === mt_rand( 0, 50 ) ) {
-				register_shutdown_function( function () use ( $cache ) {
-					$cache->clean();
-				} );
+				register_shutdown_function(
+					function () use ( $cache ) {
+							 $cache->clean();
+					}
+				);
 			}
 		}
 
@@ -129,7 +131,7 @@ class WP_CLI {
 	public static function get_http_cache_manager() {
 		static $http_cacher;
 
-		if ( !$http_cacher ) {
+		if ( ! $http_cacher ) {
 			$http_cacher = new WpHttpCacheManager( self::get_cache() );
 		}
 
@@ -263,7 +265,7 @@ class WP_CLI {
 
 		self::$hooks_passed[ $when ] = $args;
 
-		if ( !isset( self::$hooks[ $when ] ) ) {
+		if ( ! isset( self::$hooks[ $when ] ) ) {
 			return;
 		}
 
@@ -295,7 +297,10 @@ class WP_CLI {
 			add_filter( $tag, $function_to_add, $priority, $accepted_args );
 		} else {
 			$idx = self::wp_hook_build_unique_id( $tag, $function_to_add, $priority );
-			$wp_filter[$tag][$priority][$idx] = array('function' => $function_to_add, 'accepted_args' => $accepted_args);
+			$wp_filter[ $tag ][ $priority ][ $idx ] = array(
+				'function' => $function_to_add,
+				'accepted_args' => $accepted_args,
+			);
 			unset( $merged_filters[ $tag ] );
 		}
 
@@ -311,26 +316,28 @@ class WP_CLI {
 		global $wp_filter;
 		static $filter_id_count = 0;
 
-		if ( is_string($function) )
+		if ( is_string( $function ) ) {
 			return $function;
+		}
 
-		if ( is_object($function) ) {
+		if ( is_object( $function ) ) {
 			// Closures are currently implemented as objects
 			$function = array( $function, '' );
 		} else {
 			$function = (array) $function;
 		}
 
-		if (is_object($function[0]) ) {
+		if ( is_object( $function[0] ) ) {
 			// Object Class Calling
-			if ( function_exists('spl_object_hash') ) {
-				return spl_object_hash($function[0]) . $function[1];
+			if ( function_exists( 'spl_object_hash' ) ) {
+				return spl_object_hash( $function[0] ) . $function[1];
 			} else {
-				$obj_idx = get_class($function[0]).$function[1];
-				if ( !isset($function[0]->wp_filter_id) ) {
-					if ( false === $priority )
+				$obj_idx = get_class( $function[0] ) . $function[1];
+				if ( ! isset( $function[0]->wp_filter_id ) ) {
+					if ( false === $priority ) {
 						return false;
-					$obj_idx .= isset($wp_filter[$tag][$priority]) ? count((array)$wp_filter[$tag][$priority]) : $filter_id_count;
+					}
+					$obj_idx .= isset( $wp_filter[ $tag ][ $priority ] ) ? count( (array) $wp_filter[ $tag ][ $priority ] ) : $filter_id_count;
 					$function[0]->wp_filter_id = $filter_id_count;
 					++$filter_id_count;
 				} else {
@@ -404,9 +411,9 @@ class WP_CLI {
 		$valid = false;
 		if ( is_callable( $callable ) ) {
 			$valid = true;
-		} else if ( is_string( $callable ) && class_exists( (string) $callable ) ) {
+		} elseif ( is_string( $callable ) && class_exists( (string) $callable ) ) {
 			$valid = true;
-		} else if ( is_object( $callable ) ) {
+		} elseif ( is_object( $callable ) ) {
 			$valid = true;
 		}
 		if ( ! $valid ) {
@@ -414,7 +421,7 @@ class WP_CLI {
 				$callable[0] = is_object( $callable[0] ) ? get_class( $callable[0] ) : $callable[0];
 				$callable = array( $callable[0], $callable[1] );
 			}
-			WP_CLI::error( sprintf( "Callable %s does not exist, and cannot be registered as `wp %s`.", json_encode( $callable ), $name ) );
+			WP_CLI::error( sprintf( 'Callable %s does not exist, and cannot be registered as `wp %s`.', json_encode( $callable ), $name ) );
 		}
 
 		$addition = new Dispatcher\CommandAddition();
@@ -425,7 +432,7 @@ class WP_CLI {
 			return false;
 		}
 
-		foreach( array( 'before_invoke', 'after_invoke' ) as $when ) {
+		foreach ( array( 'before_invoke', 'after_invoke' ) as $when ) {
 			if ( isset( $args[ $when ] ) ) {
 				self::add_hook( "{$when}:{$name}", $args[ $when ] );
 			}
@@ -438,14 +445,14 @@ class WP_CLI {
 
 		$command = self::get_root_command();
 
-		while ( !empty( $path ) ) {
+		while ( ! empty( $path ) ) {
 			$subcommand_name = $path[0];
 			$parent = implode( ' ', $path );
 			$subcommand = $command->find_subcommand( $path );
 
 			// Parent not found. Defer addition or create an empty container as
 			// needed.
-			if ( !$subcommand ) {
+			if ( ! $subcommand ) {
 				if ( isset( $args['is_deferred'] ) && $args['is_deferred'] ) {
 					$subcommand = new Dispatcher\CompositeCommand(
 						$command,
@@ -471,8 +478,12 @@ class WP_CLI {
 		$leaf_command = Dispatcher\CommandFactory::create( $leaf_name, $callable, $command );
 
 		if ( ! $command->can_have_subcommands() ) {
-			throw new Exception( sprintf( "'%s' can't have subcommands.",
-				implode( ' ' , Dispatcher\get_path( $command ) ) ) );
+			throw new Exception(
+				sprintf(
+					"'%s' can't have subcommands.",
+					implode( ' ' , Dispatcher\get_path( $command ) )
+				)
+			);
 		}
 
 		if ( isset( $args['shortdesc'] ) ) {
@@ -482,18 +493,18 @@ class WP_CLI {
 		if ( isset( $args['synopsis'] ) ) {
 			if ( is_string( $args['synopsis'] ) ) {
 				$leaf_command->set_synopsis( $args['synopsis'] );
-			} else if ( is_array( $args['synopsis'] ) ) {
+			} elseif ( is_array( $args['synopsis'] ) ) {
 				$synopsis = \WP_CLI\SynopsisParser::render( $args['synopsis'] );
 				$leaf_command->set_synopsis( $synopsis );
 				$long_desc = '';
 				$bits = explode( ' ', $synopsis );
-				foreach( $args['synopsis'] as $key => $arg ) {
+				foreach ( $args['synopsis'] as $key => $arg ) {
 					$long_desc .= $bits[ $key ] . PHP_EOL;
 					if ( ! empty( $arg['description'] ) ) {
 						$long_desc .= ': ' . $arg['description'] . PHP_EOL;
 					}
 					$yamlify = array();
-					foreach( array( 'default', 'options' ) as $key ) {
+					foreach ( array( 'default', 'options' ) as $key ) {
 						if ( isset( $arg[ $key ] ) ) {
 							$yamlify[ $key ] = $arg[ $key ];
 						}
@@ -538,20 +549,22 @@ class WP_CLI {
 			'callable' => $callable,
 			'args'     => $args,
 		);
-		self::add_hook( "after_add_command:$parent", function () use ( $name ) {
+		self::add_hook(
+			"after_add_command:$parent", function () use ( $name ) {
 
-			$deferred_additions = WP_CLI::get_deferred_additions();
+				$deferred_additions = WP_CLI::get_deferred_additions();
 
-			if ( ! array_key_exists( $name, $deferred_additions ) ) {
-				return;
+				if ( ! array_key_exists( $name, $deferred_additions ) ) {
+					return;
+				}
+
+				$callable = $deferred_additions[ $name ]['callable'];
+				$args     = $deferred_additions[ $name ]['args'];
+				WP_CLI::remove_deferred_addition( $name );
+
+				WP_CLI::add_command( $name, $callable, $args );
 			}
-
-			$callable = $deferred_additions[ $name ]['callable'];
-			$args     = $deferred_additions[ $name ]['args'];
-			WP_CLI::remove_deferred_addition( $name );
-
-			WP_CLI::add_command( $name, $callable, $args );
-		} );
+		);
 	}
 
 	/**
@@ -721,7 +734,7 @@ class WP_CLI {
 	 * @return null
 	 */
 	public static function error( $message, $exit = true ) {
-		if ( ! isset( self::get_runner()->assoc_args[ 'completions' ] ) ) {
+		if ( ! isset( self::get_runner()->assoc_args['completions'] ) ) {
 			self::$logger->error( self::error_to_string( $message ) );
 		}
 
@@ -768,7 +781,7 @@ class WP_CLI {
 	 * @param array $message Multi-line error message to be displayed.
 	 */
 	public static function error_multi_line( $message_lines ) {
-		if ( ! isset( self::get_runner()->assoc_args[ 'completions' ] ) && is_array( $message_lines ) ) {
+		if ( ! isset( self::get_runner()->assoc_args['completions'] ) && is_array( $message_lines ) ) {
 			self::$logger->error_multi_line( array_map( array( __CLASS__, 'error_to_string' ), $message_lines ) );
 		}
 	}
@@ -793,12 +806,13 @@ class WP_CLI {
 	 */
 	public static function confirm( $question, $assoc_args = array() ) {
 		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'yes' ) ) {
-			fwrite( STDOUT, $question . " [y/n] " );
+			fwrite( STDOUT, $question . ' [y/n] ' );
 
 			$answer = strtolower( trim( fgets( STDIN ) ) );
 
-			if ( 'y' != $answer )
+			if ( 'y' != $answer ) {
 				exit;
+			}
 		}
 	}
 
@@ -926,8 +940,9 @@ class WP_CLI {
 			self::warning( "Spawned process returned exit code {$results->return_code}, which could be caused by a custom compiled version of PHP that uses the --enable-sigchild option." );
 		}
 
-		if ( $results->return_code && $exit_on_error )
+		if ( $results->return_code && $exit_on_error ) {
 			exit( $results->return_code );
+		}
 
 		if ( $return_detailed ) {
 			return $results;
@@ -968,8 +983,9 @@ class WP_CLI {
 		foreach ( $reused_runtime_args as $key ) {
 			if ( isset( $runtime_args[ $key ] ) ) {
 				$assoc_args[ $key ] = $runtime_args[ $key ];
-			} else if ( $value = self::get_runner()->config[ $key ] )
+			} elseif ( $value = self::get_runner()->config[ $key ] ) {
 				$assoc_args[ $key ] = $value;
+			}
 		}
 
 		$php_bin = self::get_php_binary();
@@ -1002,14 +1018,17 @@ class WP_CLI {
 	 * @return string
 	 */
 	public static function get_php_binary() {
-		if ( getenv( 'WP_CLI_PHP_USED' ) )
+		if ( getenv( 'WP_CLI_PHP_USED' ) ) {
 			return getenv( 'WP_CLI_PHP_USED' );
+		}
 
-		if ( getenv( 'WP_CLI_PHP' ) )
+		if ( getenv( 'WP_CLI_PHP' ) ) {
 			return getenv( 'WP_CLI_PHP' );
+		}
 
-		if ( defined( 'PHP_BINARY' ) )
+		if ( defined( 'PHP_BINARY' ) ) {
 			return PHP_BINARY;
+		}
 
 		return 'php';
 	}
@@ -1035,7 +1054,7 @@ class WP_CLI {
 			return self::get_runner()->config;
 		}
 
-		if ( !isset( self::get_runner()->config[ $key ] ) ) {
+		if ( ! isset( self::get_runner()->config[ $key ] ) ) {
 			self::warning( "Unknown config option '$key'." );
 			return null;
 		}
@@ -1117,7 +1136,7 @@ class WP_CLI {
 
 			$runcommand = "{$php_bin} {$script_path} {$runtime_config} {$command}";
 
-			$proc = proc_open( $runcommand, $descriptors, $pipes, getcwd(), NULL );
+			$proc = proc_open( $runcommand, $descriptors, $pipes, getcwd(), null );
 
 			if ( $return ) {
 				$stdout = stream_get_contents( $pipes[1] );
@@ -1127,17 +1146,17 @@ class WP_CLI {
 			}
 			$return_code = proc_close( $proc );
 			if ( -1 == $return_code ) {
-				self::warning( "Spawned process returned exit code -1, which could be caused by a custom compiled version of PHP that uses the --enable-sigchild option." );
-			} else if ( $return_code && $exit_error ) {
+				self::warning( 'Spawned process returned exit code -1, which could be caused by a custom compiled version of PHP that uses the --enable-sigchild option.' );
+			} elseif ( $return_code && $exit_error ) {
 				exit( $return_code );
 			}
 			if ( true === $return || 'stdout' === $return ) {
 				$retval = trim( $stdout );
-			} else if ( 'stderr' === $return ) {
+			} elseif ( 'stderr' === $return ) {
 				$retval = trim( $stderr );
-			} else if ( 'return_code' === $return ) {
+			} elseif ( 'return_code' === $return ) {
 				$retval = $return_code;
-			} else if ( 'all' === $return ) {
+			} elseif ( 'all' === $return ) {
 				$retval = (object) array(
 					'stdout'      => trim( $stdout ),
 					'stderr'      => trim( $stderr ),
@@ -1157,9 +1176,13 @@ class WP_CLI {
 				self::$capture_exit = true;
 			}
 			try {
-				self::get_runner()->run_command( $args, $assoc_args, array( 'back_compat_conversions' => true ) );
+				self::get_runner()->run_command(
+					$args, $assoc_args, array(
+						'back_compat_conversions' => true,
+					)
+				);
 				$return_code = 0;
-			} catch( ExitException $e ) {
+			} catch ( ExitException $e ) {
 				$return_code = $e->getCode();
 			}
 			if ( $return ) {
@@ -1169,11 +1192,11 @@ class WP_CLI {
 				$stderr = $execution_logger->stderr;
 				if ( true === $return || 'stdout' === $return ) {
 					$retval = trim( $stdout );
-				} else if ( 'stderr' === $return ) {
+				} elseif ( 'stderr' === $return ) {
 					$retval = trim( $stderr );
-				} else if ( 'return_code' === $return ) {
+				} elseif ( 'return_code' === $return ) {
 					$retval = $return_code;
-				} else if ( 'all' === $return ) {
+				} elseif ( 'all' === $return ) {
 					$retval = (object) array(
 						'stdout'      => trim( $stdout ),
 						'stderr'      => trim( $stderr ),
@@ -1233,8 +1256,12 @@ class WP_CLI {
 
 	// back-compat
 	public static function addCommand( $name, $class ) {
-		trigger_error( sprintf( 'wp %s: %s is deprecated. use WP_CLI::add_command() instead.',
-			$name, __FUNCTION__ ), E_USER_WARNING );
+		trigger_error(
+			sprintf(
+				'wp %s: %s is deprecated. use WP_CLI::add_command() instead.',
+				$name, __FUNCTION__
+			), E_USER_WARNING
+		);
 		self::add_command( $name, $class );
 	}
 }

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -60,20 +60,24 @@ class Help_Command extends WP_CLI_Command {
 		$wordwrap_width = \cli\Shell::columns();
 
 		// Wordwrap with indent.
-		$out = preg_replace_callback( '/^( *)([^\n]+)\n/m', function ( $matches ) use ( $wordwrap_width ) {
-			return $matches[1] . str_replace( "\n", "\n{$matches[1]}", wordwrap( $matches[2], $wordwrap_width - strlen( $matches[1] ) ) ) . "\n";
-		}, $out );
+		$out = preg_replace_callback(
+			'/^( *)([^\n]+)\n/m', function ( $matches ) use ( $wordwrap_width ) {
+				return $matches[1] . str_replace( "\n", "\n{$matches[1]}", wordwrap( $matches[2], $wordwrap_width - strlen( $matches[1] ) ) ) . "\n";
+			}, $out
+		);
 
 		if ( $subcommands ) {
 			// Wordwrap with column indent.
-			$subcommands = preg_replace_callback( '/^(' . $column_subpattern . ')([^\n]+)\n/m', function ( $matches ) use ( $wordwrap_width, $tab ) {
-				// Need to de-tab for wordwrapping to work properly.
-				$matches[1] = str_replace( "\t", $tab, $matches[1] );
-				$matches[2] = str_replace( "\t", $tab, $matches[2] );
-				$padding_len = strlen( $matches[1] );
-				$padding = str_repeat( ' ', $padding_len );
-				return $matches[1] . str_replace( "\n", "\n$padding", wordwrap( $matches[2], $wordwrap_width - $padding_len ) ) . "\n";
-			}, $subcommands );
+			$subcommands = preg_replace_callback(
+				'/^(' . $column_subpattern . ')([^\n]+)\n/m', function ( $matches ) use ( $wordwrap_width, $tab ) {
+					// Need to de-tab for wordwrapping to work properly.
+					$matches[1] = str_replace( "\t", $tab, $matches[1] );
+					$matches[2] = str_replace( "\t", $tab, $matches[2] );
+					$padding_len = strlen( $matches[1] );
+					$padding = str_repeat( ' ', $padding_len );
+					return $matches[1] . str_replace( "\n", "\n$padding", wordwrap( $matches[2], $wordwrap_width - $padding_len ) ) . "\n";
+				}, $subcommands
+			);
 
 			// Put subcommands back.
 			$out = str_replace( $subcommands_header, $subcommands, $out );
@@ -111,7 +115,7 @@ class Help_Command extends WP_CLI_Command {
 		}
 
 		// convert string to file handle
-		$fd = fopen( "php://temp", "r+" );
+		$fd = fopen( 'php://temp', 'r+' );
 		fputs( $fd, $out );
 		rewind( $fd );
 
@@ -171,8 +175,9 @@ class Help_Command extends WP_CLI_Command {
 		$max_len = 0;
 		foreach ( $strings as $str ) {
 			$len = strlen( $str );
-			if ( $len > $max_len )
+			if ( $len > $max_len ) {
 				$max_len = $len;
+			}
 		}
 
 		return $max_len;

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -192,7 +192,7 @@ class CLI_Command extends WP_CLI_Command {
 				array( 'version', 'update_type', 'package_url' )
 			);
 			$formatter->display_items( $updates );
-		} else if ( empty( $assoc_args['format'] ) || 'table' == $assoc_args['format'] ) {
+		} elseif ( empty( $assoc_args['format'] ) || 'table' == $assoc_args['format'] ) {
 			$update_type = $this->get_update_type_str( $assoc_args );
 			WP_CLI::success( "WP-CLI is at the latest{$update_type}version." );
 		}
@@ -244,22 +244,22 @@ class CLI_Command extends WP_CLI_Command {
 	 */
 	public function update( $_, $assoc_args ) {
 		if ( ! Utils\inside_phar() ) {
-			WP_CLI::error( "You can only self-update Phar files." );
+			WP_CLI::error( 'You can only self-update Phar files.' );
 		}
 
 		$old_phar = realpath( $_SERVER['argv'][0] );
 
 		if ( ! is_writable( $old_phar ) ) {
-			WP_CLI::error( sprintf( "%s is not writable by current user.", $old_phar ) );
-		} else if ( ! is_writeable( dirname( $old_phar ) ) ) {
-			WP_CLI::error( sprintf( "%s is not writable by current user.", dirname( $old_phar ) ) );
+			WP_CLI::error( sprintf( '%s is not writable by current user.', $old_phar ) );
+		} elseif ( ! is_writeable( dirname( $old_phar ) ) ) {
+			WP_CLI::error( sprintf( '%s is not writable by current user.', dirname( $old_phar ) ) );
 		}
 
 		if ( Utils\get_flag_value( $assoc_args, 'nightly' ) ) {
 			WP_CLI::confirm( sprintf( 'You have version %s. Would you like to update to the latest nightly?', WP_CLI_VERSION ), $assoc_args );
 			$download_url = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar';
 			$md5_url = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar.md5';
-		} else if ( Utils\get_flag_value( $assoc_args, 'stable' ) ) {
+		} elseif ( Utils\get_flag_value( $assoc_args, 'stable' ) ) {
 			WP_CLI::confirm( sprintf( 'You have version %s. Would you like to update to the latest stable release?', WP_CLI_VERSION ), $assoc_args );
 			$download_url = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar';
 			$md5_url = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar.md5';
@@ -283,7 +283,7 @@ class CLI_Command extends WP_CLI_Command {
 
 		WP_CLI::log( sprintf( 'Downloading from %s...', $download_url ) );
 
-		$temp = \WP_CLI\Utils\get_temp_dir() . uniqid('wp_') . '.phar';
+		$temp = \WP_CLI\Utils\get_temp_dir() . uniqid( 'wp_' ) . '.phar';
 
 		$headers = array();
 		$options = array(
@@ -320,18 +320,18 @@ class CLI_Command extends WP_CLI_Command {
 		$mode = fileperms( $old_phar ) & 511;
 
 		if ( false === @chmod( $temp, $mode ) ) {
-			WP_CLI::error( sprintf( "Cannot chmod %s.", $temp ) );
+			WP_CLI::error( sprintf( 'Cannot chmod %s.', $temp ) );
 		}
 
 		class_exists( '\cli\Colors' ); // This autoloads \cli\Colors - after we move the file we no longer have access to this class.
 
 		if ( false === @rename( $temp, $old_phar ) ) {
-			WP_CLI::error( sprintf( "Cannot move %s to %s", $temp, $old_phar ) );
+			WP_CLI::error( sprintf( 'Cannot move %s to %s', $temp, $old_phar ) );
 		}
 
 		if ( Utils\get_flag_value( $assoc_args, 'nightly' ) ) {
 			$updated_version = 'the latest nightly release';
-		} else if ( Utils\get_flag_value( $assoc_args, 'stable' ) ) {
+		} elseif ( Utils\get_flag_value( $assoc_args, 'stable' ) ) {
 			$updated_version = 'the latest stable release';
 		} else {
 			$updated_version = $newest['version'];
@@ -359,7 +359,7 @@ class CLI_Command extends WP_CLI_Command {
 		$response = Utils\http_request( 'GET', $url, null, $headers, $options );
 
 		if ( ! $response->success || 200 !== $response->status_code ) {
-			WP_CLI::error( sprintf( "Failed to get latest version (HTTP code %d).", $response->status_code ) );
+			WP_CLI::error( sprintf( 'Failed to get latest version (HTTP code %d).', $response->status_code ) );
 		}
 
 		$release_data = json_decode( $response->body );
@@ -393,13 +393,13 @@ class CLI_Command extends WP_CLI_Command {
 			);
 		}
 
-		foreach( $updates as $type => $value ) {
+		foreach ( $updates as $type => $value ) {
 			if ( empty( $value ) ) {
 				unset( $updates[ $type ] );
 			}
 		}
 
-		foreach( array( 'major', 'minor', 'patch' ) as $type ) {
+		foreach ( array( 'major', 'minor', 'patch' ) as $type ) {
 			if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, $type ) ) {
 				return ! empty( $updates[ $type ] ) ? array( $updates[ $type ] ) : false;
 			}
@@ -409,7 +409,7 @@ class CLI_Command extends WP_CLI_Command {
 			$version_url = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/NIGHTLY_VERSION';
 			$response = Utils\http_request( 'GET', $version_url );
 			if ( ! $response->success || 200 !== $response->status_code ) {
-				WP_CLI::error( sprintf( "Failed to get current nightly version (HTTP code %d)", $response->status_code ) );
+				WP_CLI::error( sprintf( 'Failed to get current nightly version (HTTP code %d)', $response->status_code ) );
 			}
 			$nightly_version = trim( $response->body );
 			if ( WP_CLI_VERSION != $nightly_version ) {
@@ -467,12 +467,12 @@ class CLI_Command extends WP_CLI_Command {
 			$config = \WP_CLI::get_configurator()->to_array();
 			// Copy current config values to $spec
 			foreach ( $spec as $key => $value ) {
-				if ( isset( $config[0][$key] ) ) {
-					$current = $config[0][$key];
+				if ( isset( $config[0][ $key ] ) ) {
+					$current = $config[0][ $key ];
 				} else {
-					$current = NULL;
+					$current = null;
 				}
-				$spec[$key]['current'] = $current;
+				$spec[ $key ]['current'] = $current;
 			}
 		}
 
@@ -566,7 +566,7 @@ class CLI_Command extends WP_CLI_Command {
 	 */
 	private function get_update_type_str( $assoc_args ) {
 		$update_type = ' ';
-		foreach( array( 'major', 'minor', 'patch' ) as $type ) {
+		foreach ( array( 'major', 'minor', 'patch' ) as $type ) {
 			if ( true === \WP_CLI\Utils\get_flag_value( $assoc_args, $type ) ) {
 				$update_type = ' ' . $type . ' ';
 				break;

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -5,27 +5,30 @@
 namespace WP_CLI\Utils;
 
 function wp_not_installed() {
-	if ( !is_blog_installed() && !defined( 'WP_INSTALLING' ) ) {
+	if ( ! is_blog_installed() && ! defined( 'WP_INSTALLING' ) ) {
 		\WP_CLI::error(
 			"The site you have requested is not installed.\n" .
-			'Run `wp core install`.' );
+			'Run `wp core install`.'
+		);
 	}
 }
 
 function wp_debug_mode() {
 	if ( \WP_CLI::get_config( 'debug' ) ) {
-		if ( !defined( 'WP_DEBUG' ) )
+		if ( ! defined( 'WP_DEBUG' ) ) {
 			define( 'WP_DEBUG', true );
+		}
 
 		error_reporting( E_ALL & ~E_DEPRECATED & ~E_STRICT );
 	} else {
 		if ( WP_DEBUG ) {
 			error_reporting( E_ALL );
 
-			if ( WP_DEBUG_DISPLAY )
+			if ( WP_DEBUG_DISPLAY ) {
 				ini_set( 'display_errors', 1 );
-			elseif ( null !== WP_DEBUG_DISPLAY )
+			} elseif ( null !== WP_DEBUG_DISPLAY ) {
 				ini_set( 'display_errors', 0 );
+			}
 
 			if ( WP_DEBUG_LOG ) {
 				ini_set( 'log_errors', 1 );
@@ -46,7 +49,11 @@ function wp_debug_mode() {
 
 function replace_wp_die_handler() {
 	\remove_filter( 'wp_die_handler', '_default_wp_die_handler' );
-	\add_filter( 'wp_die_handler', function() { return __NAMESPACE__ . '\\' . 'wp_die_handler'; } );
+	\add_filter(
+		'wp_die_handler', function() {
+			return __NAMESPACE__ . '\\' . 'wp_die_handler';
+		}
+	);
 }
 
 function wp_die_handler( $message ) {
@@ -99,8 +106,9 @@ function maybe_require( $since, $path ) {
 }
 
 function get_upgrader( $class ) {
-	if ( !class_exists( '\WP_Upgrader' ) )
+	if ( ! class_exists( '\WP_Upgrader' ) ) {
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+	}
 
 	return new $class( new \WP_CLI\UpgraderSkin );
 }
@@ -109,10 +117,11 @@ function get_upgrader( $class ) {
  * Converts a plugin basename back into a friendly slug.
  */
 function get_plugin_name( $basename ) {
-	if ( false === strpos( $basename, '/' ) )
+	if ( false === strpos( $basename, '/' ) ) {
 		$name = basename( $basename, '.php' );
-	else
+	} else {
 		$name = dirname( $basename );
+	}
 
 	return $name;
 }
@@ -121,8 +130,9 @@ function is_plugin_skipped( $file ) {
 	$name = get_plugin_name( str_replace( WP_PLUGIN_DIR . '/', '', $file ) );
 
 	$skipped_plugins = \WP_CLI::get_runner()->config['skip-plugins'];
-	if ( true === $skipped_plugins )
+	if ( true === $skipped_plugins ) {
 		return true;
+	}
 
 	if ( ! is_array( $skipped_plugins ) ) {
 		$skipped_plugins = explode( ',', $skipped_plugins );
@@ -139,8 +149,9 @@ function is_theme_skipped( $path ) {
 	$name = get_theme_name( $path );
 
 	$skipped_themes = \WP_CLI::get_runner()->config['skip-themes'];
-	if ( true === $skipped_themes )
+	if ( true === $skipped_themes ) {
 		return true;
+	}
 
 	if ( ! is_array( $skipped_themes ) ) {
 		$skipped_themes = explode( ',', $skipped_themes );
@@ -155,16 +166,18 @@ function is_theme_skipped( $path ) {
  */
 function wp_register_unused_sidebar() {
 
-	register_sidebar(array(
-		'name' => __('Inactive Widgets'),
-		'id' => 'wp_inactive_widgets',
-		'class' => 'inactive-sidebar',
-		'description' => __( 'Drag widgets here to remove them from the sidebar but keep their settings.' ),
-		'before_widget' => '',
-		'after_widget' => '',
-		'before_title' => '',
-		'after_title' => '',
-	));
+	register_sidebar(
+		array(
+			'name' => __( 'Inactive Widgets' ),
+			'id' => 'wp_inactive_widgets',
+			'class' => 'inactive-sidebar',
+			'description' => __( 'Drag widgets here to remove them from the sidebar but keep their settings.' ),
+			'before_widget' => '',
+			'after_widget' => '',
+			'before_title' => '',
+			'after_title' => '',
+		)
+	);
 
 }
 
@@ -185,38 +198,40 @@ function wp_get_cache_type() {
 		if ( isset( $wp_object_cache->m ) && is_a( $wp_object_cache->m, 'Memcached' ) ) {
 			$message = 'Memcached';
 
-		// Test for Memcache PECL extension memcached object cache (http://wordpress.org/extend/plugins/memcached/)
+			// Test for Memcache PECL extension memcached object cache (http://wordpress.org/extend/plugins/memcached/)
 		} elseif ( isset( $wp_object_cache->mc ) ) {
 			$is_memcache = true;
 			foreach ( $wp_object_cache->mc as $bucket ) {
-				if ( ! is_a( $bucket, 'Memcache' ) && ! is_a( $bucket, 'Memcached' ) )
+				if ( ! is_a( $bucket, 'Memcache' ) && ! is_a( $bucket, 'Memcached' ) ) {
 					$is_memcache = false;
+				}
 			}
 
-			if ( $is_memcache )
+			if ( $is_memcache ) {
 				$message = 'Memcache';
+			}
 
-		// Test for Xcache object cache (http://plugins.svn.wordpress.org/xcache/trunk/object-cache.php)
+			// Test for Xcache object cache (http://plugins.svn.wordpress.org/xcache/trunk/object-cache.php)
 		} elseif ( is_a( $wp_object_cache, 'XCache_Object_Cache' ) ) {
 			$message = 'Xcache';
 
-		// Test for WinCache object cache (http://wordpress.org/extend/plugins/wincache-object-cache-backend/)
+			// Test for WinCache object cache (http://wordpress.org/extend/plugins/wincache-object-cache-backend/)
 		} elseif ( class_exists( 'WinCache_Object_Cache' ) ) {
 			$message = 'WinCache';
 
-		// Test for APC object cache (http://wordpress.org/extend/plugins/apc/)
+			// Test for APC object cache (http://wordpress.org/extend/plugins/apc/)
 		} elseif ( class_exists( 'APC_Object_Cache' ) ) {
 			$message = 'APC';
 
-		// Test for Redis Object Cache (https://github.com/alleyinteractive/wp-redis)
+			// Test for Redis Object Cache (https://github.com/alleyinteractive/wp-redis)
 		} elseif ( isset( $wp_object_cache->redis ) && is_a( $wp_object_cache->redis, 'Redis' ) ) {
 			$message = 'Redis';
 
-		// Test for WP LCache Object cache (https://github.com/lcache/wp-lcache)
+			// Test for WP LCache Object cache (https://github.com/lcache/wp-lcache)
 		} elseif ( isset( $wp_object_cache->lcache ) && is_a( $wp_object_cache->lcache, '\LCache\Integrated' ) ) {
 			$message = 'WP LCache';
 
-		} elseif( function_exists( 'w3_instance' ) ) {
+		} elseif ( function_exists( 'w3_instance' ) ) {
 			$config = w3_instance( 'W3_Config' );
 			if ( $config->get_boolean( 'objectcache.enabled' ) ) {
 				$message = 'W3TC ' . $config->get_string( 'objectcache.engine' );
@@ -283,14 +298,14 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 				$all_tables = $wpdb->get_col( 'SHOW TABLES' );
 			}
 			$tables = array();
-			foreach ( $all_tables as $table) {
+			foreach ( $all_tables as $table ) {
 				if ( fnmatch( $glob, $table ) ) {
 					$tables[] = $table;
 				}
 			}
 			return $tables;
 		};
-		foreach( $args as $key => $table ) {
+		foreach ( $args as $key => $table ) {
 			if ( false !== strpos( $table, '*' ) || false !== strpos( $table, '?' ) ) {
 				$expanded_tables = $get_tables_for_glob( $table );
 				if ( empty( $expanded_tables ) ) {
@@ -305,7 +320,7 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 	}
 
 	// Fall back to flag if no tables were passed
-	$table_type = 'wordpress';
+	$table_type = 'WordPress';
 	if ( get_flag_value( $assoc_args, 'network' ) ) {
 		$table_type = 'network';
 	}
@@ -326,7 +341,7 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 	// '_' is a special wildcard for MySQL LIKE queries
 	// so it needs to be escaped with '\', but then '\' needs to be escaped as well
 	$sql_prefix = str_replace( '_', '\\_', $prefix );
-	$matching_tables = $wpdb->get_col( $wpdb->prepare( "SHOW TABLES LIKE %s", $sql_prefix . '%' ) );
+	$matching_tables = $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', $sql_prefix . '%' ) );
 
 	if ( 'all-tables-with-prefix' == $table_type ) {
 		return $matching_tables;
@@ -341,14 +356,14 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 	if ( $network ) {
 		$allowed_table_types[] = 'ms_global_tables';
 	}
-	foreach( $allowed_table_types as $table_type ) {
-		foreach( $wpdb->$table_type as $table ) {
+	foreach ( $allowed_table_types as $table_type ) {
+		foreach ( $wpdb->$table_type as $table ) {
 			$allowed_tables[] = $prefix . $table;
 		}
 	}
 
 	// Given our matching tables, also allow site-specific tables on the network
-	foreach( $matching_tables as $key => $matched_table ) {
+	foreach ( $matching_tables as $key => $matched_table ) {
 
 		if ( in_array( $matched_table, $allowed_tables ) ) {
 			continue;
@@ -356,7 +371,7 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 
 		if ( $network ) {
 			$valid_table = false;
-			foreach( array_merge( $wpdb->tables, $wpdb->old_tables ) as $maybe_site_table ) {
+			foreach ( array_merge( $wpdb->tables, $wpdb->old_tables ) as $maybe_site_table ) {
 				if ( preg_match( "#{$prefix}([\d]+)_{$maybe_site_table}#", $matched_table ) ) {
 					$valid_table = true;
 				}

--- a/php/utils.php
+++ b/php/utils.php
@@ -166,7 +166,7 @@ function is_path_absolute( $path ) {
 		return true;
 	}
 
-	return $path[0] === '/';
+	return '/' === $path[0];
 }
 
 /**
@@ -418,7 +418,7 @@ function mysql_host_to_cli_args( $raw_host ) {
 		if ( is_numeric( $extra ) ) {
 			$assoc_args['port'] = intval( $extra );
 			$assoc_args['protocol'] = 'tcp';
-		} elseif ( $extra !== '' ) {
+		} elseif ( '' !== $extra ) {
 			$assoc_args['socket'] = $extra;
 		}
 	} else {
@@ -880,7 +880,7 @@ function parse_str_to_argv( $arguments ) {
 	$argv = array_map(
 		function( $arg ) {
 			foreach ( array( '"', "'" ) as $char ) {
-				if ( $char === substr( $arg, 0, 1 ) && $char === substr( $arg, -1 ) ) {
+				if ( substr( $arg, 0, 1 ) === $char && substr( $arg, -1 ) === $char ) {
 					$arg = substr( $arg, 1, -1 );
 					break;
 				}
@@ -923,7 +923,7 @@ function basename( $path, $suffix = '' ) {
 function isPiped() {
 	$shellPipe = getenv( 'SHELL_PIPE' );
 
-	if ( $shellPipe !== false ) {
+	if ( false !== $shellPipe ) {
 		return filter_var( $shellPipe, FILTER_VALIDATE_BOOLEAN );
 	} else {
 		return (function_exists( 'posix_isatty' ) && ! posix_isatty( STDOUT ));

--- a/php/utils.php
+++ b/php/utils.php
@@ -28,9 +28,11 @@ function extract_from_phar( $path ) {
 
 	copy( $path, $tmp_path );
 
-	register_shutdown_function( function() use ( $tmp_path ) {
-		@unlink( $tmp_path );
-	} );
+	register_shutdown_function(
+		function() use ( $tmp_path ) {
+				 @unlink( $tmp_path );
+		}
+	);
 
 	return $tmp_path;
 }
@@ -55,9 +57,9 @@ function load_dependencies() {
 		}
 	}
 
-	if ( !$has_autoload ) {
+	if ( ! $has_autoload ) {
 		fputs( STDERR, "Internal error: Can't find Composer autoloader.\nTry running: composer install\n" );
-		exit(3);
+		exit( 3 );
 	}
 }
 
@@ -113,7 +115,7 @@ function iterator_map( $it, $fn ) {
 		$it = new \ArrayIterator( $it );
 	}
 
-	if ( !method_exists( $it, 'add_transform' ) ) {
+	if ( ! method_exists( $it, 'add_transform' ) ) {
 		$it = new Transform( $it );
 	}
 
@@ -150,7 +152,7 @@ function find_file_upward( $files, $dir = null, $stop_check = null ) {
 		}
 
 		$parent_dir = dirname( $dir );
-		if ( empty($parent_dir) || $parent_dir === $dir ) {
+		if ( empty( $parent_dir ) || $parent_dir === $dir ) {
 			break;
 		}
 		$dir = $parent_dir;
@@ -160,8 +162,9 @@ function find_file_upward( $files, $dir = null, $stop_check = null ) {
 
 function is_path_absolute( $path ) {
 	// Windows
-	if ( isset($path[1]) && ':' === $path[1] )
+	if ( isset( $path[1] ) && ':' === $path[1] ) {
 		return true;
+	}
 
 	return $path[0] === '/';
 }
@@ -188,9 +191,13 @@ function assoc_args_to_str( $assoc_args ) {
 	foreach ( $assoc_args as $key => $value ) {
 		if ( true === $value ) {
 			$str .= " --$key";
-		} elseif( is_array( $value ) ) {
-			foreach( $value as $_ => $v ) {
-				$str .= assoc_args_to_str( array( $key => $v ) );
+		} elseif ( is_array( $value ) ) {
+			foreach ( $value as $_ => $v ) {
+				$str .= assoc_args_to_str(
+					array(
+						$key => $v,
+					)
+				);
 			}
 		} else {
 			$str .= " --$key=" . escapeshellarg( $value );
@@ -205,8 +212,9 @@ function assoc_args_to_str( $assoc_args ) {
  * returns the final command, with the parameters escaped.
  */
 function esc_cmd( $cmd ) {
-	if ( func_num_args() < 2 )
+	if ( func_num_args() < 2 ) {
 		trigger_error( 'esc_cmd() requires at least two arguments.', E_USER_WARNING );
+	}
 
 	$args = func_get_args();
 
@@ -219,15 +227,17 @@ function locate_wp_config() {
 	static $path;
 
 	if ( null === $path ) {
-		if ( file_exists( ABSPATH . 'wp-config.php' ) )
+		if ( file_exists( ABSPATH . 'wp-config.php' ) ) {
 			$path = ABSPATH . 'wp-config.php';
-		elseif ( file_exists( ABSPATH . '../wp-config.php' ) && ! file_exists( ABSPATH . '/../wp-settings.php' ) )
+		} elseif ( file_exists( ABSPATH . '../wp-config.php' ) && ! file_exists( ABSPATH . '/../wp-settings.php' ) ) {
 			$path = ABSPATH . '../wp-config.php';
-		else
+		} else {
 			$path = false;
+		}
 
-		if ( $path )
+		if ( $path ) {
 			$path = realpath( $path );
+		}
 	}
 
 	return $path;
@@ -358,7 +368,7 @@ function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
 		if ( $fp ) {
 			fclose( $fp );
 		}
-	} while( ! $tmpfile );
+	} while ( ! $tmpfile );
 
 	if ( ! $tmpfile ) {
 		\WP_CLI::error( 'Error creating temporary file.' );
@@ -368,11 +378,12 @@ function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
 	file_put_contents( $tmpfile, $input );
 
 	$editor = getenv( 'EDITOR' );
-	if ( !$editor ) {
-		if ( isset( $_SERVER['OS'] ) && false !== strpos( $_SERVER['OS'], 'indows' ) )
+	if ( ! $editor ) {
+		if ( isset( $_SERVER['OS'] ) && false !== strpos( $_SERVER['OS'], 'indows' ) ) {
 			$editor = 'notepad';
-		else
+		} else {
 			$editor = 'vi';
+		}
 	}
 
 	$descriptorspec = array( STDIN, STDOUT, STDERR );
@@ -386,8 +397,9 @@ function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
 
 	unlink( $tmpfile );
 
-	if ( $output === $input )
+	if ( $output === $input ) {
 		return false;
+	}
 
 	return $output;
 }
@@ -406,7 +418,7 @@ function mysql_host_to_cli_args( $raw_host ) {
 		if ( is_numeric( $extra ) ) {
 			$assoc_args['port'] = intval( $extra );
 			$assoc_args['protocol'] = 'tcp';
-		} else if ( $extra !== '' ) {
+		} elseif ( $extra !== '' ) {
 			$assoc_args['socket'] = $extra;
 		}
 	} else {
@@ -419,8 +431,9 @@ function mysql_host_to_cli_args( $raw_host ) {
 function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
 	check_proc_available( 'run_mysql_command' );
 
-	if ( !$descriptors )
+	if ( ! $descriptors ) {
 		$descriptors = array( STDIN, STDOUT, STDERR );
+	}
 
 	if ( isset( $assoc_args['host'] ) ) {
 		$assoc_args = array_merge( $assoc_args, mysql_host_to_cli_args( $assoc_args['host'] ) );
@@ -435,14 +448,17 @@ function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
 	$final_cmd = force_env_on_nix_systems( $cmd ) . assoc_args_to_str( $assoc_args );
 
 	$proc = proc_open( $final_cmd, $descriptors, $pipes );
-	if ( !$proc )
-		exit(1);
+	if ( ! $proc ) {
+		exit( 1 );
+	}
 
 	$r = proc_close( $proc );
 
 	putenv( 'MYSQL_PWD=' . $old_pass );
 
-	if ( $r ) exit( $r );
+	if ( $r ) {
+		exit( $r );
+	}
 }
 
 /**
@@ -451,14 +467,18 @@ function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
  * IMPORTANT: Automatic HTML escaping is disabled!
  */
 function mustache_render( $template_name, $data = array() ) {
-	if ( ! file_exists( $template_name ) )
+	if ( ! file_exists( $template_name ) ) {
 		$template_name = WP_CLI_ROOT . "/templates/$template_name";
+	}
 
 	$template = file_get_contents( $template_name );
 
-	$m = new \Mustache_Engine( array(
-		'escape' => function ( $val ) { return $val; },
-	) );
+	$m = new \Mustache_Engine(
+		array(
+			'escape' => function ( $val ) {
+				return $val; },
+		)
+	);
 
 	return $m->render( $template, $data );
 }
@@ -492,8 +512,9 @@ function mustache_render( $template_name, $data = array() ) {
  * @return cli\progress\Bar|WP_CLI\NoOp
  */
 function make_progress_bar( $message, $count ) {
-	if ( \cli\Shell::isPiped() )
+	if ( \cli\Shell::isPiped() ) {
 		return new \WP_CLI\NoOp;
+	}
 
 	return new \cli\progress\Bar( $message, $count );
 }
@@ -501,7 +522,7 @@ function make_progress_bar( $message, $count ) {
 function parse_url( $url ) {
 	$url_parts = \parse_url( $url );
 
-	if ( !isset( $url_parts['scheme'] ) ) {
+	if ( ! isset( $url_parts['scheme'] ) ) {
 		$url_parts = parse_url( 'http://' . $url );
 	}
 
@@ -514,7 +535,7 @@ function parse_url( $url ) {
  * @return bool
  */
 function is_windows() {
-	return false !== ( $test_is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' ) ) ? (bool) $test_is_windows : strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+	return false !== ( $test_is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' ) ) ? (bool) $test_is_windows : strtoupper( substr( PHP_OS, 0, 3 ) ) === 'WIN';
 }
 
 /**
@@ -563,23 +584,24 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 	if ( inside_phar() ) {
 		// cURL can't read Phar archives
 		$options['verify'] = extract_from_phar(
-		WP_CLI_VENDOR_DIR . $cert_path );
+			WP_CLI_VENDOR_DIR . $cert_path
+		);
 	} else {
-		foreach( get_vendor_paths() as $vendor_path ) {
+		foreach ( get_vendor_paths() as $vendor_path ) {
 			if ( file_exists( $vendor_path . $cert_path ) ) {
 				$options['verify'] = $vendor_path . $cert_path;
 				break;
 			}
 		}
-		if ( empty( $options['verify'] ) ){
-			WP_CLI::error( "Cannot find SSL certificate." );
+		if ( empty( $options['verify'] ) ) {
+			WP_CLI::error( 'Cannot find SSL certificate.' );
 		}
 	}
 
 	try {
 		$request = \Requests::request( $url, $headers, $data, $method, $options );
 		return $request;
-	} catch( \Requests_Exception $ex ) {
+	} catch ( \Requests_Exception $ex ) {
 		// CURLE_SSL_CACERT_BADFILE only defined for PHP >= 7.
 		if ( 'curlerror' !== $ex->getType() || ! in_array( curl_errno( $ex->getData() ), array( CURLE_SSL_CONNECT_ERROR, CURLE_SSL_CERTPROBLEM, 77 /*CURLE_SSL_CACERT_BADFILE*/ ), true ) ) {
 			\WP_CLI::error( sprintf( "Failed to get url '%s': %s.", $url, $ex->getMessage() ) );
@@ -589,7 +611,7 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 		$options['verify'] = false;
 		try {
 			return \Requests::request( $url, $headers, $data, $method, $options );
-		} catch( \Requests_Exception $ex ) {
+		} catch ( \Requests_Exception $ex ) {
 			\WP_CLI::error( sprintf( "Failed to get non-verified url '%s' %s.", $url, $ex->getMessage() ) );
 		}
 	}
@@ -676,7 +698,7 @@ function get_named_sem_ver( $new_version, $original_version ) {
 
 	if ( ! is_null( $minor ) && Semver::satisfies( $new_version, "{$major}.{$minor}.x" ) ) {
 		return 'patch';
-	} else if ( Semver::satisfies( $new_version, "{$major}.x.x" ) ) {
+	} elseif ( Semver::satisfies( $new_version, "{$major}.x.x" ) ) {
 		return 'minor';
 	} else {
 		return 'major';
@@ -780,7 +802,7 @@ function get_temp_dir() {
 function parse_ssh_url( $url, $component = -1 ) {
 	preg_match( '#^((docker|docker\-compose|ssh):)?(([^@:]+)@)?([^:/~]+)(:([\d]*))?((/|~)(.+))?$#', $url, $matches );
 	$bits = array();
-	foreach( array(
+	foreach ( array(
 		2 => 'scheme',
 		4 => 'user',
 		5 => 'host',
@@ -853,17 +875,19 @@ function report_batch_operation_results( $noun, $verb, $total, $successes, $fail
  * @return array
  */
 function parse_str_to_argv( $arguments ) {
-	preg_match_all ('/(?<=^|\s)([\'"]?)(.+?)(?<!\\\\)\1(?=$|\s)/', $arguments, $matches );
+	preg_match_all( '/(?<=^|\s)([\'"]?)(.+?)(?<!\\\\)\1(?=$|\s)/', $arguments, $matches );
 	$argv = isset( $matches[0] ) ? $matches[0] : array();
-	$argv = array_map( function( $arg ){
-		foreach( array( '"', "'" ) as $char ) {
-			if ( $char === substr( $arg, 0, 1 ) && $char === substr( $arg, -1 ) ) {
-				$arg = substr( $arg, 1, -1 );
-				break;
+	$argv = array_map(
+		function( $arg ) {
+			foreach ( array( '"', "'" ) as $char ) {
+				if ( $char === substr( $arg, 0, 1 ) && $char === substr( $arg, -1 ) ) {
+					$arg = substr( $arg, 1, -1 );
+					break;
+				}
 			}
-		}
-		return $arg;
-	}, $argv );
+				 return $arg;
+		}, $argv
+	);
 	return $argv;
 }
 
@@ -897,12 +921,12 @@ function basename( $path, $suffix = '' ) {
  * @return bool
  */
 function isPiped() {
-	$shellPipe = getenv('SHELL_PIPE');
+	$shellPipe = getenv( 'SHELL_PIPE' );
 
-	if ($shellPipe !== false) {
-		return filter_var($shellPipe, FILTER_VALIDATE_BOOLEAN);
+	if ( $shellPipe !== false ) {
+		return filter_var( $shellPipe, FILTER_VALIDATE_BOOLEAN );
 	} else {
-		return (function_exists('posix_isatty') && !posix_isatty(STDOUT));
+		return (function_exists( 'posix_isatty' ) && ! posix_isatty( STDOUT ));
 	}
 }
 
@@ -1012,7 +1036,7 @@ function is_bundled_command( $command ) {
 	if ( null === $classes ) {
 		$classes = array();
 		$class_map = WP_CLI_VENDOR_DIR . '/composer/autoload_commands_classmap.php';
-		if ( file_exists( WP_CLI_VENDOR_DIR . '/composer/') ) {
+		if ( file_exists( WP_CLI_VENDOR_DIR . '/composer/' ) ) {
 			$classes = include $class_map;
 		}
 	}

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -88,7 +88,7 @@ timer_start();
  *
  * @param bool $enable_debug_mode Whether to enable debug mode checks to occur. Default true.
  */
-if ( apply_filters( 'enable_wp_debug_mode_checks', true ) ){
+if ( apply_filters( 'enable_wp_debug_mode_checks', true ) ) {
 	wp_debug_mode();
 }
 
@@ -103,7 +103,7 @@ if ( apply_filters( 'enable_wp_debug_mode_checks', true ) ){
  * @param bool $enable_advanced_cache Whether to enable loading advanced-cache.php (if present).
  *                                    Default true.
  */
-if ( WP_CACHE && apply_filters( 'enable_loading_advanced_cache_dropin', true )  ) {
+if ( WP_CACHE && apply_filters( 'enable_loading_advanced_cache_dropin', true ) ) {
 	// For an advanced caching plugin to use. Uses a static drop-in because you would only want one.
 	WP_DEBUG ? include( WP_CONTENT_DIR . '/advanced-cache.php' ) : @include( WP_CONTENT_DIR . '/advanced-cache.php' );
 }
@@ -123,8 +123,9 @@ require_wp_db();
 
 // WP-CLI: Handle db error ourselves, instead of waiting for dead_db()
 global $wpdb;
-if ( !empty( $wpdb->error ) )
+if ( ! empty( $wpdb->error ) ) {
 	wp_die( $wpdb->error );
+}
 
 // Set the database table prefix and the format specifiers for database table columns.
 // @codingStandardsIgnoreStart
@@ -151,8 +152,9 @@ if ( is_multisite() ) {
 register_shutdown_function( 'shutdown_action_hook' );
 
 // Stop most of WordPress from being loaded if we just want the basics.
-if ( SHORTINIT )
+if ( SHORTINIT ) {
 	return false;
+}
 
 // Load the L10n library.
 require_once( ABSPATH . WPINC . '/l10n.php' );
@@ -267,9 +269,10 @@ unset( $mu_plugin );
 
 // Load network activated plugins.
 if ( is_multisite() ) {
-	foreach( wp_get_active_network_plugins() as $network_plugin ) {
-		if ( $symlinked_plugins_supported )
+	foreach ( wp_get_active_network_plugins() as $network_plugin ) {
+		if ( $symlinked_plugins_supported ) {
 			wp_register_plugin_realpath( $network_plugin );
+		}
 		include_once( $network_plugin );
 	}
 	unset( $network_plugin );
@@ -277,8 +280,9 @@ if ( is_multisite() ) {
 
 do_action( 'muplugins_loaded' );
 
-if ( is_multisite() )
+if ( is_multisite() ) {
 	ms_cookie_constants();
+}
 
 // Define constants after multisite is loaded. Cookie-related constants may be overridden in ms_network_cookies().
 wp_cookie_constants();
@@ -299,8 +303,9 @@ register_theme_directory( get_theme_root() );
 
 // Load active plugins.
 foreach ( wp_get_active_and_valid_plugins() as $plugin ) {
-	if ( $symlinked_plugins_supported )
+	if ( $symlinked_plugins_supported ) {
 		wp_register_plugin_realpath( $plugin );
+	}
 	include_once( $plugin );
 }
 unset( $plugin, $symlinked_plugins_supported );
@@ -313,8 +318,9 @@ require( ABSPATH . WPINC . '/pluggable-deprecated.php' );
 wp_set_internal_encoding();
 
 // Run wp_cache_postload() if object cache is enabled and the function exists.
-if ( WP_CACHE && function_exists( 'wp_cache_postload' ) )
+if ( WP_CACHE && function_exists( 'wp_cache_postload' ) ) {
 	wp_cache_postload();
+}
 
 do_action( 'plugins_loaded' );
 
@@ -379,8 +385,9 @@ load_default_textdomain();
 
 $locale = get_locale();
 $locale_file = WP_LANG_DIR . "/$locale.php";
-if ( ( 0 === validate_file( $locale ) ) && is_readable( $locale_file ) )
+if ( ( 0 === validate_file( $locale ) ) && is_readable( $locale_file ) ) {
 	require( $locale_file );
+}
 unset( $locale_file );
 
 // Pull in locale data after loading text domain.
@@ -396,10 +403,12 @@ $GLOBALS['wp_locale'] = new WP_Locale();
 // Load the functions for the active theme, for both parent and child theme if applicable.
 global $pagenow;
 if ( ! defined( 'WP_INSTALLING' ) || 'wp-activate.php' === $pagenow ) {
-	if ( TEMPLATEPATH !== STYLESHEETPATH && file_exists( STYLESHEETPATH . '/functions.php' ) )
+	if ( TEMPLATEPATH !== STYLESHEETPATH && file_exists( STYLESHEETPATH . '/functions.php' ) ) {
 		include( STYLESHEETPATH . '/functions.php' );
-	if ( file_exists( TEMPLATEPATH . '/functions.php' ) )
+	}
+	if ( file_exists( TEMPLATEPATH . '/functions.php' ) ) {
 		include( TEMPLATEPATH . '/functions.php' );
+	}
 }
 
 do_action( 'after_setup_theme' );
@@ -418,12 +427,12 @@ do_action( 'init' );
 
 // Check site status
 # if ( is_multisite() ) {  // WP-CLI
-if ( is_multisite() && !defined('WP_INSTALLING') ) {
+if ( is_multisite() && ! defined( 'WP_INSTALLING' ) ) {
 	if ( true !== ( $file = ms_site_check() ) ) {
 		require( $file );
 		die();
 	}
-	unset($file);
+	unset( $file );
 }
 
 /**
@@ -436,4 +445,4 @@ if ( is_multisite() && !defined('WP_INSTALLING') ) {
  *
  * @since 3.0.0
  */
-do_action('wp_loaded');
+do_action( 'wp_loaded' );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,12 +2,22 @@
 <ruleset name="WP-CLI">
 	<description>WordPress Coding Standards for WP-CLI</description>
 
-	<!-- Check all PHP files in directory tree by default. -->
-	<arg name="extensions" value="php"/>
-	<file>.</file>
-
 	<!-- Show sniff codes in all reports, and progress while running -->
 	<arg value="sp"/>
+	<!-- Check all PHP files in directory tree by default. -->
+	<arg name="extensions" value="php"/>
+	<!-- Run different reports -->
+	<arg name="report" value="full"/>
+	<arg name="report" value="summary"/>
+	<arg name="report" value="source"/>
+
+	<file>.</file>
+	<exclude-pattern>*/ci/*</exclude-pattern>
+	<exclude-pattern>*/features/*</exclude-pattern>
+	<exclude-pattern>*/packages/*</exclude-pattern>
+	<exclude-pattern>*/tests/*</exclude-pattern>
+	<exclude-pattern>*/utils/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
 
 	<rule ref="WordPress-Core">
 		<exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" />
@@ -67,11 +77,4 @@
 		<exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore" />
 		<exclude name="WordPress.WP.CapitalPDangit" />
 	</rule>
-
-	<exclude-pattern>*/ci/*</exclude-pattern>
-	<exclude-pattern>*/features/*</exclude-pattern>
-	<exclude-pattern>*/packages/*</exclude-pattern>
-	<exclude-pattern>*/tests/*</exclude-pattern>
-	<exclude-pattern>*/utils/*</exclude-pattern>
-	<exclude-pattern>*/vendor/*</exclude-pattern>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,40 +20,8 @@
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
 	<rule ref="WordPress-Core">
-		<exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" />
-		<exclude name="Generic.Formatting.DisallowMultipleStatements.SameLine" />
-		<exclude name="Generic.Formatting.SpaceAfterCast.NoSpace" />
-		<exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace" />
-		<exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.SpaceBeforeBrace" />
-		<exclude name="Generic.PHP.LowerCaseKeyword.Found" />
-		<exclude name="Generic.PHP.LowerCaseConstant.Found" />
 		<exclude name="Generic.PHP.NoSilencedErrors.Discouraged" />
-		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
-		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
-		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
-		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
-		<exclude name="PEAR.Functions.FunctionCallSignature.EmptyLine" />
-		<exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
-		<exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
-		<exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeOpenBracket" />
-		<exclude name="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed" />
-		<exclude name="Squiz.Strings.ConcatenationSpacing.PaddingFound" />
-		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword" />
-		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis" />
-		<exclude name="Squiz.Commenting.LongConditionClosingComment.Missing" />
-		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen" />
 		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found" />
-		<exclude name="Squiz.Strings.DoubleQuoteUsage.NotRequired" />
-		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine" />
-		<exclude name="WordPress.Arrays.ArrayDeclaration.NotLowerCase" />
-		<exclude name="WordPress.Arrays.ArrayDeclaration.NoComma" />
-		<exclude name="WordPress.Arrays.ArrayDeclaration.NoCommaAfterLast" />
-		<exclude name="WordPress.Arrays.ArrayDeclaration.SpaceAfterKeyword" />
-		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.AssociativeKeyFound" />
-		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.NoSpaceAfterArrayOpener" />
-		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.NoSpaceBeforeArrayCloser" />
-		<exclude name="WordPress.Arrays.ArrayKeySpacingRestrictions.SpacesAroundArrayKeys" />
-		<exclude name="WordPress.Arrays.ArrayKeySpacingRestrictions.NoSpacesAroundArrayKeys" />
 		<exclude name="WordPress.DB.RestrictedFunctions.mysql_mysql_host_to_cli_args" />
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
@@ -63,18 +31,5 @@
 		<exclude name="WordPress.NamingConventions.ValidVariableName.MemberNotSnakeCase" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" />
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />
-		<exclude name="WordPress.WhiteSpace.CastStructureSpacing.NoSpaceBeforeOpenParenthesis" />
-		<exclude name="WordPress.WhiteSpace.CastStructureSpacing.NoSpaceAfterCloseParenthesis" />
-		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.BlankLineAfterEnd" />
-		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterStructureOpen" />
-		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis" />
-		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeOpenParenthesis" />
-		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterCloseParenthesis" />
-		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis" />
-		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceAfterOpenParenthesis" />
-		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceBeforeCloseParenthesis" />
-		<exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter" />
-		<exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore" />
-		<exclude name="WordPress.WP.CapitalPDangit" />
 	</rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,8 +6,8 @@
 	<arg name="extensions" value="php"/>
 	<file>.</file>
 
-	<!-- Show sniff codes in all reports -->
-	<arg value="s"/>
+	<!-- Show sniff codes in all reports, and progress while running -->
+	<arg value="sp"/>
 
 	<rule ref="WordPress-Core">
 		<exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,6 +30,5 @@
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.MemberNotSnakeCase" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" />
-		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />
 	</rule>
 </ruleset>


### PR DESCRIPTION
Partially addresses #4058.

See the individual commits for more info.

While I appreciate that the desire in #4058 was to do one commit per error (not even one per Sniff), that really doesn't make sense, as some fixes work together to produce the correct outcome i.e. one auto-fix would put something in a new line, but another would fix the indentation; applying them in separate commits doesn't achieve atomic commits that meet acceptable standards that make for easy reviewing.

As such, I did one commit of a couple of items that threw errors even with the exclusions still in place, another that removed exclusions for auto-fixable items, and another for a non-auto-fixable item.

The remaining exclusions are non-trivial to fix i.e. renaming files, renaming public methods / functions etc.

I'd encourage this to be merged, and handle the other exclusions in separate commits / PRs, since they may well need more discussion.

Also not handled is any change in CI, since I'm not familiar with how this repo is handling that.