### PR TITLE
CS: Unexclude ValidFunctionName checks

### DIFF
--- a/php/WP_CLI/Bootstrap/BootstrapState.php
+++ b/php/WP_CLI/Bootstrap/BootstrapState.php
@@ -34,6 +34,7 @@ class BootstrapState {
 	 *
 	 * @return mixed
 	 */
+	// @codingStandardsIgnoreLine
 	public function getValue( $key, $fallback = null ) {
 		return array_key_exists( $key, $this->state )
 			? $this->state[ $key ]
@@ -48,6 +49,7 @@ class BootstrapState {
 	 *
 	 * @return void
 	 */
+	// @codingStandardsIgnoreLine
 	public function setValue( $key, $value ) {
 		$this->state[ $key ] = $value;
 	}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1255,6 +1255,7 @@ class WP_CLI {
 	}
 
 	// back-compat
+	// @codingStandardsIgnoreLine
 	public static function addCommand( $name, $class ) {
 		trigger_error(
 			sprintf(

--- a/php/utils.php
+++ b/php/utils.php
@@ -935,6 +935,7 @@ function basename( $path, $suffix = '' ) {
  *
  * @return bool
  */
+// @codingStandardsIgnoreLine
 function isPiped() {
 	$shellPipe = getenv( 'SHELL_PIPE' );
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -23,8 +23,6 @@
 		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found" />
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
-		<exclude name="WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid" />
-		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.MemberNotSnakeCase" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" />


### PR DESCRIPTION
Only one function, and three methods, were found to be violating the preferred WPCS naming conventions, so these lines have been excluded.

While it does mean that the rest of the function signature line is also excluded from other checks, this seems like less of an issue than excluded the whole check from the rest of the project, which may allow other incorrectly named functions and methods to be accidentally introduced.

Once https://github.com/squizlabs/PHP_CodeSniffer/issues/604 is addressed, these ignores should be able to target just the specific check of the function / method name.

Related: #4058.