### PR TITLE
Enable displaying PHP errors to stderr if running behat.

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -349,21 +349,21 @@ Feature: Create shortcuts to specific WordPress installs
       """
     And the return code should be 1
 
-    When I run `wp @foo core is-installed --allow-root --debug`
+    When I try `wp @foo core is-installed --allow-root --debug`
     Then the return code should be 0
     And STDERR should contain:
       """
       @foo core is-installed --allow-root --debug
       """
 
-    When I run `cd bar; wp @bar core is-installed --allow-root --debug`
+    When I try `cd bar; wp @bar core is-installed --allow-root --debug`
     Then the return code should be 0
     And STDERR should contain:
       """
       @bar core is-installed --allow-root --debug
       """
 
-    When I run `wp @foobar core is-installed --allow-root --debug`
+    When I try `wp @foobar core is-installed --allow-root --debug`
     Then the return code should be 0
     And STDERR should contain:
       """

--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -13,7 +13,8 @@ Feature: Bootstrap WP-CLI
           }
       }
       """
-    And I run `composer install --no-interaction`
+    # Note: Composer outputs messages to stderr.
+    And I run `composer install --no-interaction 2>&1`
 
     When I run `vendor/bin/wp cli version`
     Then STDOUT should contain:
@@ -82,7 +83,7 @@ Feature: Bootstrap WP-CLI
         }
      }
       """
-    And I run `composer install --no-interaction`
+    And I run `composer install --no-interaction 2>&1`
 
     When I run `vendor/bin/wp cli version`
     Then STDOUT should contain:
@@ -130,7 +131,7 @@ Feature: Bootstrap WP-CLI
         }
       }
       """
-    And I run `composer install --working-dir={RUN_DIR}/cli-override-command --no-interaction`
+    And I run `composer install --working-dir={RUN_DIR}/cli-override-command --no-interaction 2>&1`
 
     When I run `wp cli version`
       Then STDOUT should contain:
@@ -185,7 +186,7 @@ Feature: Bootstrap WP-CLI
         }
       }
       """
-    And I run `composer install --working-dir={RUN_DIR}/cli-override-command --no-interaction`
+    And I run `composer install --working-dir={RUN_DIR}/cli-override-command --no-interaction 2>&1`
 
     When I run `{PHAR_PATH} cli version`
       Then STDOUT should contain:
@@ -249,11 +250,13 @@ Feature: Bootstrap WP-CLI
       Success:
       """
 
-    When I run `wp core install --url=example.com --title=example --admin_user=example --admin_email=example@example.org`
+    # Use try to cater for wp-db errors in old WPs.
+    When I try `wp core install --url=example.com --title=example --admin_user=example --admin_email=example@example.org`
     Then STDOUT should contain:
       """
       Success:
       """
+    And the return code should be 0
 
     When I run `wp eval 'echo constant( "WP_CLI_TEST_CONSTANT" );'`
     Then STDOUT should be:

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -161,8 +161,6 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		if ( $wp_version ) {
 			$cmd .= Utils\esc_cmd( ' --version=%s', $wp_version );
 		}
-		// Redirect any warnings (eg md5 hash checks not available) so as not to pollute stderr.
-		$cmd .= ' 2>&1';
 		Process::create( $cmd, null, self::get_process_env_variables() )->run_check();
 	}
 
@@ -715,10 +713,6 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	private function composer_command($cmd) {
 		if ( !isset( $this->variables['COMPOSER_PATH'] ) ) {
 			$this->variables['COMPOSER_PATH'] = exec('which composer');
-		}
-		// Redirect composer messages from stderr to stdout.
-		if ( false === strpos( $cmd, '>' ) ) {
-			$cmd .= ' 2>&1';
 		}
 		$this->proc( $this->variables['COMPOSER_PATH'] . ' ' . $cmd )->run_check();
 	}

--- a/features/command.feature
+++ b/features/command.feature
@@ -580,6 +580,8 @@ Feature: WP-CLI Commands
       """
       usage: wp foo <message> --apple=<apple> [--meal=<meal>]
       """
+    And STDERR should be empty
+    And the return code should be 1
 
     When I run `wp help foo`
     Then STDOUT should contain:
@@ -969,7 +971,7 @@ Feature: WP-CLI Commands
       WP_CLI::add_command( 'test-command-2', function () {} );
       """
 
