### PR TITLE
Run `wp cache flush` and `wp search-replace` on multisite even when site isn't found

### DIFF
--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -301,6 +301,13 @@ Feature: Bootstrap WP-CLI
       """
     And the return code should be 1
 
+    When I run `wp option update test_key '["foo"]' --format=json --url=example.com`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    # --network should permit search-replace
     When I run `wp search-replace foo bar --network`
     Then STDOUT should contain:
       """
@@ -308,6 +315,13 @@ Feature: Bootstrap WP-CLI
       """
     And the return code should be 0
 
+    When I run `wp option update test_key '["foo"]' --format=json --url=example.com`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    # --all-tables should permit search-replace
     When I run `wp search-replace foo bar --all-tables`
     Then STDOUT should contain:
       """
@@ -315,6 +329,13 @@ Feature: Bootstrap WP-CLI
       """
     And the return code should be 0
 
+    When I run `wp option update test_key '["foo"]' --format=json --url=example.com`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    # --all-tables-with-prefix should permit search-replace
     When I run `wp search-replace foo bar --all-tables-with-prefix`
     Then STDOUT should contain:
       """
@@ -322,8 +343,14 @@ Feature: Bootstrap WP-CLI
       """
     And the return code should be 0
 
-    # Specific table
-    When I run `wp search-replace foo bar wp_posts`
+    When I run `wp option update test_key '["foo"]' --format=json --url=example.com`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    # Specific tables should permit search-replace
+    When I run `wp search-replace foo bar wp_options`
     Then STDOUT should contain:
       """
       Success:

--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -263,3 +263,24 @@ Feature: Bootstrap WP-CLI
       """
       foo
       """
+
+  Scenario: Run cache flush on ms_site_not_found
+    Given a WP multisite install
+    And a wp-cli.yml file:
+      """
+      url: invalid.com
+      """
+
+    When I try `wp cache add foo bar`
+    Then STDERR should contain:
+      """
+      Error: Site 'invalid.com' not found.
+      """
+    And the return code should be 1
+
+    When I run `wp cache flush --url=invalid.com`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+    And the return code should be 0

--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -264,6 +264,7 @@ Feature: Bootstrap WP-CLI
       foo
       """
 
+  @require-wp-3.9
   Scenario: Run cache flush on ms_site_not_found
     Given a WP multisite install
     And a wp-cli.yml file:
@@ -285,6 +286,7 @@ Feature: Bootstrap WP-CLI
       """
     And the return code should be 0
 
+  @require-wp-3.9
   Scenario: Run search-replace on ms_site_not_found
     Given a WP multisite install
     And a wp-cli.yml file:

--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -286,7 +286,7 @@ Feature: Bootstrap WP-CLI
       """
     And the return code should be 0
 
-  @require-wp-3.9
+  @require-wp-4.0
   Scenario: Run search-replace on ms_site_not_found
     Given a WP multisite install
     And a wp-cli.yml file:

--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -284,3 +284,46 @@ Feature: Bootstrap WP-CLI
       Success:
       """
     And the return code should be 0
