### PR TITLE
Improve long desc

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -994,3 +994,55 @@ Feature: Get help about WP-CLI commands
         [1] https://codex.wordpress.org/Roles_and_Capabilities
         [2] https://codex.wordpress.org/Class_Reference/WP_User
       """
+
+  Scenario: Very long description for top-level command which has reference link display well
+    Given a WP install
+    And a command.php file:
+      """
+      <?php
+
+      if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+          return;
+      }
+
+      class WP_CLI_Foo_Bar_Command extends WP_CLI_Command {
+          /**
+          * The command which has a link in long description.
+          *
+          * This is a [reference link](https://wordpress.org/). Also, it is [second link](http://wp-cli.org/). It should be displayed very nice! Wow! It is very long long long description.
+          *
+          * @synopsis <constant-name>
+          */
+          public function __invoke( $args, $assoc_args ) {}
+      }
+
+      WP_CLI::add_command( 'reference-link', 'WP_CLI_Foo_Bar_Command' );
+      """
+    And a wp-cli.yml file:
+      """
+      require:
+        - command.php
+      """
+
+    When I run `TERM=vt100 COLUMNS=80 wp help reference-link`
+    Then STDOUT should contain:
+      """
+        This is a [reference link][1]. Also, it is [second link][2]. It should be
+        displayed very nice! Wow! It is very long long long description.
+
+        ---
+        [1] https://wordpress.org/
+        [2] http://wp-cli.org/
+      """
+
+    When I run `TERM=vt100 COLUMNS=60 wp help reference-link`
+    Then STDOUT should contain:
+      """
+        This is a [reference link][1]. Also, it is [second
+        link][2]. It should be displayed very nice! Wow! It is
+        very long long long description.
+
+        ---
+        [1] https://wordpress.org/
+        [2] http://wp-cli.org/
+      """

--- a/features/help.feature
+++ b/features/help.feature
@@ -91,7 +91,6 @@ Feature: Get help about WP-CLI commands
       """
     And STDERR should be empty
 
-  @less-than-php-7.2
   Scenario: Help when WordPress is downloaded but not installed
     Given an empty directory
 
@@ -940,4 +939,57 @@ Feature: Get help about WP-CLI commands
     Then STDOUT should be:
       """
       80
+      """
+
+  Scenario: Long description for top-level command which has reference link display well
+    Given a WP install
+    And a command.php file:
+      """
+      <?php
+
+      if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+          return;
+      }
+
+      class WP_CLI_Foo_Bar_Command extends WP_CLI_Command {
+          /**
+          * The command which has a link in long description.
+          *
+          * This is a [reference link](https://wordpress.org/).
+          * Also, it is [second link](http://wp-cli.org/).
+          * It should be displayed very nice!
+          *
+          * @synopsis <constant-name>
+          */
+          public function __invoke( $args, $assoc_args ) {}
+      }
+
+      WP_CLI::add_command( 'reference-link', 'WP_CLI_Foo_Bar_Command' );
+      """
+    And a wp-cli.yml file:
+      """
+      require:
+        - command.php
+      """
+
+    When I run `TERM=vt100 COLUMNS=80 wp help reference-link`
+    Then STDOUT should contain:
+      """
+        This is a [reference link][1].
+        Also, it is [second link][2].
+        It should be displayed very nice!
+
+        ---
+        [1] https://wordpress.org/
+        [2] http://wp-cli.org/
+      """
+
+    When I run `wp help role`
+    Then STDOUT should contain:
+      """
+        See references for [Roles and Capabilities][1] and [WP User class][2].
+
+        ---
+        [1] https://codex.wordpress.org/Roles_and_Capabilities
+        [2] https://codex.wordpress.org/Class_Reference/WP_User
       """

