### PR TITLE
Revert "Install a `pre-commit` Git hook on `composer install` to sniff codebase"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,11 +79,6 @@
 		"psr-0": { "WP_CLI": "php" },
 		"psr-4": { "": "php/commands/src" }
 	},
-	"scripts": {
-		"post-install-cmd": [
-			"cp -f ./utils/git-pre-commit-hook ./.git/hooks/pre-commit"
-		]
-	},
 	"extra": {
 		"autoload-splitter": {
 			"splitter-logic": "WP_CLI\\AutoloadSplitter",

--- a/utils/git-pre-commit-hook
+++ b/utils/git-pre-commit-hook
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-# Sniff codebase for coding standards
-./vendor/bin/phpcs


### PR DESCRIPTION
Reverts wp-cli/wp-cli#4489

See #4544, https://github.com/wp-cli/wp-cli/issues/4474#issuecomment-343651402