### PR TITLE
CS: Exclude class file name checks more efficiently

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -21,10 +21,14 @@
 
 	<rule ref="WordPress-Core">
 		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found" />
-		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
-		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.MemberNotSnakeCase" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" />
+	</rule>
+	<rule ref="WordPress.Files.FileName">
+		<properties>
+			<property name="strict_class_file_names" value="false"/>
+		</properties>
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 	</rule>
 </ruleset>


### PR DESCRIPTION
[This line in WPCS FileNameSniff.php](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/31f18a7168ecff69a738d7fa7687bb56902241ed/WordPress/Sniffs/Files/FileNameSniff.php#L164) shows that setting the `strict_class_file_names` property to `false` means the code that does the `InvalidClassFileName` check is not even run. It's a more efficient way to skip over the fact the class files here are not named per the WP Handbook.

WPCS has it [documented in the wiki](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#disregard-class-file-name-rules).

The moved `exclude` could be left where it was, but it made just as much sense to keep the filename-checking tweaks together.
