### PR TITLE
Phpcs.xml.dist improvements

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,12 +2,22 @@
 <ruleset name="WP-CLI">
 	<description>WordPress Coding Standards for WP-CLI</description>
 
-	<!-- Check all PHP files in directory tree by default. -->
-	<arg name="extensions" value="php"/>
-	<file>.</file>
-
 	<!-- Show sniff codes in all reports, and progress while running -->
 	<arg value="sp"/>
+	<!-- Check all PHP files in directory tree by default. -->
+	<arg name="extensions" value="php"/>
+	<!-- Run different reports -->
+	<arg name="report" value="full"/>
+	<arg name="report" value="summary"/>
+	<arg name="report" value="source"/>
+
+	<file>.</file>
+	<exclude-pattern>*/ci/*</exclude-pattern>
+	<exclude-pattern>*/features/*</exclude-pattern>
+	<exclude-pattern>*/packages/*</exclude-pattern>
+	<exclude-pattern>*/tests/*</exclude-pattern>
+	<exclude-pattern>*/utils/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
 
 	<rule ref="WordPress-Core">
 		<exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" />
@@ -67,11 +77,4 @@
 		<exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore" />
 		<exclude name="WordPress.WP.CapitalPDangit" />
 	</rule>
-
-	<exclude-pattern>*/ci/*</exclude-pattern>
-	<exclude-pattern>*/features/*</exclude-pattern>
-	<exclude-pattern>*/packages/*</exclude-pattern>
-	<exclude-pattern>*/tests/*</exclude-pattern>
-	<exclude-pattern>*/utils/*</exclude-pattern>
-	<exclude-pattern>*/vendor/*</exclude-pattern>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,8 +6,8 @@
 	<arg name="extensions" value="php"/>
 	<file>.</file>
 
-	<!-- Show sniff codes in all reports -->
-	<arg value="s"/>
+	<!-- Show sniff codes in all reports, and progress while running -->
+	<arg value="sp"/>
 
 	<rule ref="WordPress-Core">
 		<exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" />


### PR DESCRIPTION
Three improvements:

- Add progress indicator flag which makes local running of PHPCS more user-friendly
    ![screenshot 2017-09-08 11 14 08](https://user-images.githubusercontent.com/88371/30207283-e280936e-9486-11e7-81a5-297b9618b011.png)
- Add summary and source reports, which help to identify which files have issues, and which issues occur the most (and includes a count of how many can be auto-fixed with `phpcbf`)
    ![screenshot 2017-09-08 11 14 20](https://user-images.githubusercontent.com/88371/30207305-ff3c8616-9486-11e7-8759-8082d76968dc.png)
- Organise the `phpcs.xml.dist` so that exclude patterns follow the `file` (what's included).

See #4335