### PR TITLE
Don't strip Behat annotations when building the Phar file

### DIFF
--- a/tests/test-make-phar-strip-comments.php
+++ b/tests/test-make-phar-strip-comments.php
@@ -159,4 +159,40 @@ EOD;
 		$this->assertSame( $expected, $actual );
 	}
 
+	/**
+	 * Test keeps Behat comments.
+	 */
+	public function testBehat() {
+
+		$source = <<<'EOD'
+<?php
+
+/**
+ * Features context.
+ */
+class FeatureContext extends BehatContext implements ClosuredContextInterface {
+
+	/**
+	 * @BeforeScenario
+	 */
+	public function beforeScenario( $event ) {
+EOD;
+		$expected = <<<'EOD'
+<?php
+
+
+
+
+class FeatureContext extends BehatContext implements ClosuredContextInterface {
+
+	/**
+	 * @BeforeScenario
+	 */
+	public function beforeScenario( $event ) {
+EOD;
+		$actual = make_phar_strip_comments( $source, false /*strip doc comments*/ );
+		$this->assertSame( $expected, $actual );
+		$this->assertSame( substr_count( $actual, "\n" ), substr_count( $source, "\n" ) );
+	}
+
 }

--- a/utils/make-phar-strip-comments.php
+++ b/utils/make-phar-strip-comments.php
@@ -19,7 +19,7 @@ function make_phar_strip_comments( $contents, $keep_doc_comments ) {
 				// Keep for copyright reasons.
 				return $t[1];
 			}
-			if ( preg_match( '/\@(BeforeSuite|BeforeScenario|AfterSuite|AfterScenario)/', $t[1] ) ) {
+			if ( preg_match( '/\@(before|after)/i', $t[1] ) ) {
 				return $t[1];
 			}
 			return str_repeat( "\n", substr_count( $t[1], "\n" ) ); // Strip everything but newlines.

--- a/utils/make-phar-strip-comments.php
+++ b/utils/make-phar-strip-comments.php
@@ -19,6 +19,9 @@ function make_phar_strip_comments( $contents, $keep_doc_comments ) {
 				// Keep for copyright reasons.
 				return $t[1];
 			}
+			if ( preg_match( '/\@(BeforeSuite|BeforeScenario|AfterSuite|AfterScenario)/', $t[1] ) ) {
+				return $t[1];
+			}
 			return str_repeat( "\n", substr_count( $t[1], "\n" ) ); // Strip everything but newlines.
 		}
 		if ( T_WHITESPACE === $t[0] ) {


### PR DESCRIPTION
Fixes https://github.com/wp-cli/scaffold-package-command/issues/149

From #4391