### PR TITLE
Use strpos instead of substr for maintainability

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1339,7 +1339,7 @@ class Runner {
 			function( $from_email ) {
 				if ( 'wordpress@' === $from_email ) {
 					$sitename = strtolower( parse_url( site_url(), PHP_URL_HOST ) );
-					if ( substr( $sitename, 0, 4 ) == 'www.' ) {
+					if ( 0 === strpos( $sitename, 'www.' ) ) {
 						$sitename = substr( $sitename, 4 );
 					}
 					$from_email = 'wordpress@' . $sitename;

--- a/php/WP_CLI/SynopsisParser.php
+++ b/php/WP_CLI/SynopsisParser.php
@@ -142,7 +142,7 @@ class SynopsisParser {
 	 * @return array
 	 */
 	private static function is_optional( $token ) {
-		if ( '[' == substr( $token, 0, 1 ) && ']' == substr( $token, -1 ) ) {
+		if ( 0 === strpos( $token, '[' ) && ']' == substr( $token, -1 ) ) {
 			return array( true, substr( $token, 1, -1 ) );
 		} else {
 			return array( false, $token );

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -294,7 +294,7 @@ class CLI_Command extends WP_CLI_Command {
 		Utils\http_request( 'GET', $download_url, null, $headers, $options );
 
 		$md5_response = Utils\http_request( 'GET', $md5_url );
-		if ( 20 != substr( $md5_response->status_code, 0, 2 ) ) {
+		if ( 0 !== strpos( $md5_response->status_code, 20 ) ) {
 			WP_CLI::error( "Couldn't access md5 hash for release (HTTP code {$md5_response->status_code})." );
 		}
 		$md5_file = md5_file( $temp );
@@ -373,7 +373,7 @@ class CLI_Command extends WP_CLI_Command {
 
 			// Get rid of leading "v" if there is one set.
 			$release_version = $release->tag_name;
-			if ( 'v' === substr( $release_version, 0, 1 ) ) {
+			if ( 0 === strpos( $release_version, 'v' ) ) {
 				$release_version = ltrim( $release_version, 'v' );
 			}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -541,7 +541,10 @@ function parse_url( $url ) {
  * @return bool
  */
 function is_windows() {
-	return false !== ( $test_is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' ) ) ? (bool) $test_is_windows : 0 === stripos( PHP_OS, 'WIN' );
+	$getenv = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
+	$php_os_contains_win = 0 === stripos( PHP_OS, 'WIN' );
+
+	return false !== $getenv ? (bool) $getenv : $php_os_contains_win;
 }
 
 /**

--- a/php/utils.php
+++ b/php/utils.php
@@ -541,7 +541,7 @@ function parse_url( $url ) {
  * @return bool
  */
 function is_windows() {
-	return false !== ( $test_is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' ) ) ? (bool) $test_is_windows : strtoupper( substr( PHP_OS, 0, 3 ) ) === 'WIN';
+	return false !== ( $test_is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' ) ) ? (bool) $test_is_windows : 0 === stripos( PHP_OS, 'WIN' );
 }
 
 /**
@@ -895,7 +895,7 @@ function parse_str_to_argv( $arguments ) {
 	$argv = array_map(
 		function( $arg ) {
 			foreach ( array( '"', "'" ) as $char ) {
-				if ( substr( $arg, 0, 1 ) === $char && substr( $arg, -1 ) === $char ) {
+				if ( 0 === strpos( $arg, $char ) && substr( $arg, -1 ) === $char ) {
 					$arg = substr( $arg, 1, -1 );
 					break;
 				}

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -255,6 +255,13 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		) ) );
 	}
 
+	public function testIsWindows() {
+		putenv( 'WP_CLI_TEST_IS_WINDOWS=1' );
+		$this->assertTrue( Utils\is_windows() );
+
+		putenv( 'WP_CLI_TEST_IS_WINDOWS' );
+	}
+
 	public function testForceEnvOnNixSystems() {
 		putenv( 'WP_CLI_TEST_IS_WINDOWS=0' );
 		$this->assertSame( '/usr/bin/env cmd', Utils\force_env_on_nix_systems( 'cmd' ) );


### PR DESCRIPTION
`substr()` invokes additional memory allocation, which is not needed in the context. `strpos()` will do the same job, but without any overhead (it's just searching a string).