### PR TITLE
make-phar: strip autoloads of phpcs stuff.

### DIFF
--- a/features/make-phar.feature
+++ b/features/make-phar.feature
@@ -1,0 +1,28 @@
+Feature: Check `utils/make-phar.php` output
+
+  Scenario: Check autoload stripping of phpcs development classes
+    Given an empty directory
+    And a new Phar with the same version
+    And a custom-cmd.php file:
+      """
+      <?php
+
+      WP_CLI::add_command( 'command example', 'Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin' );
+      """
+
+    When I try `php -derror_log='' {PHAR_PATH} --require=custom-cmd.php help`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      Error: Callable
+      """
+    And STDERR should not contain:
+      """
+      PHP Warning
+      """
+    And STDOUT should be empty
+
+    When I try `grep '/dealerdirect\|/squizlabs\|/wimg' {PHAR_PATH}`
+    Then the return code should be 1
+    And STDOUT should be empty
+    And STDERR should be empty

--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -66,6 +66,7 @@ function add_file( $phar, $path ) {
 					'-command\/src\/',
 					'\/wp-cli\/[^\n]+-command\/',
 					'\/symfony\/(?!finder|polyfill-mbstring)[^\/]+\/',
+					'\/(?:dealerdirect|squizlabs|wimg)\/',
 				);
 			} else {
 				$strips = array(
@@ -74,6 +75,7 @@ function add_file( $phar, $path ) {
 					'\/symfony\/(?!console|filesystem|finder|polyfill-mbstring|process)[^\/]+\/',
 					'\/composer\/spdx-licenses\/',
 					'\/Composer\/(?:Command\/|Compiler\.php|Console\/|Downloader\/Pear|Installer\/Pear|Question\/|Repository\/Pear|SelfUpdate\/)',
+					'\/(?:dealerdirect|squizlabs|wimg)\/',
 				);
 			}
 			$strip_res = array_map( function ( $v ) {


### PR DESCRIPTION
Related https://github.com/wp-cli/package-command/issues/44

Strips the phpcs entries "dealerdirect/phpcodesniffer-composer-installer", "wp-coding-standards/wpcs" (squizlabs), and "wimg/php-compatibility" (added in https://github.com/wp-cli/wp-cli/pull/4339 and https://github.com/wp-cli/wp-cli/pull/4402) from the `autoload*`s in `utils/make-phar.php`.

Only partly addresses https://github.com/wp-cli/package-command/issues/44 in that that issue needs further investigation.