### PR TITLE
Remove no longer used DEPLOY_BRANCH env var check from deploy.sh.

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -7,11 +7,6 @@ if [[ "false" != "$TRAVIS_PULL_REQUEST" ]]; then
 	exit
 fi
 
-if [[ "$TRAVIS_BRANCH" != "$DEPLOY_BRANCH" ]]; then
-	echo "Not on the '$DEPLOY_BRANCH' branch."
-	exit
-fi
-
 # Turn off command traces while dealing with the private key
 set +x
 


### PR DESCRIPTION
Related https://github.com/wp-cli/wp-cli/pull/4487

`deploy.sh` not running as looking for `DEPLOY_BRANCH` env var which is no longer set (or needed I think).