### PR TITLE
Allow for xdebug locally enabled in lowercase prompt test.

### DIFF
--- a/features/prompt.feature
+++ b/features/prompt.feature
@@ -34,15 +34,13 @@ Feature: Prompt user for input
       """
 
     When I run `wp test-prompt --prompt < uppercase-session`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
-      1/1 [--flag] (Y/n): Y
       bool(true)
       """
 
     When I run `wp test-prompt --prompt < lowercase-session`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
-      1/1 [--flag] (Y/n): y
       bool(true)
       """


### PR DESCRIPTION
Related PR https://github.com/wp-cli/wp-cli/pull/4334

Just checks for "(bool)true" in `features/prompt.feature:3` to allow for running locally with xdebug enabled (which outputs the filename/line number as well on `var_dump()`).