### PR TITLE
Avoid global variable variable

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1067,8 +1067,8 @@ class Runner {
 			if ( array_key_exists( $key, $wp_cli_original_defined_vars ) || 'wp_cli_original_defined_vars' === $key ) {
 				continue;
 			}
-			global $$key;
-			$$key = $var;
+			global ${$key};
+			${$key} = $var;
 		}
 
 		$this->maybe_update_url_from_domain_constant();


### PR DESCRIPTION
http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.global shows that variable variables can no longer be used with the `global` keyword for PHP 7.0 or later. The curly brace syntax can be used to emulate the previous behaviour.

It's a simple change, but this one needs double-checking, please.