### PR TITLE
Avoid using alias functions

### DIFF
--- a/php/WP_CLI/Bootstrap/IncludeFrameworkAutoloader.php
+++ b/php/WP_CLI/Bootstrap/IncludeFrameworkAutoloader.php
@@ -41,7 +41,7 @@ final class IncludeFrameworkAutoloader extends AutoloaderStep {
 	 * @return void
 	 */
 	protected function handle_failure() {
-		fputs(
+		fwrite(
 			STDERR,
 			"Internal error: Can't find Composer autoloader.\nTry running: composer install\n"
 		);

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1486,7 +1486,7 @@ class Runner {
 
 		$existing_phar = realpath( $_SERVER['argv'][0] );
 		// Phar needs to be writable to be easily updateable.
-		if ( ! is_writable( $existing_phar ) || ! is_writeable( dirname( $existing_phar ) ) ) {
+		if ( ! is_writable( $existing_phar ) || ! is_writable( dirname( $existing_phar ) ) ) {
 			return;
 		}
 

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -120,7 +120,7 @@ class Help_Command extends WP_CLI_Command {
 
 		// convert string to file handle
 		$fd = fopen( 'php://temp', 'r+' );
-		fputs( $fd, $out );
+		fwrite( $fd, $out );
 		rewind( $fd );
 
 		$descriptorspec = array(

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -251,7 +251,7 @@ class CLI_Command extends WP_CLI_Command {
 
 		if ( ! is_writable( $old_phar ) ) {
 			WP_CLI::error( sprintf( '%s is not writable by current user.', $old_phar ) );
-		} elseif ( ! is_writeable( dirname( $old_phar ) ) ) {
+		} elseif ( ! is_writable( dirname( $old_phar ) ) ) {
 			WP_CLI::error( sprintf( '%s is not writable by current user.', dirname( $old_phar ) ) );
 		}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -60,7 +60,7 @@ function load_dependencies() {
 	}
 
 	if ( ! $has_autoload ) {
-		fputs( STDERR, "Internal error: Can't find Composer autoloader.\nTry running: composer install\n" );
+		fwrite( STDERR, "Internal error: Can't find Composer autoloader.\nTry running: composer install\n" );
 		exit( 3 );
 	}
 }


### PR DESCRIPTION
- [`fputs()`](http://php.net/manual/en/function.fputs.php) is an alias of [`fwrite()`](http://php.net/manual/en/function.fwrite.php).
- [`is_writeable()`](http://php.net/manual/en/function.is-writeable.php) is an alias of [`is_writable()`](http://php.net/manual/en/function.is-writable.php).