### PR TITLE
Add less-than-wp tag to behat-tags.php.

### DIFF
--- a/ci/behat-tags.php
+++ b/ci/behat-tags.php
@@ -37,6 +37,7 @@ $wp_version_reqs = array();
 if ( ! in_array( getenv( 'WP_VERSION' ), array( 'latest', 'nightly', 'trunk' ), true ) ) {
 	$wp_version_reqs = version_tags( 'require-wp', getenv( 'WP_VERSION' ), '<' );
 }
+$wp_version_reqs = array_merge( $wp_version_reqs, version_tags( 'less-than-wp', getenv( 'WP_VERSION' ), '>' ) );
 
 $skip_tags = array_merge(
 	$wp_version_reqs,

--- a/ci/behat-tags.php
+++ b/ci/behat-tags.php
@@ -38,17 +38,17 @@ $wp_version_reqs = array();
 if ( $wp_version && ! in_array( $wp_version, array( 'latest', 'nightly', 'trunk' ), true ) ) {
 	$wp_version_reqs = array_merge(
 		version_tags( 'require-wp', $wp_version, '<' ),
-		version_tags( 'less-than-wp', $wp_version, '>' )
+		version_tags( 'less-than-wp', $wp_version, '>=' )
 	);
 } else {
 	// But make sure @less-than-wp tags always exist for those special cases. (Note: @less-than-wp-latest etc won't work and shouldn't be used).
-	$wp_version_reqs = array_merge( $wp_version_reqs, version_tags( 'less-than-wp', '9999', '>' ) );
+	$wp_version_reqs = array_merge( $wp_version_reqs, version_tags( 'less-than-wp', '9999', '>=' ) );
 }
 
 $skip_tags = array_merge(
 	$wp_version_reqs,
 	version_tags( 'require-php', PHP_VERSION, '<' ),
-	version_tags( 'less-than-php', PHP_VERSION, '>' )
+	version_tags( 'less-than-php', PHP_VERSION, '>=' ) // Note: this was '>' prior to WP-CLI 1.5.0 but the change is unlikely to cause BC issues as usually compared against major.minor only.
 );
 
 # Skip Github API tests if `GITHUB_TOKEN` not available because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612

--- a/ci/behat-tags.php
+++ b/ci/behat-tags.php
@@ -31,13 +31,19 @@ function version_tags( $prefix, $current, $operator = '<' ) {
 	return $skip_tags;
 }
 
+$wp_version = getenv( 'WP_VERSION' );
 $wp_version_reqs = array();
-// Only apply @require-wp tags when WP_VERSION isn't 'latest' or 'nightly'
-// 'latest' and 'nightly' are expected to work with all features
-if ( ! in_array( getenv( 'WP_VERSION' ), array( 'latest', 'nightly', 'trunk' ), true ) ) {
-	$wp_version_reqs = version_tags( 'require-wp', getenv( 'WP_VERSION' ), '<' );
+// Only apply @require-wp tags when WP_VERSION isn't 'latest', 'nightly' or 'trunk'.
+// 'latest', 'nightly' and 'trunk' are expected to work with all features.
+if ( $wp_version && ! in_array( $wp_version, array( 'latest', 'nightly', 'trunk' ), true ) ) {
+	$wp_version_reqs = array_merge(
+		version_tags( 'require-wp', $wp_version, '<' ),
+		version_tags( 'less-than-wp', $wp_version, '>' )
+	);
+} else {
+	// But make sure @less-than-wp tags always exist for those special cases. (Note: @less-than-wp-latest etc won't work and shouldn't be used).
+	$wp_version_reqs = array_merge( $wp_version_reqs, version_tags( 'less-than-wp', '9999', '>' ) );
 }
-$wp_version_reqs = array_merge( $wp_version_reqs, version_tags( 'less-than-wp', getenv( 'WP_VERSION' ), '>' ) );
 
 $skip_tags = array_merge(
 	$wp_version_reqs,

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -161,7 +161,7 @@ Feature: `wp cli` tasks
     And STDERR should be empty
     And the return code should be 0
 
-  @github-api @less-than-php-7
+  @github-api
   Scenario: Install WP-CLI stable
     Given an empty directory
     And a new Phar with version "0.14.0"

--- a/tests/test-behat-tags.php
+++ b/tests/test-behat-tags.php
@@ -31,6 +31,10 @@ class BehatTagsTest extends PHPUnit_Framework_TestCase {
 	 * @dataProvider data_behat_tags_wp_version
 	 */
 	function test_behat_tags_wp_version( $env, $expected ) {
+		$env_github_token = getenv( 'GITHUB_TOKEN' );
+
+		putenv( 'GITHUB_TOKEN' );
+
 		$behat_tags = dirname( __DIR__ ) . '/ci/behat-tags.php';
 
 		$contents = '@require-wp-4.6 @require-wp-4.8 @require-wp-4.9 @less-than-wp-4.6 @less-than-wp-4.8 @less-than-wp-4.9';
@@ -38,6 +42,8 @@ class BehatTagsTest extends PHPUnit_Framework_TestCase {
 
 		$output = exec( "cd {$this->temp_dir}; $env php $behat_tags" );
 		$this->assertSame( $expected, $output );
+
+		putenv( false === $env_github_token ? 'GITHUB_TOKEN' : "GITHUB_TOKEN=$env_github_token" );
 	}
 
 	function data_behat_tags_wp_version() {

--- a/tests/test-behat-tags.php
+++ b/tests/test-behat-tags.php
@@ -28,9 +28,9 @@ class BehatTagsTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider data_behat_tags_wp_version
+	 * @dataProvider data_behat_tags_wp_version_github_token
 	 */
-	function test_behat_tags_wp_version( $env, $expected ) {
+	function test_behat_tags_wp_version_github_token( $env, $expected ) {
 		$env_wp_version = getenv( 'WP_VERSION' );
 		$env_github_token = getenv( 'GITHUB_TOKEN' );
 
@@ -43,25 +43,95 @@ class BehatTagsTest extends PHPUnit_Framework_TestCase {
 		file_put_contents( $this->temp_dir . '/features/wp_version.feature', $contents );
 
 		$output = exec( "cd {$this->temp_dir}; $env php $behat_tags" );
-		$this->assertSame( $expected, $output );
+		$this->assertSame( '--tags=' . $expected . '&&~@broken', $output );
 
 		putenv( false === $env_wp_version ? 'WP_VERSION' : "WP_VERSION=$env_wp_version" );
 		putenv( false === $env_github_token ? 'GITHUB_TOKEN' : "GITHUB_TOKEN=$env_github_token" );
 	}
 
-	function data_behat_tags_wp_version() {
+	function data_behat_tags_wp_version_github_token() {
 		return array(
-			array( 'WP_VERSION=4.5', '--tags=~@require-wp-4.6&&~@require-wp-4.8&&~@require-wp-4.9&&~@github-api&&~@broken' ),
-			array( 'WP_VERSION=4.6', '--tags=~@require-wp-4.8&&~@require-wp-4.9&&~@github-api&&~@broken' ),
-			array( 'WP_VERSION=4.7', '--tags=~@require-wp-4.8&&~@require-wp-4.9&&~@less-than-wp-4.6&&~@github-api&&~@broken' ),
-			array( 'WP_VERSION=4.8', '--tags=~@require-wp-4.9&&~@less-than-wp-4.6&&~@github-api&&~@broken' ),
-			array( 'WP_VERSION=4.9', '--tags=~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@github-api&&~@broken' ),
-			array( 'WP_VERSION=5.0', '--tags=~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api&&~@broken' ),
-			array( 'WP_VERSION=latest', '--tags=~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api&&~@broken' ),
-			array( 'WP_VERSION=trunk', '--tags=~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api&&~@broken' ),
-			array( 'WP_VERSION=nightly', '--tags=~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api&&~@broken' ),
-			array( '', '--tags=~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api&&~@broken' ),
-			array( 'GITHUB_TOKEN=blah', '--tags=~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@broken' ),
+			array( 'WP_VERSION=4.5', '~@require-wp-4.6&&~@require-wp-4.8&&~@require-wp-4.9&&~@github-api' ),
+			array( 'WP_VERSION=4.6', '~@require-wp-4.8&&~@require-wp-4.9&&~@less-than-wp-4.6&&~@github-api' ),
+			array( 'WP_VERSION=4.7', '~@require-wp-4.8&&~@require-wp-4.9&&~@less-than-wp-4.6&&~@github-api' ),
+			array( 'WP_VERSION=4.8', '~@require-wp-4.9&&~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@github-api' ),
+			array( 'WP_VERSION=4.9', '~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api' ),
+			array( 'WP_VERSION=5.0', '~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api' ),
+			array( 'WP_VERSION=latest', '~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api' ),
+			array( 'WP_VERSION=trunk', '~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api' ),
+			array( 'WP_VERSION=nightly', '~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api' ),
+			array( '', '~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api' ),
+			array( 'GITHUB_TOKEN=blah', '~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9' ),
 		);
+	}
+
+	function test_behat_tags_php_version() {
+		$env_github_token = getenv( 'GITHUB_TOKEN' );
+
+		putenv( 'GITHUB_TOKEN' );
+
+		$behat_tags = dirname( __DIR__ ) . '/ci/behat-tags.php';
+
+		$php_version = substr( PHP_VERSION, 0, 3 );
+		$contents = $expected = '';
+
+		if ( '5.3' === $php_version ) {
+			$contents = '@require-php-5.2 @require-php-5.3 @require-php-5.4 @less-than-php-5.2 @less-than-php-5.3 @less-than-php-5.4';
+			$expected = '~@require-php-5.4&&~@less-than-php-5.2&&~@less-than-php-5.3';
+		} elseif ( '5.4' === $php_version ) {
+			$contents = '@require-php-5.3 @require-php-5.4 @require-php-5.5 @less-than-php-5.3 @less-than-php-5.4 @less-than-php-5.5';
+			$expected = '~@require-php-5.5&&~@less-than-php-5.3&&~@less-than-php-5.4';
+		} elseif ( '5.5' === $php_version ) {
+			$contents = '@require-php-5.4 @require-php-5.5 @require-php-5.6 @less-than-php-5.4 @less-than-php-5.5 @less-than-php-5.6';
+			$expected = '~@require-php-5.6&&~@less-than-php-5.4&&~@less-than-php-5.5';
+		} elseif ( '5.6' === $php_version ) {
+			$contents = '@require-php-5.5 @require-php-5.6 @require-php-7.0 @less-than-php-5.5 @less-than-php-5.6 @less-than-php-7.0';
+			$expected = '~@require-php-7.0&&~@less-than-php-5.5&&~@less-than-php-5.6';
+		} elseif ( '7.0' === $php_version ) {
+			$contents = '@require-php-5.6 @require-php-7.0 @require-php-7.1 @less-than-php-5.6 @less-than-php-7.0 @less-than-php-7.1';
+			$expected = '~@require-php-7.1&&~@less-than-php-5.6&&~@less-than-php-7.0';
+		} elseif ( '7.1' === $php_version ) {
+			$contents = '@require-php-7.0 @require-php-7.1 @require-php-7.2 @less-than-php-7.0 @less-than-php-7.1 @less-than-php-7.2';
+			$expected = '~@require-php-7.2&&~@less-than-php-7.0&&~@less-than-php-7.1';
+		} elseif ( '7.2' === $php_version ) {
+			$contents = '@require-php-7.1 @require-php-7.2 @require-php-7.3 @less-than-php-7.1 @less-than-php-7.2 @less-than-php-7.3';
+			$expected = '~@require-php-7.3&&~@less-than-php-7.1&&~@less-than-php-7.2';
+		} else {
+			$this->markTestSkipped( "No test for PHP_VERSION $php_version." );
+		}
+
+		file_put_contents( $this->temp_dir . '/features/php_version.feature', $contents );
+
+		$output = exec( "cd {$this->temp_dir}; php $behat_tags" );
+		$this->assertSame( '--tags=' . $expected . '&&~@github-api&&~@broken', $output );
+
+		putenv( false === $env_github_token ? 'GITHUB_TOKEN' : "GITHUB_TOKEN=$env_github_token" );
+	}
+
+	function test_behat_tags_extension() {
+		$env_github_token = getenv( 'GITHUB_TOKEN' );
+
+		putenv( 'GITHUB_TOKEN' );
+
+		$behat_tags = dirname( __DIR__ ) . '/ci/behat-tags.php';
+
+		file_put_contents( $this->temp_dir . '/features/extension.feature', '@require-extension-imagick @require-extension-intl' );
+
+		$expecteds = array();
+		if ( ! extension_loaded( 'imagick' ) ) {
+			$expecteds[] = '~@require-extension-imagick';
+		}
+		if ( ! extension_loaded( 'intl' ) ) {
+			$expecteds[] = '~@require-extension-intl';
+		}
+		$expected = '--tags=' . implode( '&&', array_merge( array( '~@github-api', '~@broken' ), $expecteds ) );
+		$output = exec( "cd {$this->temp_dir}; php $behat_tags" );
+		$this->assertSame( $expected, $output );
+
+		$expected = '--tags=' . implode( '&&', array( '~@github-api', '~@broken', '~@require-extension-imagick', '~@require-extension-intl' ) );
+		$output = exec( "cd {$this->temp_dir}; php -n $behat_tags" ); // Disable all extensions.
+		$this->assertSame( $expected, $output );
+
+		putenv( false === $env_github_token ? 'GITHUB_TOKEN' : "GITHUB_TOKEN=$env_github_token" );
 	}
 }

--- a/tests/test-behat-tags.php
+++ b/tests/test-behat-tags.php
@@ -1,0 +1,58 @@
+<?php
+
+use WP_CLI\Utils;
+
+class BehatTagsTest extends PHPUnit_Framework_TestCase {
+
+	var $temp_dir;
+
+	function setUp() {
+		parent::setUp();
+
+		$this->temp_dir = Utils\get_temp_dir() . uniqid( 'wp-cli-test-behat-tags-', true );
+		mkdir( $this->temp_dir );
+		mkdir( $this->temp_dir . '/features' );
+	}
+
+	function tearDown() {
+
+		if ( $this->temp_dir && file_exists( $this->temp_dir ) ) {
+			foreach ( glob( $this->temp_dir . '/features/*' ) as $feature_file ) {
+				unlink( $feature_file );
+			}
+			rmdir( $this->temp_dir . '/features' );
+			rmdir( $this->temp_dir );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider data_behat_tags_wp_version
+	 */
+	function test_behat_tags_wp_version( $env, $expected ) {
+		$behat_tags = dirname( __DIR__ ) . '/ci/behat-tags.php';
+
+		$contents = '@require-wp-4.6 @require-wp-4.8 @require-wp-4.9 @less-than-wp-4.6 @less-than-wp-4.8 @less-than-wp-4.9';
+		file_put_contents( $this->temp_dir . '/features/wp_version.feature', $contents );
+
+		$output = exec( "cd {$this->temp_dir}; $env php $behat_tags" );
+		$this->assertSame( $expected, $output );
+	}
+
+	function data_behat_tags_wp_version() {
+		return array(
+			array( 'WP_VERSION=4.5', '--tags=~@require-wp-4.6&&~@require-wp-4.8&&~@require-wp-4.9&&~@github-api&&~@broken' ),
+			array( 'WP_VERSION=4.6', '--tags=~@require-wp-4.8&&~@require-wp-4.9&&~@github-api&&~@broken' ),
+			array( 'WP_VERSION=4.7', '--tags=~@require-wp-4.8&&~@require-wp-4.9&&~@less-than-wp-4.6&&~@github-api&&~@broken' ),
+			array( 'WP_VERSION=4.8', '--tags=~@require-wp-4.9&&~@less-than-wp-4.6&&~@github-api&&~@broken' ),
+			array( 'WP_VERSION=4.9', '--tags=~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@github-api&&~@broken' ),
+			array( 'WP_VERSION=5.0', '--tags=~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api&&~@broken' ),
+			array( 'WP_VERSION=latest', '--tags=~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api&&~@broken' ),
+			array( 'WP_VERSION=trunk', '--tags=~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api&&~@broken' ),
+			array( 'WP_VERSION=nightly', '--tags=~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api&&~@broken' ),
+			array( '', '--tags=~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@github-api&&~@broken' ),
+			array( 'GITHUB_TOKEN=blah', '--tags=~@less-than-wp-4.6&&~@less-than-wp-4.8&&~@less-than-wp-4.9&&~@broken' ),
+		);
+	}
+}

--- a/tests/test-behat-tags.php
+++ b/tests/test-behat-tags.php
@@ -31,8 +31,10 @@ class BehatTagsTest extends PHPUnit_Framework_TestCase {
 	 * @dataProvider data_behat_tags_wp_version
 	 */
 	function test_behat_tags_wp_version( $env, $expected ) {
+		$env_wp_version = getenv( 'WP_VERSION' );
 		$env_github_token = getenv( 'GITHUB_TOKEN' );
 
+		putenv( 'WP_VERSION' );
 		putenv( 'GITHUB_TOKEN' );
 
 		$behat_tags = dirname( __DIR__ ) . '/ci/behat-tags.php';
@@ -43,6 +45,7 @@ class BehatTagsTest extends PHPUnit_Framework_TestCase {
 		$output = exec( "cd {$this->temp_dir}; $env php $behat_tags" );
 		$this->assertSame( $expected, $output );
 
+		putenv( false === $env_wp_version ? 'WP_VERSION' : "WP_VERSION=$env_wp_version" );
 		putenv( false === $env_github_token ? 'GITHUB_TOKEN' : "GITHUB_TOKEN=$env_github_token" );
 	}
 

--- a/tests/test-behat-tags.php
+++ b/tests/test-behat-tags.php
@@ -115,7 +115,7 @@ class BehatTagsTest extends PHPUnit_Framework_TestCase {
 
 		$behat_tags = dirname( __DIR__ ) . '/ci/behat-tags.php';
 
-		file_put_contents( $this->temp_dir . '/features/extension.feature', '@require-extension-imagick @require-extension-intl' );
+		file_put_contents( $this->temp_dir . '/features/extension.feature', '@require-extension-imagick @require-extension-curl' );
 
 		$expecteds = array();
 		if ( ! extension_loaded( 'imagick' ) ) {
@@ -128,7 +128,7 @@ class BehatTagsTest extends PHPUnit_Framework_TestCase {
 		$output = exec( "cd {$this->temp_dir}; php $behat_tags" );
 		$this->assertSame( $expected, $output );
 
-		$expected = '--tags=' . implode( '&&', array( '~@github-api', '~@broken', '~@require-extension-imagick', '~@require-extension-intl' ) );
+		$expected = '--tags=' . implode( '&&', array( '~@github-api', '~@broken', '~@require-extension-imagick', '~@require-extension-curl' ) );
 		$output = exec( "cd {$this->temp_dir}; php -n $behat_tags" ); // Disable all extensions.
 		$this->assertSame( $expected, $output );
 

--- a/tests/test-behat-tags.php
+++ b/tests/test-behat-tags.php
@@ -128,10 +128,6 @@ class BehatTagsTest extends PHPUnit_Framework_TestCase {
 		$output = exec( "cd {$this->temp_dir}; php $behat_tags" );
 		$this->assertSame( $expected, $output );
 
-		$expected = '--tags=' . implode( '&&', array( '~@github-api', '~@broken', '~@require-extension-imagick', '~@require-extension-curl' ) );
-		$output = exec( "cd {$this->temp_dir}; php -n $behat_tags" ); // Disable all extensions.
-		$this->assertSame( $expected, $output );
-
 		putenv( false === $env_github_token ? 'GITHUB_TOKEN' : "GITHUB_TOKEN=$env_github_token" );
 	}
 }


### PR DESCRIPTION
See https://github.com/wp-cli/embed-command/pull/29#issuecomment-355042624

Adds `@less-than-wp` tag, analog of `@less-than-php`, to `behat-tags.php`. Useful for testing old WP behaviour.