### PR TITLE
Add Utils\proc_open_compat() for Windows compat, plus misc other compat.

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -117,8 +117,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		// Ensure we're using the expected `wp` binary
 		$bin_dir = getenv( 'WP_CLI_BIN_DIR' ) ?: realpath( __DIR__ . '/../../bin' );
 		$vendor_dir = realpath( __DIR__ . '/../../vendor/bin' );
+		$path_separator = Utils\is_windows() ? ';' : ':';
 		$env = array(
-			'PATH' =>  $bin_dir . ':' . $vendor_dir . ':' . getenv( 'PATH' ),
+			'PATH' =>  $bin_dir . $path_separator . $vendor_dir . $path_separator . getenv( 'PATH' ),
 			'BEHAT_RUN' => 1,
 			'HOME' => sys_get_temp_dir() . '/wp-cli-home',
 		);

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -162,7 +162,7 @@ class DocParser {
 	 * @return array|null Interpreted YAML document, or null.
 	 */
 	private function get_arg_or_param_args( $regex ) {
-		$bits = explode( PHP_EOL, $this->docComment );
+		$bits = explode( "\n", $this->docComment );
 		$within_arg = $within_doc = false;
 		$document = array();
 		foreach ( $bits as $bit ) {
@@ -189,7 +189,7 @@ class DocParser {
 		}
 
 		if ( $document ) {
-			return Spyc::YAMLLoadString( implode( PHP_EOL, $document ) );
+			return Spyc::YAMLLoadString( implode( "\n", $document ) );
 		}
 		return null;
 	}

--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -2,6 +2,8 @@
 
 namespace WP_CLI;
 
+use WP_CLI\Utils;
+
 /**
  * Run a system process, and learn what happened.
  */
@@ -67,7 +69,7 @@ class Process {
 	public function run() {
 		$start_time = microtime( true );
 
-		$proc = proc_open( $this->command, self::$descriptors, $pipes, $this->cwd, $this->env );
+		$proc = Utils\proc_open_compat( $this->command, self::$descriptors, $pipes, $this->cwd, $this->env );
 
 		$stdout = stream_get_contents( $pipes[1] );
 		fclose( $pipes[1] );

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -880,7 +880,7 @@ class Runner {
 	private function run_alias_group( $aliases ) {
 		Utils\check_proc_available( 'group alias' );
 
-		$php_bin = Utils\get_php_binary();
+		$php_bin = escapeshellarg( Utils\get_php_binary() );
 
 		$script_path = $GLOBALS['argv'][0];
 
@@ -897,7 +897,7 @@ class Runner {
 			$assoc_args = Utils\assoc_args_to_str( $this->assoc_args );
 			$runtime_config = Utils\assoc_args_to_str( $this->runtime_config );
 			$full_command = "WP_CLI_CONFIG_PATH={$config_path} {$php_bin} {$script_path} {$alias} {$args}{$assoc_args}{$runtime_config}";
-			$proc = proc_open( $full_command, array( STDIN, STDOUT, STDERR ), $pipes );
+			$proc = Utils\proc_open_compat( $full_command, array( STDIN, STDOUT, STDERR ), $pipes );
 			proc_close( $proc );
 		}
 	}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -999,7 +999,7 @@ class WP_CLI {
 			}
 		}
 
-		$php_bin = Utils\get_php_binary();
+		$php_bin = escapeshellarg( Utils\get_php_binary() );
 
 		$script_path = $GLOBALS['argv'][0];
 
@@ -1121,7 +1121,7 @@ class WP_CLI {
 				);
 			}
 
-			$php_bin = Utils\get_php_binary();
+			$php_bin = escapeshellarg( Utils\get_php_binary() );
 			$script_path = $GLOBALS['argv'][0];
 
 			// Persist runtime arguments unless they've been specified otherwise.
@@ -1137,7 +1137,7 @@ class WP_CLI {
 
 			$runcommand = "{$php_bin} {$script_path} {$runtime_config} {$command}";
 
-			$proc = proc_open( $runcommand, $descriptors, $pipes, getcwd(), null );
+			$proc = Utils\proc_open_compat( $runcommand, $descriptors, $pipes, getcwd() );
 
 			if ( $return ) {
 				$stdout = stream_get_contents( $pipes[1] );

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -129,7 +129,7 @@ class Help_Command extends WP_CLI_Command {
 			2 => STDERR,
 		);
 
-		return proc_close( proc_open( $pager, $descriptorspec, $pipes ) );
+		return proc_close( Utils\proc_open_compat( $pager, $descriptorspec, $pipes ) );
 	}
 
 	private static function get_initial_markdown( $command ) {

--- a/php/utils.php
+++ b/php/utils.php
@@ -383,15 +383,11 @@ function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
 
 	$editor = getenv( 'EDITOR' );
 	if ( ! $editor ) {
-		$editor = 'vi';
-
-		if ( isset( $_SERVER['OS'] ) && false !== strpos( $_SERVER['OS'], 'indows' ) ) {
-			$editor = 'notepad';
-		}
+		$editor = is_windows() ? 'notepad' : 'vi';
 	}
 
 	$descriptorspec = array( STDIN, STDOUT, STDERR );
-	$process = proc_open( "$editor " . escapeshellarg( $tmpfile ), $descriptorspec, $pipes );
+	$process = proc_open_compat( "$editor " . escapeshellarg( $tmpfile ), $descriptorspec, $pipes );
 	$r = proc_close( $process );
 	if ( $r ) {
 		exit( $r );
@@ -453,7 +449,7 @@ function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
 
 	$final_cmd = force_env_on_nix_systems( $cmd ) . assoc_args_to_str( $assoc_args );
 
-	$proc = proc_open( $final_cmd, $descriptors, $pipes );
+	$proc = proc_open_compat( $final_cmd, $descriptors, $pipes );
 	if ( ! $proc ) {
 		exit( 1 );
 	}
@@ -790,14 +786,8 @@ function get_temp_dir() {
 		return $temp;
 	}
 
-	$temp = '/tmp/';
-
-	// `sys_get_temp_dir()` introduced PHP 5.2.1.
-	if ( $try = sys_get_temp_dir() ) {
-		$temp = trailingslashit( $try );
-	} elseif ( $try = ini_get( 'upload_tmp_dir' ) ) {
-		$temp = trailingslashit( $try );
-	}
+	// `sys_get_temp_dir()` introduced PHP 5.2.1. Will always return something.
+	$temp = trailingslashit( sys_get_temp_dir() );
 
 	if ( ! is_writable( $temp ) ) {
 		\WP_CLI::warning( "Temp directory isn't writable: {$temp}" );
@@ -1317,4 +1307,51 @@ function get_php_binary() {
 	}
 
 	return 'php';
+}
+
+/**
+ * Windows compatible `proc_open()`.
+ * Works around bug in PHP, and also deals with *nix-like `ENV_VAR=blah cmd` environment variable prefixes.
+ *
+ * @access public
+ *
+ * @param string $command Command to execute.
+ * @param array $descriptorspec Indexed array of descriptor numbers and their values.
+ * @param array &$pipes Indexed array of file pointers that correspond to PHP's end of any pipes that are created.
+ * @param string $cwd Initial working directory for the command.
+ * @param array $env Array of environment variables.
+ * @param array $other_options Array of additional options (Windows only).
+ *
+ * @return string Command stripped of any environment variable settings.
+ */
+function proc_open_compat( $cmd, $descriptorspec, &$pipes, $cwd = null, $env = null, $other_options = null ) {
+	if ( is_windows() ) {
+		// Need to encompass the whole command in double quotes - PHP bug https://bugs.php.net/bug.php?id=49139
+		$cmd = '"' . _proc_open_compat_win_env( $cmd, $env ) . '"';
+	}
+	return proc_open( $cmd, $descriptorspec, $pipes, $cwd, $env, $other_options );
+}
+
+/**
+ * For use by `proc_open_compat()` only. Separated out for ease of testing. Windows only.
+ * Turns *nix-like `ENV_VAR=blah command` environment variable prefixes into stripped `cmd` with prefixed environment variables added to passed in environment array.
+ *
+ * @access private
+ *
+ * @param string $command Command to execute.
+ * @param array &$env Array of existing environment variables. Will be modified if any settings in command.
+ *
+ * @return string Command stripped of any environment variable settings.
+ */
+function _proc_open_compat_win_env( $cmd, &$env ) {
+	if ( false !== strpos( $cmd, '=' ) ) {
+		while ( preg_match( '/^([A-Za-z_][A-Za-z0-9_]*)=("[^"]*"|[^ ]*) /', $cmd, $matches ) ) {
+			$cmd = substr( $cmd, strlen( $matches[0] ) );
+			if ( null === $env ) {
+				$env = array();
+			}
+			$env[ $matches[1] ] = isset( $matches[2][0] ) && '"' === $matches[2][0] ? substr( $matches[2], 1, -1 ) : $matches[2];
+		}
+	}
+	return $cmd;
 }

--- a/tests/test-extractor.php
+++ b/tests/test-extractor.php
@@ -112,7 +112,8 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 		// Create test tarball.
 		$output = array();
 		$return_var = -1;
-		exec( Utils\esc_cmd( 'tar czvf %1$s --directory=%2$s/src wordpress', $tarball, $temp_dir ), $output, $return_var );
+		// Need --force-local for Windows to avoid "C:" being interpreted as being on remote machine.
+		exec( Utils\esc_cmd( 'tar czvf %1$s --force-local --directory=%2$s/src wordpress', $tarball, $temp_dir ), $output, $return_var );
 		$this->assertSame( 0, $return_var );
 		$this->assertFalse( empty( $output ) );
 		sort( $output );

--- a/tests/test-file-cache.php
+++ b/tests/test-file-cache.php
@@ -57,12 +57,15 @@ class FileCacheTest extends PHPUnit_Framework_TestCase {
 		$result = $method->invokeArgs( $cache, array( $cache_dir . '/test1' ) );
 		$this->assertTrue( $result );
 
-		// It should be failed because permission denied.
-		$logger->stderr = '';
-		chmod( $cache_dir . '/test1', 0000 );
-		$result = $method->invokeArgs( $cache, array( $cache_dir . '/test1/error' ) );
-		$expected = "/^Warning: Failed to create directory '.+': mkdir\(\): Permission denied\.$/";
-		$this->assertRegexp( $expected, $logger->stderr );
+		// `chmod()` doesn't work on Windows.
+		if ( ! Utils\is_windows() ) {
+			// It should be failed because permission denied.
+			$logger->stderr = '';
+			chmod( $cache_dir . '/test1', 0000 );
+			$result = $method->invokeArgs( $cache, array( $cache_dir . '/test1/error' ) );
+			$expected = "/^Warning: Failed to create directory '.+': mkdir\(\): Permission denied\.$/";
+			$this->assertRegexp( $expected, $logger->stderr );
+		}
 
 		// It should be failed because file exists.
 		$logger->stderr = '';

--- a/tests/test-help.php
+++ b/tests/test-help.php
@@ -11,19 +11,17 @@ class HelpTest extends PHPUnit_Framework_TestCase {
 	public function testPassThroughPagerProcDisabled() {
 		$err_msg = 'Warning: check_proc_available() failed in pass_through_pager().';
 
-		$cmd = "WP_CLI_PHP_ARGS='-ddisable_functions=proc_open' bin/wp help --debug 2>&1";
+		$cmd = 'php -ddisable_functions=proc_open php/boot-fs.php help --debug 2>&1';
 		$output = array();
 		exec( $cmd, $output );
-		$this->assertTrue( count( $output ) > 0 );
-		$last = array_pop( $output );
-		$this->assertTrue( false !== strpos( trim( $last ), $err_msg ) );
+		$output = trim( implode( "\n", $output ) );
+		$this->assertTrue( false !== strpos( $output, $err_msg ) );
 
-		$cmd = "WP_CLI_PHP_ARGS='-ddisable_functions=proc_close' bin/wp help --debug 2>&1";
+		$cmd = 'php -ddisable_functions=proc_close php/boot-fs.php help --debug 2>&1';
 		$output = array();
 		exec( $cmd, $output );
-		$this->assertTrue( count( $output ) > 0 );
-		$last = array_pop( $output );
-		$this->assertTrue( false !== strpos( trim( $last ), $err_msg ) );
+		$output = trim( implode( "\n", $output ) );
+		$this->assertTrue( false !== strpos( $output, $err_msg ) );
 	}
 
 	public function test_parse_reference_links() {

--- a/tests/test-process.php
+++ b/tests/test-process.php
@@ -1,0 +1,29 @@
+<?php
+
+use WP_CLI\Process;
+use WP_CLI\Utils;
+
+class ProcessTests extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider data_process_env
+	 */
+	function test_process_env( $cmd_prefix, $env, $expected_env_vars, $expected_out ) {
+		$code = vsprintf( str_repeat( 'echo getenv( \'%s\' );', count( $expected_env_vars ) ), $expected_env_vars );
+
+		$cmd = $cmd_prefix . ' ' . escapeshellarg( Utils\get_php_binary() ) . ' -r ' . escapeshellarg( $code );
+		$process_run = Process::create( $cmd, null /*cwd*/, $env )->run();
+
+		$this->assertSame( $process_run->stdout, $expected_out );
+	}
+
+	function data_process_env() {
+		return array(
+			array( '', array(), array(), '' ),
+			array( 'ENV=blah', array(), array( 'ENV' ), 'blah' ),
+			array( 'ENV="blah blah"', array(), array( 'ENV' ), 'blah blah' ),
+			array( 'ENV_1="blah1 blah1" ENV_2="blah2" ENV_3=blah3', array( 'ENV' => 'in' ), array( 'ENV', 'ENV_1', 'ENV_2', 'ENV_3' ), 'inblah1 blah1blah2blah3' ),
+			array( 'ENV=blah', array( 'ENV_1' => 'in1', 'ENV_2' => 'in2' ), array( 'ENV_1', 'ENV_2', 'ENV' ), 'in1in2blah' ),
+		);
+	}
+}

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -251,12 +251,21 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testAssocArgsToString() {
-		$this->assertEquals( " --url='foo.dev' --porcelain --apple='banana'" , Utils\assoc_args_to_str( array(
+		// Strip quotes for Windows compat.
+		$strip_quotes = function ( $str ) {
+			return str_replace( array( '"', "'" ), '', $str );
+		};
+
+		$expected = " --url='foo.dev' --porcelain --apple='banana'";
+		$actual = Utils\assoc_args_to_str( array(
 			'url'       => 'foo.dev',
 			'porcelain' => true,
 			'apple'     => 'banana'
-		) ) );
-		$this->assertEquals( " --url='foo.dev' --require='file-a.php' --require='file-b.php' --porcelain --apple='banana'" , Utils\assoc_args_to_str( array(
+		) );
+		$this->assertSame( $strip_quotes( $expected ), $strip_quotes( $actual ) );
+
+		$expected = " --url='foo.dev' --require='file-a.php' --require='file-b.php' --porcelain --apple='banana'";
+		$actual = Utils\assoc_args_to_str( array(
 			'url'       => 'foo.dev',
 			'require'   => array(
 				'file-a.php',
@@ -264,10 +273,13 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			),
 			'porcelain' => true,
 			'apple'     => 'banana'
-		) ) );
+		) );
+		$this->assertSame( $strip_quotes( $expected ), $strip_quotes( $actual ) );
 	}
 
 	public function testForceEnvOnNixSystems() {
+		$env_is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
+
 		putenv( 'WP_CLI_TEST_IS_WINDOWS=0' );
 		$this->assertSame( '/usr/bin/env cmd', Utils\force_env_on_nix_systems( 'cmd' ) );
 		$this->assertSame( '/usr/bin/env cmd', Utils\force_env_on_nix_systems( '/usr/bin/env cmd' ) );
@@ -276,7 +288,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame( 'cmd', Utils\force_env_on_nix_systems( 'cmd' ) );
 		$this->assertSame( 'cmd', Utils\force_env_on_nix_systems( '/usr/bin/env cmd' ) );
 
-		putenv( 'WP_CLI_TEST_IS_WINDOWS' );
+		putenv( false === $env_is_windows ? 'WP_CLI_TEST_IS_WINDOWS' : "WP_CLI_TEST_IS_WINDOWS=$env_is_windows" );
 	}
 
 	public function testGetHomeDir() {
@@ -288,11 +300,18 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 
 		putenv( 'HOME=/home/user' );
 		$this->assertSame('/home/user', Utils\get_home_dir() );
-		putenv( 'HOME=' );
-		putenv( 'HOMEDRIVE=C:/\\Windows/\\User/\\' );
-		$this->assertSame( 'C:/\Windows/\User', Utils\get_home_dir() );
-		putenv( 'HOMEPATH=HOGE/\\' );
-		$this->assertSame( 'C:/\Windows/\User/\HOGE', Utils\get_home_dir() );
+
+		putenv( 'HOME' );
+
+		putenv( 'HOMEDRIVE=D:' );
+		putenv( 'HOMEPATH' );
+		$this->assertSame( 'D:', Utils\get_home_dir() );
+
+		putenv( 'HOMEPATH=\\Windows\\User\\' );
+		$this->assertSame( 'D:\\Windows\\User', Utils\get_home_dir() );
+
+		putenv( 'HOMEPATH=\\Windows\\User\\HOGE\\' );
+		$this->assertSame( 'D:\\Windows\\User\\HOGE', Utils\get_home_dir() );
 
 		// restore environments
 		putenv( false === $home ? 'HOME' : "HOME=$home" );
@@ -313,36 +332,23 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		// INI directive `sys_temp_dir` introduced PHP 5.5.0.
 		if ( version_compare( PHP_VERSION, '5.5.0', '>=' ) ) {
 
-			// `sys_temp_dir` set.
+			// `sys_temp_dir` set to unwritable.
 
-			$cmd = "WP_CLI_PHP_ARGS='-dsys_temp_dir=\\tmp\\' bin/wp eval 'echo WP_CLI\\Utils\\get_temp_dir();' --skip-wordpress 2>&1";
+			$cmd = 'php ' . escapeshellarg( '-dsys_temp_dir=\\tmp\\' ) . ' php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'echo WP_CLI\\Utils\\get_temp_dir();' ) . ' 2>&1';
 			$output = array();
 			exec( $cmd, $output );
-			$this->assertTrue( 2 === count( $output ) );
-			$this->assertTrue( 2 === preg_match_all( '/warning|writable/i', $output[0] ) );
-			$this->assertSame( '\\tmp/', $output[1] );
+			$output = trim( implode( "\n", $output ) );
+			$this->assertTrue( false !== strpos( $output, 'Warning' ) );
+			$this->assertTrue( false !== strpos( $output, 'writable' ) );
+			$this->assertTrue( false !== strpos( $output, '\\tmp/' ) );
 
-			// `sys_temp_dir` unset and `upload_tmp_dir' set.
+			// `sys_temp_dir` unset.
 
-			// `upload_tmp_dir` needs to be a legitimate writable directory.
-			$temp_dir = sys_get_temp_dir() . '/' . uniqid( 'test-utils-get-temp-dir', true );
-			mkdir( $temp_dir, 0777, true );
-			$cmd = "WP_CLI_PHP_ARGS='-dsys_temp_dir=0 -dupload_tmp_dir=$temp_dir\\' bin/wp eval 'echo WP_CLI\\Utils\\get_temp_dir();' --skip-wordpress 2>&1";
+			$cmd = 'php ' . escapeshellarg( '-dsys_temp_dir=' ) . ' php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'echo WP_CLI\\Utils\\get_temp_dir();' ) . ' 2>&1';
 			$output = array();
 			exec( $cmd, $output );
-
-			rmdir( $temp_dir );
-
-			$this->assertTrue( 1 === count( $output ) );
-			$this->assertSame( $temp_dir . '/', trim( $output[0] ) );
-
-			// Both `sys_temp_dir` and `upload_tmp_dir' unset.
-
-			$cmd = "WP_CLI_PHP_ARGS='-dsys_temp_dir=0 -dupload_tmp_dir=0' bin/wp eval 'echo WP_CLI\\Utils\\get_temp_dir();' --skip-wordpress --quiet 2>&1";
-			$output = array();
-			exec( $cmd, $output );
-			$this->assertTrue( 1 === count( $output ) );
-			$this->assertSame( '/tmp/', trim( $output[0] ) );
+			$output = trim( implode( "\n", $output ) );
+			$this->assertTrue( '/' === substr( $output, -1 ) );
 		}
 	}
 
@@ -444,33 +450,33 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 	public function testRunMysqlCommandProcDisabled() {
 		$err_msg = 'Error: Cannot do \'run_mysql_command\': The PHP functions `proc_open()` and/or `proc_close()` are disabled';
 
-		$cmd = "WP_CLI_PHP_ARGS='-ddisable_functions=proc_open' bin/wp eval 'WP_CLI\\Utils\\run_mysql_command( null, array() );' --skip-wordpress 2>&1";
+		$cmd = 'php -ddisable_functions=proc_open php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI\\Utils\\run_mysql_command( null, array() );' ) . ' 2>&1';
 		$output = array();
 		exec( $cmd, $output );
-		$this->assertTrue( 1 === count( $output ) );
-		$this->assertTrue( false !== strpos( trim( $output[0] ), $err_msg ) );
+		$output = trim( implode( "\n", $output ) );
+		$this->assertTrue( false !== strpos( $output, $err_msg ) );
 
-		$cmd = "WP_CLI_PHP_ARGS='-ddisable_functions=proc_close' bin/wp eval 'WP_CLI\\Utils\\run_mysql_command( null, array() );' --skip-wordpress 2>&1";
+		$cmd = 'php -ddisable_functions=proc_close php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI\\Utils\\run_mysql_command( null, array() );' ) . ' 2>&1';
 		$output = array();
 		exec( $cmd, $output );
-		$this->assertTrue( 1 === count( $output ) );
-		$this->assertTrue( false !== strpos( trim( $output[0] ), $err_msg ) );
+		$output = trim( implode( "\n", $output ) );
+		$this->assertTrue( false !== strpos( $output, $err_msg ) );
 	}
 
 	public function testLaunchEditorForInputProcDisabled() {
 		$err_msg = 'Error: Cannot do \'launch_editor_for_input\': The PHP functions `proc_open()` and/or `proc_close()` are disabled';
 
-		$cmd = "WP_CLI_PHP_ARGS='-ddisable_functions=proc_open' bin/wp eval 'WP_CLI\\Utils\\launch_editor_for_input( null, null );' --skip-wordpress 2>&1";
+		$cmd = 'php -ddisable_functions=proc_open php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI\\Utils\\launch_editor_for_input( null, null );' ) . ' 2>&1';
 		$output = array();
 		exec( $cmd, $output );
-		$this->assertTrue( 1 === count( $output ) );
-		$this->assertTrue( false !== strpos( trim( $output[0] ), $err_msg ) );
+		$output = trim( implode( "\n", $output ) );
+		$this->assertTrue( false !== strpos( $output, $err_msg ) );
 
-		$cmd = "WP_CLI_PHP_ARGS='-ddisable_functions=proc_close' bin/wp eval 'WP_CLI\\Utils\\launch_editor_for_input( null, null );' --skip-wordpress 2>&1";
+		$cmd = 'php -ddisable_functions=proc_close php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI\\Utils\\launch_editor_for_input( null, null );' ) . ' 2>&1';
 		$output = array();
 		exec( $cmd, $output );
-		$this->assertTrue( 1 === count( $output ) );
-		$this->assertTrue( false !== strpos( trim( $output[0] ), $err_msg ) );
+		$output = trim( implode( "\n", $output ) );
+		$this->assertTrue( false !== strpos( $output, $err_msg ) );
 	}
 
 	/**
@@ -501,7 +507,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			array( 'check', 'checked' ),
 			array( 'crop', 'cropped' ),
 			array( 'fix', 'fixed' ), // One vowel + final "x" excluded.
-			array( 'hurrah', 'hurrahed' ), // One vowel + final "h" excluded.
+			array( 'ah', 'ahed' ), // One vowel + final "h" excluded.
 			array( 'show', 'showed' ), // One vowel + final "w" excluded.
 			array( 'ski', 'skied' ),
 			array( 'slay', 'slayed' ), // One vowel + final "y" excluded (nearly all irregular anyway).
@@ -624,5 +630,41 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 
 		putenv( false === $env_php_used ? 'WP_CLI_PHP_USED' : "WP_CLI_PHP_USED=$env_php_used" );
 		putenv( false === $env_php ? 'WP_CLI_PHP' : "WP_CLI_PHP=$env_php" );
+	}
+
+	/**
+	 * @dataProvider dataProcOpenCompatWinEnv
+	 */
+	public function testProcOpenCompatWinEnv( $cmd, $env, $expected_cmd, $expected_env ) {
+		$env_is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
+
+		putenv( 'WP_CLI_TEST_IS_WINDOWS=1' );
+
+		$cmd = Utils\_proc_open_compat_win_env( $cmd, $env );
+		$this->assertSame( $expected_cmd, $cmd );
+		$this->assertSame( $expected_env, $env );
+
+		putenv( false === $env_is_windows ? 'WP_CLI_TEST_IS_WINDOWS' : "WP_CLI_TEST_IS_WINDOWS=$env_is_windows" );
+	}
+
+	function dataProcOpenCompatWinEnv() {
+		return array(
+			array( 'echo', array(), 'echo', array() ),
+			array( 'ENV=blah echo', array(), 'echo', array( 'ENV' => 'blah' ) ),
+			array( 'ENV="blah blah" echo', array(), 'echo', array( 'ENV' => 'blah blah' ) ),
+			array( 'ENV_1="blah1 blah1" ENV_2="blah2" ENV_3=blah3 echo', array(), 'echo', array( 'ENV_1' => 'blah1 blah1', 'ENV_2' => 'blah2', 'ENV_3' => 'blah3' ) ),
+			array( 'ENV= echo', array(), 'echo', array( 'ENV' => '' ) ),
+			array( 'ENV=0 echo', array(), 'echo', array( 'ENV' => '0' ) ),
+
+			// With `$env` set.
+			array( 'echo', array( 'ENV' => 'in' ), 'echo', array( 'ENV' => 'in' ) ),
+			array( 'ENV=blah echo', array( 'ENV_1' => 'in1', 'ENV_2' => 'in2' ), 'echo', array( 'ENV_1' => 'in1', 'ENV_2' => 'in2', 'ENV' => 'blah' ) ),
+			array( 'ENV="blah blah" echo', array( 'ENV' => 'in' ), 'echo', array( 'ENV' => 'blah blah' ) ),
+
+			// Special cases.
+			array( '1=1 echo', array(), '1=1 echo', array() ), // Must begin with alphabetic or underscore.
+			array( '_eNv=1 echo', array(), 'echo', array( '_eNv' => '1' ) ), // Mixed-case and beginning with underscore allowed.
+			array( 'ENV=\'blah blah\' echo', array(), 'blah\' echo', array( 'ENV' => '\'blah' ) ), // Unix escaping not supported, ie treated literally.
+		);
 	}
 }

--- a/tests/test-wp-cli.php
+++ b/tests/test-wp-cli.php
@@ -5,33 +5,33 @@ class WP_CLI_Test extends PHPUnit_Framework_TestCase {
 	public function testLaunchProcDisabled() {
 		$err_msg = 'Error: Cannot do \'launch\': The PHP functions `proc_open()` and/or `proc_close()` are disabled';
 
-		$cmd = "WP_CLI_PHP_ARGS='-ddisable_functions=proc_open' bin/wp eval 'WP_CLI::launch( null );' --skip-wordpress 2>&1";
+		$cmd = 'php -ddisable_functions=proc_open php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI::launch( null );' ) . ' 2>&1';
 		$output = array();
 		exec( $cmd, $output );
-		$this->assertTrue( 1 === count( $output ) );
-		$this->assertTrue( false !== strpos( trim( $output[0] ), $err_msg ) );
+		$output = trim( implode( "\n", $output ) );
+		$this->assertTrue( false !== strpos( $output, $err_msg ) );
 
-		$cmd = "WP_CLI_PHP_ARGS='-ddisable_functions=proc_close' bin/wp eval 'WP_CLI::launch( null );' --skip-wordpress 2>&1";
+		$cmd = 'php -ddisable_functions=proc_close php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI::launch( null );' ) . ' 2>&1';
 		$output = array();
 		exec( $cmd, $output );
-		$this->assertTrue( 1 === count( $output ) );
-		$this->assertTrue( false !== strpos( trim( $output[0] ), $err_msg ) );
+		$output = trim( implode( "\n", $output ) );
+		$this->assertTrue( false !== strpos( $output, $err_msg ) );
 	}
 
 	public function testRuncommandLaunchProcDisabled() {
 		$err_msg = 'Error: Cannot do \'launch option\': The PHP functions `proc_open()` and/or `proc_close()` are disabled';
 
-		$cmd = "WP_CLI_PHP_ARGS='-ddisable_functions=proc_open' bin/wp eval 'WP_CLI::runcommand( null, array( \"launch\" => 1 ) );' --skip-wordpress 2>&1";
+		$cmd = 'php -ddisable_functions=proc_open php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI::runcommand( null, array( \'launch\' => 1 ) );' ) . ' 2>&1';
 		$output = array();
 		exec( $cmd, $output );
-		$this->assertTrue( 1 === count( $output ) );
-		$this->assertTrue( false !== strpos( trim( $output[0] ), $err_msg ) );
+		$output = trim( implode( "\n", $output ) );
+		$this->assertTrue( false !== strpos( $output, $err_msg ) );
 
-		$cmd = "WP_CLI_PHP_ARGS='-ddisable_functions=proc_close' bin/wp eval 'WP_CLI::runcommand( null, array( \"launch\" => 1 ) );' --skip-wordpress 2>&1";
+		$cmd = 'php -ddisable_functions=proc_close php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI::runcommand( null, array( \'launch\' => 1 ) );' ) . ' 2>&1';
 		$output = array();
 		exec( $cmd, $output );
-		$this->assertTrue( 1 === count( $output ) );
-		$this->assertTrue( false !== strpos( trim( $output[0] ), $err_msg ) );
+		$output = trim( implode( "\n", $output ) );
+		$this->assertTrue( false !== strpos( $output, $err_msg ) );
 	}
 
 	public function testGetPHPBinary() {


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/4566

Adds `Utils\proc_open_compat()` (and companion private `Utils\_proc_open_compat_win_env()`) function for Windows compatible `proc_open()`, and uses it instead of `proc_open()` throughout (there's another instance in `server-command`). Also escapes all instances of`get_php_binary()`.

Changes `DocParser\get_arg_or_param_args()` to use `"\n"` instead of `PHP_EOL` as it's been subbed already.

Also simplifies `Utils\get_temp_dir()` to just use `sys_get_temp_dir()` as it always returns some non-empty value.

Makes various Windows-compat changes to the `phpunit` tests, in particular not using `WP_CLI_PHP_ARGS`  and `bin/wp` but calling `php\boot-fs.php` directly as `bin/wp.bat` doesn't have `WP_CLI_PHP_ARGS` and the invocation was *nix-specific anyway.

Also makes `FeatureContext\get_process_env_variables()` more Windows-compat by setting the path separator for the `PATH` appropriately.