### PR TITLE
Improve to display long description which has reference links

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -951,15 +951,7 @@ Feature: Get help about WP-CLI commands
           return;
       }
 
-      /**
-      * The command which has a link in long description.
-      *
-      * This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/). It should be displayed very nice!
-      *
-      */
       class WP_CLI_Foo_Bar_Command extends WP_CLI_Command {
-
-
           /**
           * The command which has a link in long description.
           *
@@ -968,7 +960,6 @@ Feature: Get help about WP-CLI commands
           * @synopsis <constant-name>
           */
           public function __invoke( $args, $assoc_args ) {}
-
       }
 
       WP_CLI::add_command( 'reference-link', 'WP_CLI_Foo_Bar_Command' );
@@ -979,10 +970,11 @@ Feature: Get help about WP-CLI commands
         - command.php
       """
 
-    When I run `wp help reference-link`
+    When I run `TERM=vt100 COLUMNS=80 wp help reference-link`
     Then STDOUT should contain:
       """
-        This is a [reference link][1] and [second link][2]. It should be displayed very nice!
+        This is a [reference link][1] and [second link][2]. It should be displayed
+        very nice!
         ---
         [1] https://wordpress.org/
         [2] http://wp-cli.org/

--- a/features/help.feature
+++ b/features/help.feature
@@ -940,3 +940,59 @@ Feature: Get help about WP-CLI commands
       """
       80
       """
