### PR TITLE
Make Execution logger capture WP::success and optionally output buffer.

### DIFF
--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -1,4 +1,3 @@
-@require-php-5.4
 Feature: Run a WP-CLI command
 
   Background:
@@ -192,6 +191,40 @@ Feature: Run a WP-CLI command
     Then STDOUT should be:
       """
       returned: NULL
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    Examples:
+      | flag        |
+      | --no-launch |
+      | --launch    |
+
+  Scenario Outline: Output using echo and log, success, warning and error
+    Given a WP install
+
+    When I run `wp run <flag> --no-exit_error --return=all 'eval "WP_CLI::log( '\'log\'' ); echo '\'echo\''; WP_CLI::error( '\'error\'' );"'`
+    Then STDOUT should be:
+      """
+      returned: array (
+        'stdout' => 'log
+      echo',
+        'stderr' => 'Error: error',
+        'return_code' => 1,
+      )
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
+    When I try `wp run <flag> --no-exit_error --return=all 'eval "echo '\'echo\''; WP_CLI::log( '\'log\'' ); WP_CLI::warning( '\'warning\''); WP_CLI::success( '\'success\'' );"'`
+    Then STDOUT should be:
+      """
+      returned: array (
+        'stdout' => 'echolog
+      Success: success',
+        'stderr' => 'Warning: warning',
+        'return_code' => 0,
+      )
       """
     And STDERR should be empty
     And the return code should be 0

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -203,7 +203,7 @@ Feature: Run a WP-CLI command
   Scenario Outline: Output using echo and log, success, warning and error
     Given a WP install
 
-	# Note WP_CLI::error() terminates eval processing so needs to be last.
+    # Note WP_CLI::error() terminates eval processing so needs to be last.
     When I run `wp run <flag> --no-exit_error --return=all 'eval "WP_CLI::log( '\'log\'' ); echo '\'echo\''; WP_CLI::success( '\'success\'' ); WP_CLI::error( '\'error\'' );"'`
     Then STDOUT should be:
       """

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -203,12 +203,13 @@ Feature: Run a WP-CLI command
   Scenario Outline: Output using echo and log, success, warning and error
     Given a WP install
 
-    When I run `wp run <flag> --no-exit_error --return=all 'eval "WP_CLI::log( '\'log\'' ); echo '\'echo\''; WP_CLI::error( '\'error\'' );"'`
+	# Note WP_CLI::error() terminates eval processing so needs to be last.
+    When I run `wp run <flag> --no-exit_error --return=all 'eval "WP_CLI::log( '\'log\'' ); echo '\'echo\''; WP_CLI::success( '\'success\'' ); WP_CLI::error( '\'error\'' );"'`
     Then STDOUT should be:
       """
       returned: array (
         'stdout' => 'log
-      echo',
+      echoSuccess: success',
         'stderr' => 'Error: error',
         'return_code' => 1,
       )
@@ -216,7 +217,7 @@ Feature: Run a WP-CLI command
     And STDERR should be empty
     And the return code should be 0
 
