### PR TITLE
Indicate other WP installs in db when install isn't found

### DIFF
--- a/features/framework.feature
+++ b/features/framework.feature
@@ -285,7 +285,7 @@ Feature: Load WP-CLI
     Then STDERR should be:
       """
       Error: The site you have requested is not installed.
-      Your table prefix is 'cli_'. Found install(s) with table prefix: wp_.
+      Your table prefix is 'cli_'. Found install with table prefix: wp_.
       Or, run `wp core install` to create database tables.
       """
     And STDOUT should be empty
@@ -302,7 +302,7 @@ Feature: Load WP-CLI
     Then STDERR should be:
       """
       Error: The site you have requested is not installed.
-      Your table prefix is 'test_'. Found install(s) with table prefix: cli_, wp_.
+      Your table prefix is 'test_'. Found installs with table prefix: cli_, wp_.
       Or, run `wp core install` to create database tables.
       """
     And STDOUT should be empty

--- a/features/framework.feature
+++ b/features/framework.feature
@@ -265,6 +265,48 @@ Feature: Load WP-CLI
       https://example.com/
       """
 
+  Scenario: Show error message when site isn't found and there aren't additional prefixes.
+    Given a WP install
+    And I run `wp db reset --yes`
+
+    When I try `wp option get home`
+    Then STDERR should be:
+      """
+      Error: The site you have requested is not installed.
+      Run `wp core install` to create database tables.
+      """
+    And STDOUT should be empty
+
+  Scenario: Show potential table prefixes when site isn't found, single site.
+    Given a WP install
+    And "$table_prefix = 'wp_';" replaced with "$table_prefix = 'cli_';" in the wp-config.php file
+
+    When I try `wp option get home`
+    Then STDERR should be:
+      """
+      Error: The site you have requested is not installed.
+      Your table prefix is 'cli_'. Found install(s) with table prefix: wp_.
+      Or, run `wp core install` to create database tables.
+      """
+    And STDOUT should be empty
+
+    When I run `wp core install --url=example.com --title=example --admin_user=wpcli --admin_email=wpcli@example.com`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    Given "$table_prefix = 'cli_';" replaced with "$table_prefix = 'test_';" in the wp-config.php file
+
+    When I try `wp option get home`
+    Then STDERR should be:
+      """
+      Error: The site you have requested is not installed.
+      Your table prefix is 'test_'. Found install(s) with table prefix: cli_, wp_.
+      Or, run `wp core install` to create database tables.
+      """
+    And STDOUT should be empty
+
   @require-wp-3.9
   Scenario: Display a more helpful error message when site can't be found
     Given a WP multisite install

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -5,11 +5,31 @@
 namespace WP_CLI\Utils;
 
 function wp_not_installed() {
+	global $wpdb, $table_prefix;
 	if ( ! is_blog_installed() && ! defined( 'WP_INSTALLING' ) ) {
-		\WP_CLI::error(
-			"The site you have requested is not installed.\n" .
-			'Run `wp core install`.'
-		);
+		$tables = $wpdb->get_col( "SHOW TABLES LIKE '%_options'" );
+		$found_prefixes = array();
+		if ( count( $tables ) ) {
+			foreach ( $tables as $table ) {
+				$maybe_prefix = substr( $table, 0, - strlen( 'options' ) );
+				if ( $maybe_prefix !== $table_prefix ) {
+					$found_prefixes[] = $maybe_prefix;
+				}
+			}
+		}
+		if ( count( $found_prefixes ) ) {
+			$prefix_list = implode( ', ', $found_prefixes );
+			\WP_CLI::error(
+				"The site you have requested is not installed.\n" .
+				"Your table prefix is '{$table_prefix}'. Found install(s) with table prefix: {$prefix_list}.\n" .
+				'Or, run `wp core install` to create database tables.'
+			);
+		} else {
+			\WP_CLI::error(
+				"The site you have requested is not installed.\n" .
+				'Run `wp core install` to create database tables.'
+			);
+		}
 	}
 }
 

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -19,9 +19,10 @@ function wp_not_installed() {
 		}
 		if ( count( $found_prefixes ) ) {
 			$prefix_list = implode( ', ', $found_prefixes );
+			$install_label = count( $found_prefixes ) > 1 ? 'installs' : 'install';
 			\WP_CLI::error(
 				"The site you have requested is not installed.\n" .
-				"Your table prefix is '{$table_prefix}'. Found install(s) with table prefix: {$prefix_list}.\n" .
+				"Your table prefix is '{$table_prefix}'. Found {$install_label} with table prefix: {$prefix_list}.\n" .
 				'Or, run `wp core install` to create database tables.'
 			);
 		} else {


### PR DESCRIPTION
```
Error: The site you have requested is not installed.
Your table prefix is 'cli_'. Found install with table prefix: wp_.
Or, run `wp core install` to create database tables.
```

Fixes #3825