### PR TITLE
Initial implementation of command namespaces.

### DIFF
--- a/php/WP_CLI/Dispatcher/CommandFactory.php
+++ b/php/WP_CLI/Dispatcher/CommandFactory.php
@@ -139,9 +139,7 @@ class CommandFactory {
 		$reflection = new \ReflectionClass( $callable );
 		$doc_comment = self::get_doc_comment( $reflection );
 		if ( ! $doc_comment ) {
-			\WP_CLI::debug( null === $doc_comment
-				? "Failed to get doc comment for {$name}."
-				: "No doc comment for {$name}.", 'commandfactory' );
+			\WP_CLI::debug( null === $doc_comment ? "Failed to get doc comment for {$name}." : "No doc comment for {$name}.", 'commandfactory' );
 		}
 		$docparser = new \WP_CLI\DocParser( $doc_comment );
 

--- a/php/WP_CLI/Dispatcher/CommandNamespace.php
+++ b/php/WP_CLI/Dispatcher/CommandNamespace.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace WP_CLI\Dispatcher;
+
+use WP_CLI;
+
+/**
+ * Adds a command namespace without actual functionality.
+ *
+ * This is meant to provide the means to attach meta information to a namespace
+ * when there's no actual command needed.
+ *
+ * In case a real command gets registered for the same name, it replaces the
+ * command namespace.
+ *
+ * @package WP_CLI
+ */
+class CommandNamespace extends CompositeCommand {
+
+	/**
+	 * Show the usage for all subcommands contained
+	 * by the composite command.
+	 */
+	public function show_usage() {
+		$methods = $this->get_subcommands();
+
+		$i = 0;
+		$count = 0;
+
+		foreach ( $methods as $name => $subcommand ) {
+			$prefix = ( 0 == $i++ ) ? 'usage: ' : '   or: ';
+
+			if ( \WP_CLI::get_runner()->is_command_disabled( $subcommand ) ) {
+				continue;
+			}
+
+			\WP_CLI::line( $subcommand->get_usage( $prefix ) );
+			$count++;
+		}
+
+		$cmd_name = implode( ' ', array_slice( get_path( $this ), 1 ) );
+		$message = $count > 0
+			? "See 'wp help $cmd_name <command>' for more information on a specific command."
+			: "The namespace $cmd_name does not contain any usable commands in the current context.";
+
+		\WP_CLI::line();
+		\WP_CLI::line( $message );
+
+	}
+}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -479,6 +479,11 @@ class WP_CLI {
 
 		$leaf_command = Dispatcher\CommandFactory::create( $leaf_name, $callable, $command );
 
+		if ( $leaf_command instanceof Dispatcher\CommandNamespace
+		     && array_key_exists( $leaf_name, $command->get_subcommands() ) ) {
+			return false;
+		}
+
 		if ( ! $command->can_have_subcommands() ) {
 			throw new Exception(
 				sprintf(

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -479,8 +479,7 @@ class WP_CLI {
 
 		$leaf_command = Dispatcher\CommandFactory::create( $leaf_name, $callable, $command );
 
-		if ( $leaf_command instanceof Dispatcher\CommandNamespace
-		     && array_key_exists( $leaf_name, $command->get_subcommands() ) ) {
+		if ( $leaf_command instanceof Dispatcher\CommandNamespace && array_key_exists( $leaf_name, $command->get_subcommands() ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
A command namespace is a command placeholder that can receive annotations, sub-commands and all other shenanigans that a normal composite command can have, with the following changes:

* A namespace will never replace a previously added command of the same name.
* A namespace will always be replaced by a command of the same name that is added later.
* An empty namespace shows a corresponding notice when invoked.

See #4385