### PR TITLE
Introduce `wp cli has-command` to detect whether a command is registered

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -1,5 +1,18 @@
 Feature: `wp cli` tasks
 
+  Scenario: Ability to detect a WP-CLI registered command
+    Given an empty directory
+    And save the {SRC_DIR}/VERSION file as {TRUE_VERSION}
+    And a new Phar with version "1.3.0"
+
+    When I try `{PHAR_PATH} cli has-command scaffold package`
+    Then the return code should be 1
+
+    When I run `wp package install git@github.com:wp-cli/scaffold-package-command.git`
+    When I run `{PHAR_PATH} cli has-command scaffold package`
+    Then the return code should be 0
+
+
   Scenario: Ability to set a custom version when building
     Given an empty directory
     And save the {SRC_DIR}/VERSION file as {TRUE_VERSION}

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -8,7 +8,7 @@ Feature: `wp cli` tasks
     When I try `{PHAR_PATH} cli has-command scaffold package`
     Then the return code should be 1
 
-    When I run `wp package install git@github.com:wp-cli/scaffold-package-command.git`
+    When I run `{PHAR_PATH} package install git@github.com:wp-cli/scaffold-package-command.git`
     When I run `{PHAR_PATH} cli has-command scaffold package`
     Then the return code should be 0
 

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -8,7 +8,7 @@ Feature: `wp cli` tasks
     When I try `{PHAR_PATH} cli has-command scaffold package`
     Then the return code should be 1
 
-    When I run `{PHAR_PATH} package install git@github.com:wp-cli/scaffold-package-command.git`
+    When I try `{PHAR_PATH} package install git@github.com:wp-cli/scaffold-package-command.git`
     When I run `{PHAR_PATH} cli has-command scaffold package`
     Then the return code should be 0
 

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -8,7 +8,7 @@ Feature: `wp cli` tasks
     When I try `{PHAR_PATH} cli has-command scaffold package`
     Then the return code should be 1
 
-    When I try `{PHAR_PATH} package install git@github.com:wp-cli/scaffold-package-command.git`
+    When I run `{PHAR_PATH} package install wp-cli/scaffold-package-command`
     When I run `{PHAR_PATH} cli has-command scaffold package`
     Then the return code should be 0
 

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -2,16 +2,14 @@ Feature: `wp cli` tasks
 
   Scenario: Ability to detect a WP-CLI registered command
     Given an empty directory
-    And save the {SRC_DIR}/VERSION file as {TRUE_VERSION}
-    And a new Phar with version "1.3.0"
 
-    When I try `{PHAR_PATH} cli has-command scaffold package`
-    Then the return code should be 1
-
-    When I run `{PHAR_PATH} package install wp-cli/scaffold-package-command`
-    When I run `{PHAR_PATH} cli has-command scaffold package`
+    When I run `wp package install wp-cli/scaffold-package-command`
+    When I run `wp cli has-command scaffold package`
     Then the return code should be 0
-
+    
+    When I run `wp package uninstall wp-cli/scaffold-package-command`
+    When I try `wp cli has-command scaffold package`
+    Then the return code should be 1
 
   Scenario: Ability to set a custom version when building
     Given an empty directory

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -588,12 +588,12 @@ class CLI_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     The "site delete" command is registered.
+	 *     # The "site delete" command is registered.
 	 *     $ wp cli has-command "site delete"
 	 *     $ echo $?
 	 *     0
 	 *
