### PR TITLE
make-phar: strip non-essential comments and squeeze whitespace.

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -3,6 +3,48 @@ Feature: WP-CLI Commands
   Scenario: Registered WP-CLI commands
     Given an empty directory
 
+    When I run `wp cache --help`
+    Then STDOUT should contain:
+      """
+      wp cache <command>
+      """
+
+    When I run `wp cap --help`
+    Then STDOUT should contain:
+      """
+      wp cap <command>
+      """
+
+    When I run `wp checksum --help`
+    Then STDOUT should contain:
+      """
+      wp checksum <command>
+      """
+
+    When I run `wp comment --help`
+    Then STDOUT should contain:
+      """
+      wp comment <command>
+      """
+
+    When I run `wp config --help`
+    Then STDOUT should contain:
+      """
+      wp config <command>
+      """
+
+    When I run `wp core --help`
+    Then STDOUT should contain:
+      """
+      wp core <command>
+      """
+
+    When I run `wp cron --help`
+    Then STDOUT should contain:
+      """
+      wp cron <command>
+      """
+
     When I run `wp cron`
     Then STDOUT should contain:
       """
@@ -11,16 +53,16 @@ Feature: WP-CLI Commands
          or: wp cron test
       """
 
+    When I run `wp db --help`
+    Then STDOUT should contain:
+      """
+      wp db <command>
+      """
+
     When I run `wp db`
     Then STDOUT should contain:
       """
       or: wp db cli
-      """
-
-    When I run `wp export --help`
-    Then STDOUT should contain:
-      """
-      wp export [--dir=<dirname>]
       """
 
     When I run `wp eval --help`
@@ -29,10 +71,40 @@ Feature: WP-CLI Commands
       wp eval <php-code>
       """
 
+    When I run `wp eval-file --help`
+    Then STDOUT should contain:
+      """
+      wp eval-file <file> [<arg>...]
+      """
+
+    When I run `wp export --help`
+    Then STDOUT should contain:
+      """
+      wp export [--dir=<dirname>]
+      """
+
+    When I run `wp help --help`
+    Then STDOUT should contain:
+      """
+      wp help [<command>...]
+      """
+
     When I run `wp import --help`
     Then STDOUT should contain:
       """
       wp import <file>... --authors=<authors>
+      """
+
+    When I run `wp language --help`
+    Then STDOUT should contain:
+      """
+      wp language <command>
+      """
+
+    When I run `wp media --help`
+    Then STDOUT should contain:
+      """
+      wp media <command>
       """
 
     When I run `wp media`
@@ -41,10 +113,70 @@ Feature: WP-CLI Commands
       or: wp media regenerate
       """
 
+    When I run `wp menu --help`
+    Then STDOUT should contain:
+      """
+      wp menu <command>
+      """
+
+    When I run `wp network --help`
+    Then STDOUT should contain:
+      """
+      wp network <command>
+      """
+
+    When I run `wp option --help`
+    Then STDOUT should contain:
+      """
+      wp option <command>
+      """
+
+    When I run `wp package --help`
+    Then STDOUT should contain:
+      """
+      wp package <command>
+      """
+
     When I run `wp package`
     Then STDOUT should contain:
       """
       or: wp package install
+      """
+
+    When I run `wp plugin --help`
+    Then STDOUT should contain:
+      """
+      wp plugin <command>
+      """
+
+    When I run `wp post --help`
+    Then STDOUT should contain:
+      """
+      wp post <command>
+      """
+
+    When I run `wp post-type --help`
+    Then STDOUT should contain:
+      """
+      wp post-type <command>
+      """
+
+    When I run `wp rewrite --help`
+    Then STDOUT should contain:
+      """
+      wp rewrite <command>
+      """
+
+    When I run `wp role --help`
+    Then STDOUT should contain:
+      """
+      wp role <command>
+      """
+
+    When I run `wp scaffold --help`
+    Then STDOUT should contain:
+      """
+      wp scaffold <command>
       """
 
     When I run `wp search-replace --help`
