### PR TITLE
"utils" directory - use "installation" rather than "install"

### DIFF
--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -154,7 +154,7 @@ if ( 'cli' === BUILD ) {
 		->exclude('composer/composer/src/Composer/Command')
 		->exclude('composer/composer/src/Composer/Compiler.php')
 		->exclude('composer/composer/src/Composer/Console')
-		->exclude('composer/composer/src/Composer/Downloader/PearPackageExtractor.php') // Assuming Pear install isn't supported by wp-cli.
+		->exclude('composer/composer/src/Composer/Downloader/PearPackageExtractor.php') // Assuming Pear installation isn't supported by wp-cli.
 		->exclude('composer/composer/src/Composer/Installer/PearBinaryInstaller.php')
 		->exclude('composer/composer/src/Composer/Installer/PearInstaller.php')
 		->exclude('composer/composer/src/Composer/Question')

--- a/utils/wp-cli-rpm.spec
+++ b/utils/wp-cli-rpm.spec
@@ -12,7 +12,7 @@ Requires:   php >= 5.3.29
 
 %description
 WP-CLI is the command-line interface for WordPress.
-You can update plugins, configure multisite installs
+You can update plugins, configure multisite installations
 and much more, without using a web browser.
 
 %prep

--- a/utils/wp-cli-updatedeb.sh
+++ b/utils/wp-cli-updatedeb.sh
@@ -35,7 +35,7 @@ Depends: php5-cli (>= 5.3.29) | php-cli | php7-cli, php5-mysql | php5-mysqlnd | 
 Homepage: http://wp-cli.org/
 Description: wp-cli is a set of command-line tools for managing
  WordPress installations. You can update plugins, set up multisite
- installs and much more, without using a web browser.
+ installations and much more, without using a web browser.
 
 EOF
 }


### PR DESCRIPTION
Per issue https://github.com/wp-cli/wp-cli/issues/4541