### PR TITLE
Fix parameters number mismatch declaration

### DIFF
--- a/php/WP_CLI/Bootstrap/AutoloaderStep.php
+++ b/php/WP_CLI/Bootstrap/AutoloaderStep.php
@@ -44,8 +44,7 @@ abstract class AutoloaderStep implements BootstrapStep {
 				} catch ( \Exception $exception ) {
 					\WP_CLI::warning(
 						"Failed to load autoloader '{$autoloader_path}'. Reason: "
-						. $exception->getMessage(),
-						'bootstrap'
+						. $exception->getMessage()
 					);
 				}
 			}

--- a/php/WP_CLI/Bootstrap/RegisterFrameworkCommands.php
+++ b/php/WP_CLI/Bootstrap/RegisterFrameworkCommands.php
@@ -32,8 +32,7 @@ final class RegisterFrameworkCommands implements BootstrapStep {
 				include_once "$cmd_dir/$filename";
 			} catch ( \Exception $exception ) {
 				\WP_CLI::warning(
-					"Could not add command {$cmd_dir}/{$filename}. Reason: " . $exception->getMessage(),
-					'bootstrap'
+					"Could not add command {$cmd_dir}/{$filename}. Reason: " . $exception->getMessage()
 				);
 			}
 		}


### PR DESCRIPTION
[`WP_CLI::warning()`](https://github.com/wp-cli/wp-cli/blob/7f4c4e4b674a8a993cfb1ff719b9d2dac72a4f7f/php/class-wp-cli.php#L709) only accepts a single parameter.

https://github.com/wp-cli/wp-cli/blob/7f4c4e4b674a8a993cfb1ff719b9d2dac72a4f7f/php/class-wp-cli.php#L709