-    When I run `wp --require=abort-add-command.php`
+    When I try `wp --require=abort-add-command.php`
     Then STDOUT should contain:
       """
       test-command-1
@@ -978,6 +980,11 @@ Feature: WP-CLI Commands
       """
       test-command-2
       """
+    And STDERR should be:
+      """
+      Warning: Aborting the addition of the command 'test-command-2' with reason: Testing hooks..
+      """
+    And the return code should be 0
 
   Scenario: Adding a command can depend on a previous command having been added before
     Given an empty directory
@@ -1323,7 +1330,7 @@ Feature: WP-CLI Commands
       WP_CLI::add_command( 'my-namespaced-command', 'My_Command_Namespace' );
       """
 
-    When I try `wp help --require=command-namespace.php`
+    When I run `wp help --require=command-namespace.php`
     Then STDOUT should contain:
       """
       my-namespaced-command
@@ -1352,7 +1359,7 @@ Feature: WP-CLI Commands
       WP_CLI::add_command( 'my-namespaced-command', 'My_Command_Namespace' );
       """
 
-    When I try `wp help --require=command-namespace.php`
+    When I run `wp help --require=command-namespace.php`
     Then STDOUT should contain:
       """
       my-namespaced-command
@@ -1381,7 +1388,7 @@ Feature: WP-CLI Commands
       WP_CLI::add_command( 'my-namespaced-command', 'My_Namespaced_Command' );
       """
 
-    When I try `wp help --require=command-namespace.php`
+    When I run `wp help --require=command-namespace.php`
     Then STDOUT should contain:
       """
       my-namespaced-command
@@ -1404,7 +1411,7 @@ Feature: WP-CLI Commands
       WP_CLI::add_command( 'my-namespaced-command', 'My_Command_Namespace' );
       """
 
-    When I try `wp --require=command-namespace.php my-namespaced-command`
+    When I run `wp --require=command-namespace.php my-namespaced-command`
     Then STDOUT should contain:
       """
       The namespace my-namespaced-command does not contain any usable commands in the current context.

--- a/features/config.feature
+++ b/features/config.feature
@@ -237,7 +237,7 @@ Feature: Have a config file
   Scenario: Load WordPress with `--debug`
     Given a WP install
 
-    When I run `wp option get home --debug`
+    When I try `wp option get home --debug`
     Then STDERR should contain:
       """
       No readable global config found
@@ -262,8 +262,9 @@ Feature: Have a config file
       """
       Running command: option get
       """
+    And the return code should be 0
 
-    When I run `wp option get home --debug=bootstrap`
+    When I try `wp option get home --debug=bootstrap`
     Then STDERR should contain:
       """
       No readable global config found
@@ -288,8 +289,9 @@ Feature: Have a config file
       """
       Running command: option get
       """
+    And the return code should be 0
 
-    When I run `wp option get home --debug=foo`
+    When I try `wp option get home --debug=foo`
     Then STDERR should not contain:
       """
       No readable global config found
@@ -314,6 +316,7 @@ Feature: Have a config file
       """
       Running command: option get
       """
+    And the return code should be 0
 
   Scenario: Missing required files should not fatal WP-CLI
     Given an empty directory

--- a/features/flags.feature
+++ b/features/flags.feature
@@ -46,13 +46,18 @@ Feature: Global flags
   Scenario: Debug run
     Given a WP install
 
-    When I run `wp eval 'echo CONST_WITHOUT_QUOTES;'`
+    When I try `wp eval 'echo CONST_WITHOUT_QUOTES;'`
     Then STDOUT should be:
       """
       CONST_WITHOUT_QUOTES
       """
+    And STDERR should contain:
+      """
+      Use of undefined constant CONST_WITHOUT_QUOTES
+      """
+    And the return code should be 0
 
-    When I try `wp eval 'ini_set( "error_log", null ); echo CONST_WITHOUT_QUOTES;' --debug`
+    When I try `wp eval 'echo CONST_WITHOUT_QUOTES;' --debug`
     Then the return code should be 0
     And STDOUT should be:
       """
@@ -111,6 +116,8 @@ Feature: Global flags
       """
       log: called 'error' method
       """
+    And STDERR should be empty
+    And the return code should be 1
 
   Scenario: Using --require
     Given an empty directory

--- a/features/framework.feature
+++ b/features/framework.feature
@@ -290,11 +290,13 @@ Feature: Load WP-CLI
       """
     And STDOUT should be empty
 