@@ -63,6 +195,60 @@ Feature: WP-CLI Commands
     Then STDOUT should contain:
       """
       wp shell [--basic]
+      """
+
+    When I run `wp sidebar --help`
+    Then STDOUT should contain:
+      """
+      wp sidebar <command>
+      """
+
+    When I run `wp site --help`
+    Then STDOUT should contain:
+      """
+      wp site <command>
+      """
+
+    When I run `wp super-admin --help`
+    Then STDOUT should contain:
+      """
+      wp super-admin <command>
+      """
+
+    When I run `wp taxonomy --help`
+    Then STDOUT should contain:
+      """
+      wp taxonomy <command>
+      """
+
+    When I run `wp term --help`
+    Then STDOUT should contain:
+      """
+      wp term <command>
+      """
+
+    When I run `wp theme --help`
+    Then STDOUT should contain:
+      """
+      wp theme <command>
+      """
+
+    When I run `wp transient --help`
+    Then STDOUT should contain:
+      """
+      wp transient <command>
+      """
+
+    When I run `wp user --help`
+    Then STDOUT should contain:
+      """
+      wp user <command>
+      """
+
+    When I run `wp widget --help`
+    Then STDOUT should contain:
+      """
+      wp widget <command>
       """
 
   Scenario: Invalid class is specified for a command

--- a/tests/test-make-phar-strip-comments.php
+++ b/tests/test-make-phar-strip-comments.php
@@ -1,0 +1,162 @@
+<?php
+
+require_once dirname( __DIR__ ) . '/utils/make-phar-strip-comments.php';
+
+class MakePharStripCommentsTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * Test basic functionality.
+	 */
+	function testBasic() {
+		
+		// Just doc comment.
+		$source = <<<'EOD'
+<?php
+/**
+ * Blah
+ */
+class Blah_Command extends WP_CLI_Command {
+}
+EOD;
+		$actual = make_phar_strip_comments( $source, true /*keep_doc_comments*/ );
+		$this->assertSame( $source, $actual );
+		$this->assertSame( substr_count( $actual, "\n" ), substr_count( $source, "\n" ) );
+		$expected = <<<'EOD'
+<?php
+
+
+
+class Blah_Command extends WP_CLI_Command {
+}
+EOD;
+		$actual = make_phar_strip_comments( $source, false /*keep_doc_comments*/ );
+		$this->assertSame( $expected, $actual );
+		$this->assertSame( substr_count( $actual, "\n" ), substr_count( $source, "\n" ) );
+
+	}
+
+	/**
+	 * Test inline comment behaviour.
+	 */
+	function testInlineComments() {
+
+		// Doc comment and inline comments.
+		$source = <<<'EOD'
+<?php
+/**
+ * Blah
+ */
+class Blah_Command extends WP_CLI_Command {
+	function __construct() {
+		$blah =  'blah';  // 1 space left at end of line.
+		if (      'blah' === $blah ) {
+			/* 3 tabs kept on this line. */
+		}
+	}
+}
+EOD;
+
+		$expected = <<<'EOD'
+<?php
+/**
+ * Blah
+ */
+class Blah_Command extends WP_CLI_Command {
+	function __construct() {
+		$blah = 'blah'; 
+		if ( 'blah' === $blah ) {
+			
+		}
+	}
+}
+EOD;
+		$actual = make_phar_strip_comments( $source, true /*keep_doc_comments*/ );
+		$this->assertSame( $expected, $actual );
+		$this->assertSame( substr_count( $actual, "\n" ), substr_count( $source, "\n" ) );
+
+		$expected = <<<'EOD'
+<?php
+
+
+
+class Blah_Command extends WP_CLI_Command {
+	function __construct() {
+		$blah = 'blah'; 
+		if ( 'blah' === $blah ) {
+			
+		}
+	}
+}
+EOD;
+		$actual = make_phar_strip_comments( $source, false /*keep_doc_comments*/ );
+		$this->assertSame( $expected, $actual );
+		$this->assertSame( substr_count( $actual, "\n" ), substr_count( $source, "\n" ) );
+	}
+
+	/**
+	 * Test keeps copyright comments.
+	 */
+	function testCopyright() {
+
+		// Doc comment and inline copyrights.
+		$source = <<<'EOD'
+<?php
+/**
+ * Public domain
+ */
+class Blah_Command extends WP_CLI_Command {
+	function __construct() {
+		$blah =  'blah';  // Copyright
+		if (      'blah' === $blah ) { /* Brit licence. */
+			/* (c) */
+		}
+		/**
+		 * License.
+		 */
+	}
+}
+EOD;
+
+		$expected = <<<'EOD'
+<?php
+/**
+ * Public domain
+ */
+class Blah_Command extends WP_CLI_Command {
+	function __construct() {
+		$blah = 'blah'; // Copyright
+		if ( 'blah' === $blah ) { /* Brit licence. */
+			/* (c) */
+		}
+		/**
+		 * License.
+		 */
+	}
+}
+EOD;
+		$actual = make_phar_strip_comments( $source, true /*keep_doc_comments*/ );
+		$this->assertSame( $expected, $actual );
+
+		$expected = <<<'EOD'
+<?php
+
+
+
+class Blah_Command extends WP_CLI_Command {
+	function __construct() {
+		$blah = 'blah'; // Copyright
+		if ( 'blah' === $blah ) { /* Brit licence. */
+			/* (c) */
+		}
+		/**
+		 * License.
+		 */
+	}
+}
+EOD;
+
+		$actual = make_phar_strip_comments( $source, false /*keep_doc_comments*/ );
+		$this->assertSame( $expected, $actual );
+	}
+
+}

