### PR TITLE
Only provide dictionary-based suggestions if they produce valid options.

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -1129,8 +1129,7 @@ function get_suggestion( $target, array $options, $threshold = 2 ) {
 		'v' => 'version',
 	);
 
-	if ( array_key_exists( $target, $suggestion_map )
-	     && in_array( $suggestion_map[ $target ], $options, true ) ) {
+	if ( array_key_exists( $target, $suggestion_map ) && in_array( $suggestion_map[ $target ], $options, true ) ) {
 		return $suggestion_map[ $target ];
 	}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -1129,7 +1129,8 @@ function get_suggestion( $target, array $options, $threshold = 2 ) {
 		'v' => 'version',
 	);
 
-	if ( array_key_exists( $target, $suggestion_map ) ) {
+	if ( array_key_exists( $target, $suggestion_map )
+	     && in_array( $suggestion_map[ $target ], $options, true ) ) {
 		return $suggestion_map[ $target ];
 	}
 


### PR DESCRIPTION
As there is some overlap between parameters across commands, we need to make sure the dictionary of hard-coded suggestions doesn't get blindly applied to commands it wasn't meant for.

Fixes #4578