### PR TITLE
Check if ABSPATH constant is defined before defining ABSPATH

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -232,7 +232,9 @@ class Runner {
 	 * @param string $path
 	 */
 	private static function set_wp_root( $path ) {
-		define( 'ABSPATH', Utils\trailingslashit( $path ) );
+		if ( !defined( 'ABSPATH' ) ) {
+			define( 'ABSPATH', Utils\trailingslashit( $path ) );
+		}
 		WP_CLI::debug( 'ABSPATH defined: ' . ABSPATH, 'bootstrap' );
 
 		$_SERVER['DOCUMENT_ROOT'] = realpath( $path );


### PR DESCRIPTION
If a `wp-cli.yml` has a _require_ in which the ABSPATH is defined wp-cli command will throw a notice.
Example:

`wp-cli.yaml`

    require:
         - abspath.php

`abspath.php`

    <?php
    if ( ! defined( 'ABSPATH' ) ) {
	    define( 'ABSPATH', dirname( __FILE__ ) . '/custom_path/wp/' );
    }

When would you want this? In short symlinks, if you include WordPress in a symlink.

WordPress tries to define the ABSPATH it uses wp-load.php and if it's in a symlink it will define the path baed on the actual location. Not the symlink path.
That will give a problem if the wp-config.php is one directory above wp-load.php.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
