### PR TITLE
Improve Extractor error messages.

### DIFF
--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -28,7 +28,7 @@ class Extractor {
 		if ( preg_match( '/\.tar\.gz$/', $tarball_or_zip ) ) {
 			return self::extract_tarball( $tarball_or_zip, $dest );
 		}
-		throw new \Exception( 'Extension not supported.' );
+		throw new \Exception( "Extraction only supported for '.zip' and '.tar.gz' file types." );
 	}
 
 	/**
@@ -59,7 +59,7 @@ class Extractor {
 			self::copy_overwrite_files( $tempdir, $dest );
 			self::rmdir( dirname( $tempdir ) );
 		} else {
-			throw new \Exception( $res );
+			throw new \Exception( sprintf( "ZipArchive failed to unzip '%s': %s.", $zipfile, self::zip_error_msg( $res ) ) );
 		}
 	}
 
@@ -90,14 +90,24 @@ class Extractor {
 				self::rmdir( dirname( $tempdir ) );
 				return;
 			} catch ( \Exception $e ) {
-				WP_CLI::warning( "PharData failed, falling back to 'tar gz' (" . $e->getMessage() . ')' );
+				WP_CLI::warning( "PharData failed, falling back to 'tar xz' (" . $e->getMessage() . ')' );
 				// Fall through to trying `tar xz` below
 			}
 		}
-		$cmd = "tar xz --strip-components=1 --directory=%s -f $tarball";
-		WP_CLI::launch( Utils\esc_cmd( $cmd, $dest ) );
+		// Note: directory must exist for tar --directory to work.
+		$cmd = Utils\esc_cmd( 'tar xz --strip-components=1 --directory=%s -f %s', $dest, $tarball );
+		$process_run = WP_CLI::launch( $cmd, false /*exit_on_error*/, true /*return_detailed*/ );
+		if ( 0 !== $process_run->return_code ) {
+			throw new \Exception( sprintf( 'Failed to execute `%s`: %s.', $cmd, self::tar_error_msg( $process_run ) ) );
+		}
 	}
 
