### PR TITLE
Improve AutoloadSplitter regexes

### DIFF
--- a/php/WP_CLI/AutoloadSplitter.php
+++ b/php/WP_CLI/AutoloadSplitter.php
@@ -27,7 +27,7 @@ class AutoloadSplitter {
 	 * @return bool Whether to split out the class into a separate autoloader.
 	 */
 	public function __invoke( $class, $code ) {
-		return 1 === preg_match( '/\/wp-cli\/\w*(?:-\w*)*-command\//', $code )
+		return 1 === preg_match( '/\/wp-cli\/\w+(?:-\w+)*-command\//', $code )
 			|| 1 === preg_match( '/\/php\/commands\/src\//', $code );
 	}
 }

--- a/php/WP_CLI/AutoloadSplitter.php
+++ b/php/WP_CLI/AutoloadSplitter.php
@@ -27,7 +27,7 @@ class AutoloadSplitter {
 	 * @return bool Whether to split out the class into a separate autoloader.
 	 */
 	public function __invoke( $class, $code ) {
-		return 1 === preg_match( '/.*\/wp-cli\/\w*(?:-\w*)*-command\/.*/', $code )
-			|| 1 === preg_match( '/.*\/php\/commands\/src\/.*/', $code );
+		return 1 === preg_match( '/\/wp-cli\/\w*(?:-\w*)*-command\//', $code )
+			|| 1 === preg_match( '/\/php\/commands\/src\//', $code );
 	}
 }

--- a/tests/test-autoload-splitter.php
+++ b/tests/test-autoload-splitter.php
@@ -37,8 +37,6 @@ class AutoloadSplitterTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function dataCodePaths() {
 		return array(
-			array( '/wp-cli/-command/', true ), // Questionable value.
-			array( '/wp-cli/--command/', true ), // Questionable value.
 			array( '/wp-cli/a-command/', true ),
 			array( '/wp-cli/abcd-command/', true ),
 			array( '/wp-cli/a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z-command/', true ),
@@ -47,6 +45,8 @@ class AutoloadSplitterTest extends PHPUnit_Framework_TestCase {
 			array( '/php/commands/src/', true ),
 			array( 'xyz/php/commands/src/zyx', true ),
 
+			array( '/wp-cli/-command/', false ), // No command name.
+			array( '/wp-cli/--command/', false ), // No command name.
 			array( '/wp-cli/abcd-command-/', false ), // End is not '-command/`
 			array( '/wp-cli/abcd-/', false ), // End is not '-command/'.
 			array( '/wp-cli/abcd-command', false ), // End is not '-command/'.

--- a/tests/test-autoload-splitter.php
+++ b/tests/test-autoload-splitter.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Test AutoloadSplitter class
+ *
+ * @package   WP_CLI\Tests\Unit
+ * @author    WP-CLI Contributors
+ * @copyright 2017 WP-CLI
+ * @license   GPL-2.0+
+ */
+
+namespace WP_CLI\Tests\Unit;
+
+use PHPUnit_Framework_TestCase;
+use WP_CLI\AutoloadSplitter;
+
+/**
+ * Class AutoloadSplitterTest.
+ *
+ * @group autoloadsplitter
+ */
+class AutoloadSplitterTest extends PHPUnit_Framework_TestCase {
+	/**
+	 * Test that AutoloadSplitter returns correct login
+	 *
+	 * @dataProvider dataCodePaths
+	 */
+	public function testAutoloadSplitter( $code, $expected ) {
+		$autoload_splitter = new AutoloadSplitter();
+
+		$this->assertSame( $expected, $autoload_splitter('foo', $code) );
+	}
+
+	/**
+	 * Data provider of code paths.
+	 *
+	 * @return array
+	 */
+	public function dataCodePaths() {
+		return array(
+			array( '/wp-cli/-command/', true ), // Questionable value.
+			array( '/wp-cli/--command/', true ), // Questionable value.
+			array( '/wp-cli/a-command/', true ),
+			array( '/wp-cli/abcd-command/', true ),
+			array( '/wp-cli/a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z-command/', true ),
+			array( 'xyz/wp-cli/abcd-command/zxy', true ),
+
+			array( '/php/commands/src/', true ),
+			array( 'xyz/php/commands/src/zyx', true ),
+
+			array( '/wp-cli/abcd-command-/', false ), // End is not '-command/`
+			array( '/wp-cli/abcd-/', false ), // End is not '-command/'.
+			array( '/wp-cli/abcd-command', false ), // End is not '-command/'.
+			array( 'wp-cli/abcd-command/', false ), // Start is not '/wp-cli/'.
+			array( '/wp--cli/abcd-command/', false ),  // Start is not '/wp-cli/'.
+			array( '/wp-cliabcd-command/', false ),  // Start is not '/wp-cli/'.
+			array( '/wp-cli//abcd-command/', false ),  // Middle contains two '/'.
+
+			array( '/php-/commands/src/', false ),  // Start is not '/php/'.
+			array( 'php/commands/src/', false ), // Start is not '/php/'.
+			array( '/php/commands/src', false ), // End is not '/src/'.
+			array( '/php/commands/srcs/', false ),  // End is not '/src/'.
+			array( '/php/commandssrc/', false ),  // End is not '/src/'.
+		);
+	}
+}


### PR DESCRIPTION
Two commits - the first is fine, but the second one may be too strict.

1. Remove leading and trailing .*:
- With no pinning of the pattern to the start or end of a string, the leading and trailing `.*` are redundant.

2. Ensure filename has at least one name before command:
- This tightens the regex to disallow:

  - `/wp-cli/-command/`
  - `/wp-cli/foo--command/`
  - etc.