### PR TITLE
Use mt_rand() instead of rand()

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -362,7 +362,7 @@ function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
 	do {
 		$tmpfile = basename( $filename );
 		$tmpfile = preg_replace( '|\.[^.]*$|', '', $tmpfile );
-		$tmpfile .= '-' . substr( md5( rand() ), 0, 6 );
+		$tmpfile .= '-' . substr( md5( mt_rand() ), 0, 6 );
 		$tmpfile = $tmpdir . $tmpfile . '.tmp';
 		$fp = fopen( $tmpfile, 'x' );
 		if ( ! $fp && is_writable( $tmpdir ) && file_exists( $tmpfile ) ) {


### PR DESCRIPTION
From [official documentation](http://php.net/manual/en/function.mt-rand.php):

"The `mt_rand()` function is a drop-in replacement for the older `rand()`. It uses a random number generator with known characteristics using the » Mersenne Twister, which will produce random numbers four times faster than what the average libc `rand()` provides."
