### PR TITLE
Remove redundant else keyword

### DIFF
--- a/php/WP_CLI/Completions.php
+++ b/php/WP_CLI/Completions.php
@@ -128,9 +128,13 @@ class Completions {
 		foreach ( \WP_CLI::get_configurator()->get_spec() as $key => $details ) {
 			if ( false === $details['runtime'] ) {
 				continue;
-			} elseif ( isset( $details['deprecated'] ) ) {
+			}
+
+			if ( isset( $details['deprecated'] ) ) {
 				continue;
-			} elseif ( isset( $details['hidden'] ) ) {
+			}
+
+			if ( isset( $details['hidden'] ) ) {
 				continue;
 			}
 			$params[ $key ] = $details['runtime'];

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -105,9 +105,9 @@ class Configurator {
 				}
 			}
 			return $returned_aliases;
-		} else {
-			return $this->aliases;
 		}
+
+		return $this->aliases;
 	}
 
 	/**

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -117,10 +117,11 @@ class Subcommand extends CompositeCommand {
 		$question .= ': ';
 		if ( function_exists( 'readline' ) ) {
 			return readline( $question );
-		} else {
-			echo $question;
-			return stream_get_line( STDIN, 1024, PHP_EOL );
 		}
+
+		echo $question;
+
+		return stream_get_line( STDIN, 1024, PHP_EOL );
 	}
 
 	/**

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -128,9 +128,9 @@ class FileCache {
 
 		if ( $filename ) {
 			return file_put_contents( $filename, $contents ) && touch( $filename );
-		} else {
-			return false;
 		}
+
+		return false;
 	}
 
 	/**
@@ -145,9 +145,9 @@ class FileCache {
 
 		if ( $filename ) {
 			return file_get_contents( $filename );
-		} else {
-			return false;
 		}
+
+		return false;
 	}
 
 	/**
@@ -162,9 +162,9 @@ class FileCache {
 
 		if ( $filename ) {
 			return copy( $source, $filename ) && touch( $filename );
-		} else {
-			return false;
 		}
+
+		return false;
 	}
 
 	/**
@@ -180,9 +180,9 @@ class FileCache {
 
 		if ( $filename ) {
 			return copy( $filename, $target );
-		} else {
-			return false;
 		}
+
+		return false;
 	}
 
 	/**
@@ -200,9 +200,9 @@ class FileCache {
 
 		if ( file_exists( $filename ) ) {
 			return unlink( $filename );
-		} else {
-			return false;
 		}
+
+		return false;
 	}
 
 	/**

--- a/php/WP_CLI/Iterators/Query.php
+++ b/php/WP_CLI/Iterators/Query.php
@@ -77,9 +77,9 @@ class Query implements \Iterator {
 		if ( ! $this->results ) {
 			if ( $this->db->last_error ) {
 				throw new Exception( 'Database error: ' . $this->db->last_error );
-			} else {
-				return false;
 			}
+
+			return false;
 		}
 
 		$this->offset += $this->chunk_size;

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -84,10 +84,11 @@ class Runner {
 
 		if ( is_readable( $config_path ) ) {
 			return $config_path;
-		} else {
-			$this->_global_config_path_debug = 'No readable global config found';
-			return false;
 		}
+
+		$this->_global_config_path_debug = 'No readable global config found';
+
+		return false;
 	}
 
 	/**
@@ -276,14 +277,15 @@ class Runner {
 						$parent_name,
 						! empty( $suggestion ) ? PHP_EOL . "Did you mean '{$suggestion}'?" : ''
 					);
-				} else {
-					$suggestion = $this->get_subcommand_suggestion( $full_name, $command );
-					return sprintf(
-						"'%s' is not a registered wp command. See 'wp help' for available commands.%s",
-						$full_name,
-						! empty( $suggestion ) ? PHP_EOL . "Did you mean '{$suggestion}'?" : ''
-					);
 				}
+
+				$suggestion = $this->get_subcommand_suggestion( $full_name, $command );
+
+				return sprintf(
+					"'%s' is not a registered wp command. See 'wp help' for available commands.%s",
+					$full_name,
+					! empty( $suggestion ) ? PHP_EOL . "Did you mean '{$suggestion}'?" : ''
+				);
 			}
 
 			if ( $this->is_command_disabled( $subcommand ) ) {
@@ -911,9 +913,9 @@ class Runner {
 				}
 				$this->run_alias_group( $group_aliases );
 				exit;
-			} else {
-				$this->set_alias( $this->alias );
 			}
+
+			$this->set_alias( $this->alias );
 		}
 
 		if ( empty( $this->arguments ) ) {

--- a/php/WP_CLI/SynopsisParser.php
+++ b/php/WP_CLI/SynopsisParser.php
@@ -144,9 +144,9 @@ class SynopsisParser {
 	private static function is_optional( $token ) {
 		if ( '[' == substr( $token, 0, 1 ) && ']' == substr( $token, -1 ) ) {
 			return array( true, substr( $token, 1, -1 ) );
-		} else {
-			return array( false, $token );
 		}
+
+		return array( false, $token );
 	}
 
 	/**
@@ -158,8 +158,8 @@ class SynopsisParser {
 	private static function is_repeating( $token ) {
 		if ( '...' === substr( $token, -3 ) ) {
 			return array( true, substr( $token, 0, -3 ) );
-		} else {
-			return array( false, $token );
 		}
+
+		return array( false, $token );
 	}
 }

--- a/php/WP_CLI/WpHttpCacheManager.php
+++ b/php/WP_CLI/WpHttpCacheManager.php
@@ -58,9 +58,9 @@ class WpHttpCacheManager {
 					),
 					'filename' => $args['filename'],
 				);
-			} else {
-				WP_CLI::error( sprintf( 'Error copying cached file %s to %s', $filename, $url ) );
 			}
+
+			WP_CLI::error( sprintf( 'Error copying cached file %s to %s', $filename, $url ) );
 		}
 		return $response;
 	}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -331,22 +331,24 @@ class WP_CLI {
 			// Object Class Calling
 			if ( function_exists( 'spl_object_hash' ) ) {
 				return spl_object_hash( $function[0] ) . $function[1];
-			} else {
-				$obj_idx = get_class( $function[0] ) . $function[1];
-				if ( ! isset( $function[0]->wp_filter_id ) ) {
-					if ( false === $priority ) {
-						return false;
-					}
-					$obj_idx .= isset( $wp_filter[ $tag ][ $priority ] ) ? count( (array) $wp_filter[ $tag ][ $priority ] ) : $filter_id_count;
-					$function[0]->wp_filter_id = $filter_id_count;
-					++$filter_id_count;
-				} else {
-					$obj_idx .= $function[0]->wp_filter_id;
-				}
-
-				return $obj_idx;
 			}
-		} elseif ( is_string( $function[0] ) ) {
+
+			$obj_idx = get_class( $function[0] ) . $function[1];
+			if ( ! isset( $function[0]->wp_filter_id ) ) {
+				if ( false === $priority ) {
+					return false;
+				}
+				$obj_idx .= isset( $wp_filter[ $tag ][ $priority ] ) ? count( (array) $wp_filter[ $tag ][ $priority ] ) : $filter_id_count;
+				$function[0]->wp_filter_id = $filter_id_count;
+				++$filter_id_count;
+			} else {
+				$obj_idx .= $function[0]->wp_filter_id;
+			}
+
+			return $obj_idx;
+		}
+
+		if ( is_string( $function[0] ) ) {
 			// Static Calling
 			return $function[0] . '::' . $function[1];
 		}
@@ -894,18 +896,18 @@ class WP_CLI {
 		$render_data = function( $data ) {
 			if ( is_array( $data ) || is_object( $data ) ) {
 				return json_encode( $data );
-			} else {
-				return '"' . $data . '"';
 			}
+
+			return '"' . $data . '"';
 		};
 
 		if ( is_object( $errors ) && is_a( $errors, 'WP_Error' ) ) {
 			foreach ( $errors->get_error_messages() as $message ) {
 				if ( $errors->get_error_data() ) {
 					return $message . ' ' . $render_data( $errors->get_error_data() );
-				} else {
-					return $message;
 				}
+
+				return $message;
 			}
 		}
 	}
@@ -946,9 +948,9 @@ class WP_CLI {
 
 		if ( $return_detailed ) {
 			return $results;
-		} else {
-			return $results->return_code;
 		}
+
+		return $results->return_code;
 	}
 
 	/**

--- a/php/utils.php
+++ b/php/utils.php
@@ -717,11 +717,13 @@ function get_named_sem_ver( $new_version, $original_version ) {
 
 	if ( ! is_null( $minor ) && Semver::satisfies( $new_version, "{$major}.{$minor}.x" ) ) {
 		return 'patch';
-	} elseif ( Semver::satisfies( $new_version, "{$major}.x.x" ) ) {
-		return 'minor';
-	} else {
-		return 'major';
 	}
+
+	if ( Semver::satisfies( $new_version, "{$major}.x.x" ) ) {
+		return 'minor';
+	}
+
+	return 'major';
 }
 
 /**
@@ -940,9 +942,9 @@ function isPiped() {
 
 	if ( false !== $shellPipe ) {
 		return filter_var( $shellPipe, FILTER_VALIDATE_BOOLEAN );
-	} else {
-		return (function_exists( 'posix_isatty' ) && ! posix_isatty( STDOUT ));
 	}
+
+	return (function_exists( 'posix_isatty' ) && ! posix_isatty( STDOUT ));
 }
 
 /**
@@ -1013,7 +1015,9 @@ function glob_brace( $pattern, $dummy_flags = null ) {
 				} else {
 					if ( ( '}' === $pattern[ $current ] && 0 === $depth-- ) || ( ',' === $pattern[ $current ] && 0 === $depth ) ) {
 						break;
-					} elseif ( '{' === $pattern[ $current++ ] ) {
+					}
+
+					if ( '{' === $pattern[ $current++ ] ) {
 						$depth++;
 					}
 				}


### PR DESCRIPTION
Certain if-else conditions can have their else clause removed without changing the semantic. Generally, this is because the preceding `if` clause returns, continues, breaks, exits or throws.
