### PR TITLE
[WIP] add suggestion_map array to php/utils.php

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -1070,6 +1070,31 @@ function glob_brace( $pattern, $dummy_flags = null ) {
  * @return string
  */
 function get_suggestion( $target, array $options, $threshold = 2 ) {
+
+	$suggestion_map = array(
+		'check' => 'check-update',
+		'clear' => 'flush',
+		'decrement' => 'decr',
+		'del' => 'delete',
+		'directory' => 'dir',
+		'exec' => 'eval',
+		'exec-file' => 'eval-file',
+		'increment' => 'incr',
+		'language' => 'locale',
+		'lang' => 'locale',
+		'new' => 'create',
+		'number' => 'count',
+		'remove' => 'delete',
+		'regen' => 'regenerate',
+		'rep' => 'replace',
+		'repl' => 'replace',
+		'v' => 'version',
+	);
+
+	if ( array_key_exists( $target, $suggestion_map ) ) {
+		return $suggestion_map[ $target ];
+	}
+
 	if ( empty( $options ) ) {
 		return '';
 	}


### PR DESCRIPTION
Hey folks!

This PR seeks to get the ball rolling on (or resolve) this issue: https://github.com/wp-cli/wp-cli/issues/4379

Per  Alain's leading, I've added in the `$suggestion_map` array and the return check. 

Several items in the array are used across different commands (e.g., `wp post new` and `wp db new` would both return the correct suggestion: `Did you mean 'create'?`

I've label this as a WIP, so happy to make edits or expand this. 

Thanks!
Nate