--- a/features/help.feature
+++ b/features/help.feature
@@ -954,11 +954,11 @@ Feature: Get help about WP-CLI commands
 
       class WP_CLI_Foo_Bar_Command extends WP_CLI_Command {
           /**
-          * The command which has a link in long description.
+          * A command that has a link in its long description.
           *
           * This is a [reference link](https://wordpress.org/).
-          * Also, it is [second link](http://wp-cli.org/).
-          * It should be displayed very nice!
+          * Also, there is a [second link](http://wp-cli.org/).
+          * They should be displayed nicely!
           *
           * @synopsis <constant-name>
           */
@@ -977,8 +977,8 @@ Feature: Get help about WP-CLI commands
     Then STDOUT should contain:
       """
         This is a [reference link][1].
-        Also, it is [second link][2].
-        It should be displayed very nice!
+        Also, there is a [second link][2].
+        They should be displayed nicely!
 
         ---
         [1] https://wordpress.org/
@@ -1007,9 +1007,9 @@ Feature: Get help about WP-CLI commands
 
       class WP_CLI_Foo_Bar_Command extends WP_CLI_Command {
           /**
-          * The command which has a link in long description.
+          * A command that has a link in its long description.
           *
-          * This is a [reference link](https://wordpress.org/). Also, it is [second link](http://wp-cli.org/). It should be displayed very nice! Wow! It is very long long long description.
+          * This is a [reference link](https://wordpress.org/). Also, there is a [second link](http://wp-cli.org/). They should be displayed nicely! Wow! This is a very, very long description.
           *
           * @synopsis <constant-name>
           */
@@ -1027,8 +1027,8 @@ Feature: Get help about WP-CLI commands
     When I run `TERM=vt100 COLUMNS=80 wp help reference-link`
     Then STDOUT should contain:
       """
-        This is a [reference link][1]. Also, it is [second link][2]. It should be
-        displayed very nice! Wow! It is very long long long description.
+        This is a [reference link][1]. Also, there is a [second link][2]. They should
+        be displayed nicely! Wow! This is a very, very long description.
 
         ---
         [1] https://wordpress.org/
@@ -1038,9 +1038,9 @@ Feature: Get help about WP-CLI commands
     When I run `TERM=vt100 COLUMNS=60 wp help reference-link`
     Then STDOUT should contain:
       """
-        This is a [reference link][1]. Also, it is [second
-        link][2]. It should be displayed very nice! Wow! It is
-        very long long long description.
+        This is a [reference link][1]. Also, there is a [second
+        link][2]. They should be displayed nicely! Wow! This is a
+        very, very long description.
 
         ---
         [1] https://wordpress.org/

--- a/features/help.feature
+++ b/features/help.feature
@@ -91,6 +91,7 @@ Feature: Get help about WP-CLI commands
       """
     And STDERR should be empty
 
+  @less-than-php-7.2
   Scenario: Help when WordPress is downloaded but not installed
     Given an empty directory
 

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -194,7 +194,7 @@ class Help_Command extends WP_CLI_Command {
 	 * @return string The longdescription which has links as footnote.
 	 */
 	private static function parse_reference_links( $longdesc ) {
-		$description = ''; // The head of the $longdescription.
+		$description = '';
 		foreach ( explode( "\n", $longdesc ) as $line ) {
 			if ( 0 === strpos( $line, '#' ) ) {
 				break;
@@ -202,26 +202,27 @@ class Help_Command extends WP_CLI_Command {
 			$description .= $line . "\n";
 		}
 
-		$links = array(); // An array of URLs from the description.
+		// Fires if it has description text at the head of `$longdesc`.
 		if ( $description ) {
-			$pattern = '/(\[.+?\]\((https?:\/\/.+?)\))/';
-			$newdesc = preg_replace_callback( $pattern, function( $matches ) use( &$links ) {
+			$links = array(); // An array of URLs from the description.
+			$pattern = '/\[.+?\]\((https?:\/\/.+?)\)/';
+			$newdesc = preg_replace_callback( $pattern, function( $matches ) use ( &$links ) {
 				static $count = 0;
 				$count++;
-				$links[] = $matches[2];
-				return str_replace( '(' . $matches[2] . ')', '[' . $count . ']', $matches[0] );
+				$links[] = $matches[1];
+				return str_replace( '(' . $matches[1] . ')', '[' . $count . ']', $matches[0] );
 			}, $description );
-		}
 
-		$footnote = '';
-		for ( $i = 0; $i < count( $links ); $i++ ) {
-			$n = $i + 1;
-			$footnote .= '[' . $n . '] ' . $links[ $i ] . "\n";
-		}
+			$footnote = '';
+			for ( $i = 0; $i < count( $links ); $i++ ) {
+				$n = $i + 1;
+				$footnote .= '[' . $n . '] ' . $links[ $i ] . "\n";
+			}
 
-		if ( $footnote ) {
-			$newdesc = trim( $newdesc ) . "\n\n---\n" . $footnote;
-			$longdesc = str_replace( trim( $description ), trim( $newdesc ), $longdesc );
+			if ( $footnote ) {
+				$newdesc = trim( $newdesc ) . "\n\n---\n" . $footnote;
+				$longdesc = str_replace( trim( $description ), trim( $newdesc ), $longdesc );
+			}
 		}
 
 		return $longdesc;

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -44,7 +44,7 @@ class Help_Command extends WP_CLI_Command {
 			$out = substr_replace( $out, $subcommands_header, $matches[1][1], strlen( $subcommands ) );
 		}
 
-		$out .= $command->get_longdesc();
+		$out .= self::parse_reference_links( $command->get_longdesc() );
 
 		// definition lists
 		$out = preg_replace_callback( '/([^\n]+)\n: (.+?)(\n\n|$)/s', array( __CLASS__, 'rewrap_param_desc' ), $out );
@@ -187,6 +187,45 @@ class Help_Command extends WP_CLI_Command {
 		return $max_len;
 	}
 
+	/**
+	 * Parse reference links from longdescription.
+	 *
+	 * @param  string $longdesc The longdescription from the `$command->get_longdesc()`.
+	 * @return string The longdescription which has links as footnote.
+	 */
+	private static function parse_reference_links( $longdesc ) {
+		$description = ''; // The head of the $longdescription.
+		foreach ( explode( "\n", $longdesc ) as $line ) {
+			if ( 0 === strpos( $line, '#' ) ) {
+				break;
+			}
+			$description .= $line . "\n";
+		}
+
+		$links = array(); // An array of URLs from the description.
+		if ( $description ) {
+			$pattern = '/(\[.+?\]\((https?:\/\/.+?)\))/';
+			$newdesc = preg_replace_callback( $pattern, function( $matches ) use( &$links ) {
+				static $count = 0;
+				$count++;
+				$links[] = $matches[2];
+				return str_replace( '(' . $matches[2] . ')', '[' . $count . ']', $matches[0] );
+			}, $description );
+		}
+
+		$footnote = '';
+		for ( $i = 0; $i < count( $links ); $i++ ) {
+			$n = $i + 1;
+			$footnote .= '[' . $n . '] ' . $links[ $i ] . "\n";
+		}
+
+		if ( $footnote ) {
+			$newdesc = $newdesc . "---\n" . $footnote . "\n";
+			$longdesc = str_replace( $description, $newdesc, $longdesc );
+		}
+
+		return $longdesc;
+	}
 }
 
 WP_CLI::add_command( 'help', 'Help_Command' );

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -220,8 +220,8 @@ class Help_Command extends WP_CLI_Command {
 		}
 
 		if ( $footnote ) {
-			$newdesc = $newdesc . "---\n" . $footnote . "\n";
-			$longdesc = str_replace( $description, $newdesc, $longdesc );
+			$newdesc = trim( $newdesc ) . "\n\n---\n" . $footnote;
+			$longdesc = str_replace( trim( $description ), trim( $newdesc ), $longdesc );
 		}
 
 		return $longdesc;

--- a/tests/test-help.php
+++ b/tests/test-help.php
@@ -1,5 +1,11 @@
 <?php
 
+use WP_CLI\Utils;
+
+require_once dirname( __DIR__ ) . '/php/class-wp-cli.php';
+require_once dirname( __DIR__ ) . '/php/class-wp-cli-command.php';
+require_once dirname( __DIR__ ) . '/php/commands/help.php';
+
 class HelpTest extends PHPUnit_Framework_TestCase {
 
 	public function testPassThroughPagerProcDisabled() {
@@ -20,4 +26,74 @@ class HelpTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( false !== strpos( trim( $last ), $err_msg ) );
 	}
 
+	public function test_parse_reference_links() {
+		$test_class = new ReflectionClass( 'Help_Command' );
+		$method = $test_class->getMethod( 'parse_reference_links' );
+		$method->setAccessible( true );
+
+		$desc = 'This is a [reference link](https://wordpress.org/). It should be displayed very nice!';
+		$result = $method->invokeArgs( null, array( $desc ) );
+
+		$expected =<<<EOL
+This is a [reference link][1]. It should be displayed very nice!
+
+---
+[1] https://wordpress.org/
+EOL;
+		$this->assertSame( $expected, $result );
+
+		$desc = 'This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/). It should be displayed very nice!';
+		$result = $method->invokeArgs( null, array( $desc ) );
+
+		$expected =<<<EOL
+This is a [reference link][1] and [second link][2]. It should be displayed very nice!
+
+---
+[1] https://wordpress.org/
+[2] http://wp-cli.org/
+EOL;
+		$this->assertSame( $expected, $result );
+
+		$desc =<<<EOL
+This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/).
+It should be displayed very nice!
+EOL;
+		$result = $method->invokeArgs( null, array( $desc ) );
+
+		$expected =<<<EOL
+This is a [reference link][1] and [second link][2].
+It should be displayed very nice!
+
+---
+[1] https://wordpress.org/
+[2] http://wp-cli.org/
+EOL;
+
+		$this->assertSame( $expected, $result );
+
+		$desc =<<<EOL
+This is a [reference link](https://wordpress.org/).
+It should be displayed very nice!
+
+## Example
+
+It doesn't expect to be link here like [reference link](https://wordpress.org/).
+EOL;
+		$result = $method->invokeArgs( null, array( $desc ) );
+
+		$expected =<<<EOL
+This is a [reference link][1].
+It should be displayed very nice!
+
+---
+[1] https://wordpress.org/
+
+## Example
+
+It doesn't expect to be link here like [reference link](https://wordpress.org/).
+EOL;
+
+		$this->assertSame( $expected, $result );
+
+	}
 }

--- a/tests/test-help.php
+++ b/tests/test-help.php
@@ -72,7 +72,7 @@ EOL;
 		$this->assertSame( $expected, $result );
 
 		$desc =<<<EOL
-This is a [reference link](https://wordpress.org/).
+This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/).
 It should be displayed very nice!
 
 ## Example
@@ -82,11 +82,12 @@ EOL;
 		$result = $method->invokeArgs( null, array( $desc ) );
 
 		$expected =<<<EOL
-This is a [reference link][1].
+This is a [reference link][1] and [second link][2].
 It should be displayed very nice!
 
 ---
 [1] https://wordpress.org/
+[2] http://wp-cli.org/
 
 ## Example
 

--- a/tests/test-help.php
+++ b/tests/test-help.php
@@ -96,5 +96,40 @@ EOL;
 
 		$this->assertSame( $expected, $result );
 
+		$desc =<<<EOL
+## Example
+
+It doesn't expect to be link here like [reference link](https://wordpress.org/).
+EOL;
+		$result = $method->invokeArgs( null, array( $desc ) );
+
+		$expected =<<<EOL
+## Example
+
+It doesn't expect to be link here like [reference link](https://wordpress.org/).
+EOL;
+
+		$this->assertSame( $expected, $result );
+
+		$desc =<<<EOL
+This is a long description.
+It doesn't have any link.
+
+## Example
+
+It doesn't expect to be link here like [reference link](https://wordpress.org/).
+EOL;
+		$result = $method->invokeArgs( null, array( $desc ) );
+
+		$expected =<<<EOL
+This is a long description.
+It doesn't have any link.
+
+## Example
+
+It doesn't expect to be link here like [reference link](https://wordpress.org/).
+EOL;
+
+		$this->assertSame( $expected, $result );
 	}
 }


### PR DESCRIPTION
Related: #4336 #4444 

Note: It will parse at the head of description only.

Example:

```
This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/).
It should be displayed very nice!

## Example

It doesn't expect to be link here like [reference link](https://wordpress.org/).
```

Result:

```
This is a [reference link][1] and [second link][2].
It should be displayed very nice!

---
[1] https://wordpress.org/
[2] http://wp-cli.org/

## Example

It doesn't expect to be link here like [reference link](https://wordpress.org/).
```