### PR TITLE
CS: Add PHP Compatibility Check for 5.3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ matrix:
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - |
-    composer global require wp-coding-standards/wpcs
-    phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
   - ./ci/prepare.sh
 
 script: ./ci/test.sh

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # Run CodeSniffer
-phpcs
+vendor/bin/phpcs
 
 # Run the unit tests
 phpunit

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
 		"phpunit/phpunit": "3.7.*",
 		"roave/security-advisories": "dev-master",
+		"wimg/php-compatibility": "^8.0",
 		"wp-coding-standards/wpcs": "^0.13.1"
 	},
 	"suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "44e3cc8333d254657f0e412eb0c1c73e",
+    "content-hash": "0dc5e25ccc983dbe1ac137a5638b8654",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3494,6 +3494,58 @@
                 "standards"
             ],
             "time": "2017-05-22T02:43:20+00:00"
+        },
+        {
+            "name": "wimg/php-compatibility",
+            "version": "8.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wimg/PHPCompatibility.git",
+                "reference": "4c4385fb891dff0501009670f988d4fe36785249"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wimg/PHPCompatibility/zipball/4c4385fb891dff0501009670f988d4fe36785249",
+                "reference": "4c4385fb891dff0501009670f988d4fe36785249",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.2 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "PHPCompatibility\\": "PHPCompatibility/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-08-07T19:39:05+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -19,6 +19,15 @@
 	<exclude-pattern>*/utils/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
+	<rule ref="PHPCompatibility">
+		<!-- Polyfill package is used so array_column() is available for PHP 5.4- -->
+		<exclude name="PHPCompatibility.PHP.NewFunctions.array_columnFound"/>
+		<!-- Both magic quotes directives set in wp-settings-cli.php to provide consistent starting point. -->
+		<exclude name="PHPCompatibility.PHP.DeprecatedIniDirectives.magic_quotes_runtimeDeprecatedRemoved"/>
+		<exclude name="PHPCompatibility.PHP.DeprecatedIniDirectives.magic_quotes_sybaseDeprecatedRemoved"/>
+	</rule>
+	<config name="testVersion" value="5.3-"/>
+
 	<rule ref="WordPress-Core">
 		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar" />


### PR DESCRIPTION
This checks that all code in the project is compatible with PHP 5.3 and later.

The only other issue that was flagged by PHPCompatibility is fixed via #4401, so that should be merged first. Travis tests will likely fail until that is done.