### PR TITLE
Update Composer dependencies (2017-11-15)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "9dd73a03951357922d8aee6cc084500de93e2343"
+                "reference": "36344aeffdc37711335563e6108cda86566432a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/9dd73a03951357922d8aee6cc084500de93e2343",
-                "reference": "9dd73a03951357922d8aee6cc084500de93e2343",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/36344aeffdc37711335563e6108cda86566432a6",
+                "reference": "36344aeffdc37711335563e6108cda86566432a6",
                 "shasum": ""
             },
             "require": {
@@ -63,7 +63,7 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2017-09-11T07:24:36+00:00"
+            "time": "2017-11-13T15:51:25+00:00"
         },
         {
             "name": "composer/composer",
@@ -702,7 +702,7 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.8.29",
+            "version": "v2.8.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
@@ -758,16 +758,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.29",
+            "version": "v2.8.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "89143ce2b463515a75b5f5e9650e6ecfb2684158"
+                "reference": "3eeaec6a5d9a253925139cd19eda07d882635d87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/89143ce2b463515a75b5f5e9650e6ecfb2684158",
-                "reference": "89143ce2b463515a75b5f5e9650e6ecfb2684158",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3eeaec6a5d9a253925139cd19eda07d882635d87",
+                "reference": "3eeaec6a5d9a253925139cd19eda07d882635d87",
                 "shasum": ""
             },
             "require": {
@@ -815,11 +815,11 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-07T14:08:47+00:00"
+            "time": "2017-11-12T16:36:54+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.8.29",
+            "version": "v2.8.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
@@ -876,7 +876,7 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.8.29",
+            "version": "v2.8.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
@@ -939,7 +939,7 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.29",
+            "version": "v2.8.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -999,7 +999,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.8.29",
+            "version": "v2.8.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -1048,7 +1048,7 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v2.8.29",
+            "version": "v2.8.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -1156,7 +1156,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.29",
+            "version": "v2.8.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -1205,7 +1205,7 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v2.8.29",
+            "version": "v2.8.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
@@ -1269,7 +1269,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.29",
+            "version": "v2.8.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",


### PR DESCRIPTION
```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 11 updates, 0 removals
  - Updating symfony/filesystem (v2.8.29 => v2.8.30):  Checking out 10507c5f24
  - Updating symfony/config (v2.8.29 => v2.8.30):  Checking out f4f3f1d709
  - Updating symfony/debug (v2.8.29 => v2.8.30):  Checking out a0a29e9867
  - Updating symfony/console (v2.8.29 => v2.8.30):  Checking out 3eeaec6a5d
  - Updating symfony/dependency-injection (v2.8.29 => v2.8.30):	 Checking out bc84511148
  - Updating symfony/event-dispatcher (v2.8.29 => v2.8.30):  Checking out b59aacf238
  - Updating symfony/finder (v2.8.29 => v2.8.30):  Checking out efeceae6a0
  - Updating symfony/process (v2.8.29 => v2.8.30):  Checking out d25449e031
  - Updating symfony/translation (v2.8.29 => v2.8.30):	Checking out 0c63d56516
  - Updating symfony/yaml (v2.8.29 => v2.8.30):	 Checking out d819bf267e
  - Updating composer/ca-bundle (1.0.8 => 1.0.9):  Checking out 36344aeffd
Writing lock file
Generating autoload files
```