### PR TITLE
Use wp_cache_flush in Utils\wp_clear_object_cache & check props.

### DIFF
--- a/features/utils-wp.feature
+++ b/features/utils-wp.feature
@@ -1,0 +1,22 @@
+Feature: Utilities that depend on WordPress code
+
+  Scenario: Clear WP cache
+    Given a WP install
+    And a test.php file:
+      """
+      <?php
+      WP_CLI::add_hook( 'after_wp_load', function () {
+        global $wp_object_cache;
+        echo empty( $wp_object_cache->cache ) . ',' . isset( $wp_object_cache->group_ops ) . ',' . isset( $wp_object_cache->stats ) . ',' . isset( $wp_object_cache->memcache_debug ) . "\n";
+        WP_CLI\Utils\wp_clear_object_cache();
+        echo empty( $wp_object_cache->cache ) . ',' . isset( $wp_object_cache->group_ops ) . ',' . isset( $wp_object_cache->stats ) . ',' . isset( $wp_object_cache->memcache_debug ) . "\n";
+      } );
+      """
+
+    When I run `wp post create --post_title="Foo Bar" --porcelain`
+    And I run `wp --require=test.php eval ''`
+    Then STDOUT should be:
+      """
+      ,,,
+      1,,,
+      """

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -287,13 +287,23 @@ function wp_clear_object_cache() {
 		return;
 	}
 
-	$wp_object_cache->group_ops = array();
-	$wp_object_cache->stats = array();
-	$wp_object_cache->memcache_debug = array();
-	$wp_object_cache->cache = array();
+	wp_cache_flush();
 
-	if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
-		$wp_object_cache->__remoteset(); // important
+	// The following are Memcached (Redux) plugin specific (see https://core.trac.wordpress.org/ticket/31463).
+	if ( isset( $wp_object_cache->group_ops ) ) {
+		$wp_object_cache->group_ops = array();
+	}
+	if ( isset( $wp_object_cache->stats ) ) {
+		$wp_object_cache->stats = array();
+	}
+	if ( isset( $wp_object_cache->memcache_debug ) ) {
+		$wp_object_cache->memcache_debug = array();
+	}
+	if ( ! empty( $wp_object_cache->cache ) ) { // This is cleared by `WP_Object_Cache::flush()` but keep for BC with Memcached.
+		$wp_object_cache->cache = array();
+	}
+	if ( method_exists( $wp_object_cache, '__remoteset' ) ) { // Apparently specific to wp.com version of Memcached plugin.
+		$wp_object_cache->__remoteset();
 	}
 }
 

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -277,6 +277,7 @@ function wp_get_cache_type() {
  *
  * @access public
  * @category System
+ * @deprecated 1.5.0
  */
 function wp_clear_object_cache() {
 	global $wpdb, $wp_object_cache;
@@ -297,11 +298,9 @@ function wp_clear_object_cache() {
 	if ( isset( $wp_object_cache->memcache_debug ) ) {
 		$wp_object_cache->memcache_debug = array();
 	}
+	// Used by `WP_Object_Cache` also.
 	if ( isset( $wp_object_cache->cache ) ) {
 		$wp_object_cache->cache = array();
-	}
-	if ( method_exists( $wp_object_cache, '__remoteset' ) ) { // Apparently specific to wp.com version of Memcached plugin.
-		$wp_object_cache->__remoteset();
 	}
 }
 

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -287,8 +287,6 @@ function wp_clear_object_cache() {
 		return;
 	}
 
-	wp_cache_flush();
-
 	// The following are Memcached (Redux) plugin specific (see https://core.trac.wordpress.org/ticket/31463).
 	if ( isset( $wp_object_cache->group_ops ) ) {
 		$wp_object_cache->group_ops = array();
@@ -299,7 +297,7 @@ function wp_clear_object_cache() {
 	if ( isset( $wp_object_cache->memcache_debug ) ) {
 		$wp_object_cache->memcache_debug = array();
 	}
-	if ( ! empty( $wp_object_cache->cache ) ) { // This is cleared by `WP_Object_Cache::flush()` but keep for BC with Memcached.
+	if ( isset( $wp_object_cache->cache ) ) {
 		$wp_object_cache->cache = array();
 	}
 	if ( method_exists( $wp_object_cache, '__remoteset' ) ) { // Apparently specific to wp.com version of Memcached plugin.


### PR DESCRIPTION
Noticed on doing https://github.com/wp-cli/media-command/pull/62 PR that `Utils\wp_clear_object_cache()` was setting some non-defined properties on the `WP_Object_Cache` object.

The code appears to be Memcached and Memcached Redux plugin specific according to https://core.trac.wordpress.org/ticket/31463. See also `WP_UnitTestCase::flush_cache()` in core test suite https://github.com/WordPress/wordpress-develop/blob/4.9.1/tests/phpunit/includes/testcase.php#L321.

So this PR updates the `wp_clear_object_cache()` to use the standard `wp_cache_flush()` function, keeping the other stuff for BC but checking first and using `method_exists()` on `__remoteset` check.