### PR TITLE
Add support for running commands over inside vagrant ssh

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -449,11 +449,10 @@ class Runner {
 
 		// Vagrant ssh-config.
 		if ( 'vagrant' === $bits['scheme'] ) {
-			$command = 'vagrant ssh %s-c %s %s';
+			$command = 'vagrant ssh -c %s %s';
 
 			$escaped_command = sprintf(
 				$command,
-				$is_tty ? '-t ' : ' ',
 				escapeshellarg( $wp_command ),
 				escapeshellarg( $bits['host'] )
 			);

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -447,6 +447,18 @@ class Runner {
 			);
 		}
 
+		// Vagrant ssh-config.
+		if ( 'vagrant' === $bits['scheme'] ) {
+			$command = 'vagrant ssh %s-c %s %s';
+
+			$escaped_command = sprintf(
+				$command,
+				$is_tty ? '-t ' : ' ',
+				escapeshellarg( $wp_command ),
+				escapeshellarg( $bits['host'] )
+			);
+		}
+
 		// Default scheme is SSH.
 		if ( 'ssh' === $bits['scheme'] || null === $bits['scheme'] ) {
 			$command = 'ssh -q %s%s %s %s';

--- a/php/utils.php
+++ b/php/utils.php
@@ -778,7 +778,7 @@ function get_temp_dir() {
  * @return mixed
  */
 function parse_ssh_url( $url, $component = -1 ) {
-	preg_match( '#^((docker|docker\-compose|ssh):)?(([^@:]+)@)?([^:/~]+)(:([\d]*))?((/|~)(.+))?$#', $url, $matches );
+	preg_match( '#^((docker|docker\-compose|ssh|vagrant):)?(([^@:]+)@)?([^:/~]+)(:([\d]*))?((/|~)(.+))?$#', $url, $matches );
 	$bits = array();
 	foreach( array(
 		2 => 'scheme',

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -198,6 +198,18 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( '~/path/to/dir', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 
+		// vagrant scheme
+		$testcase = 'vagrant:default';
+		$this->assertEquals( array(
+			'scheme' => 'vagrant',
+			'host' => 'default',
+		), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( 'vagrant', Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
+		$this->assertEquals( 'default', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
+
 		// unsupported scheme, should not match
 		$testcase = 'foo:bar';
 		$this->assertEquals( array(), Utils\parse_ssh_url( $testcase ) );


### PR DESCRIPTION
This adds support for a vagrant scheme, which uses vagrant to define ssh connection parameters via `vagrant ssh`.

This can either be used via a cli arg: `wp --ssh=vagrant:default shell` or via wp-cli.yml as `ssh: vagrant:default`. `default` here being the vagrant machine ID.

I'm not sure where best to document that, let me know if I can help with that.