-    When I run `wp core install --url=example.com --title=example --admin_user=wpcli --admin_email=wpcli@example.com`
+    # Use try to cater for wp-db errors in old WPs.
+    When I try `wp core install --url=example.com --title=example --admin_user=wpcli --admin_email=wpcli@example.com`
     Then STDOUT should contain:
       """
       Success:
       """
+    And the return code should be 0
 
     Given "$table_prefix = 'cli_';" replaced with "$table_prefix = 'test_';" in the wp-config.php file
 

--- a/features/help.feature
+++ b/features/help.feature
@@ -50,12 +50,8 @@ Feature: Get help about WP-CLI commands
   @require-wp-4.3
   Scenario: Help for internal commands with WP
     Given a WP install
-    And a stderr-error-log.php file:
-      """
-      <?php define( 'WP_DEBUG', true ); define( 'WP_DEBUG_DISPLAY', null ); define( 'WP_DEBUG_LOG', false ); ini_set( "error_log", '' ); ini_set( 'display_errors', 'STDERR' );
-      """
 
-    When I run `wp --require=stderr-error-log.php help`
+    When I run `wp help`
     Then STDOUT should contain:
       """
         Run 'wp help <command>' to get more information on a specific command.
@@ -63,28 +59,28 @@ Feature: Get help about WP-CLI commands
       """
     And STDERR should be empty
 
-    When I run `wp --require=stderr-error-log.php help core`
+    When I run `wp help core`
     Then STDOUT should contain:
       """
         wp core
       """
     And STDERR should be empty
 
-    When I run `wp --require=stderr-error-log.php help core download`
+    When I run `wp help core download`
     Then STDOUT should contain:
       """
         wp core download
       """
     And STDERR should be empty
 
-    When I run `wp --require=stderr-error-log.php help help`
+    When I run `wp help help`
     Then STDOUT should contain:
       """
         wp help
       """
     And STDERR should be empty
 
-    When I run `wp --require=stderr-error-log.php help help`
+    When I run `wp help help`
     Then STDOUT should contain:
       """
       GLOBAL PARAMETERS
@@ -484,9 +480,9 @@ Feature: Get help about WP-CLI commands
     Given a wp-content/plugins/test-cli/command.php file:
       """
       <?php
-      // Plugin Name: Test CLI Extra Config Command
+      // Plugin Name: Test CLI Extra Command
 
