### PR TITLE
"installation" instead of "install"

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -124,7 +124,7 @@ class Runner {
 		);
 
 		// Stop looking upward when we find we have emerged from a subdirectory
-		// install into a parent install
+		// installation into a parent installation
 		$project_config_path = Utils\find_file_upward(
 			$config_files,
 			getcwd(),
@@ -162,7 +162,7 @@ class Runner {
 	}
 
 	/**
-	 * Attempts to find the path to the WP install inside index.php
+	 * Attempts to find the path to the WP installation inside index.php
 	 *
 	 * @param string $index_path
 	 * @return string|false
@@ -757,12 +757,12 @@ class Runner {
 			$suggestion_or_disabled = $this->find_command_to_run( $args );
 			if ( is_string( $suggestion_or_disabled ) ) {
 				if ( ! preg_match( '/disabled from the config file.$/', $suggestion_or_disabled ) ) {
-					WP_CLI::warning( "No WordPress install found. If the command '" . implode( ' ', $args ) . "' is in a plugin or theme, pass --path=`path/to/wordpress`." );
+					WP_CLI::warning( "No WordPress installation found. If the command '" . implode( ' ', $args ) . "' is in a plugin or theme, pass --path=`path/to/wordpress`." );
 				}
 				WP_CLI::error( $suggestion_or_disabled );
 			}
 			WP_CLI::error(
-				"This does not seem to be a WordPress install.\n" .
+				"This does not seem to be a WordPress installation.\n" .
 				'Pass --path=`path/to/wordpress` or run `wp core download`.'
 			);
 		}
@@ -843,7 +843,7 @@ class Runner {
 
 		WP_CLI::error(
 			"YIKES! It looks like you're running this as root. You probably meant to " .
-			"run this as the user that your WordPress install exists under.\n" .
+			"run this as the user that your WordPress installation exists under.\n" .
 			"\n" .
 			"If you REALLY mean to run this as root, we won't stop you, but just " .
 			'bear in mind that any code on this site will then have full control of ' .
@@ -1302,7 +1302,7 @@ class Runner {
 			}
 		);
 
-		// In a multisite install, die if unable to find site given in --url parameter
+		// In a multisite installation, die if unable to find site given in --url parameter
 		if ( $this->is_multisite() ) {
 			$run_on_site_not_found = false;
 			if ( $this->cmd_starts_with( array( 'cache', 'flush' ) ) ) {
@@ -1525,7 +1525,7 @@ class Runner {
 	}
 
 	/**
-	 * Whether or not this WordPress install is multisite.
+	 * Whether or not this WordPress installation is multisite.
 	 *
 	 * For use after wp-config.php has loaded, but before the rest of WordPress
 	 * is loaded.

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -223,7 +223,7 @@ class WP_CLI {
 	 * WP_CLI::add_command( 'network meta', 'Network_Meta_Command', array(
 	 *    'before_invoke' => function () {
 	 *        if ( !is_multisite() ) {
-	 *            WP_CLI::error( 'This is not a multisite install.' );
+	 *            WP_CLI::error( 'This is not a multisite installation.' );
 	 *        }
 	 *    }
 	 * ) );

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -66,7 +66,7 @@ class CLI_Command extends WP_CLI_Command {
 	 * * PHP binary used.
 	 * * PHP binary version.
 	 * * php.ini configuration file used (which is typically different than web).
-	 * * WP-CLI root dir: where WP-CLI is installed (if non-Phar install).
+	 * * WP-CLI root dir: where WP-CLI is installed (if non-Phar installation).
 	 * * WP-CLI global config: where the global config YAML file is located.
 	 * * WP-CLI project config: where the project config YAML file is located.
 	 * * WP-CLI version: currently installed version.
@@ -524,9 +524,9 @@ class CLI_Command extends WP_CLI_Command {
 	/**
 	 * List available WP-CLI aliases.
 	 *
-	 * Aliases are shorthand references to WordPress installs. For instance,
-	 * `@dev` could refer to a development install and `@prod` could refer to
-	 * a production install. This command gives you visibility in what
+	 * Aliases are shorthand references to WordPress installations. For instance,
+	 * `@dev` could refer to a development installation and `@prod` could refer to
+	 * a production installation. This command gives you visibility in what
 	 * registered aliases you have available.
 	 *
 	 * ## OPTIONS

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -22,7 +22,7 @@ return array(
 	'http' => array(
 		'runtime' => '=<http>',
 		'file' => '<http>',
-		'desc' => 'Perform operation against a remote WordPress install over HTTP.',
+		'desc' => 'Perform operation against a remote WordPress installation over HTTP.',
 	),
 
 	'blog' => array(

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -19,7 +19,7 @@ function wp_not_installed() {
 		}
 		if ( count( $found_prefixes ) ) {
 			$prefix_list = implode( ', ', $found_prefixes );
-			$install_label = count( $found_prefixes ) > 1 ? 'installs' : 'install';
+			$install_label = count( $found_prefixes ) > 1 ? 'installations' : 'installation';
 			\WP_CLI::error(
 				"The site you have requested is not installed.\n" .
 				"Your table prefix is '{$table_prefix}'. Found {$install_label} with table prefix: {$prefix_list}.\n" .

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -19,7 +19,7 @@ require ABSPATH . WPINC . '/plugin.php';
 
 /*
  * These can't be directly globalized in version.php. When updating,
- * we're including version.php from another install and don't want
+ * we're including version.php from another installation and don't want
  * these values to be overridden if already set.
  */
 global $wp_version, $wp_db_version, $tinymce_version, $required_php_version, $required_mysql_version, $wp_local_package;

--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -154,7 +154,7 @@ if ( 'cli' === BUILD ) {
 		->exclude('composer/composer/src/Composer/Command')
 		->exclude('composer/composer/src/Composer/Compiler.php')
 		->exclude('composer/composer/src/Composer/Console')
-		->exclude('composer/composer/src/Composer/Downloader/PearPackageExtractor.php') // Assuming Pear install isn't supported by wp-cli.
+		->exclude('composer/composer/src/Composer/Downloader/PearPackageExtractor.php') // Assuming Pear installation isn't supported by wp-cli.
 		->exclude('composer/composer/src/Composer/Installer/PearBinaryInstaller.php')
 		->exclude('composer/composer/src/Composer/Installer/PearInstaller.php')
 		->exclude('composer/composer/src/Composer/Question')

--- a/utils/wp-cli-rpm.spec
+++ b/utils/wp-cli-rpm.spec
@@ -12,7 +12,7 @@ Requires:   php >= 5.3.29
 
 %description
 WP-CLI is the command-line interface for WordPress.
-You can update plugins, configure multisite installs
+You can update plugins, configure multisite installations
 and much more, without using a web browser.
 
 %prep

--- a/utils/wp-cli-updatedeb.sh
+++ b/utils/wp-cli-updatedeb.sh
@@ -35,7 +35,7 @@ Depends: php5-cli (>= 5.3.29) | php-cli | php7-cli, php5-mysql | php5-mysqlnd | 
 Homepage: http://wp-cli.org/
 Description: wp-cli is a set of command-line tools for managing
  WordPress installations. You can update plugins, set up multisite
- installs and much more, without using a web browser.
+ installations and much more, without using a web browser.
 
 EOF
 }


### PR DESCRIPTION
Per https://github.com/wp-cli/wp-cli/issues/4541 use "installation" instead of "install"