### PR TITLE
Use a softer PHP requirement in RPM build

### DIFF
--- a/utils/wp-cli-rpm.spec
+++ b/utils/wp-cli-rpm.spec
@@ -1,6 +1,6 @@
 Name:       wp-cli
 Version:    0.0.0
-Release:    1%{?dist}
+Release:    2%{?dist}
 Summary:    The command line interface for WordPress
 License:    MIT
 URL:        http://wp-cli.org/

--- a/utils/wp-cli-rpm.spec
+++ b/utils/wp-cli-rpm.spec
@@ -8,7 +8,8 @@ Source0:    wp-cli.phar
 Source1:    wp.1
 BuildArch:  noarch
 
-Requires:   php >= 5.3.29
+%post
+echo "PHP 5.3.29 or above must be installed."
 
 %description
 WP-CLI is the command-line interface for WordPress.
@@ -16,6 +17,14 @@ You can update plugins, configure multisite installs
 and much more, without using a web browser.
 
 %prep
+chmod +x %{SOURCE0}
+{
+    echo '.TH "WP" "1"'
+    php %{SOURCE0} --help
+} \
+    | sed -e 's/^\([A-Z ]\+\)$/.SH "\1"/' \
+    | sed -e 's/^  wp$/wp \\- The command line interface for WordPress/' \
+    > %{SOURCE1}
 
 %build
 
@@ -30,6 +39,11 @@ install -p -m 0644 %{SOURCE1} %{buildroot}%{_mandir}/man1/
 %attr(0644, root, root) %{_mandir}/man1/wp.1*
 
 %changelog
+* Tue Dec 12 2017 Murtaza Sarıaltun <murtaza.sarialtun@ozguryazzilim.com.tr> - 0.0.0-2
+- Remove php requirements.
+- Update creating man page steps.
+- Added output message. 
+
 * Fri Jul 7 2017 Murtaza Sarıaltun <murtaza.sarialtun@ozguryazilim.com.tr> - 0.0.0-1
 - First release of the spec file
 - Check the spec file with `rpmlint -i -v wp-cli-rpm.spec`


### PR DESCRIPTION
Removed PHP Requirement from spec file.
Added Post install message "PHP 5.3.29 or above must be installed."
Added man page creating steps.
Changed Release version.