-      class Test_CLI_Extra_Config_Command extends WP_CLI_Command {
+      class Test_CLI_Extra_Command extends WP_CLI_Command {
 
         /**
          * A dummy command.
@@ -497,66 +493,27 @@ Feature: Get help about WP-CLI commands
 
       }
 
-      WP_CLI::add_command( 'config test-extra', 'Test_CLI_Extra_Config_Command' );
+      WP_CLI::add_command( 'config test-extra-config', 'Test_CLI_Extra_Command' );
+      WP_CLI::add_command( 'core test-extra-core', 'Test_CLI_Extra_Command' );
+      WP_CLI::add_command( 'db test-extra-db', 'Test_CLI_Extra_Command' );
       """
-    And I run `wp plugin activate test-cli`
 
     When I run `wp help config`
     Then STDOUT should contain:
       """
-      test-extra
+      test-extra-config
       """
-
-    Given a wp-content/plugins/test-cli/command.php file:
-      """
-      <?php
-      // Plugin Name: Test CLI Extra Core Command
-
-      class Test_CLI_Extra_Core_Command extends WP_CLI_Command {
-
-        /**
-         * A dummy command.
-         *
-         * @subcommand my-command
-         */
-        function my_command() {}
-
-      }
-
-      WP_CLI::add_command( 'core test-extra', 'Test_CLI_Extra_Core_Command' );
-      """
-    And I run `wp plugin activate test-cli`
 
     When I run `wp help core`
     Then STDOUT should contain:
       """
-      test-extra
+      test-extra-core
       """
-
-    Given a wp-content/plugins/test-cli/command.php file:
-      """
-      <?php
-      // Plugin Name: Test CLI Extra DB Command
-
-      class Test_CLI_Extra_DB_Command extends WP_CLI_Command {
-
-        /**
-         * A dummy command.
-         *
-         * @subcommand my-command
-         */
-        function my_command() {}
-
-      }
-
-      WP_CLI::add_command( 'db test-extra', 'Test_CLI_Extra_DB_Command' );
-      """
-    And I run `wp plugin activate test-cli`
 
     When I run `wp help db`
     Then STDOUT should contain:
       """
-      test-extra
+      test-extra-db
       """
 
   Scenario: Help renders global parameters correctly

--- a/features/skip-plugins.feature
+++ b/features/skip-plugins.feature
@@ -32,7 +32,7 @@ Feature: Skipping plugins
       """
 
     # Can specify multiple plugins to skip
-    When I try `wp eval --skip-plugins=hello,akismet 'ini_set( "error_log", null ); echo hello_dolly();'`
+    When I try `wp eval --skip-plugins=hello,akismet 'echo hello_dolly();'`
     Then STDERR should contain:
       """
       Call to undefined function hello_dolly()
@@ -55,7 +55,7 @@ Feature: Skipping plugins
       """
 
     When I run `wp plugin activate hello`
-    And I try `wp eval 'ini_set( "error_log", null ); echo hello_dolly();'`
+    And I try `wp eval 'echo hello_dolly();'`
     Then STDERR should contain:
       """
       Call to undefined function hello_dolly()
@@ -69,7 +69,7 @@ Feature: Skipping plugins
       """
 
     When I run `wp plugin activate hello`
-    And I try `wp eval 'ini_set( "error_log", null ); echo hello_dolly();'`
+    And I try `wp eval 'echo hello_dolly();'`
     Then STDERR should contain:
       """
       Call to undefined function hello_dolly()
@@ -77,10 +77,21 @@ Feature: Skipping plugins
 
   Scenario: Skip network active plugins
     Given a WP multisite install
-    And I run `wp plugin deactivate akismet hello`
-    And I run `wp plugin activate --network akismet hello`
 
-    When I run `wp eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
+    When I try `wp plugin deactivate akismet hello`
+    Then STDERR should be:
+      """
+      Warning: Plugin 'akismet' isn't active.
+      Warning: Plugin 'hello' isn't active.
+      """
+    And STDOUT should be:
+      """
+      Success: Plugins already deactivated.
+      """
+    And the return code should be 0
+
+    When I run `wp plugin activate --network akismet hello`
+    And I run `wp eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
     Then STDOUT should be:
       """
       truetrue

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -97,11 +97,7 @@ $steps->Given( '/^a WP multisite (subdirectory|subdomain)?\s?install$/',
 	function ( $world, $type = 'subdirectory' ) {
 		$world->install_wp();
 		$subdomains = ! empty( $type ) && 'subdomain' === $type ? 1 : 0;
-		// Ignore "Warning: Wildcard DNS may not be configured correctly." so as not to pollute stderr.
-		$r = $world->proc( 'wp core install-network', array( 'title' => 'WP CLI Network', 'subdomains' => $subdomains ) )->run();
-		if ( $r->return_code || ( ! empty( $r->stderr ) && 'Warning: Wildcard DNS may not be configured correctly.' !== trim( $r->stderr ) ) ) {
-			throw new \RuntimeException( $r );
-		}
+		$world->proc( 'wp core install-network', array( 'title' => 'WP CLI Network', 'subdomains' => $subdomains ) )->run_check();
 	}
 );
 

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -97,7 +97,11 @@ $steps->Given( '/^a WP multisite (subdirectory|subdomain)?\s?install$/',
 	function ( $world, $type = 'subdirectory' ) {
 		$world->install_wp();
 		$subdomains = ! empty( $type ) && 'subdomain' === $type ? 1 : 0;
-		$world->proc( 'wp core install-network', array( 'title' => 'WP CLI Network', 'subdomains' => $subdomains ) )->run_check();
+		// Ignore "Warning: Wildcard DNS may not be configured correctly." so as not to pollute stderr.
+		$r = $world->proc( 'wp core install-network', array( 'title' => 'WP CLI Network', 'subdomains' => $subdomains ) )->run();
+		if ( $r->return_code || ( ! empty( $r->stderr ) && 'Warning: Wildcard DNS may not be configured correctly.' !== trim( $r->stderr ) ) ) {
+			throw new \RuntimeException( $r );
+		}
 	}
 );
 

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -3,9 +3,9 @@
 use Behat\Gherkin\Node\PyStringNode,
     Behat\Gherkin\Node\TableNode;
 
-$steps->Then( '/^the return code should be (\d+)$/',
-	function ( $world, $return_code ) {
-		if ( $return_code != $world->result->return_code ) {
+$steps->Then( '/^the return code should( not)? be (\d+)$/',
+	function ( $world, $not, $return_code ) {
+		if ( ( ! $not && $return_code != $world->result->return_code ) || ( $not && $return_code == $world->result->return_code ) ) {
 			throw new RuntimeException( $world->result );
 		}
 	}

--- a/features/steps/when.php
+++ b/features/steps/when.php
@@ -6,7 +6,7 @@ use Behat\Gherkin\Node\PyStringNode,
 
 function invoke_proc( $proc, $mode ) {
 	$map = array(
-		'run' => 'run_check',
+		'run' => 'run_check_stderr',
 		'try' => 'run'
 	);
 	$method = $map[ $mode ];

--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -112,6 +112,10 @@ class Process {
 		if ( $r->return_code || ! empty( $r->STDERR ) ) {
 			throw new \RuntimeException( $r );
 		}
+		// But do it right if testing.
+		if ( ! empty( $this->env['BEHAT_RUN'] ) && ! empty( $r->stderr ) ) {
+			throw new \RuntimeException( $r );
+		}
 
 		return $r;
 	}

--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -112,8 +112,20 @@ class Process {
 		if ( $r->return_code || ! empty( $r->STDERR ) ) {
 			throw new \RuntimeException( $r );
 		}
-		// But do it right if testing.
-		if ( ! empty( $this->env['BEHAT_RUN'] ) && ! empty( $r->stderr ) ) {
+
+		return $r;
+	}
+
+	/**
+	 * Run the command, but throw an Exception on error.
+	 * Same as `run_check()` above, but checks the correct stderr.
+	 *
+	 * @return ProcessRun
+	 */
+	public function run_check_stderr() {
+		$r = $this->run();
+
+		if ( $r->return_code || ! empty( $r->stderr ) ) {
 			throw new \RuntimeException( $r );
 		}
 

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -898,6 +898,11 @@ class Runner {
 
 	public function start() {
 
+		// Enable PHP error reporting to stderr if testing. Will need to be re-enabled after WP loads.
+		if ( getenv( 'BEHAT_RUN' ) ) {
+			$this->enable_error_reporting();
+		}
+
 		WP_CLI::debug( $this->_global_config_path_debug, 'bootstrap' );
 		WP_CLI::debug( $this->_project_config_path_debug, 'bootstrap' );
 		WP_CLI::debug( 'argv: ' . implode( ' ', $GLOBALS['argv'] ), 'bootstrap' );
@@ -1133,6 +1138,11 @@ class Runner {
 			},
 			99
 		);
+
+		// Re-enable PHP error reporting to stderr if testing.
+		if ( getenv( 'BEHAT_RUN' ) ) {
+			$this->enable_error_reporting();
+		}
 
 		WP_CLI::debug( 'Loaded WordPress', 'bootstrap' );
 		WP_CLI::do_hook( 'after_wp_load' );
@@ -1617,5 +1627,16 @@ class Runner {
 
 			$this->enumerate_commands( $subcommand, $list, $command_string );
 		}
+	}
+
+	/**
+	 * Enables (almost) full PHP error reporting to stderr.
+	 */
+	private function enable_error_reporting() {
+		if ( E_ALL !== error_reporting() ) {
+			// Don't enable E_DEPRECATED as old versions of WP use PHP 4 style constructors and the mysql extension.
+			error_reporting( E_ALL & ~E_DEPRECATED );
+		}
+		ini_set( 'display_errors', 'stderr' );
 	}
 }


### PR DESCRIPTION
Fixes #4504

Enables displaying PHP errors (except `E_DEPRECATED`) to stderr if running behat, first on starting WP-CLI and then after WP loads.

Changes `WP_CLI\Process` to throw an error if `stderr` is non-empty if running behat.

Changes `FeatureContext` to redirect composer messages (which are output to stderr) to stdout, and to redirect warning messages on caching wp core download, and to `skip-email`, so as not to pollute stderr.

Suppresses "Warning: Wildcard DNS may not be configured correctly" message on `Given a WP multisite install`, so as not to pollute stderr. Also adds `not` option to the `Then the return code should` step for situations where there could be OS-dependent return values.

Adjusts various tests to allow for these changes, and removes individual stderr handling. Also in `help.feature` simplifies some copy-pasta introduced (by me) in https://github.com/wp-cli/wp-cli/pull/4285.

As noted in https://github.com/wp-cli/wp-cli/issues/4504, this PR will cause tests for bundled commands to fail until they're adjusted. It will also cause breakage in any external code that uses the behat test suite.