+
+  Scenario: Long description for top-level command which has reference link display well
+    Given a WP install
+    And a command.php file:
+      """
+      <?php
+
+      if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+          return;
+      }
+
+      /**
+      * The command which has a link in long description.
+      *
+      * This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/). It should be displayed very nice!
+      *
+      */
+      class WP_CLI_Foo_Bar_Command extends WP_CLI_Command {
+
+
+          /**
+          * The command which has a link in long description.
+          *
+          * This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/). It should be displayed very nice!
+          *
+          * @synopsis <constant-name>
+          */
+          public function __invoke( $args, $assoc_args ) {}
+
+      }
+
+      WP_CLI::add_command( 'reference-link', 'WP_CLI_Foo_Bar_Command' );
+      """
+    And a wp-cli.yml file:
+      """
+      require:
+        - command.php
+      """
+
+    When I run `wp help reference-link`
+    Then STDOUT should contain:
+      """
+        This is a [reference link][1] and [second link][2]. It should be displayed very nice!
+        ---
+        [1] https://wordpress.org/
+        [2] http://wp-cli.org/
+      """
+
+    When I run `wp help role`
+    Then STDOUT should contain:
+      """
+        See references for [Roles and Capabilities][1] and [WP User class][2].
+        ---
+        [1] https://codex.wordpress.org/Roles_and_Capabilities
+        [2] https://codex.wordpress.org/Class_Reference/WP_User
+      """

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -72,18 +72,17 @@ class DocParser {
 
 			if ( preg_match_all( '/(\[.+?\]\((.+?)\))/', $line, $m ) ) {
 				$matches = $m[1];
-				$references = array();
+				$references = $m[2];
 				for ( $i = 0; $i < count( $matches ); $i++ ) {
 					$index = $i + 1;
 					$line = str_replace( "(" . $m[2][ $i ] . ")", "[$index]", $line );
-					$references[] = trim( $m[2][ $i ] );
 				}
 				if ( count( $references ) ) {
 					$line .= "\n";
 					$line .= '---' . "\n";
 					for ( $i = 0; $i < count( $matches ); $i++ ) {
 						$index = $i + 1;
-						$line .= "[$index] " . $references[$i] . "\n";
+						$line .= "[$index] " . trim( $references[$i] ) . "\n";
 					}
 				}
 			}

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -70,17 +70,17 @@ class DocParser {
 				break;
 			}
 
-			if ( preg_match_all( '/(\[.+?\]\((.+?)\))/', $line, $m ) ) {
+			if ( preg_match_all( '/(\[.+?\]\((https?:\/\/.+?)\))/', $line, $m ) ) {
 				$matches = $m[1];
 				$references = $m[2];
 				for ( $i = 0; $i < count( $matches ); $i++ ) {
 					$index = $i + 1;
-					$line = str_replace( '(' . $m[2][ $i ] . ')', '[' . $index . ']', $line );
+					$line = str_replace( '(' . $references[ $i ] . ')', '[' . $index . ']', $line );
 				}
 				if ( count( $references ) ) {
 					$line .= "\n";
 					$line .= '---' . "\n";
-					for ( $i = 0; $i < count( $matches ); $i++ ) {
+					for ( $i = 0; $i < count( $references ); $i++ ) {
 						$index = $i + 1;
 						$line .= '[' . $index . '] ' . trim( $references[ $i ] ) . "\n";
 					}

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -70,16 +70,13 @@ class DocParser {
 				break;
 			}
 
-			if ( preg_match_all( '/(\[.+?\]\(.+?\))/', $line, $m ) ) {
+			if ( preg_match_all( '/(\[.+?\]\((.+?)\))/', $line, $m ) ) {
 				$matches = $m[1];
 				$references = array();
 				for ( $i = 0; $i < count( $matches ); $i++ ) {
-					if ( preg_match( '/\[.+\]\((.+)\)/', $matches[ $i ], $_m ) ) {
-						$index = $i + 1;
-						$desc = preg_replace( '/\(.+\)/', "[$index]", $matches[$i] );
-						$line = str_replace( $matches[$i], $desc, $line );
-						$references[] = $_m[1];
-					}
+					$index = $i + 1;
+					$line = str_replace( "(" . $m[2][ $i ] . ")", "[$index]", $line );
+					$references[] = $m[2][ $i ];
 				}
 				if ( count( $references ) ) {
 					$line .= "\n";

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -82,7 +82,7 @@ class DocParser {
 					$line .= '---' . "\n";
 					for ( $i = 0; $i < count( $matches ); $i++ ) {
 						$index = $i + 1;
-						$line .= '[' . $index . '] ' . trim( $references[$i] ) . "\n";
+						$line .= '[' . $index . '] ' . trim( $references[ $i ] ) . "\n";
 					}
 				}
 			}

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -70,22 +70,7 @@ class DocParser {
 				break;
 			}
 
-			if ( preg_match_all( '/(\[.+?\]\((https?:\/\/.+?)\))/', $line, $m ) ) {
-				$matches = $m[1];
-				$references = $m[2];
-				for ( $i = 0; $i < count( $matches ); $i++ ) {
-					$index = $i + 1;
-					$line = str_replace( '(' . $references[ $i ] . ')', '[' . $index . ']', $line );
-				}
-				if ( count( $references ) ) {
-					$line .= "\n";
-					$line .= '---' . "\n";
-					for ( $i = 0; $i < count( $references ); $i++ ) {
-						$index = $i + 1;
-						$line .= '[' . $index . '] ' . trim( $references[ $i ] ) . "\n";
-					}
-				}
-			}
+			$line = self::parse_reference_links( $line );
 
 			$lines[] = $line;
 		}
@@ -171,6 +156,32 @@ class DocParser {
 	public function get_param_args( $key ) {
 		return $this->get_arg_or_param_args( "/^\[?--{$key}=.*/" );
 	}
+
+	/**
+	 * Parse reference link in long description
+	 *
+	 * @param string $line The line of description
+	 * @return string
+	 */
+	private static function parse_reference_links( $line ) {
+		if ( preg_match_all( '/(\[.+?\]\((https?:\/\/.+?)\))/', $line, $m ) ) {
+			$matches = $m[1];
+			$references = $m[2];
+			$links = array();
+			for ( $i = 0; $i < count( $matches ); $i++ ) {
+				$index = $i + 1;
+				$line = str_replace( '(' . $references[ $i ] . ')', '[' . $index . ']', $line );
+				$links[] = '[' . $index . '] ' . trim( $references[ $i ] );
+			}
+
+			$line .= "\n";
+			$line .= '---' . "\n";
+			$line .= join( "\n", $links );
+		}
+
+		return $line;
+	}
+
 
 	/**
 	 * Get the args for an arg or param

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -75,14 +75,14 @@ class DocParser {
 				$references = $m[2];
 				for ( $i = 0; $i < count( $matches ); $i++ ) {
 					$index = $i + 1;
-					$line = str_replace( "(" . $m[2][ $i ] . ")", "[$index]", $line );
+					$line = str_replace( '(' . $m[2][ $i ] . ')', '[' . $index . ']', $line );
 				}
 				if ( count( $references ) ) {
 					$line .= "\n";
 					$line .= '---' . "\n";
 					for ( $i = 0; $i < count( $matches ); $i++ ) {
 						$index = $i + 1;
-						$line .= "[$index] " . trim( $references[$i] ) . "\n";
+						$line .= '[' . $index . '] ' . trim( $references[$i] ) . "\n";
 					}
 				}
 			}

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -76,7 +76,7 @@ class DocParser {
 				for ( $i = 0; $i < count( $matches ); $i++ ) {
 					$index = $i + 1;
 					$line = str_replace( "(" . $m[2][ $i ] . ")", "[$index]", $line );
-					$references[] = $m[2][ $i ];
+					$references[] = trim( $m[2][ $i ] );
 				}
 				if ( count( $references ) ) {
 					$line .= "\n";

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -86,7 +86,7 @@ class DocParser {
 					$line .= '---' . "\n";
 					for ( $i = 0; $i < count( $matches ); $i++ ) {
 						$index = $i + 1;
-						$line .= "[$index]" . $references[$i] . "\n";
+						$line .= "[$index] " . $references[$i] . "\n";
 					}
 				}
 			}

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -74,7 +74,7 @@ class DocParser {
 
 			$lines[] = $line;
 		}
-		$longdesc = trim( implode( $lines, "\n" ) );
+		$longdesc = trim( implode( "\n", $lines ) );
 
 		return $longdesc;
 	}
@@ -176,7 +176,7 @@ class DocParser {
 
 			$line .= "\n";
 			$line .= '---' . "\n";
-			$line .= join( "\n", $links );
+			$line .= implode( "\n", $links );
 		}
 
 		return $line;

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -70,6 +70,28 @@ class DocParser {
 				break;
 			}
 
+			if ( preg_match_all( '/(\[.+?\]\(.+?\))/', $line, $m ) ) {
+				$matches = $m[1];
+				$references = array();
+				for ( $i = 0; $i < count( $matches ); $i++ ) {
+					if ( preg_match( '/\[.+\]\((.+)\)/', $matches[ $i ], $_m ) ) {
+						$index = $i + 1;
+						$desc = preg_replace( '/\(.+\)/', "[$index]", $matches[$i] );
+						$line = str_replace( $matches[$i], $desc, $line );
+						$references[] = $_m[1];
+					}
+				}
+				if ( count( $references ) ) {
+					$line .= "\n";
+					$line .= '---' . "\n";
+					for ( $i = 0; $i < count( $matches ); $i++ ) {
+						$index = $i + 1;
+						$line .= "[$index]" . $references[$i] . "\n";
+					}
+					$line .= "\n";
+				}
+			}
+
 			$lines[] = $line;
 		}
 		$longdesc = trim( implode( $lines, "\n" ) );

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -88,7 +88,6 @@ class DocParser {
 						$index = $i + 1;
 						$line .= "[$index]" . $references[$i] . "\n";
 					}
-					$line .= "\n";
 				}
 			}
 

--- a/tests/test-doc-parser.php
+++ b/tests/test-doc-parser.php
@@ -236,7 +236,7 @@ EOB;
 		$this->assertSame( $expect, $result );
 	}
 
-	function test_long_desc_which_has_not_url() {
+	function test_long_desc_which_has_illegal_markdown() {
 		$doc = new DocParser( '' );
 		$test_class = new ReflectionClass( $doc );
 		$method = $test_class->getMethod( 'parse_reference_links' );

--- a/tests/test-doc-parser.php
+++ b/tests/test-doc-parser.php
@@ -50,6 +50,8 @@ EOB
 /**
  * Rock and roll!
  *
+ * This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/). It should be displayed very nice!
+ *
  * ## OPTIONS
  *
  * <genre>...
@@ -78,6 +80,11 @@ EOB
 		$this->assertEquals( 'rock-on', $doc->get_tag('alias') );
 
 		$longdesc = <<<EOB
+This is a [reference link][1] and [second link][2]. It should be displayed very nice!
+---
+[1] https://wordpress.org/
+[2] http://wp-cli.org/
+
 ## OPTIONS
 
 <genre>...
@@ -196,5 +203,51 @@ EOB;
 		$this->assertNull( $doc->get_arg_args( 'hook' ) );
 	}
 
+	function test_reference_link_in_long_desc_should_be_parsed() {
+		$doc = new DocParser( '' );
+		$test_class = new ReflectionClass( $doc );
+		$method = $test_class->getMethod( 'parse_reference_links' );
+		$method->setAccessible( true );
+
+		$desc = 'This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/). It should be displayed very nice!';
+		$result = $method->invokeArgs( null, array( $desc ) );
+
+		$expect =<<<EOB
+This is a [reference link][1] and [second link][2]. It should be displayed very nice!
+---
+[1] https://wordpress.org/
+[2] http://wp-cli.org/
+EOB;
+
+		$this->assertSame( $expect, $result );
+	}
+
+	function test_long_desc_which_does_not_have_link() {
+		$doc = new DocParser( '' );
+		$test_class = new ReflectionClass( $doc );
+		$method = $test_class->getMethod( 'parse_reference_links' );
+		$method->setAccessible( true );
+
+		$desc = 'It should be displayed very nice!';
+		$result = $method->invokeArgs( null, array( $desc ) );
+
+		$expect = "It should be displayed very nice!";
+
+		$this->assertSame( $expect, $result );
+	}
+
+	function test_long_desc_which_has_not_url() {
+		$doc = new DocParser( '' );
+		$test_class = new ReflectionClass( $doc );
+		$method = $test_class->getMethod( 'parse_reference_links' );
+		$method->setAccessible( true );
+
+		$desc = 'It should be [displayed](Hello) very nice!';
+		$result = $method->invokeArgs( null, array( $desc ) );
+
+		$expect = "It should be [displayed](Hello) very nice!";
+
+		$this->assertSame( $expect, $result );
+	}
 }
 


### PR DESCRIPTION
Fixes #4336

It will be like following for now.

```
$ bin/wp help role

NAME

  wp role

DESCRIPTION

  Manages user roles, including creating new roles and resetting to defaults.

SYNOPSIS

  wp role <command>

SUBCOMMANDS

  create      Create a new role.
  delete      Delete an existing role.
  exists      Check if a role exists.
  list        List all roles.
  reset       Reset any default role to default capabilities.

  See references for [Roles and Capabilities][1] and [WP User class][2].
  ---
  [1] https://codex.wordpress.org/Roles_and_Capabilities
  [2] https://codex.wordpress.org/Class_Reference/WP_User


EXAMPLES

...
```