### PR TITLE
wp-cli/db-command dev-15-after-wp-config-load -> 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 		"wp-cli/config-command": "^1.0",
 		"wp-cli/core-command": "^1.0",
 		"wp-cli/cron-command": "^1.0",
-		"wp-cli/db-command": "dev-15-after-wp-config-load",
+		"wp-cli/db-command": "^1.0",
 		"wp-cli/entity-command": "^1.0",
 		"wp-cli/eval-command": "^1.0",
 		"wp-cli/export-command": "^1.0",


### PR DESCRIPTION
Related https://github.com/wp-cli/wp-cli/pull/4488

Changes the require of `db-command` in `composer.json` back to `1.0`, in the hope of eventually getting the builds to work.