--- a/utils/make-phar-strip-comments.php
+++ b/utils/make-phar-strip-comments.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Strips comments and squeezes whitespace from source.
+ *
+ * Part of utils/make-phar.php.
+ *
+ * @param string $contents The source.
+ * @param bool   $keep_doc_comments Whether to keep doc comments or not (for command sources).
+ * @return string The source stripped of comments.
+ */
+function make_phar_strip_comments( $contents, $keep_doc_comments ) {
+	$strs = array_map( function ( $t ) use ( $keep_doc_comments ) {
+		if ( is_string( $t ) ) {
+			return $t;
+		}
+		if ( T_COMMENT === $t[0] || ( ! $keep_doc_comments && T_DOC_COMMENT === $t[0] ) ) {
+			if ( preg_match( '/copyright|licen[sc]e|\(c\)/i', $t[1] ) ) {
+				// Keep for copyright reasons.
+				return $t[1];
+			}
+			return str_repeat( "\n", substr_count( $t[1], "\n" ) ); // Strip everything but newlines.
+		}
+		if ( T_WHITESPACE === $t[0] ) {
+			$str = preg_replace( '/[^\t\n]/', '', $t[1] ); // Keep tabs and newlines.
+			return '' !== $str ? $str : ' '; // Keep at least one space.
+		}
+		return $t[1];
+	}, token_get_all( $contents ) );
+
+	return implode( '', $strs );
+}

--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -14,6 +14,7 @@ if ( file_exists( WP_CLI_ROOT . '/vendor/autoload.php' ) ) {
 }
 require WP_CLI_VENDOR_DIR . '/autoload.php';
 require WP_CLI_ROOT . '/php/utils.php';
+require __DIR__ . '/make-phar-strip-comments.php';
 
 use Symfony\Component\Finder\Finder;
 use WP_CLI\Utils;
@@ -56,7 +57,7 @@ function add_file( $phar, $path ) {
 	$file_contents = file_get_contents( $path );
 	if ( 0 === substr_compare( $path, '.php', -4 ) ) {
 		$is_wp_cli_command = preg_match( '/\/(?:php\/commands|vendor\/wp-cli\/[^\/]+?-command\/src)\//', $path );
-		$file_contents = strip_comments( $file_contents, $is_wp_cli_command /*keep_doc_comments*/ );
+		$file_contents = make_phar_strip_comments( $file_contents, $is_wp_cli_command /*keep_doc_comments*/ );
 	}
 
 	$basename = basename( $path );
@@ -90,28 +91,6 @@ function add_file( $phar, $path ) {
 	} else {
 		$phar[ $key ] = $file_contents;
 	}
-}
-
-function strip_comments( $contents, $keep_doc_comments ) {
-	$strs = array_map( function ( $t ) use ( $keep_doc_comments ) {
-		if ( is_string( $t ) ) {
-			return $t;
-		}
-		if ( T_COMMENT === $t[0] || ( ! $keep_doc_comments && T_DOC_COMMENT === $t[0] ) ) {
-			if ( preg_match( '/copyright|licen[sc]e|\(c\)/i', $t[1] ) ) {
-				// Keep for copyright reasons.
-				return $t[1];
-			}
-			return str_repeat( "\n", substr_count( $t[1], "\n" ) ); // Strip everything but newlines.
-		}
-		if ( T_WHITESPACE === $t[0] ) {
-			$str = preg_replace( '/[^\t\n]/', '', $t[1] ); // Keep tabs and newlines.
-			return '' !== $str ? $str : ' '; // Keep at least one space.
-		}
-		return $t[1];
-	}, token_get_all( $contents ) );
-
-	return implode( '', $strs );
 }
 
 function set_file_contents( $phar, $path, $content ) {


### PR DESCRIPTION
Issue https://github.com/wp-cli/ideas/issues/61

Strips non-essential comments (ie those not in commands) and squeezes whitespace from PHP source in `utils/make-phar.php`, to reduce the size of the WP-CLI phar.

Does this conservatively, keeping line numbers the same so any error reports match and keeping tabs so that the source remains readable if you open it in an editor (if you're into that sort of thing) and keeping at least one space on squeezing whitespace so there's no possibility of triggering one of the (very few) disambiguity requirements PHP has.

Also keeps any copyright/license comments.