### PR TITLE
Add Utils\esc_like() polyfill of wpdb version.

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -1356,3 +1356,21 @@ function _proc_open_compat_win_env( $cmd, &$env ) {
 	}
 	return $cmd;
 }
+
+/**
+ * First half of escaping for LIKE special characters % and _ before preparing for MySQL.
+ *
+ * Use this only before wpdb::prepare() or esc_sql().  Reversing the order is very bad for security.
+ *
+ * Copied from core "wp-includes/wp-db.php". Avoids dependency on WP 4.4 wpdb.
+ *
+ * @access public
+ *
+ * @param string $text The raw text to be escaped. The input typed by the user should have no
+ *                     extra or deleted slashes.
+ * @return string Text in the form of a LIKE phrase. The output is not SQL safe. Call $wpdb::prepare()
+ *                or real_escape next.
+ */
+function esc_like( $text ) {
+	return addcslashes( $text, '_%\\' );
+}

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -667,4 +667,28 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			array( 'ENV=\'blah blah\' echo', array(), 'blah\' echo', array( 'ENV' => '\'blah' ) ), // Unix escaping not supported, ie treated literally.
 		);
 	}
+
+	/**
+	 * Copied from core "tests/phpunit/tests/db.php" (adapted to not use `$wpdb`).
+	 */
+	function test_esc_like() {
+		$inputs   = array(
+			'howdy%', //Single Percent
+			'howdy_', //Single Underscore
+			'howdy\\', //Single slash
+			'howdy\\howdy%howdy_', //The works
+			'howdy\'"[[]*#[^howdy]!+)(*&$#@!~|}{=--`/.,<>?', //Plain text
+		);
+		$expected = array(
+			'howdy\\%',
+			'howdy\\_',
+			'howdy\\\\',
+			'howdy\\\\howdy\\%howdy\\_',
+			'howdy\'"[[]*#[^howdy]!+)(*&$#@!~|}{=--`/.,<>?',
+		);
+
+		foreach ( $inputs as $key => $input ) {
+			$this->assertEquals( $expected[ $key ], Utils\esc_like( $input ) );
+		}
+	}
 }


### PR DESCRIPTION
Related https://github.com/wp-cli/db-command/issues/65 and https://github.com/wp-cli/db-command/issues/66, and also https://github.com/wp-cli/wp-cli/pull/4527#discussion_r152706464

Adds `wpdb::esc_like()` polyfill to `utils.php`. Copied directly from core.

Will be used to close https://github.com/wp-cli/db-command/issues/65 and by-pass https://github.com/wp-cli/db-command/issues/66.

Should also be used in `search-replace-command` and `entity-command`.