### PR TITLE
Case mismatch in function/method call

### DIFF
--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -79,7 +79,7 @@ class Extractor {
 					array(
 						dirname( $tarball ),
 						Utils\basename( $tarball, '.tar.gz' ),
-						$phar->getFileName(),
+						$phar->getFilename(),
 					)
 				);
 


### PR DESCRIPTION
Method call (`getFileName()`) does not respect case of method [declaration](http://php.net/manual/en/splfileinfo.getfilename.php) (`getFilename()`).
