### PR TITLE
Don't show 'sitecategories' table unless global terms are enabled

### DIFF
--- a/features/framework.feature
+++ b/features/framework.feature
@@ -345,3 +345,18 @@ Feature: Load WP-CLI
       """
       Error: Site 'example.io' not found. Verify `--url=<url>` matches an existing site.
       """
+
+  Scenario: Don't show 'sitecategories' table unless global terms are enabled
+    Given a WP multisite installation
+
+    When I run `wp db tables`
+    Then STDOUT should not contain:
+      """
+      wp_sitecategories
+      """
+
+    When I run `wp db tables --network`
+    Then STDOUT should not contain:
+      """
+      wp_sitecategories
+      """

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -368,8 +368,22 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 		return $matching_tables;
 	}
 
+	$filter_sitecategories = function( $matching_tables ) {
+		global $wpdb;
+		// Only include sitecategories when it's actually enabled.
+		if ( ! global_terms_enabled() ) {
+			$key = array_search( $wpdb->sitecategories, $matching_tables );
+			if ( false !== $key ) {
+				unset( $matching_tables[ $key ] );
+			}
+		}
+		return $matching_tables;
+	};
+
 	if ( $scope = get_flag_value( $assoc_args, 'scope' ) ) {
-		return $wpdb->tables( $scope );
+		$matching_tables = $wpdb->tables( $scope );
+		$matching_tables = $filter_sitecategories( $matching_tables );
+		return $matching_tables;
 	}
 
 	$allowed_tables = array();
@@ -406,5 +420,6 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 
 	}
 
+	$filter_sitecategories( $matching_tables );
 	return array_values( $matching_tables );
 }


### PR DESCRIPTION
Fixes https://github.com/wp-cli/db-command/issues/61