### PR TITLE
Use justinrainbow/json-schema:~5.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"php": ">=5.3.29",
 		"composer/composer": "^1.2.0",
 		"composer/semver": "~1.0",
-		"justinrainbow/json-schema": "5.2.1",
+		"justinrainbow/json-schema": "~5.2.1",
 		"mustache/mustache": "~2.4",
 		"ramsey/array_column": "~1.1",
 		"rmccue/requests": "~1.6",


### PR DESCRIPTION
Update `composer.json` to use `"justinrainbow/json-schema": "~5.2.1"` to prevent following error.

* https://github.com/wp-cli/scaffold-package-command/pull/146
* https://github.com/wp-cli/scaffold-package-command/pull/147