### PR TITLE
Use binary-safe fopen

### DIFF
--- a/php/WP_CLI/Iterators/CSV.php
+++ b/php/WP_CLI/Iterators/CSV.php
@@ -18,7 +18,7 @@ class CSV implements \Iterator {
 	private $currentElement;
 
 	public function __construct( $filename, $delimiter = ',' ) {
-		$this->filePointer = fopen( $filename, 'r' );
+		$this->filePointer = fopen( $filename, 'rb' );
 		if ( ! $this->filePointer ) {
 			\WP_CLI::error( sprintf( 'Could not open file: %s', $filename ) );
 		}

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -119,7 +119,7 @@ class Help_Command extends WP_CLI_Command {
 		}
 
 		// convert string to file handle
-		$fd = fopen( 'php://temp', 'r+' );
+		$fd = fopen( 'php://temp', 'r+b' );
 		fputs( $fd, $out );
 		rewind( $fd );
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -364,7 +364,7 @@ function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
 		$tmpfile = preg_replace( '|\.[^.]*$|', '', $tmpfile );
 		$tmpfile .= '-' . substr( md5( rand() ), 0, 6 );
 		$tmpfile = $tmpdir . $tmpfile . '.tmp';
-		$fp = fopen( $tmpfile, 'x' );
+		$fp = fopen( $tmpfile, 'xb' );
 		if ( ! $fp && is_writable( $tmpdir ) && file_exists( $tmpfile ) ) {
 			$tmpfile = '';
 			continue;


### PR DESCRIPTION
From [official documentation](http://php.net/manual/en/function.fopen.php):

"The default translation mode depends on the SAPI and version of PHP that you are using, so you are encouraged to always specify the appropriate flag for portability reasons."

"For portability, it is strongly recommended that you always use the 'b' flag when opening files with fopen()."