-	 *     The "foo bar" command is not registered.
+	 *     # The "foo bar" command is not registered.
 	 *     $ wp cli has-command "foo bar"
 	 *     $ echo $?
 	 *     1

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -587,24 +587,25 @@ class CLI_Command extends WP_CLI_Command {
 	 * : The command
 	 *
 	 * ## EXAMPLES
-	 *     wp cli has-command "wp site delete"
-	 *     wp cli has-command wp site delete
+	 *
+	 *     The "site delete" command is registered.
+	 *     wp cli has-command "site delete"
+	 *     echo $?
+	 *     0
+	 *
+	 *     The "foo bar" command is not registered.
+	 *     wp cli has-command "foo bar"
+	 *     echo $?
+	 *     1
 	 *
 	 * @subcommand has-command
 	 *
 	 * @when after_wp_load
-	 *
-	 * @param array $_          Array of positional arguments.
-	 * @param array $assoc_args Array of associative arguments.
 	 */
 	public function has_command( $_, $assoc_args ) {
 
 		// If command is input as a string, then explode it into array.
 		$command = explode( ' ', implode( ' ', $_ ) );
-
-		if ( 'wp' === $command[0] ) {
-			array_shift( $command );
-		}
 
 		WP_CLI::halt( is_array( WP_CLI::get_runner()->find_command_to_run( $command ) ) ? 0 : 1 );
 	}

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -589,13 +589,13 @@ class CLI_Command extends WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     The "site delete" command is registered.
-	 *     wp cli has-command "site delete"
-	 *     echo $?
+	 *     $ wp cli has-command "site delete"
+	 *     $ echo $?
 	 *     0
 	 *
 	 *     The "foo bar" command is not registered.
-	 *     wp cli has-command "foo bar"
-	 *     echo $?
+	 *     $ wp cli has-command "foo bar"
+	 *     $ echo $?
 	 *     1
 	 *
 	 * @subcommand has-command

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -592,79 +592,20 @@ class CLI_Command extends WP_CLI_Command {
 	 *
 	 * @subcommand has-command
 	 *
-	 * @when before_wp_load
+	 * @when after_wp_load
 	 *
 	 * @param array $_          Array of positional arguments.
 	 * @param array $assoc_args Array of associative arguments.
 	 */
 	public function has_command( $_, $assoc_args ) {
 
-		/**
-		 * Get dump as array.
-		 */
-		$json_decoded = self::command_to_array( WP_CLI::get_root_command() );
+		// If command is input as a string, then explode it into array.
+		$command = explode( ' ', implode( ' ', $_ ) );
 
-		/**
-		 * If command is input as a string, then explode it into array.
-		 */
-		$command = ( 1 === count( $_ ) ) ? explode( ' ', $_[0] ) : $_;
-
-		/**
-		 * If command doesn't start with WP, then halt script execution and exit with status 1.
-		 */
-		if ( 'wp' !== $command[0] ) {
-			WP_CLI::halt( 1 );
-		}
-
-		/**
-		 * Length of the command array.
-		 */
-		$command_length = count( $command );
-
-		/**
-		 * Traverse the entire array to check if sequence of commands exist.
-		 */
-		$this->recursive_search( $command, $json_decoded, $command_length );
-	}
-
-	/**
-	 * This function traverses the wp cli cmd-dump JSON that's converted to multi-level associative array.
-	 *
-	 * @param array  $command        The array containing separate parts of the command.
-	 * @param array  $data           The JSON to array converted data.
-	 * @param number $command_length Length of the command array.
-	 * @param number $ticker         Updates if a subcommand is successfully detected.
-	 * @param number $counter        Index as starting point required for next recursive call.
-	 */
-	private function recursive_search( $command, $data, $command_length, $ticker = 0, $counter = 0 ) {
-
-		/**
-		 * Exit with status 0 if command is found.
-		 */
-		if ( ( $ticker + 1 ) === $command_length ) {
-			WP_CLI::halt( 0 );
-		}
-
-		/**
-		 * Exit with status 1 if command is not found.
-		 */
-		if ( empty( $command ) || empty( $data['subcommands'][ $counter ]['name'] ) ) {
-			WP_CLI::halt( 1 );
-		}
-
-		if ( ! empty( $command ) && 'wp' === $command[0] ) {
+		if ( 'wp' === $command[0] ) {
 			array_shift( $command );
 		}
 
-		if ( array_key_exists( 'subcommands', $data ) ) {
-			if ( is_array( $data['subcommands'] ) ) {
-				if ( $command[0] === $data['subcommands'][ $counter ]['name'] ) {
-					array_shift( $command );
-					return $this->recursive_search( $command, $data['subcommands'][ $counter ], $command_length, ++$ticker );
-				} else {
-					return $this->recursive_search( $command, $data, $command_length, $ticker, ++$counter );
-				}
-			}
-		}
+		WP_CLI::halt( is_array( WP_CLI::get_runner()->find_command_to_run( $command ) ) ? 0 : 1 );
 	}
 }

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -587,8 +587,8 @@ class CLI_Command extends WP_CLI_Command {
 	 * : The command
 	 *
 	 * ## EXAMPLES
-	 *		wp cli has-command "wp site delete"
-	 *		wp cli has-command wp site delete
+	 *     wp cli has-command "wp site delete"
+	 *     wp cli has-command wp site delete
 	 *
 	 * @subcommand has-command
 	 *

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -646,7 +646,7 @@ class CLI_Command extends WP_CLI_Command {
 		}
 
 		/**
-		 * Exit with status 1 if command is found.
+		 * Exit with status 1 if command is not found.
 		 */
 		if ( empty( $command ) || empty( $data['subcommands'][ $counter ]['name'] ) ) {
 			WP_CLI::halt( 1 );


### PR DESCRIPTION
I've created a recursive function that traverses the array of the dump output by `self::command_to_array( WP_CLI::get_root_command() )`

See #4283 

- [x] Tested locally
- [x] Functional tests