### PR TITLE
Fix dynamic methods invocation via ::

### DIFF
--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -35,7 +35,7 @@ class CLI_Command extends WP_CLI_Command {
 		);
 
 		foreach ( $command->get_subcommands() as $subcommand ) {
-			$dump['subcommands'][] = self::command_to_array( $subcommand );
+			$dump['subcommands'][] = $this->command_to_array( $subcommand );
 		}
 
 		if ( empty( $dump['subcommands'] ) ) {
@@ -495,7 +495,7 @@ class CLI_Command extends WP_CLI_Command {
 	 * @subcommand cmd-dump
 	 */
 	public function cmd_dump() {
-		echo json_encode( self::command_to_array( WP_CLI::get_root_command() ) );
+		echo json_encode( $this->command_to_array( WP_CLI::get_root_command() ) );
 	}
 
 	/**


### PR DESCRIPTION
Non-static methods should not usually be called via `::`, but as a method call on an object / `$this`.

https://github.com/wp-cli/wp-cli/blob/7f4c4e4b674a8a993cfb1ff719b9d2dac72a4f7f/php/commands/src/CLI_Command.php#L30