### PR TITLE
Define missing access modifiers for methods

### DIFF
--- a/php/WP_CLI/Completions.php
+++ b/php/WP_CLI/Completions.php
@@ -7,7 +7,7 @@ class Completions {
 	private $words;
 	private $opts = array();
 
-	function __construct( $line ) {
+	public function __construct( $line ) {
 		// TODO: properly parse single and double quotes
 		$this->words = explode( ' ', $line );
 

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -50,7 +50,7 @@ class Configurator {
 	/**
 	 * @param string $path Path to config spec file.
 	 */
-	function __construct( $path ) {
+	public function __construct( $path ) {
 		$this->spec = include $path;
 
 		$defaults = array(
@@ -73,7 +73,7 @@ class Configurator {
 	 *
 	 * @return array
 	 */
-	function to_array() {
+	public function to_array() {
 		return array( $this->config, $this->extra_config );
 	}
 
@@ -82,7 +82,7 @@ class Configurator {
 	 *
 	 * @return array
 	 */
-	function get_spec() {
+	public function get_spec() {
 		return $this->spec;
 	}
 
@@ -91,7 +91,7 @@ class Configurator {
 	 *
 	 * @return array
 	 */
-	function get_aliases() {
+	public function get_aliases() {
 		if ( $runtime_alias = getenv( 'WP_CLI_RUNTIME_ALIAS' ) ) {
 			$returned_aliases = array();
 			foreach ( json_decode( $runtime_alias, true ) as $key => $value ) {

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -16,7 +16,7 @@ class Subcommand extends CompositeCommand {
 
 	private $when_invoked;
 
-	function __construct( $parent, $name, $docparser, $when_invoked ) {
+	public function __construct( $parent, $name, $docparser, $when_invoked ) {
 		parent::__construct( $parent, $name, $docparser );
 
 		$this->when_invoked = $when_invoked;
@@ -46,7 +46,7 @@ class Subcommand extends CompositeCommand {
 	 *
 	 * @return bool
 	 */
-	function can_have_subcommands() {
+	public function can_have_subcommands() {
 		return false;
 	}
 
@@ -57,7 +57,7 @@ class Subcommand extends CompositeCommand {
 	 *
 	 * @return string
 	 */
-	function get_synopsis() {
+	public function get_synopsis() {
 		return $this->synopsis;
 	}
 
@@ -77,7 +77,7 @@ class Subcommand extends CompositeCommand {
 	 *
 	 * @return string
 	 */
-	function get_alias() {
+	public function get_alias() {
 		return $this->alias;
 	}
 
@@ -86,7 +86,7 @@ class Subcommand extends CompositeCommand {
 	 *
 	 * @param string $prefix
 	 */
-	function show_usage( $prefix = 'usage: ' ) {
+	public function show_usage( $prefix = 'usage: ' ) {
 		\WP_CLI::line( $this->get_usage( $prefix ) );
 	}
 
@@ -96,7 +96,7 @@ class Subcommand extends CompositeCommand {
 	 * @param string $prefix
 	 * @return string
 	 */
-	function get_usage( $prefix ) {
+	public function get_usage( $prefix ) {
 		return sprintf(
 			'%s%s %s',
 			$prefix,

--- a/php/WP_CLI/Iterators/Query.php
+++ b/php/WP_CLI/Iterators/Query.php
@@ -86,20 +86,20 @@ class Query implements \Iterator {
 		return true;
 	}
 
-	function current() {
+	public function current() {
 		return $this->results[ $this->index_in_results ];
 	}
 
-	function key() {
+	public function key() {
 		return $this->global_index;
 	}
 
-	function next() {
+	public function next() {
 		$this->index_in_results++;
 		$this->global_index++;
 	}
 
-	function rewind() {
+	public function rewind() {
 		$this->results = array();
 		$this->global_index = 0;
 		$this->index_in_results = 0;
@@ -107,7 +107,7 @@ class Query implements \Iterator {
 		$this->depleted = false;
 	}
 
-	function valid() {
+	public function valid() {
 		if ( $this->depleted ) {
 			return false;
 		}

--- a/php/WP_CLI/Iterators/Table.php
+++ b/php/WP_CLI/Iterators/Table.php
@@ -38,7 +38,7 @@ class Table extends Query {
 	 *                it's a key/value pair. In the latter case the value is automatically quoted and escaped
 	 *      append - add arbitrary extra SQL
 	 */
-	function __construct( $args = array() ) {
+	public function __construct( $args = array() ) {
 		$defaults = array(
 			'fields' => '*',
 			'where' => array(),

--- a/php/WP_CLI/Loggers/Regular.php
+++ b/php/WP_CLI/Loggers/Regular.php
@@ -10,7 +10,7 @@ class Regular extends Base {
 	/**
 	 * @param bool $in_color Whether or not to Colorize strings.
 	 */
-	function __construct( $in_color ) {
+	public function __construct( $in_color ) {
 		$this->in_color = $in_color;
 	}
 

--- a/php/WP_CLI/NoOp.php
+++ b/php/WP_CLI/NoOp.php
@@ -7,11 +7,11 @@ namespace WP_CLI;
  */
 final class NoOp {
 
-	function __set( $key, $value ) {
+	public function __set( $key, $value ) {
 		// do nothing
 	}
 
-	function __call( $method, $args ) {
+	public function __call( $method, $args ) {
 		// do nothing
 	}
 }

--- a/php/WP_CLI/UpgraderSkin.php
+++ b/php/WP_CLI/UpgraderSkin.php
@@ -11,12 +11,12 @@ class UpgraderSkin extends \WP_Upgrader_Skin {
 
 	public $api;
 
-	function header() {}
-	function footer() {}
-	function bulk_header() {}
-	function bulk_footer() {}
+	public function header() {}
+	public function footer() {}
+	public function bulk_header() {}
+	public function bulk_footer() {}
 
-	function error( $error ) {
+	public function error( $error ) {
 		if ( ! $error ) {
 			return;
 		}
@@ -29,7 +29,7 @@ class UpgraderSkin extends \WP_Upgrader_Skin {
 		\WP_CLI::warning( $error );
 	}
 
-	function feedback( $string ) {
+	public function feedback( $string ) {
 
 		if ( 'parent_theme_prepare_install' === $string ) {
 			\WP_CLI::get_http_cache_manager()->whitelist_package( $this->api->download_link, 'theme', $this->api->slug, $this->api->version );

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -21,7 +21,7 @@ class Help_Command extends WP_CLI_Command {
 	 *     # get help for `core download` subcommand
 	 *     wp help core download
 	 */
-	function __invoke( $args, $assoc_args ) {
+	public function __invoke( $args, $assoc_args ) {
 		$r = WP_CLI::get_runner()->find_command_to_run( $args );
 
 		if ( is_array( $r ) ) {

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -460,7 +460,7 @@ class CLI_Command extends WP_CLI_Command {
 	 *
 	 * @subcommand param-dump
 	 */
-	function param_dump( $_, $assoc_args ) {
+	public function param_dump( $_, $assoc_args ) {
 		$spec = \WP_CLI::get_configurator()->get_spec();
 
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'with-values' ) ) {


### PR DESCRIPTION
Of itself, the changes here shouldn't have much impact, but it allows future code to be inspected / checked to ensure that access modifiers are explicitly defined.

It also provides consistency with the (far more) methods that are already explicitly defined as being public.