-    When I try `wp run <flag> --no-exit_error --return=all 'eval "echo '\'echo\''; WP_CLI::log( '\'log\'' ); WP_CLI::warning( '\'warning\''); WP_CLI::success( '\'success\'' );"'`
+    When I run `wp run <flag> --no-exit_error --return=all 'eval "echo '\'echo\''; WP_CLI::log( '\'log\'' ); WP_CLI::warning( '\'warning\''); WP_CLI::success( '\'success\'' );"'`
     Then STDOUT should be:
       """
       returned: array (

--- a/php/WP_CLI/Loggers/Base.php
+++ b/php/WP_CLI/Loggers/Base.php
@@ -32,6 +32,10 @@ abstract class Base {
 	 * @param string $group Organize debug message to a specific group.
 	 */
 	public function debug( $message, $group = false ) {
+		static $start_time = null;
+		if ( null === $start_time ) {
+			$start_time = microtime( true );
+		}
 		$debug = $this->get_runner()->config['debug'];
 		if ( ! $debug ) {
 			return;
@@ -39,7 +43,7 @@ abstract class Base {
 		if ( true !== $debug && $group !== $debug ) {
 			return;
 		}
-		$time = round( microtime( true ) - WP_CLI_START_MICROTIME, 3 );
+		$time = round( microtime( true ) - ( defined( 'WP_CLI_START_MICROTIME' ) ? WP_CLI_START_MICROTIME : $start_time ), 3 );
 		$prefix = 'Debug';
 		if ( $group && true === $debug ) {
 			$prefix = 'Debug (' . $group . ')';

--- a/php/WP_CLI/Loggers/Execution.php
+++ b/php/WP_CLI/Loggers/Execution.php
@@ -54,7 +54,7 @@ class Execution extends Regular {
 	}
 
 	/**
-	 * Starts output buffering, using a callback to capture output from `echo`, `print`, `printf` (which write to the output buffer 'php://output' rather than STDIN).
+	 * Starts output buffering, using a callback to capture output from `echo`, `print`, `printf` (which write to the output buffer 'php://output' rather than STDOUT).
 	 */
 	public function ob_start() {
 		// To ensure sequential output, give a chunk size of 1 (or 2 if PHP < 5.4 as 1 was a special value meaning a 4KB chunk) to `ob_start()`, so that each write gets flushed immediately.

--- a/php/WP_CLI/Loggers/Execution.php
+++ b/php/WP_CLI/Loggers/Execution.php
@@ -5,7 +5,7 @@ namespace WP_CLI\Loggers;
 /**
  * Execution logger captures all STDOUT and STDERR writes
  */
-class Execution extends Base {
+class Execution extends Regular {
 
 	/**
 	 * Captured writes to STDOUT.
@@ -18,39 +18,10 @@ class Execution extends Base {
 	public $stderr = '';
 
 	/**
-	 * Write an informational message to STDOUT.
-	 *
-	 * @param string $message Message to write.
+	 * @param bool $in_color Whether or not to Colorize strings.
 	 */
-	public function info( $message ) {
-		$this->write( 'STDOUT', $message . "\n" );
-	}
-
-	/**
-	 * Write a success message, prefixed with "Success: ".
-	 *
-	 * @param string $message Message to write.
-	 */
-	public function success( $message ) {
-		$this->_line( $message, 'Success', '%G' );
-	}
-
-	/**
-	 * Write a warning message to STDERR, prefixed with "Warning: ".
-	 *
-	 * @param string $message Message to write.
-	 */
-	public function warning( $message ) {
-		$this->_line( $message, 'Warning', '%C', 'STDERR' );
-	}
-
-	/**
-	 * Write an message to STDERR, prefixed with "Error: ".
-	 *
-	 * @param string $message Message to write.
-	 */
-	public function error( $message ) {
-		$this->_line( $message, 'Error', '%R', 'STDERR' );
+	function __construct( $in_color = false ) {
+		parent::__construct( $in_color );
 	}
 
 	/**
@@ -61,8 +32,8 @@ class Execution extends Base {
 	public function error_multi_line( $message_lines ) {
 		$message = implode( "\n", $message_lines );
 
-		$this->write( 'STDERR', \WP_CLI::colorize( "%RError:%n\n$message\n" ) );
-		$this->write( 'STDERR', \WP_CLI::colorize( "%R---------%n\n\n" ) );
+		$this->write( STDERR, \WP_CLI::colorize( "%RError:%n\n$message\n" ) );
+		$this->write( STDERR, \WP_CLI::colorize( "%R---------%n\n\n" ) );
 	}
 
 	/**
@@ -73,12 +44,38 @@ class Execution extends Base {
 	 */
 	protected function write( $handle, $str ) {
 		switch ( $handle ) {
-			case 'STDOUT':
+			case STDOUT:
 				$this->stdout .= $str;
 				break;
-			case 'STDERR':
+			case STDERR:
 				$this->stderr .= $str;
 				break;
 		}
+	}
+
+	/**
+	 * Starts output buffering, using a callback to capture output from `echo`, `print`, `printf` (which write to the output buffer 'php://output' rather than STDIN).
+	 */
+	public function ob_start() {
+		// To ensure sequential output, give a chunk size of 1 (or 2 if PHP < 5.4 as 1 was a special value meaning a 4KB chunk) to `ob_start()`, so that each write gets flushed immediately.
+		ob_start( array( $this, 'ob_start_callback' ), version_compare( PHP_VERSION, '5.4.0', '<' ) ? 2 : 1 );
+	}
+
+	/**
+	 * Callback for `ob_start()`.
+	 *
+	 * @param string $str String to write.
+	 * @return string Returns zero-length string so nothing gets written to the output buffer.
+	 */
+	public function ob_start_callback( $str ) {
+		$this->write( STDOUT, $str );
+		return '';
+	}
+
+	/**
+	 * To match `ob_start() above. Does an `ob_end_flush()`.
+	 */
+	public function ob_end() {
+		ob_end_flush();
 	}
 }

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -24,6 +24,8 @@ class Runner {
 
 	private $arguments, $assoc_args, $runtime_config;
 
+	private $colorize = false;
+
 	private $_early_invoke = array();
 
 	private $_global_config_path_debug;

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1168,9 +1168,9 @@ class WP_CLI {
 			$argv = Utils\parse_str_to_argv( $command );
 			list( $args, $assoc_args, $runtime_config ) = $configurator->parse_args( $argv );
 			if ( $return ) {
-				ob_start();
 				$existing_logger = self::$logger;
 				self::$logger = new WP_CLI\Loggers\Execution;
+				self::$logger->ob_start();
 			}
 			if ( ! $exit_error ) {
 				self::$capture_exit = true;
@@ -1187,8 +1187,9 @@ class WP_CLI {
 			}
 			if ( $return ) {
 				$execution_logger = self::$logger;
+				$execution_logger->ob_end();
 				self::$logger = $existing_logger;
-				$stdout = trim( ob_get_clean() );
+				$stdout = $execution_logger->stdout;
 				$stderr = $execution_logger->stderr;
 				if ( true === $return || 'stdout' === $return ) {
 					$retval = trim( $stdout );

--- a/tests/test-logging.php
+++ b/tests/test-logging.php
@@ -29,7 +29,6 @@ class MockQuietLogger extends WP_CLI\Loggers\Quiet {
 class LoggingTests extends PHPUnit_Framework_TestCase {
 
 	function testLogDebug() {
-		define( 'WP_CLI_START_MICROTIME', microtime( true ) );
 		$message = 'This is a test message.';
 
 		$regularLogger = new MockRegularLogger( false );
@@ -48,5 +47,67 @@ class LoggingTests extends PHPUnit_Framework_TestCase {
 
 		$this->expectOutputString( "Success: $message\n" );
 		$logger->success( $message );
+	}
+
+	function testExecutionLogger() {
+		// Save Runner config.
+		$runner = WP_CLI::get_runner();
+		$runner_config = new \ReflectionProperty( $runner, 'config' );
+		$runner_config->setAccessible( true );
+
+		$prev_config = $runner_config->getValue( $runner );
+
+		// Set debug.
+		$runner_config->setValue( $runner, array( 'debug' => true ) );
+
+		$logger = new WP_CLI\Loggers\Execution;
+
+		// Standard use.
+
+		$logger->info( 'info' );
+		$logger->info( 'info2' );
+		$logger->success( 'success' );
+		$logger->warning( 'warning' );
+		$logger->error( 'error' );
+		$logger->success( 'success2' );
+		$logger->warning( 'warning2' );
+		$logger->debug( 'debug', 'group' );
+		$logger->error_multi_line( array( "line11", "line12", "line13" ) );
+		$logger->error( 'error2' );
+		$logger->error_multi_line( array( "line21" ) );
+		$logger->debug( 'debug2', 'group2' );
+
+		$this->assertSame( "info\ninfo2\nSuccess: success\nSuccess: success2\n", $logger->stdout );
+		$this->assertSame( 1, preg_match( '/^'
+			. 'Warning: warning\nError: error\n'
+			. 'Warning: warning2\nDebug \(group\): debug \([0-9.]+s\)\n'
+			. 'Error:\nline11\nline12\nline13\n---------\n\nError: error2\n'
+			. 'Error:\nline21\n---------\n\nDebug \(group2\): debug2 \([0-9.]+s\)$/', $logger->stderr ) );
+
+		$logger->stdout = $logger->stderr = '';
+
+		// With output buffering.
+
+		$logger->ob_start();
+
+		echo "echo";
+		$logger->info( 'info' );
+		print "print\n";
+		$logger->success( 'success' );
+		echo "echo2\n";
+		$logger->error( 'error' );
+		echo "echo3\n";
+		$logger->success( 'success2' );
+		echo "echo4";
+
+		$logger->ob_end();
+
+		$this->assertSame( "echoinfo\nprint\nSuccess: success\necho2\necho3\nSuccess: success2\necho4", $logger->stdout );
+		$this->assertSame( "Error: error\n", $logger->stderr );
+
+		$logger->stdout = $logger->stderr = '';
+
+		// Restore.
+		$runner_config->setValue( $runner, $prev_config );
 	}
 }


### PR DESCRIPTION
Related https://github.com/wp-cli/media-command/pull/48#discussion_r142796610

On writing a unit test for adding the `$skips` arg to `Utils\report_batch_operation_results()`, I noticed that `Loggers\Execution` doesn't actually capture STDOUT for `WP_CLI::success()` as the implementation https://github.com/wp-cli/wp-cli/blob/v1.3.0/php/WP_CLI/Loggers/Execution.php#L34 calls `_line()` with the default handle `STDOUT`, rather than the string `'STDOUT'` expected by the overridden `write()`.

And `WP_CLI::runcommand()` on `--no-launch` doesn't use the captured stdout anyway from `Execution` but just does a `ob_start()` and `ob_get_clean()` https://github.com/wp-cli/wp-cli/blob/v1.3.0/php/class-wp-cli.php#L1168 to capture the output buffer, which is used by `echo`, `print` and `printf` but not by `fwrite( STDOUT )`.

So long story somewhat short this PR makes `Loggers\Execution` capture stdout from `WP_CLI::success()` by refactoring `Loggers\Execution` to inherit from `Loggers\Regular` and switch on the actual handles `STDOUT` and `STDERR` in `write()` rather than pseudo string ones.

Also incorporates the output buffering into new methods `ob_start()` and `ob_end()` so that it's captured sequentially in `$this->stdout`, and `WP_CLI::runcommand()` is changed to use these and `$execution_logger->stdout`.

Also in `Loggers\Base::debug()` the global define `WP_CLI_START_MICROTIME` is checked first before using, and the define of this in the unit test `testLogDebug` in `tests/test-logging.php` is removed, to avoid defining globals in tests.

Also `WP_CLI\Runner::$colorize` is added and defaulted to false to remove its dependency on being set by `Runner::init_colorization()`.

Also the global `@require-php-5.4` tag has been removed from `features/runcommand.feature` as it doesn't appear to be necessary.
