### PR TITLE
Add tests around `Utils\wp_version_compare()`; strip '-src' for compare

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -246,7 +246,9 @@ function locate_wp_config() {
 }
 
 function wp_version_compare( $since, $operator ) {
-	return version_compare( str_replace( array( '-src' ), '', $GLOBALS['wp_version'] ), $since, $operator );
+	$wp_version = str_replace( '-src', '', $GLOBALS['wp_version'] );
+	$since = str_replace( '-src', '', $since );
+	return version_compare( $wp_version, $since, $operator );
 }
 
 /**

--- a/tests/test-wp-version-compare.php
+++ b/tests/test-wp-version-compare.php
@@ -48,6 +48,21 @@ class WPVersionCompareTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse( Utils\wp_version_compare( '4.9', '>=' ) );
 		$this->assertTrue( Utils\wp_version_compare( '4.9', '<' ) );
 
+		$GLOBALS['wp_version'] = '4.9-rc1-47000';
+		$this->assertTrue( Utils\wp_version_compare( '4.8', '>=' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.8', '<' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-alpha-40870-src', '>' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-alpha-40870-src', '=' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-beta1', '<' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-beta1', '>' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-beta1-45000', '>' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-beta2-45550', '>' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-beta2-45550', '<' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-rc2', '<' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-rc2-48000', '<' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9', '>=' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9', '<' ) );
+
 		$GLOBALS['wp_version'] = '4.9';
 		$this->assertTrue( Utils\wp_version_compare( '4.8', '>=' ) );
 		$this->assertFalse( Utils\wp_version_compare( '4.8', '<' ) );

--- a/tests/test-wp-version-compare.php
+++ b/tests/test-wp-version-compare.php
@@ -1,0 +1,55 @@
+<?php
+
+use WP_CLI\Utils;
+
+class WPVersionCompareTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * Test basic functionality
+	 */
+	public function testBasic() {
+		$GLOBALS['wp_version'] = '4.9-alpha-40870-src';
+		$this->assertTrue( Utils\wp_version_compare( '4.8', '>=' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.8', '<' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-alpha-40870-src', '>' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-alpha-40870-src', '=' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-alpha-40870-src', '<' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-beta1-45000', '>' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-beta2-46000', '<' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9', '>=' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9', '<' ) );
+
+		$GLOBALS['wp_version'] = '4.9-beta1-45000';
+		$this->assertTrue( Utils\wp_version_compare( '4.8', '>=' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.8', '<' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-alpha-40870-src', '>' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-beta1-45000', '>=' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-beta1-45000', '=' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-beta1-45000', '>' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-beta2-46000', '<' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-beta2-46000', '>=' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9', '>=' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9', '<' ) );
+
+		$GLOBALS['wp_version'] = '4.9-beta2-46000';
+		$this->assertTrue( Utils\wp_version_compare( '4.8', '>=' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.8', '<' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-alpha-40870-src', '>' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-alpha-40870-src', '=' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-beta1-45000', '>' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-beta2-45550', '>' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-beta2-45550', '<' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9', '>=' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9', '<' ) );
+
+		$GLOBALS['wp_version'] = '4.9';
+		$this->assertTrue( Utils\wp_version_compare( '4.8', '>=' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.8', '<' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-alpha-40870-src', '>' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-alpha-40870-src', '<' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-beta1-45000', '>' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9', '>=' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9', '<' ) );
+	}
+
+}

--- a/tests/test-wp-version-compare.php
+++ b/tests/test-wp-version-compare.php
@@ -14,6 +14,8 @@ class WPVersionCompareTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse( Utils\wp_version_compare( '4.9-alpha-40870-src', '>' ) );
 		$this->assertTrue( Utils\wp_version_compare( '4.9-alpha-40870-src', '=' ) );
 		$this->assertFalse( Utils\wp_version_compare( '4.9-alpha-40870-src', '<' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-beta1', '<' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-beta1', '>' ) );
 		$this->assertFalse( Utils\wp_version_compare( '4.9-beta1-45000', '>' ) );
 		$this->assertTrue( Utils\wp_version_compare( '4.9-beta2-46000', '<' ) );
 		$this->assertFalse( Utils\wp_version_compare( '4.9', '>=' ) );
@@ -23,6 +25,8 @@ class WPVersionCompareTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( Utils\wp_version_compare( '4.8', '>=' ) );
 		$this->assertFalse( Utils\wp_version_compare( '4.8', '<' ) );
 		$this->assertTrue( Utils\wp_version_compare( '4.9-alpha-40870-src', '>' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-beta1', '<' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-beta1', '>' ) );
 		$this->assertTrue( Utils\wp_version_compare( '4.9-beta1-45000', '>=' ) );
 		$this->assertTrue( Utils\wp_version_compare( '4.9-beta1-45000', '=' ) );
 		$this->assertFalse( Utils\wp_version_compare( '4.9-beta1-45000', '>' ) );
@@ -36,6 +40,8 @@ class WPVersionCompareTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse( Utils\wp_version_compare( '4.8', '<' ) );
 		$this->assertTrue( Utils\wp_version_compare( '4.9-alpha-40870-src', '>' ) );
 		$this->assertFalse( Utils\wp_version_compare( '4.9-alpha-40870-src', '=' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-beta1', '<' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-beta1', '>' ) );
 		$this->assertTrue( Utils\wp_version_compare( '4.9-beta1-45000', '>' ) );
 		$this->assertTrue( Utils\wp_version_compare( '4.9-beta2-45550', '>' ) );
 		$this->assertFalse( Utils\wp_version_compare( '4.9-beta2-45550', '<' ) );
@@ -48,6 +54,8 @@ class WPVersionCompareTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( Utils\wp_version_compare( '4.9-alpha-40870-src', '>' ) );
 		$this->assertFalse( Utils\wp_version_compare( '4.9-alpha-40870-src', '<' ) );
 		$this->assertTrue( Utils\wp_version_compare( '4.9-beta1-45000', '>' ) );
+		$this->assertFalse( Utils\wp_version_compare( '4.9-beta1', '<' ) );
+		$this->assertTrue( Utils\wp_version_compare( '4.9-beta1', '>' ) );
 		$this->assertTrue( Utils\wp_version_compare( '4.9', '>=' ) );
 		$this->assertFalse( Utils\wp_version_compare( '4.9', '<' ) );
 	}


### PR DESCRIPTION
Fixes #4380