### PR TITLE
Use short timeout for bad address request test.

### DIFF
--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -352,7 +352,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 
 		$exception = null;
 		try {
-			Utils\http_request( 'GET', 'https://nosuchhost_asdf_asdf_asdf.com' );
+			Utils\http_request( 'GET', 'https://nosuchhost_asdf_asdf_asdf.com', null /*data*/, array() /*headers*/, array( 'timeout' => 0.01 ) );
 		} catch ( \WP_CLI\ExitException $ex ) {
 			$exception = $ex;
 		}
@@ -368,6 +368,10 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testHttpRequestBadCAcert() {
+		if ( ! extension_loaded( 'curl' ) ) {
+			$this->markTestSkipped( 'curl not available' );
+		}
+
 		// Save WP_CLI state.
 		$class_wp_cli_logger = new \ReflectionProperty( 'WP_CLI', 'logger' );
 		$class_wp_cli_logger->setAccessible( true );


### PR DESCRIPTION
Related https://github.com/wp-cli/wp-cli/pull/4327

Reduces timeout on bad address request in `testHttpRequestBadAddress()` phpunit test to minimize delay (can be noticeable when running locally).

Also marks `testHttpRequestBadCAcert()` as skipped if curl not available as it's curl dependent.