### PR TITLE
Get the hostname automatically with `vagrant ssh-config`

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -833,6 +833,18 @@ function parse_ssh_url( $url, $component = -1 ) {
 			$bits[ $key ] = $matches[ $i ];
 		}
 	}
+
+	// Find the hostname from `vagrant ssh-config` automatically.
+	if ( preg_match( '/^vagrant:?/', $url ) ) {
+		if ( 'vagrant' === $bits['host'] && empty( $bits['scheme'] ) ) {
+			$ssh_config = shell_exec( 'vagrant ssh-config 2>/dev/null' );
+			if ( preg_match( '/Host\s(.+)/', $ssh_config, $matches ) ) {
+				$bits['scheme'] = 'vagrant';
+				$bits['host']   = $matches[1];
+			}
+		}
+	}
+
 	switch ( $component ) {
 		case PHP_URL_SCHEME:
 			return isset( $bits['scheme'] ) ? $bits['scheme'] : null;

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -210,6 +210,18 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 
+		// vagrant scheme
+		$testcase = 'vagrant:/var/www/html';
+		$this->assertEquals( array(
+			'host' => 'vagrant',
+			'path' => '/var/www/html',
+		), Utils\parse_ssh_url( $testcase ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
+		$this->assertEquals( 'vagrant', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
+		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
+		$this->assertEquals( '/var/www/html', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
+
 		// unsupported scheme, should not match
 		$testcase = 'foo:bar';
 		$this->assertEquals( array(), Utils\parse_ssh_url( $testcase ) );


### PR DESCRIPTION
When we use the ssh with scheme `vagrant`, it can get the hostname automatically like following.

```
$ wp theme list --ssh=vagrant:/var/www/html
+-----------------+----------+--------+---------+
| name            | status   | update | version |
+-----------------+----------+--------+---------+
| twentyeleven    | inactive | none   | 2.7     |
| twentyfifteen   | inactive | none   | 1.9     |
| twentyfourteen  | inactive | none   | 2.1     |
| twentyseventeen | active   | none   | 1.4     |
| twentysixteen   | inactive | none   | 1.4     |
| twentyten       | inactive | none   | 2.4     |
| twentythirteen  | inactive | none   | 2.3     |
| twentytwelve    | inactive | none   | 2.4     |
+-----------------+----------+--------+---------+
Connection to 127.0.0.1 closed.
```