### PR TITLE
Add past_tense_verb() utils func for report_batch_operation_results().

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -821,11 +821,7 @@ function parse_ssh_url( $url, $component = -1 ) {
  */
 function report_batch_operation_results( $noun, $verb, $total, $successes, $failures ) {
 	$plural_noun = $noun . 's';
-	if ( in_array( $verb, array( 'reset' ), true ) ) {
-		$past_tense_verb = $verb;
-	} else {
-		$past_tense_verb = 'e' === substr( $verb, -1 ) ? $verb . 'd' : $verb . 'ed';
-	}
+	$past_tense_verb = past_tense_verb( $verb );
 	$past_tense_verb_upper = ucfirst( $past_tense_verb );
 	if ( $failures ) {
 		if ( $successes ) {
@@ -1070,4 +1066,28 @@ function check_proc_available( $context = null, $return = false ) {
 		}
 	}
 	return true;
+}
+
+/**
+ * Returns past tense of verb, with limited accuracy. Only regular verbs catered for, apart from "reset".
+ *
+ * @param string $verb Verb to return past tense of.
+ *
+ * @return string
+ */
+function past_tense_verb( $verb ) {
+	static $irregular = array( 'reset' => 'reset' );
+	if ( isset( $irregular[ $verb ] ) ) {
+		return $irregular[ $verb ];
+	}
+	$last = substr( $verb, -1 );
+	if ( 'e' === $last ) {
+		$verb = substr( $verb, 0, -1 );
+	} elseif ( 'y' === $last && ! preg_match( '/[aeiou]y$/', $verb ) ) {
+		$verb = substr( $verb, 0, -1 ) . 'i';
+	} elseif ( preg_match( '/^[^aeiou]*[aeiou][^aeiouhwxy]$/', $verb ) ) {
+		// Rule of thumb that most (all?) one-voweled regular verbs ending in vowel + consonant (excluding "h", "w", "x", "y") double their final consonant - misses many cases (eg "submit").
+		$verb .= $last;
+	}
+	return $verb . 'ed';
 }

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -445,4 +445,41 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( false !== strpos( trim( $output[0] ), $err_msg ) );
 	}
 
+	/**
+	 * @dataProvider dataPastTenseVerb
+	 */
+	public function testPastTenseVerb( $verb, $expected ) {
+		$this->assertSame( $expected, Utils\past_tense_verb( $verb ) );
+	}
+
+	public function dataPastTenseVerb() {
+		return array(
+			// Known to be used by commands.
+			array( 'activate', 'activated' ),
+			array( 'deactivate', 'deactivated' ),
+			array( 'delete', 'deleted' ),
+			array( 'import', 'imported' ),
+			array( 'install', 'installed' ),
+			array( 'network activate', 'network activated' ),
+			array( 'network deactivate', 'network deactivated' ),
+			array( 'regenerate', 'regenerated' ),
+			array( 'reset', 'reset' ),
+			array( 'spam', 'spammed' ),
+			array( 'toggle', 'toggled' ),
+			array( 'uninstall', 'uninstalled' ),
+			array( 'update', 'updated' ),
+			// Some others.
+			array( 'call', 'called' ),
+			array( 'check', 'checked' ),
+			array( 'crop', 'cropped' ),
+			array( 'fix', 'fixed' ), // One vowel + final "x" excluded.
+			array( 'hurrah', 'hurrahed' ), // One vowel + final "h" excluded.
+			array( 'show', 'showed' ), // One vowel + final "w" excluded.
+			array( 'ski', 'skied' ),
+			array( 'slay', 'slayed' ), // One vowel + final "y" excluded (nearly all irregular anyway).
+			array( 'submit', 'submited' ), // BUG: multi-voweled verbs that double not catered for - should be "submitted".
+			array( 'try', 'tried' ),
+		);
+	}
+
 }


### PR DESCRIPTION
Issue https://github.com/wp-cli/wp-cli/issues/4338

Adds utils function `past_tense_verb()` to pastify verbs better for `report_batch_operation_results()`.