### PR TITLE
In runcommand test use pluck now that option get returns error string

### DIFF
--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -187,7 +187,7 @@ Feature: Run a WP-CLI command
     And STDERR should be empty
     And the return code should be 0
 
-    When I run `wp <flag> --no-exit_error run 'option get foo$bar'`
+    When I run `wp <flag> --no-exit_error run 'option pluck foo$bar barfoo'`
     Then STDOUT should be:
       """
       returned: NULL


### PR DESCRIPTION
Related https://github.com/wp-cli/entity-command/pull/126 and https://github.com/wp-cli/entity-command/issues/123

Changes the runcommand test `Override erroring on exit` that checks for `NULL` returned to use `option pluck` instead of `option get` now that `option get` returns an error string if an option doesn't exist.