### PR TITLE
show warning when it couldn't make cache dir

### DIFF
--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -258,10 +258,6 @@ class FileCache {
 	 */
 	protected function ensure_dir_exists( $dir ) {
 		if ( ! is_dir( $dir ) ) {
-			if ( file_exists( $dir ) ) {
-				// exists and not a dir
-				return false;
-			}
 			if ( ! @mkdir( $dir, 0777, true ) ) { // @codingStandardsIgnoreLine
 				$error = error_get_last();
 				\WP_CLI::warning( sprintf( "Failed to create directory '%s': %s.", $dir, $error['message'] ) );

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -263,7 +263,8 @@ class FileCache {
 				return false;
 			}
 			if ( ! @mkdir( $dir, 0777, true ) ) { // @codingStandardsIgnoreLine
-				\WP_CLI::warning( 'You don\'t have permission to make directory at "' . $dir . '".' );
+				$error = error_get_last();
+				\WP_CLI::warning( sprintf( "Failed to create directory '%s': %s.", $download_dir, $error['message'] ) );
 				return false;
 			}
 		}

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -262,7 +262,8 @@ class FileCache {
 				// exists and not a dir
 				return false;
 			}
-			if ( ! mkdir( $dir, 0777, true ) ) {
+			if ( ! is_writeable( $dir ) || ! mkdir( $dir, 0777, true ) ) {
+				\WP_CLI::warning( "You don't have permission to make directory at \"" . $dir . "\"." );
 				return false;
 			}
 		}

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -262,8 +262,8 @@ class FileCache {
 				// exists and not a dir
 				return false;
 			}
-			if ( ! @mkdir( $dir, 0777, true ) ) {
-				\WP_CLI::warning( "You don't have permission to make directory at \"" . $dir . "\"." );
+			if ( ! @mkdir( $dir, 0777, true ) ) { // @codingStandardsIgnoreLine
+				\WP_CLI::warning( 'You don\'t have permission to make directory at "' . $dir . '".' );
 				return false;
 			}
 		}

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -264,7 +264,7 @@ class FileCache {
 			}
 			if ( ! @mkdir( $dir, 0777, true ) ) { // @codingStandardsIgnoreLine
 				$error = error_get_last();
-				\WP_CLI::warning( sprintf( "Failed to create directory '%s': %s.", $download_dir, $error['message'] ) );
+				\WP_CLI::warning( sprintf( "Failed to create directory '%s': %s.", $dir, $error['message'] ) );
 				return false;
 			}
 		}

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -262,7 +262,7 @@ class FileCache {
 				// exists and not a dir
 				return false;
 			}
-			if ( ! is_writeable( $dir ) || ! mkdir( $dir, 0777, true ) ) {
+			if ( ! @mkdir( $dir, 0777, true ) ) {
 				\WP_CLI::warning( "You don't have permission to make directory at \"" . $dir . "\"." );
 				return false;
 			}

--- a/tests/test-file-cache.php
+++ b/tests/test-file-cache.php
@@ -73,6 +73,9 @@ class FileCacheTest extends PHPUnit_Framework_TestCase {
 
 		// Restore
 		chmod( $cache_dir . '/test1', 0755 );
+		rmdir( $cache_dir . '/test1' );
+		unlink( $cache_dir . '/test2' );
+		rmdir( $cache_dir );
 		$class_wp_cli_logger->setValue( $prev_logger );
 	}
 }

--- a/tests/test-file-cache.php
+++ b/tests/test-file-cache.php
@@ -3,6 +3,8 @@
 use WP_CLI\FileCache;
 use WP_CLI\Utils;
 
+require_once dirname( __DIR__ ) . '/php/class-wp-cli.php';
+
 class FileCacheTest extends PHPUnit_Framework_TestCase {
 
 	/**
@@ -27,5 +29,50 @@ class FileCacheTest extends PHPUnit_Framework_TestCase {
 		unset( $cache );
 
 		rmdir( $cache_dir );
+	}
+
+	public function test_ensure_dir_exists() {
+		$class_wp_cli_logger = new ReflectionProperty( 'WP_CLI', 'logger' );
+		$class_wp_cli_logger->setAccessible( true );
+		$prev_logger = $class_wp_cli_logger->getValue();
+
+		$logger = new WP_CLI\Loggers\Execution;
+		WP_CLI::set_logger( $logger );
+
+		$max_size = 32;
+		$ttl = 60;
+		$cache_dir = Utils\get_temp_dir() . uniqid( 'wp-cli-test-file-cache', true );
+
+		$cache = new FileCache( $cache_dir, $ttl, $max_size );
+		$test_class = new ReflectionClass( $cache );
+		$method = $test_class->getMethod( 'ensure_dir_exists' );
+		$method->setAccessible( true );
+
+		// Cache directory should be created.
+		$result = $method->invokeArgs( $cache, array( $cache_dir . '/test1' ) );
+		$this->assertTrue( $result );
+		$this->assertTrue( is_dir( $cache_dir . '/test1' ) );
+
+		// Try to create the same direcotry again. it should return true.
+		$result = $method->invokeArgs( $cache, array( $cache_dir . '/test1' ) );
+		$this->assertTrue( $result );
+
+		// Failed because permission denied.
+		$logger->stderr = '';
+		chmod( $cache_dir . '/test1', 0000 );
+		$result = $method->invokeArgs( $cache, array( $cache_dir . '/test1/error' ) );
+		$expected = "/^Warning: Failed to create directory '.+': mkdir\(\): Permission denied\.$/";
+		$this->assertRegexp( $expected, $logger->stderr );
+
+		// Failed because file exists.
+		$logger->stderr = '';
+		file_put_contents( $cache_dir . '/test2', '' );
+		$result = $method->invokeArgs( $cache, array( $cache_dir . '/test2' ) );
+		$expected = "/^Warning: Failed to create directory '.+': mkdir\(\): File exists\.$/";
+		$this->assertRegexp( $expected, $logger->stderr );
+
+		// Restore
+		chmod( $cache_dir . '/test1', 0755 );
+		$class_wp_cli_logger->setValue( $prev_logger );
 	}
 }

--- a/tests/test-file-cache.php
+++ b/tests/test-file-cache.php
@@ -53,18 +53,18 @@ class FileCacheTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $result );
 		$this->assertTrue( is_dir( $cache_dir . '/test1' ) );
 
-		// Try to create the same direcotry again. it should return true.
+		// Try to create the same directory again. it should return true.
 		$result = $method->invokeArgs( $cache, array( $cache_dir . '/test1' ) );
 		$this->assertTrue( $result );
 
-		// Failed because permission denied.
+		// It should be failed because permission denied.
 		$logger->stderr = '';
 		chmod( $cache_dir . '/test1', 0000 );
 		$result = $method->invokeArgs( $cache, array( $cache_dir . '/test1/error' ) );
 		$expected = "/^Warning: Failed to create directory '.+': mkdir\(\): Permission denied\.$/";
 		$this->assertRegexp( $expected, $logger->stderr );
 
-		// Failed because file exists.
+		// It should be failed because file exists.
 		$logger->stderr = '';
 		file_put_contents( $cache_dir . '/test2', '' );
 		$result = $method->invokeArgs( $cache, array( $cache_dir . '/test2' ) );


### PR DESCRIPTION
If `wp core download` has an error to make cache directory by some reason, warning is not useful for us.

```
$ wp core download
Warning: mkdir(): Permission denied in phar:///tmp/wp-cli.phar/php/WP_CLI/FileCache.php on line 265
md5 hash verified: 2e8744a702a3d9527782d9135a4c9544
Success: WordPress downloaded.
```

This PR will try to improve this warning like following.

```
$ wp core download
Downloading WordPress 4.8.2 (en_US)...
md5 hash verified: 2e8744a702a3d9527782d9135a4c9544
Warning: You don't have permission to make directory at "/Users/miyauchi/.wp-cli/cache/core".
Success: WordPress downloaded.
```