### PR TITLE
Add shell array parsing helper

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -1318,3 +1318,27 @@ function get_php_binary() {
 
 	return 'php';
 }
+
+/**
+ * Check whether a given string is a valid JSON representation.
+ *
+ * @param string $argument String to evaluate.
+ * @param bool   $ignore_scalars Optional. Whether to ignore scalar values.
+ *                               Defaults to true.
+ * @return bool Whether the provided string is a valid JSON representation.
+ */
+function is_json( $argument, $ignore_scalars = true ) {
+	if ( empty( $argument )
+	     || ! is_string( $argument ) ) {
+		return false;
+	}
+
+	if ( $ignore_scalars
+	     && ! in_array( $argument[0], array( '{', '[' ), true ) ) {
+		return false;
+	}
+
+	json_decode( $argument );
+
+	return json_last_error() === JSON_ERROR_NONE;
+}

--- a/php/utils.php
+++ b/php/utils.php
@@ -1385,13 +1385,11 @@ function esc_like( $text ) {
  * @return bool Whether the provided string is a valid JSON representation.
  */
 function is_json( $argument, $ignore_scalars = true ) {
-	if ( empty( $argument )
-	     || ! is_string( $argument ) ) {
+	if ( empty( $argument ) || ! is_string( $argument ) ) {
 		return false;
 	}
 
-	if ( $ignore_scalars
-	     && ! in_array( $argument[0], array( '{', '[' ), true ) ) {
+	if ( $ignore_scalars && ! in_array( $argument[0], array( '{', '[' ), true ) ) {
 		return false;
 	}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -1322,9 +1322,10 @@ function get_php_binary() {
 /**
  * Check whether a given string is a valid JSON representation.
  *
- * @param string $argument String to evaluate.
+ * @param string $argument       String to evaluate.
  * @param bool   $ignore_scalars Optional. Whether to ignore scalar values.
  *                               Defaults to true.
+ *
  * @return bool Whether the provided string is a valid JSON representation.
  */
 function is_json( $argument, $ignore_scalars = true ) {
@@ -1338,7 +1339,30 @@ function is_json( $argument, $ignore_scalars = true ) {
 		return false;
 	}
 
-	json_decode( $argument );
+	json_decode( $argument, $assoc = true );
 
 	return json_last_error() === JSON_ERROR_NONE;
+}
+
+/**
+ * Parse known shell arrays included in the $assoc_args array.
+ *
+ * @param array $assoc_args      Associative array of arguments.
+ * @param array $array_arguments Array of argument keys that should receive an
+ *                               array through the shell.
+ *
+ * @return array
+ */
+function parse_shell_arrays( $assoc_args, $array_arguments ) {
+	if ( empty( $assoc_args ) || empty( $array_arguments ) ) {
+		return $assoc_args;
+	}
+
+	foreach ( $array_arguments as $key ) {
+		if ( array_key_exists( $key, $assoc_args ) && is_json( $assoc_args[ $key ] ) ) {
+			$assoc_args[ $key ] = json_decode( $assoc_args[ $key ], $assoc = true );
+		}
+	}
+
+	return $assoc_args;
 }

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -625,4 +625,22 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		putenv( false === $env_php_used ? 'WP_CLI_PHP_USED' : "WP_CLI_PHP_USED=$env_php_used" );
 		putenv( false === $env_php ? 'WP_CLI_PHP' : "WP_CLI_PHP=$env_php" );
 	}
+
+	/** @dataProvider dataIsJson */
+	public function testIsJson( $argument, $ignore_scalars, $expected ) {
+		$this->assertEquals( $expected, Utils\is_json( $argument, $ignore_scalars ) );
+	}
+
+	public function dataIsJson() {
+		return array(
+			array( '42', true, false ),
+			array( '42', false, true ),
+			array( '"test"', true, false ),
+			array( '"test"', false, true ),
+			array( '{"key1":"value1","key2":"value2"}', true, true ),
+			array( '{"key1":"value1","key2":"value2"}', false, true ),
+			array( '["value1","value2"]', true, true ),
+			array( '["value1","value2"]', false, true ),
+		);
+	}
 }

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -643,4 +643,17 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			array( '["value1","value2"]', false, true ),
 		);
 	}
+
+	/** @dataProvider dataParseShellArray */
+	public function testParseShellArray( $assoc_args, $array_arguments, $expected ) {
+		$this->assertEquals( $expected, Utils\parse_shell_arrays( $assoc_args, $array_arguments ) );
+	}
+
+	public function dataParseShellArray() {
+		return array(
+			array( array( 'alpha' => '{"key":"value"}' ), array(), array( 'alpha' => '{"key":"value"}' ) ),
+			array( array( 'alpha' => '{"key":"value"}' ), array( 'alpha' ), array( 'alpha' => array( 'key' => 'value' ) ) ),
+			array( array( 'alpha' => '{"key":"value"}' ), array( 'beta' ), array( 'alpha' => '{"key":"value"}' ) ),
+		);
+	}
 }


### PR DESCRIPTION
Adds two helper functions:

* `WP_CLI\Utils\parse_shell_arrays( $assoc_args, $array_arguments )`
    This takes an existing `$assoc_args` array, and parses possible shell arguments for all keys that are provided in `$array_arguments`

* `WP_CLI\Utils\is_json( $argument, $ignore_scalars = true )`
    Helper function for the above parsing, that detects whether a given string is valid JSON.

See #4616 