+
+  Scenario: Run search-replace on ms_site_not_found
+    Given a WP multisite install
+    And a wp-cli.yml file:
+      """
+      url: invalid.com
+      """
+
+    When I try `wp search-replace foo bar`
+    Then STDERR should contain:
+      """
+      Error: Site 'invalid.com' not found.
+      """
+    And the return code should be 1
+
+    When I run `wp search-replace foo bar --network`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+    And the return code should be 0
+
+    When I run `wp search-replace foo bar --all-tables`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+    And the return code should be 0
+
+    When I run `wp search-replace foo bar --all-tables-with-prefix`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+    And the return code should be 0
+
+    # Specific table
+    When I run `wp search-replace foo bar wp_posts`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+    And the return code should be 0

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1304,6 +1304,18 @@ class Runner {
 
 		// In a multisite install, die if unable to find site given in --url parameter
 		if ( $this->is_multisite() ) {
+			if ( $this->cmd_starts_with( array( 'cache', 'flush' ) ) ) {
+				WP_CLI::add_wp_hook(
+					'ms_site_not_found',
+					function() {
+						// PHP 5.3 compatible implementation of _run_command_and_exit().
+						$runner = WP_CLI::get_runner();
+						$runner->run_command( $runner->arguments, $runner->assoc_args );
+						exit;
+					},
+					1
+				);
+			}
 			WP_CLI::add_wp_hook(
 				'ms_site_not_found',
 				function( $current_site, $domain, $path ) {

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1304,7 +1304,22 @@ class Runner {
 
 		// In a multisite install, die if unable to find site given in --url parameter
 		if ( $this->is_multisite() ) {
+			$run_on_site_not_found = false;
 			if ( $this->cmd_starts_with( array( 'cache', 'flush' ) ) ) {
+				$run_on_site_not_found = true;
+			}
+			if ( $this->cmd_starts_with( array( 'search-replace' ) ) ) {
+				// Table-specified
+				// Bits: search-replace <search> <replace> [<table>...]
+				// Or not against a specific blog
+				if ( count( $this->arguments ) > 3
+					|| ! empty( $this->assoc_args['network'] )
+					|| ! empty( $this->assoc_args['all-tables'] )
+					|| ! empty( $this->assoc_args['all-tables-with-prefix'] ) ) {
+					$run_on_site_not_found = true;
+				}
+			}
+			if ( $run_on_site_not_found ) {
 				WP_CLI::add_wp_hook(
 					'ms_site_not_found',
 					function() {

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1319,7 +1319,8 @@ class Runner {
 					$run_on_site_not_found = true;
 				}
 			}
-			if ( $run_on_site_not_found ) {
+			if ( $run_on_site_not_found
+				&& Utils\wp_version_compare( '3.9', '>=' ) ) {
 				WP_CLI::add_wp_hook(
 					'ms_site_not_found',
 					function() {

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1306,7 +1306,7 @@ class Runner {
 		if ( $this->is_multisite() ) {
 			$run_on_site_not_found = false;
 			if ( $this->cmd_starts_with( array( 'cache', 'flush' ) ) ) {
-				$run_on_site_not_found = true;
+				$run_on_site_not_found = 'cache flush';
 			}
 			if ( $this->cmd_starts_with( array( 'search-replace' ) ) ) {
 				// Table-specified
@@ -1316,14 +1316,18 @@ class Runner {
 					|| ! empty( $this->assoc_args['network'] )
 					|| ! empty( $this->assoc_args['all-tables'] )
 					|| ! empty( $this->assoc_args['all-tables-with-prefix'] ) ) {
-					$run_on_site_not_found = true;
+					$run_on_site_not_found = 'search-replace';
 				}
 			}
 			if ( $run_on_site_not_found
-				&& Utils\wp_version_compare( '3.9', '>=' ) ) {
+				&& Utils\wp_version_compare( '4.0', '>=' ) ) {
 				WP_CLI::add_wp_hook(
 					'ms_site_not_found',
-					function() {
+					function() use ( $run_on_site_not_found ) {
+						// esc_sql() isn't yet loaded, but needed.
+						if ( 'search-replace' === $run_on_site_not_found ) {
+							require_once ABSPATH . WPINC . '/formatting.php';
+						}
 						// PHP 5.3 compatible implementation of _run_command_and_exit().
 						$runner = WP_CLI::get_runner();
 						$runner->run_command( $runner->arguments, $runner->assoc_args );


### PR DESCRIPTION
Avoids annoying "Error: Site not found" failure when you'd expect these commands to work.

Because these operations can be global (`cache flush` always, `search-replace` with specific arguments), they're safe to run as long as the cache / database have been initialized.

In considering all possible implementations (e.g. registering a new `@when` invoke, etc.), this approach seems to have the least possible impact.

Fixes https://github.com/wp-cli/cache-command/issues/17
Fixes https://github.com/wp-cli/search-replace-command/issues/41