+	/**
+	 * Copy files from source directory to destination directory. Source directory must exist.
+	 *
+	 * @param string $source
+	 * @param string $dest
+	 */
 	public static function copy_overwrite_files( $source, $dest ) {
 		$iterator = new RecursiveIteratorIterator(
 			new RecursiveDirectoryIterator( $source, RecursiveDirectoryIterator::SKIP_DOTS ),
@@ -135,6 +145,11 @@ class Extractor {
 		}
 	}
 
+	/**
+	 * Delete all files and directories recursively from directory. Directory must exist.
+	 *
+	 * @param string $dir
+	 */
 	public static function rmdir( $dir ) {
 		$files = new RecursiveIteratorIterator(
 			new RecursiveDirectoryIterator( $dir, RecursiveDirectoryIterator::SKIP_DOTS ),
@@ -148,4 +163,61 @@ class Extractor {
 		rmdir( $dir );
 	}
 
+	/**
+	 * Return formatted ZipArchive error message from error code.
+	 *
+	 * @param int $error_code
+	 * @return string
+	 */
+	public static function zip_error_msg( $error_code ) {
+		// From https://github.com/php/php-src/blob/php-5.3.0/ext/zip/php_zip.c#L2623-L2646
+		static $zip_err_msgs = array(
+			ZipArchive::ER_OK => 'No error',
+			ZipArchive::ER_MULTIDISK => 'Multi-disk zip archives not supported',
+			ZipArchive::ER_RENAME => 'Renaming temporary file failed',
+			ZipArchive::ER_CLOSE => 'Closing zip archive failed',
+			ZipArchive::ER_SEEK => 'Seek error',
+			ZipArchive::ER_READ => 'Read error',
+			ZipArchive::ER_WRITE => 'Write error',
+			ZipArchive::ER_CRC => 'CRC error',
+			ZipArchive::ER_ZIPCLOSED => 'Containing zip archive was closed',
+			ZipArchive::ER_NOENT => 'No such file',
+			ZipArchive::ER_EXISTS => 'File already exists',
+			ZipArchive::ER_OPEN => 'Can\'t open file',
+			ZipArchive::ER_TMPOPEN => 'Failure to create temporary file',
+			ZipArchive::ER_ZLIB => 'Zlib error',
+			ZipArchive::ER_MEMORY => 'Malloc failure',
+			ZipArchive::ER_CHANGED => 'Entry has been changed',
+			ZipArchive::ER_COMPNOTSUPP => 'Compression method not supported',
+			ZipArchive::ER_EOF => 'Premature EOF',
+			ZipArchive::ER_INVAL => 'Invalid argument',
+			ZipArchive::ER_NOZIP => 'Not a zip archive',
+			ZipArchive::ER_INTERNAL => 'Internal error',
+			ZipArchive::ER_INCONS => 'Zip archive inconsistent',
+			ZipArchive::ER_REMOVE => 'Can\'t remove file',
+			ZipArchive::ER_DELETED => 'Entry has been deleted',
+		);
+
+		if ( isset( $zip_err_msgs[ $error_code ] ) ) {
+			return sprintf( '%s (%d)', $zip_err_msgs[ $error_code ], $error_code );
+		}
+		return $error_code;
+	}
+
+	/**
+	 * Return formatted error message from ProcessRun of tar command.
+	 *
+	 * @param Processrun $process_run
+	 * @return string
+	 */
+	public static function tar_error_msg( $process_run ) {
+		$stderr = trim( $process_run->stderr );
+		if ( false !== ( $nl_pos = strpos( $stderr, "\n" ) ) ) {
+			$stderr = trim( substr( $stderr, 0, $nl_pos ) );
+		}
+		if ( $stderr ) {
+			return sprintf( '%s (%d)', $stderr, $process_run->return_code );
+		}
+		return $process_run->return_code;
+	}
 }

--- a/tests/test-extractor.php
+++ b/tests/test-extractor.php
@@ -1,0 +1,273 @@
+<?php
+
+use WP_CLI\Extractor;
+use WP_CLI\Utils;
+
+class Extractor_Test extends PHPUnit_Framework_TestCase {
+
+	static $copy_overwrite_files_prefix = 'wp-cli-test-utils-copy-overwrite-files-';
+
+	static $expected_wp = array(
+		'index1.php',
+		'license2.php',
+		'wp-admin/',
+		'wp-admin/about3.php',
+		'wp-admin/includes/',
+		'wp-admin/includes/file4.php',
+		'wp-admin/widgets5.php',
+		'wp-config6.php',
+		'wp-includes/',
+		'wp-includes/file7.php',
+		'xmlrpc8.php',
+	);
+
+	static $logger = null;
+	static $prev_logger = null;
+
+	public function setUp() {
+		parent::setUp();
+
+		// Save and set logger.
+		$class_wp_cli_logger = new \ReflectionProperty( 'WP_CLI', 'logger' );
+		$class_wp_cli_logger->setAccessible( true );
+		self::$prev_logger = $class_wp_cli_logger->getValue();
+
+		self::$logger = new \WP_CLI\Loggers\Execution;
+		WP_CLI::set_logger( self::$logger );
+
+		// Remove any failed tests detritus.
+		$temp_dirs = Utils\get_temp_dir() . self::$copy_overwrite_files_prefix . '*';
+		foreach ( glob( $temp_dirs ) as $temp_dir ) {
+			Extractor::rmdir( $temp_dir );
+		}
+	}
+
+	public function tearDown() {
+		// Restore logger.
+		WP_CLI::set_logger( self::$prev_logger );
+
+		parent::tearDown();
+	}
+
+	public function test_rmdir() {
+		list( $temp_dir, $src_dir, $wp_dir ) = self::create_test_directory_structure();
+
+		$this->assertTrue( is_dir( $wp_dir ) );
+		Extractor::rmdir( $wp_dir );
+		$this->assertFalse( file_exists( $wp_dir ) );
+
+		$this->assertTrue( is_dir( $temp_dir ) );
+		Extractor::rmdir( $temp_dir );
+		$this->assertFalse( file_exists( $temp_dir ) );
+	}
+
+	public function test_err_rmdir() {
+		$msg = '';
+		try {
+			Extractor::rmdir( 'no-such-dir' );
+		} catch ( \Exception $e ) {
+			$msg = $e->getMessage();
+		}
+		$this->assertTrue( false !== strpos( $msg, 'no-such-dir' ) );
+		$this->assertTrue( empty( self::$logger->stderr ) );
+	}
+
+	public function test_copy_overwrite_files() {
+		list( $temp_dir, $src_dir, $wp_dir ) = self::create_test_directory_structure();
+
+		$dest_dir = $temp_dir . '/dest';
+
+		Extractor::copy_overwrite_files( $wp_dir, $dest_dir );
+
+		$files = self::recursive_scandir( $dest_dir );
+
+		$this->assertSame( self::$expected_wp, $files );
+		$this->assertTrue( empty( self::$logger->stderr ) );
+
+		// Clean up.
+		Extractor::rmdir( $temp_dir );
+	}
+
+	public function test_err_copy_overwrite_files() {
+		$msg = '';
+		try {
+			Extractor::copy_overwrite_files( 'no-such-dir', 'dest-dir' );
+		} catch ( \Exception $e ) {
+			$msg = $e->getMessage();
+		}
+		$this->assertTrue( false !== strpos( $msg, 'no-such-dir' ) );
+		$this->assertTrue( empty( self::$logger->stderr ) );
+	}
+
+	public function test_extract_tarball() {
+		if ( ! exec( 'tar --version' ) ) {
+			$this->markTestSkipped( 'tar not installed.' );
+		}
+
+		list( $temp_dir, $src_dir, $wp_dir ) = self::create_test_directory_structure();
+
+		$tarball = $temp_dir . '/test.tar.gz';
+		$dest_dir = $temp_dir . '/dest';
+
+		// Create test tarball.
+		$output = array();
+		$return_var = -1;
+		exec( Utils\esc_cmd( 'tar czvf %1$s --directory=%2$s/src wordpress', $tarball, $temp_dir ), $output, $return_var );
+		$this->assertSame( 0, $return_var );
+		$this->assertFalse( empty( $output ) );
+		sort( $output );
+		$this->assertSame( self::recursive_scandir( $src_dir ), $output );
+
+		// Test.
+		Extractor::extract( $tarball, $dest_dir );
+
+		$files = self::recursive_scandir( $dest_dir );
+		$this->assertSame( self::$expected_wp, $files );
+		$this->assertTrue( empty( self::$logger->stderr ) );
+
+		// Clean up.
+		Extractor::rmdir( $temp_dir );
+	}
+
+	public function test_err_extract_tarball() {
+		// Non-existent.
+		$msg = '';
+		try {
+			Extractor::extract( 'no-such-tar.tar.gz', 'dest-dir' );
+		} catch ( \Exception $e ) {
+			$msg = $e->getMessage();
+		}
+		$this->assertTrue( false !== strpos( $msg, 'no-such-tar' ) );
+		$this->assertTrue( 0 === strpos( self::$logger->stderr, 'Warning: PharData failed' ) );
+		$this->assertTrue( false !== strpos( self::$logger->stderr, 'no-such-tar' ) );
+
+		self::$logger->stderr = self::$logger->stdout = ''; // Reset logger.
+
+		// Zero-length.
+		$zero_tar = Utils\get_temp_dir() . 'zero-tar.tar.gz';
+		touch( $zero_tar );
+		$msg = '';
+		try {
+			Extractor::extract( $zero_tar, 'dest-dir' );
+		} catch ( \Exception $e ) {
+			$msg = $e->getMessage();
+		}
+		unlink( $zero_tar );
+		$this->assertTrue( false !== strpos( $msg, 'zero-tar' ) );
+		$this->assertTrue( 0 === strpos( self::$logger->stderr, 'Warning: PharData failed' ) );
+		$this->assertTrue( false !== strpos( self::$logger->stderr, 'zero-tar' ) );
+	}
+
+	public function test_extract_zip() {
+		if ( ! class_exists( 'ZipArchive' ) ) {
+			$this->markTestSkipped( 'ZipArchive not installed.' );
+		}
+
+		list( $temp_dir, $src_dir, $wp_dir ) = self::create_test_directory_structure();
+
+		$zipfile = $temp_dir . '/test.zip';
+		$dest_dir = $temp_dir . '/dest';
+
+		// Create test zip.
+		$zip = new ZipArchive;
+		$result = $zip->open( $zipfile, ZipArchive::CREATE );
+		$this->assertTrue( $result );
+		$files = self::recursive_scandir( $src_dir );
+		foreach ( $files as $file ) {
+			if ( 0 === substr_compare( $file, '/', -1 ) ) {
+				$result = $zip->addEmptyDir( $file );
+			} else {
+				$result = $zip->addFile( $src_dir . '/' . $file, $file );
+			}
+			$this->assertTrue( $result );
+		}
+		$result = $zip->close();
+		$this->assertTrue( $result );
+
+		// Test.
+		Extractor::extract( $zipfile, $dest_dir );
+
+		$files = self::recursive_scandir( $dest_dir );
+		$this->assertSame( self::$expected_wp, $files );
+		$this->assertTrue( empty( self::$logger->stderr ) );
+
+		// Clean up.
+		Extractor::rmdir( $temp_dir );
+	}
+
+	public function test_err_extract_zip() {
+		if ( ! class_exists( 'ZipArchive' ) ) {
+			$this->markTestSkipped( 'ZipArchive not installed.' );
+		}
+
+		// Non-existent.
+		$msg = '';
+		try {
+			Extractor::extract( 'no-such-zip.zip', 'dest-dir' );
+		} catch ( \Exception $e ) {
+			$msg = $e->getMessage();
+		}
+		$this->assertTrue( false !== strpos( $msg, 'no-such-zip' ) );
+		$this->assertTrue( empty( self::$logger->stderr ) );
+
+		self::$logger->stderr = self::$logger->stdout = ''; // Reset logger.
+
+		// Zero-length.
+		$zero_zip = Utils\get_temp_dir() . 'zero-zip.zip';
+		touch( $zero_zip );
+		$msg = '';
+		try {
+			Extractor::extract( $zero_zip, 'dest-dir' );
+		} catch ( \Exception $e ) {
+			$msg = $e->getMessage();
+		}
+		unlink( $zero_zip );
+		$this->assertTrue( false !== strpos( $msg, 'zero-zip' ) );
+		$this->assertTrue( empty( self::$logger->stderr ) );
+	}
+
+	public function test_err_extract() {
+		$msg = '';
+		try {
+			Extractor::extract( 'not-supported.tar.xz', 'dest-dir' );
+		} catch ( \Exception $e ) {
+			$msg = $e->getMessage();
+		}
+		$this->assertSame( "Extraction only supported for '.zip' and '.tar.gz' file types.", $msg );
+		$this->assertTrue( empty( self::$logger->stderr ) );
+	}
+
+	private function create_test_directory_structure() {
+		$temp_dir = Utils\get_temp_dir() . uniqid( self::$copy_overwrite_files_prefix, true );
+		mkdir( $temp_dir );
+
+		$src_dir = $temp_dir . '/src';
+		mkdir( $src_dir );
+
+		$wp_dir = $src_dir . '/wordpress';
+		mkdir( $wp_dir );
+
+		foreach ( self::$expected_wp as $file ) {
+			if ( 0 === substr_compare( $file, '/', -1 ) ) {
+				mkdir( $wp_dir . '/' . $file );
+			} else {
+				touch( $wp_dir . '/' . $file );
+			}
+		}
+
+		return array( $temp_dir, $src_dir, $wp_dir );
+	}
+
+	private function recursive_scandir( $dir, $prefix_dir = '' ) {
+		$ret = array();
+		foreach ( array_diff( scandir( $dir ), array( '.', '..' ) ) as $file ) {
+			if ( is_dir( $dir . '/' . $file ) ) {
+				$ret[] = ( $prefix_dir ? ( $prefix_dir . '/'. $file ) : $file ) . '/';
+				$ret = array_merge( $ret, self::recursive_scandir( $dir . '/' . $file, $prefix_dir ? ( $prefix_dir . '/' . $file ) : $file ) );
+			} else {
+				$ret[] = $prefix_dir ? ( $prefix_dir . '/'. $file ) : $file;
+			}
+		}
+		return $ret;
+	}
+}


### PR DESCRIPTION
Related: `package-command` error handling of bad input.

Improves error messages returned by `Extractor`, in particular for `ZipArchive` and shell tar.

Throws error for shell tar if reached (currently will just exit on error).

Adds docblocks to functions, unit tests.