### PR TITLE
Add processing of {INVOKE_WP_CLI_WITH_PHP_ARGS-} vars to FeatureContext.

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -392,7 +392,7 @@ Feature: Create shortcuts to specific WordPress installs
         - @bar
       """
 
-    When I try `WP_CLI_PHP_ARGS='-ddisable_functions=<func>' {SRC_DIR}/bin/wp @foobar core is-installed`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--ddisable_functions=<func>} @foobar core is-installed`
     Then STDERR should contain:
       """
       Error: Cannot do 'group alias': The PHP functions `proc_open()` and/or `proc_close()` are disabled

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -331,13 +331,13 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 	/**
 	 * Replace standard {VARIABLE_NAME} variables and the special {INVOKE_WP_CLI_WITH_PHP_ARGS-args} and {WP_VERSION-version-latest} variables.
-	 * Note that standard variable names can only contain uppercase letters and underscores (no numbers).
+	 * Note that standard variable names can only contain uppercase letters, digits and underscores and cannot begin with a digit.
 	 */
 	public function replace_variables( $str ) {
 		if ( false !== strpos( $str, '{INVOKE_WP_CLI_WITH_PHP_ARGS-' ) ) {
 			$str = $this->replace_invoke_wp_cli_with_php_args( $str );
 		}
-		$str = preg_replace_callback( '/\{([A-Z_]+)\}/', array( $this, 'replace_var' ), $str );
+		$str = preg_replace_callback( '/\{([A-Z_][A-Z_0-9]*)\}/', array( $this, 'replace_var' ), $str );
 		if ( false !== strpos( $str, '{WP_VERSION-' ) ) {
 			$str = $this->replace_wp_versions( $str );
 		}

--- a/features/help.feature
+++ b/features/help.feature
@@ -1002,3 +1002,17 @@ Feature: Get help about WP-CLI commands
         [1] https://wordpress.org/
         [2] http://wp-cli.org/
       """
+
+  Scenario Outline: Check that proc_open() and proc_close() aren't disabled for help pager
+    Given an empty directory
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--ddisable_functions=<func>} help --debug`
+    Then STDERR should contain:
+      """
+      Warning: check_proc_available() failed in pass_through_pager().
+      """
+    And the return code should be 0
+
+    Examples:
+      | func       |
+      | proc_open  |
+      | proc_close |

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -287,3 +287,18 @@ Feature: Run a WP-CLI command
     | flag        |
     | --no-launch |
     | --launch    |
+
+  Scenario Outline: Check that proc_open() and proc_close() aren't disabled for launch
+    Given a WP install
+
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--ddisable_functions=<func>} --launch run 'option get home'`
+    Then STDERR should contain:
+      """
+      Error: Cannot do 'launch option': The PHP functions `proc_open()` and/or `proc_close()` are disabled
+      """
+    And the return code should be 1
+
+    Examples:
+      | func       |
+      | proc_open  |
+      | proc_close |

--- a/features/steps.feature
+++ b/features/steps.feature
@@ -1,0 +1,59 @@
+Feature: Make sure "Given", "When", "Then" steps work as expected
+
+  Scenario: Variable names can only contain uppercase letters, digits and underscores and cannot begin with a digit.
+
+    When I run `echo value`
+    And save STDOUT as {VARIABLE_NAME}
+    And save STDOUT as {V}
+    And save STDOUT as {_VARIABLE_NAME_STARTING_WITH_UNDERSCORE}
+    And save STDOUT as {_}
+    And save STDOUT as {VARIABLE_NAME_WITH_DIGIT_2}
+    And save STDOUT as {V2}
+    And save STDOUT as {_2}
+    And save STDOUT as {2_VARIABLE_NAME_STARTING_WITH_DIGIT}
+    And save STDOUT as {2}
+    And save STDOUT as {VARIABLE_NAME_WITH_lowercase}
+    And save STDOUT as {v}
+    # Note this would give behat "undefined step" message as "save" step uses "\w+"
+    #And save STDOUT as {VARIABLE_NAME_WITH_PERCENT_%}
+
+    When I run `echo {VARIABLE_NAME}`
+    Then STDOUT should match /^value$/
+    And STDOUT should be:
+    """
+    value
+    """
+
+    When I run `echo {V}`
+    Then STDOUT should match /^value$/
+
+    When I run `echo {_VARIABLE_NAME_STARTING_WITH_UNDERSCORE}`
+    Then STDOUT should match /^value$/
+
+    When I run `echo {_}`
+    Then STDOUT should match /^value$/
+
+    When I run `echo {VARIABLE_NAME_WITH_DIGIT_2}`
+    Then STDOUT should match /^value$/
+
+    When I run `echo {V2}`
+    Then STDOUT should match /^value$/
+
+    When I run `echo {_2}`
+    Then STDOUT should match /^value$/
+
+    When I run `echo {2_VARIABLE_NAME_STARTING_WITH_DIGIT}`
+    Then STDOUT should match /^\{2_VARIABLE_NAME_STARTING_WITH_DIGIT}$/
+    And STDOUT should contain:
+    """
+    {
+    """
+
+    When I run `echo {2}`
+    Then STDOUT should match /^\{2}$/
+
+    When I run `echo {VARIABLE_NAME_WITH_lowercase}`
+    Then STDOUT should match /^\{VARIABLE_NAME_WITH_lowercase}$/
+
+    When I run `echo {v}`
+    Then STDOUT should match /^\{v}$/

--- a/tests/test-help.php
+++ b/tests/test-help.php
@@ -8,22 +8,6 @@ require_once dirname( __DIR__ ) . '/php/commands/help.php';
 
 class HelpTest extends PHPUnit_Framework_TestCase {
 
-	public function testPassThroughPagerProcDisabled() {
-		$err_msg = 'Warning: check_proc_available() failed in pass_through_pager().';
-
-		$cmd = 'php -ddisable_functions=proc_open php/boot-fs.php help --debug 2>&1';
-		$output = array();
-		exec( $cmd, $output );
-		$output = trim( implode( "\n", $output ) );
-		$this->assertTrue( false !== strpos( $output, $err_msg ) );
-
-		$cmd = 'php -ddisable_functions=proc_close php/boot-fs.php help --debug 2>&1';
-		$output = array();
-		exec( $cmd, $output );
-		$output = trim( implode( "\n", $output ) );
-		$this->assertTrue( false !== strpos( $output, $err_msg ) );
-	}
-
 	public function test_parse_reference_links() {
 		$test_class = new ReflectionClass( 'Help_Command' );
 		$method = $test_class->getMethod( 'parse_reference_links' );

--- a/tests/test-wp-cli.php
+++ b/tests/test-wp-cli.php
@@ -18,22 +18,6 @@ class WP_CLI_Test extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( false !== strpos( $output, $err_msg ) );
 	}
 
-	public function testRuncommandLaunchProcDisabled() {
-		$err_msg = 'Error: Cannot do \'launch option\': The PHP functions `proc_open()` and/or `proc_close()` are disabled';
-
-		$cmd = 'php -ddisable_functions=proc_open php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI::runcommand( null, array( \'launch\' => 1 ) );' ) . ' 2>&1';
-		$output = array();
-		exec( $cmd, $output );
-		$output = trim( implode( "\n", $output ) );
-		$this->assertTrue( false !== strpos( $output, $err_msg ) );
-
-		$cmd = 'php -ddisable_functions=proc_close php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI::runcommand( null, array( \'launch\' => 1 ) );' ) . ' 2>&1';
-		$output = array();
-		exec( $cmd, $output );
-		$output = trim( implode( "\n", $output ) );
-		$this->assertTrue( false !== strpos( $output, $err_msg ) );
-	}
-
 	public function testGetPHPBinary() {
 		$this->assertSame( WP_CLI\Utils\get_php_binary(), WP_CLI::get_php_binary() );
 	}


### PR DESCRIPTION
Related https://github.com/wp-cli/wp-cli/pull/4245

Adds processing of special variable `{INVOKE_WP_CLI_WITH_PHP_ARGS-}` to `FeatureContext::replace_variables()` so that PHP args can be given to either the wp-cli phar or the shell file, in order to test stuff under varying PHP conditions.

Uses it in `aliases.feature`, `help.feature` and `runcommand.feature` to test running with `proc_open()`/`proc_close()` unavailable, and removes corresponding phpunit tests.

Before (and still with the remaining phpunit tests) was only testing git not phar invocation. Will be useful in other cases also (eg https://github.com/wp-cli/package-command/issues/27).
