### PR TITLE
Move get_php_binary() to Utils to DRY code.

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -131,6 +131,12 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		if ( $php_args = getenv( 'WP_CLI_PHP_ARGS' ) ) {
 			$env['WP_CLI_PHP_ARGS'] = $php_args;
 		}
+		if ( $php_used = getenv( 'WP_CLI_PHP_USED' ) ) {
+			$env['WP_CLI_PHP_USED'] = $php_used;
+		}
+		if ( $php = getenv( 'WP_CLI_PHP' ) ) {
+			$env['WP_CLI_PHP'] = $php;
+		}
 		if ( $travis_build_dir = getenv( 'TRAVIS_BUILD_DIR' ) ) {
 			$env['TRAVIS_BUILD_DIR'] = $travis_build_dir;
 		}
@@ -686,46 +692,13 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		$this->composer_command( 'require wp-cli/wp-cli:dev-master --optimize-autoloader --no-interaction' );
 	}
 
-	/**
-	 * Copied from `WP_CLI::get_php_binary()`.
-	 * Get the path to the PHP binary used when executing WP-CLI.
-	 *
-	 * Environment values permit specific binaries to be indicated.
-	 *
-	 * @access public
-	 * @category System
-	 *
-	 * @return string
-	 */
-	public static function get_php_binary() {
-		if ( getenv( 'WP_CLI_PHP_USED' ) ) {
-			return getenv( 'WP_CLI_PHP_USED' );
-		}
-
-		if ( getenv( 'WP_CLI_PHP' ) ) {
-			return getenv( 'WP_CLI_PHP' );
-		}
-
-		// Available since PHP 5.4.
-		if ( defined( 'PHP_BINARY' ) ) {
-			return PHP_BINARY;
-		}
-
-		// @codingStandardsIgnoreLine
-		if ( @is_executable( PHP_BINDIR . '/php' ) || ( Utils\is_windows() && @is_executable( PHP_BINDIR . '/php.exe' ) ) ) {
-			return PHP_BINDIR . '/php';
-		}
-
-		return 'php';
-	}
-
 	public function start_php_server( $subdir = '' ) {
 		$dir = $this->variables['RUN_DIR'] . '/';
 		if ( $subdir ) {
 			$dir .= trim( $subdir, '/' ) . '/';
 		}
 		$cmd = Utils\esc_cmd( '%s -S %s -t %s -c %s %s',
-			self::get_php_binary(),
+			Utils\get_php_binary(),
 			'localhost:8080',
 			$dir,
 			get_cfg_var( 'cfg_file_path' ),

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -863,7 +863,7 @@ class Runner {
 	private function run_alias_group( $aliases ) {
 		Utils\check_proc_available( 'group alias' );
 
-		$php_bin = WP_CLI::get_php_binary();
+		$php_bin = Utils\get_php_binary();
 
 		$script_path = $GLOBALS['argv'][0];
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -994,7 +994,7 @@ class WP_CLI {
 			}
 		}
 
-		$php_bin = self::get_php_binary();
+		$php_bin = Utils\get_php_binary();
 
 		$script_path = $GLOBALS['argv'][0];
 
@@ -1018,31 +1018,15 @@ class WP_CLI {
 	 *
 	 * Environment values permit specific binaries to be indicated.
 	 *
+	 * Note: moved to Utils, left for BC.
+	 *
 	 * @access public
 	 * @category System
 	 *
 	 * @return string
 	 */
 	public static function get_php_binary() {
-		if ( getenv( 'WP_CLI_PHP_USED' ) ) {
-			return getenv( 'WP_CLI_PHP_USED' );
-		}
-
-		if ( getenv( 'WP_CLI_PHP' ) ) {
-			return getenv( 'WP_CLI_PHP' );
-		}
-
-		// Available since PHP 5.4.
-		if ( defined( 'PHP_BINARY' ) ) {
-			return PHP_BINARY;
-		}
-
-		// @codingStandardsIgnoreLine
-		if ( @is_executable( PHP_BINDIR . '/php' ) || ( Utils\is_windows() && @is_executable( PHP_BINDIR . '/php.exe' ) ) ) {
-			return PHP_BINDIR . '/php';
-		}
-
-		return 'php';
+		return Utils\get_php_binary();
 	}
 
 	/**
@@ -1132,7 +1116,7 @@ class WP_CLI {
 				);
 			}
 
-			$php_bin = self::get_php_binary();
+			$php_bin = Utils\get_php_binary();
 			$script_path = $GLOBALS['argv'][0];
 
 			// Persist runtime arguments unless they've been specified otherwise.

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -99,7 +99,7 @@ class CLI_Command extends WP_CLI_Command {
 	 *     WP-CLI version: 0.24.1
 	 */
 	public function info( $_, $assoc_args ) {
-		$php_bin = WP_CLI::get_php_binary();
+		$php_bin = Utils\get_php_binary();
 
 		$runner = WP_CLI::get_runner();
 
@@ -306,7 +306,7 @@ class CLI_Command extends WP_CLI_Command {
 		}
 
 		$allow_root = WP_CLI::get_runner()->config['allow-root'] ? '--allow-root' : '';
-		$php_binary = WP_CLI::get_php_binary();
+		$php_binary = Utils\get_php_binary();
 		$process = WP_CLI\Process::create( "{$php_binary} $temp --info {$allow_root}" );
 		$result = $process->run();
 		if ( 0 !== $result->return_code || false === stripos( $result->stdout, 'WP-CLI version:' ) ) {

--- a/php/utils.php
+++ b/php/utils.php
@@ -1269,3 +1269,40 @@ function past_tense_verb( $verb ) {
 	}
 	return $verb . 'ed';
 }
+
+/**
+ * Get the path to the PHP binary used when executing WP-CLI.
+ *
+ * Environment values permit specific binaries to be indicated.
+ *
+ * @access public
+ * @category System
+ *
+ * @return string
+ */
+function get_php_binary() {
+	if ( $wp_cli_php_used = getenv( 'WP_CLI_PHP_USED' ) ) {
+		return $wp_cli_php_used;
+	}
+
+	if ( $wp_cli_php = getenv( 'WP_CLI_PHP' ) ) {
+		return $wp_cli_php;
+	}
+
+	// Available since PHP 5.4.
+	if ( defined( 'PHP_BINARY' ) ) {
+		return PHP_BINARY;
+	}
+
+	// @codingStandardsIgnoreLine
+	if ( @is_executable( PHP_BINDIR . '/php' ) ) {
+		return PHP_BINDIR . '/php';
+	}
+
+	// @codingStandardsIgnoreLine
+	if ( is_windows() && @is_executable( PHP_BINDIR . '/php.exe' ) ) {
+		return PHP_BINDIR . '/php.exe';
+	}
+
+	return 'php';
+}

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -587,4 +587,30 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			array( '', "Error: Only verbed 1 of 6 nouns (3 failed, 2 skipped).\n", 'noun', 'verb', 6, 1, 3, 2 ),
 		);
 	}
+
+	public function testGetPHPBinary() {
+		$env_php_used = getenv( 'WP_CLI_PHP_USED' );
+		$env_php = getenv( 'WP_CLI_PHP' );
+
+		putenv( 'WP_CLI_PHP_USED' );
+		putenv( 'WP_CLI_PHP' );
+		$get_php_binary = Utils\get_php_binary();
+		$this->assertTrue( is_executable( $get_php_binary ) );
+
+		putenv( 'WP_CLI_PHP_USED=/my-php-5.3' );
+		putenv( 'WP_CLI_PHP' );
+		$get_php_binary = Utils\get_php_binary();
+		$this->assertSame( $get_php_binary, '/my-php-5.3' );
+
+		putenv( 'WP_CLI_PHP=/my-php-7.3' );
+		$get_php_binary = Utils\get_php_binary();
+		$this->assertSame( $get_php_binary, '/my-php-5.3' ); // WP_CLI_PHP_USED wins.
+
+		putenv( 'WP_CLI_PHP_USED' );
+		$get_php_binary = Utils\get_php_binary();
+		$this->assertSame( $get_php_binary, '/my-php-7.3' );
+
+		putenv( false === $env_php_used ? 'WP_CLI_PHP_USED' : "WP_CLI_PHP_USED=$env_php_used" );
+		putenv( false === $env_php ? 'WP_CLI_PHP' : "WP_CLI_PHP=$env_php" );
+	}
 }

--- a/tests/test-wp-cli.php
+++ b/tests/test-wp-cli.php
@@ -34,4 +34,7 @@ class WP_CLI_Test extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( false !== strpos( trim( $output[0] ), $err_msg ) );
 	}
 
+	public function testGetPHPBinary() {
+		$this->assertSame( WP_CLI\Utils\get_php_binary(), WP_CLI::get_php_binary() );
+	}
 }


### PR DESCRIPTION
Related https://github.com/wp-cli/wp-cli/pull/4481

Moves body of `WP_CLI::get_php_binary()` to `Utils\get_php_binary()` and removes version in `FeatureContext` to DRY up code, leaving stub `WP_CLI::get_php_binary()` for BC. Also changes it to return full Windows path (ie includes `.exe` extension) for PHP 5.3 for easier testing.

Also exports `WP_CLI_PHP_USED` and `WP_CLI_PHP` in `Feature::get_process_env_variables()` as could be useful for testing different PHP versions locally.