### PR TITLE
Fail back to `tar xz` when `PharData` throws an Exception

### DIFF
--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -90,7 +90,7 @@ class Extractor {
 				self::rmdir( dirname( $tempdir ) );
 				return;
 			} catch( \Exception $e ) {
-				WP_CLI::warning( $e->getMessage() );
+				WP_CLI::warning( "PharData failed, falling back to 'tar gz' (" . $e->getMessage()  . ')' );
 				// Fall through to trying `tar xz` below
 			}
 		}

--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -89,8 +89,8 @@ class Extractor {
 
 				self::rmdir( dirname( $tempdir ) );
 				return;
-			} catch( \Exception $e ) {
-				WP_CLI::warning( "PharData failed, falling back to 'tar gz' (" . $e->getMessage()  . ')' );
+			} catch ( \Exception $e ) {
+				WP_CLI::warning( "PharData failed, falling back to 'tar gz' (" . $e->getMessage() . ')' );
 				// Fall through to trying `tar xz` below
 			}
 		}


### PR DESCRIPTION
In certain systems, `PharData` fails on invalid archives that `tar` can
successfully handle.

See #4370