### PR TITLE
Use \n in stream_get_line in Subcommand::prompt for git/cygwin bash compat.

### DIFF
--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -121,7 +121,7 @@ class Subcommand extends CompositeCommand {
 
 		echo $question;
 
-		return stream_get_line( STDIN, 1024, PHP_EOL );
+		return stream_get_line( STDIN, 1024, "\n" );
 	}
 
 	/**

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -121,7 +121,11 @@ class Subcommand extends CompositeCommand {
 
 		echo $question;
 
-		return stream_get_line( STDIN, 1024, "\n" );
+		$ret = stream_get_line( STDIN, 1024, "\n" );
+		if ( Utils\is_windows() && "\r" === substr( $ret, -1 ) ) {
+			$ret = substr( $ret, 0, -1 );
+		}
+		return $ret;
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/4546