### PR TITLE
Rewrite wp_get_table_names to deal correctly with wildcards.

### DIFF
--- a/features/utils-wp.feature
+++ b/features/utils-wp.feature
@@ -1,0 +1,683 @@
+Feature: Utilities that depend on WordPress code
+
+  Scenario: Get WP table names for single site install
+    Given a WP install
+    And I run `wp db query "CREATE TABLE xx_wp_posts ( id int );"`
+    And I run `wp db query "CREATE TABLE wp_xx_posts ( id int );"`
+    And I run `wp db query "CREATE TABLE wp_posts_xx ( id int );"`
+    And I run `wp db query "CREATE TABLE wp_categories ( id int );"`
+    And a table_names.php file:
+      """
+      <?php
+      /**
+       * Test WP get table names.
+       *
+       * ## OPTIONS
+       *
+       * [<table>...]
+       * : List tables based on wildcard search, e.g. 'wp_*_options' or 'wp_post?'.
+       *
+       * [--scope=<scope>]
+       * : Can be all, global, ms_global, blog, or old tables. Defaults to all.
+       *
+       * [--network]
+       * : List all the tables in a multisite install. Overrides --scope=<scope>.
+       *
+       * [--all-tables-with-prefix]
+       * : List all tables that match the table prefix even if not registered on $wpdb. Overrides --network.
+       *
+       * [--all-tables]
+       * : List all tables in the database, regardless of the prefix, and even if not registered on $wpdb. Overrides --all-tables-with-prefix.
+       */
+      function test_wp_get_table_names( $args, $assoc_args ) {
+        if ( $tables = WP_CLI\Utils\wp_get_table_names( $args, $assoc_args ) ) {
+            echo implode( PHP_EOL, $tables ) . PHP_EOL;
+        }
+      }
+      WP_CLI::add_command( 'get_table_names', 'test_wp_get_table_names' );
+      """
+
+    When I run `wp --require=table_names.php get_table_names`
+    Then STDOUT should be:
+      """
+      wp_commentmeta
+      wp_comments
+      wp_links
+      wp_options
+      wp_postmeta
+      wp_posts
+      wp_term_relationships
+      wp_term_taxonomy
+      wp_termmeta
+      wp_terms
+      wp_usermeta
+      wp_users
+      """
+    And save STDOUT as {DEFAULT_STDOUT}
+
+    When I run `wp --require=table_names.php get_table_names --scope=all`
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
+    When I run `wp --require=table_names.php get_table_names --scope=blog`
+    Then STDOUT should be:
+      """
+      wp_commentmeta
+      wp_comments
+      wp_links
+      wp_options
+      wp_postmeta
+      wp_posts
+      wp_term_relationships
+      wp_term_taxonomy
+      wp_termmeta
+      wp_terms
+      """
+
+    When I run `wp --require=table_names.php get_table_names --scope=global`
+    Then STDOUT should be:
+      """
+      wp_usermeta
+      wp_users
+      """
+
+    When I run `wp --require=table_names.php get_table_names --scope=ms_global`
+    Then STDOUT should be empty
+
+    When I run `wp --require=table_names.php get_table_names --scope=old`
+    Then STDOUT should be:
+      """
+      wp_categories
+      """
+
+    When I run `wp --require=table_names.php get_table_names --network`
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
+    When I run `wp --require=table_names.php get_table_names --all-tables-with-prefix`
+    Then STDOUT should be:
+      """
+      wp_categories
+      wp_commentmeta
+      wp_comments
+      wp_links
+      wp_options
+      wp_postmeta
+      wp_posts
+      wp_posts_xx
+      wp_term_relationships
+      wp_term_taxonomy
+      wp_termmeta
+      wp_terms
+      wp_usermeta
+      wp_users
+      wp_xx_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names --all-tables`
+    Then STDOUT should be:
+      """
+      wp_categories
+      wp_commentmeta
+      wp_comments
+      wp_links
+      wp_options
+      wp_postmeta
+      wp_posts
+      wp_posts_xx
+      wp_term_relationships
+      wp_term_taxonomy
+      wp_termmeta
+      wp_terms
+      wp_usermeta
+      wp_users
+      wp_xx_posts
+      xx_wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names '*_posts'`
+    Then STDOUT should be:
+      """
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names 'wp_post*'`
+    Then STDOUT should be:
+      """
+      wp_postmeta
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names 'wp*osts'`
+    Then STDOUT should be:
+      """
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names '*_posts' --scope=blog`
+    Then STDOUT should be:
+      """
+      wp_posts
+      """
+
+    When I try `wp --require=table_names.php get_table_names '*_posts' --scope=global`
+    Then STDERR should be:
+      """
+      Error: Couldn't find any tables matching: *_posts
+      """
+    And STDOUT should be empty
+
+    When I run `wp --require=table_names.php get_table_names '*_posts' --network`
+    Then STDOUT should be:
+      """
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names '*_posts' --all-tables-with-prefix`
+    Then STDOUT should be:
+      """
+      wp_posts
+      wp_xx_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names '*wp_posts' --all-tables-with-prefix`
+    Then STDOUT should be:
+      """
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names 'wp_post*' --all-tables-with-prefix`
+    Then STDOUT should be:
+      """
+      wp_postmeta
+      wp_posts
+      wp_posts_xx
+      """
+
+    When I run `wp --require=table_names.php get_table_names 'wp*osts' --all-tables-with-prefix`
+    Then STDOUT should be:
+      """
+      wp_posts
+      wp_xx_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names '*_posts' --all-tables`
+    Then STDOUT should be:
+      """
+      wp_posts
+      wp_xx_posts
+      xx_wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names '*wp_posts' --all-tables`
+    Then STDOUT should be:
+      """
+      wp_posts
+      xx_wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names 'wp_post*' --all-tables`
+    Then STDOUT should be:
+      """
+      wp_postmeta
+      wp_posts
+      wp_posts_xx
+      """
+
+    When I run `wp --require=table_names.php get_table_names 'wp*osts' --all-tables`
+    Then STDOUT should be:
+      """
+      wp_posts
+      wp_xx_posts
+      """
+
+    When I try `wp --require=table_names.php get_table_names non_existent_table`
+    Then STDERR should be:
+      """
+      Error: Couldn't find any tables matching: non_existent_table
+      """
+    And STDOUT should be empty
+
+    When I run `wp --require=table_names.php get_table_names wp_posts non_existent_table`
+    Then STDOUT should be:
+      """
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names wp_posts non_existent_table 'wp_?ption*'`
+    Then STDOUT should be:
+      """
+      wp_options
+      wp_posts
+      """
+
+  Scenario: Get WP table names for single site install
+    Given a WP multisite install
+    And I run `wp db query "CREATE TABLE xx_wp_posts ( id int );"`
+    And I run `wp db query "CREATE TABLE xx_wp_2_posts ( id int );"`
+    And I run `wp db query "CREATE TABLE wp_xx_posts ( id int );"`
+    And I run `wp db query "CREATE TABLE wp_2_xx_posts ( id int );"`
+    And I run `wp db query "CREATE TABLE wp_posts_xx ( id int );"`
+    And I run `wp db query "CREATE TABLE wp_2_posts_xx ( id int );"`
+    And I run `wp db query "CREATE TABLE wp_categories ( id int );"`
+    And I run `wp db query "CREATE TABLE wp_sitecategories ( id int );"`
+    And a table_names.php file:
+      """
+      <?php
+      /**
+       * Test WP get table names.
+       *
+       * ## OPTIONS
+       *
+       * [<table>...]
+       * : List tables based on wildcard search, e.g. 'wp_*_options' or 'wp_post?'.
+       *
+       * [--scope=<scope>]
+       * : Can be all, global, ms_global, blog, or old tables. Defaults to all.
+       *
+       * [--network]
+       * : List all the tables in a multisite install. Overrides --scope=<scope>.
+       *
+       * [--all-tables-with-prefix]
+       * : List all tables that match the table prefix even if not registered on $wpdb. Overrides --network.
+       *
+       * [--all-tables]
+       * : List all tables in the database, regardless of the prefix, and even if not registered on $wpdb. Overrides --all-tables-with-prefix.
+       */
+      function test_wp_get_table_names( $args, $assoc_args ) {
+        if ( $tables = WP_CLI\Utils\wp_get_table_names( $args, $assoc_args ) ) {
+            echo implode( PHP_EOL, $tables ) . PHP_EOL;
+        }
+      }
+      WP_CLI::add_command( 'get_table_names', 'test_wp_get_table_names' );
+      """
+
+    # With no subsite.
+    When I run `wp --require=table_names.php get_table_names`
+    Then STDOUT should be:
+      """
+      wp_blog_versions
+      wp_blogs
+      wp_commentmeta
+      wp_comments
+      wp_links
+      wp_options
+      wp_postmeta
+      wp_posts
+      wp_registration_log
+      wp_signups
+      wp_site
+      wp_sitemeta
+      wp_term_relationships
+      wp_term_taxonomy
+      wp_termmeta
+      wp_terms
+      wp_usermeta
+      wp_users
+      """
+    And save STDOUT as {DEFAULT_STDOUT}
+
+    When I run `wp --require=table_names.php get_table_names --scope=all`
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
+    When I run `wp --require=table_names.php get_table_names --scope=blog`
+    Then STDOUT should be:
+      """
+      wp_commentmeta
+      wp_comments
+      wp_links
+      wp_options
+      wp_postmeta
+      wp_posts
+      wp_term_relationships
+      wp_term_taxonomy
+      wp_termmeta
+      wp_terms
+      """
+
+    When I run `wp --require=table_names.php get_table_names --scope=global`
+    Then STDOUT should be:
+      """
+      wp_blog_versions
+      wp_blogs
+      wp_registration_log
+      wp_signups
+      wp_site
+      wp_sitemeta
+      wp_usermeta
+      wp_users
+      """
+    And save STDOUT as {GLOBAL_STDOUT}
+
+    When I run `wp --require=table_names.php get_table_names --scope=ms_global`
+    Then STDOUT should be:
+      """
+      wp_blog_versions
+      wp_blogs
+      wp_registration_log
+      wp_signups
+      wp_site
+      wp_sitemeta
+      """
+
+    When I run `wp --require=table_names.php get_table_names --scope=old`
+    Then STDOUT should be:
+      """
+      wp_categories
+      """
+
+    When I run `wp --require=table_names.php get_table_names --network`
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
+    # With subsite.
+    Given I run `wp site create --slug=foo`
+    When I run `wp --require=table_names.php get_table_names`
+    Then STDOUT should be:
+      """
+      {DEFAULT_STDOUT}
+      """
+
+    When I run `wp --require=table_names.php get_table_names --url=example.com/foo --scope=blog`
+    Then STDOUT should be:
+      """
+      wp_2_commentmeta
+      wp_2_comments
+      wp_2_links
+      wp_2_options
+      wp_2_postmeta
+      wp_2_posts
+      wp_2_term_relationships
+      wp_2_term_taxonomy
+      wp_2_termmeta
+      wp_2_terms
+      """
+    And save STDOUT as {SUBSITE_BLOG_STDOUT}
+
+    When I run `wp --require=table_names.php get_table_names --url=example.com/foo`
+    Then STDOUT should be:
+      """
+      {SUBSITE_BLOG_STDOUT}
+      {GLOBAL_STDOUT}
+      """
+
+    When I run `wp --require=table_names.php get_table_names --network`
+    Then STDOUT should be:
+      """
+      {SUBSITE_BLOG_STDOUT}
+      {DEFAULT_STDOUT}
+      """
+    And save STDOUT as {NETWORK_STDOUT}
+
+    When I run `wp --require=table_names.php get_table_names --network --url=example.com/foo`
+    Then STDOUT should be:
+      """
+      {NETWORK_STDOUT}
+      """
+
+    When I run `wp --require=table_names.php get_table_names --all-tables-with-prefix`
+    Then STDOUT should be:
+      """
+      wp_2_commentmeta
+      wp_2_comments
+      wp_2_links
+      wp_2_options
+      wp_2_postmeta
+      wp_2_posts
+      wp_2_posts_xx
+      wp_2_term_relationships
+      wp_2_term_taxonomy
+      wp_2_termmeta
+      wp_2_terms
+      wp_2_xx_posts
+      wp_blog_versions
+      wp_blogs
+      wp_categories
+      wp_commentmeta
+      wp_comments
+      wp_links
+      wp_options
+      wp_postmeta
+      wp_posts
+      wp_posts_xx
+      wp_registration_log
+      wp_signups
+      wp_site
+      wp_sitecategories
+      wp_sitemeta
+      wp_term_relationships
+      wp_term_taxonomy
+      wp_termmeta
+      wp_terms
+      wp_usermeta
+      wp_users
+      wp_xx_posts
+      """
+    And save STDOUT as {ALL_TABLES_WITH_PREFIX_STDOUT}
+
+    # Network overriden by all-tables-with-prefix.
+    When I run `wp --require=table_names.php get_table_names --all-tables-with-prefix --network`
+    Then STDOUT should contain:
+      """
+      {ALL_TABLES_WITH_PREFIX_STDOUT}
+      """
+
+    When I run `wp --require=table_names.php get_table_names --all-tables`
+    Then STDOUT should be:
+      """
+      {ALL_TABLES_WITH_PREFIX_STDOUT}
+      xx_wp_2_posts
+      xx_wp_posts
+      """
+    And save STDOUT as {ALL_TABLES_STDOUT}
+
+    # Network overriden by all-tables.
+    When I run `wp --require=table_names.php get_table_names --all-tables --network`
+    Then STDOUT should be:
+      """
+      {ALL_TABLES_STDOUT}
+      """
+
+    When I run `wp --require=table_names.php get_table_names '*_posts'`
+    Then STDOUT should be:
+      """
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names '*_posts' --network`
+    Then STDOUT should be:
+      """
+      wp_2_posts
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names 'wp_post*'`
+    Then STDOUT should be:
+      """
+      wp_postmeta
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names 'wp_post*' --network`
+    Then STDOUT should be:
+      """
+      wp_postmeta
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names 'wp*osts'`
+    Then STDOUT should be:
+      """
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names 'wp*osts' --network`
+    Then STDOUT should be:
+      """
+      wp_2_posts
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names '*_posts' --scope=blog`
+    Then STDOUT should be:
+      """
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names '*_posts' --scope=blog --network`
+    Then STDOUT should be:
+      """
+      wp_2_posts
+      wp_posts
+      """
+
+    When I try `wp --require=table_names.php get_table_names '*_posts' --scope=global`
+    Then STDERR should be:
+      """
+      Error: Couldn't find any tables matching: *_posts
+      """
+    And STDOUT should be empty
+
+    # Note: BC change 1.5.0, network does not override scope.
+    When I try `wp --require=table_names.php get_table_names '*_posts' --scope=global --network`
+    Then STDERR should be:
+      """
+      Error: Couldn't find any tables matching: *_posts
+      """
+    And STDOUT should be empty
+
+    When I run `wp --require=table_names.php get_table_names '*_posts' --all-tables-with-prefix`
+    Then STDOUT should be:
+      """
+      wp_2_posts
+      wp_2_xx_posts
+      wp_posts
+      wp_xx_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names 'wp_post*' --all-tables-with-prefix`
+    Then STDOUT should be:
+      """
+      wp_postmeta
+      wp_posts
+      wp_posts_xx
+      """
+
+    When I run `wp --require=table_names.php get_table_names 'wp*osts' --all-tables-with-prefix`
+    Then STDOUT should be:
+      """
+      wp_2_posts
+      wp_2_xx_posts
+      wp_posts
+      wp_xx_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names '*_posts' --all-tables`
+    Then STDOUT should be:
+      """
+      wp_2_posts
+      wp_2_xx_posts
+      wp_posts
+      wp_xx_posts
+      xx_wp_2_posts
+      xx_wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names '*wp_posts' --all-tables`
+    Then STDOUT should be:
+      """
+      wp_posts
+      xx_wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names 'wp_post*' --all-tables`
+    Then STDOUT should be:
+      """
+      wp_postmeta
+      wp_posts
+      wp_posts_xx
+      """
+
+    When I run `wp --require=table_names.php get_table_names 'wp*osts' --all-tables`
+    Then STDOUT should be:
+      """
+      wp_2_posts
+      wp_2_xx_posts
+      wp_posts
+      wp_xx_posts
+      """
+
+    When I try `wp --require=table_names.php get_table_names non_existent_table`
+    Then STDERR should be:
+      """
+      Error: Couldn't find any tables matching: non_existent_table
+      """
+    And STDOUT should be empty
+
+    When I run `wp --require=table_names.php get_table_names wp_posts non_existent_table`
+    Then STDOUT should be:
+      """
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names wp_posts non_existent_table 'wp_?ption*'`
+    Then STDOUT should be:
+      """
+      wp_options
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names wp_posts non_existent_table 'wp_*ption?'`
+    Then STDOUT should be:
+      """
+      wp_options
+      wp_posts
+      """
+
+    When I run `wp --require=table_names.php get_table_names wp_posts non_existent_table 'wp_*ption?' --network`
+    Then STDOUT should be:
+      """
+      wp_2_options
+      wp_options
+      wp_posts
+      """
+
+    Given an enable_sitecategories.php file:
+      """
+      <?php 
+      WP_CLI::add_hook( 'after_wp_load', function () {
+        add_filter( 'global_terms_enabled', '__return_true' );
+      } );
+      """
+    When I run `wp --require=table_names.php --require=enable_sitecategories.php get_table_names`
+    Then STDOUT should be:
+      """
+      wp_blog_versions
+      wp_blogs
+      wp_commentmeta
+      wp_comments
+      wp_links
+      wp_options
+      wp_postmeta
+      wp_posts
+      wp_registration_log
+      wp_signups
+      wp_site
+      wp_sitecategories
+      wp_sitemeta
+      wp_term_relationships
+      wp_term_taxonomy
+      wp_termmeta
+      wp_terms
+      wp_usermeta
+      wp_users
+      """

--- a/features/utils-wp.feature
+++ b/features/utils-wp.feature
@@ -38,7 +38,7 @@ Feature: Utilities that depend on WordPress code
       """
 
     When I run `wp --require=table_names.php get_table_names`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       wp_commentmeta
       wp_comments
@@ -48,7 +48,10 @@ Feature: Utilities that depend on WordPress code
       wp_posts
       wp_term_relationships
       wp_term_taxonomy
-      wp_termmeta
+      """
+	# Leave out wp_termmeta for old WP compat.
+    And STDOUT should contain:
+      """
       wp_terms
       wp_usermeta
       wp_users
@@ -62,7 +65,7 @@ Feature: Utilities that depend on WordPress code
       """
 
     When I run `wp --require=table_names.php get_table_names --scope=blog`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       wp_commentmeta
       wp_comments
@@ -72,7 +75,10 @@ Feature: Utilities that depend on WordPress code
       wp_posts
       wp_term_relationships
       wp_term_taxonomy
-      wp_termmeta
+      """
+	# Leave out wp_termmeta for old WP compat.
+    And STDOUT should contain:
+      """
       wp_terms
       """
 
@@ -99,7 +105,7 @@ Feature: Utilities that depend on WordPress code
       """
 
     When I run `wp --require=table_names.php get_table_names --all-tables-with-prefix`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       wp_categories
       wp_commentmeta
@@ -111,7 +117,10 @@ Feature: Utilities that depend on WordPress code
       wp_posts_xx
       wp_term_relationships
       wp_term_taxonomy
-      wp_termmeta
+      """
+	# Leave out wp_termmeta for old WP compat.
+    And STDOUT should contain:
+      """
       wp_terms
       wp_usermeta
       wp_users
@@ -119,7 +128,7 @@ Feature: Utilities that depend on WordPress code
       """
 
     When I run `wp --require=table_names.php get_table_names --all-tables`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       wp_categories
       wp_commentmeta
@@ -131,7 +140,10 @@ Feature: Utilities that depend on WordPress code
       wp_posts_xx
       wp_term_relationships
       wp_term_taxonomy
-      wp_termmeta
+      """
+	# Leave out wp_termmeta for old WP compat.
+    And STDOUT should contain:
+      """
       wp_terms
       wp_usermeta
       wp_users
@@ -298,7 +310,7 @@ Feature: Utilities that depend on WordPress code
 
     # With no subsite.
     When I run `wp --require=table_names.php get_table_names`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       wp_blog_versions
       wp_blogs
@@ -314,7 +326,10 @@ Feature: Utilities that depend on WordPress code
       wp_sitemeta
       wp_term_relationships
       wp_term_taxonomy
-      wp_termmeta
+      """
+	# Leave out wp_termmeta for old WP compat.
+    And STDOUT should contain:
+      """
       wp_terms
       wp_usermeta
       wp_users
@@ -328,7 +343,7 @@ Feature: Utilities that depend on WordPress code
       """
 
     When I run `wp --require=table_names.php get_table_names --scope=blog`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       wp_commentmeta
       wp_comments
@@ -338,7 +353,10 @@ Feature: Utilities that depend on WordPress code
       wp_posts
       wp_term_relationships
       wp_term_taxonomy
-      wp_termmeta
+      """
+	# Leave out wp_termmeta for old WP compat.
+    And STDOUT should contain:
+      """
       wp_terms
       """
 
@@ -388,7 +406,7 @@ Feature: Utilities that depend on WordPress code
       """
 
     When I run `wp --require=table_names.php get_table_names --url=example.com/foo --scope=blog`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       wp_2_commentmeta
       wp_2_comments
@@ -398,7 +416,10 @@ Feature: Utilities that depend on WordPress code
       wp_2_posts
       wp_2_term_relationships
       wp_2_term_taxonomy
-      wp_2_termmeta
+      """
+	# Leave out wp_2_termmeta for old WP compat.
+    And STDOUT should contain:
+      """
       wp_2_terms
       """
     And save STDOUT as {SUBSITE_BLOG_STDOUT}
@@ -425,7 +446,7 @@ Feature: Utilities that depend on WordPress code
       """
 
     When I run `wp --require=table_names.php get_table_names --all-tables-with-prefix`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       wp_2_commentmeta
       wp_2_comments
@@ -436,7 +457,10 @@ Feature: Utilities that depend on WordPress code
       wp_2_posts_xx
       wp_2_term_relationships
       wp_2_term_taxonomy
-      wp_2_termmeta
+      """
+	# Leave out wp_2_termmeta for old WP compat.
+    And STDOUT should contain:
+      """
       wp_2_terms
       wp_2_xx_posts
       wp_blog_versions
@@ -456,7 +480,10 @@ Feature: Utilities that depend on WordPress code
       wp_sitemeta
       wp_term_relationships
       wp_term_taxonomy
-      wp_termmeta
+      """
+	# Leave out wp_termmeta for old WP compat.
+    And STDOUT should contain:
+      """
       wp_terms
       wp_usermeta
       wp_users
@@ -659,7 +686,7 @@ Feature: Utilities that depend on WordPress code
       } );
       """
     When I run `wp --require=table_names.php --require=enable_sitecategories.php get_table_names`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       wp_blog_versions
       wp_blogs
@@ -676,7 +703,10 @@ Feature: Utilities that depend on WordPress code
       wp_sitemeta
       wp_term_relationships
       wp_term_taxonomy
-      wp_termmeta
+      """
+	# Leave out wp_termmeta for old WP compat.
+    And STDOUT should contain:
+      """
       wp_terms
       wp_usermeta
       wp_users

--- a/features/utils-wp.feature
+++ b/features/utils-wp.feature
@@ -267,7 +267,7 @@ Feature: Utilities that depend on WordPress code
       wp_posts
       """
 
-  Scenario: Get WP table names for single site install
+  Scenario: Get WP table names for multisite install
     Given a WP multisite install
     And I run `wp db query "CREATE TABLE xx_wp_posts ( id int );"`
     And I run `wp db query "CREATE TABLE xx_wp_2_posts ( id int );"`

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -340,6 +340,7 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 		}
 
 		// Note: BC change 1.5.0, tables are sorted (via TABLES view).
+		// @codingStandardsIgnoreLine
 		$tables = $wpdb->get_col( sprintf( "SHOW TABLES WHERE %s IN ('%s')", esc_sql_ident( 'Tables_in_' . $wpdb->dbname ), implode( "', '", $wpdb->_escape( $wp_tables ) ) ) );
 	}
 

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -309,117 +309,57 @@ function wp_clear_object_cache() {
 function wp_get_table_names( $args, $assoc_args = array() ) {
 	global $wpdb;
 
-	// Prioritize any supplied $args as tables
-	if ( ! empty( $args ) ) {
-		$new_tables = array();
-		$get_tables_for_glob = function( $glob ) {
-			global $wpdb;
-			static $all_tables = array();
-			if ( ! $all_tables ) {
-				$all_tables = $wpdb->get_col( 'SHOW TABLES' );
-			}
-			$tables = array();
-			foreach ( $all_tables as $table ) {
-				if ( fnmatch( $glob, $table ) ) {
-					$tables[] = $table;
-				}
-			}
-			return $tables;
-		};
-		foreach ( $args as $key => $table ) {
-			if ( false !== strpos( $table, '*' ) || false !== strpos( $table, '?' ) ) {
-				$expanded_tables = $get_tables_for_glob( $table );
-				if ( empty( $expanded_tables ) ) {
-					\WP_CLI::error( "Couldn't find any tables matching: {$table}" );
-				}
-				$new_tables = array_merge( $new_tables, $expanded_tables );
-			} else {
-				$new_tables[] = $table;
-			}
-		}
-		return $new_tables;
-	}
-
-	// Fall back to flag if no tables were passed
-	$table_type = 'WordPress';
-	if ( get_flag_value( $assoc_args, 'network' ) ) {
-		$table_type = 'network';
-	}
-	if ( get_flag_value( $assoc_args, 'all-tables-with-prefix' ) ) {
-		$table_type = 'all-tables-with-prefix';
-	}
+	$tables = array();
 	if ( get_flag_value( $assoc_args, 'all-tables' ) ) {
-		$table_type = 'all-tables';
-	}
+		$tables = $wpdb->get_col( 'SHOW TABLES' );
 
-	$network = 'network' == $table_type;
+	} elseif ( get_flag_value( $assoc_args, 'all-tables-with-prefix' ) ) {
+		$tables = $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', esc_like( $wpdb->get_blog_prefix() ) . '%' ) );
 
-	if ( 'all-tables' == $table_type ) {
-		return $wpdb->get_col( 'SHOW TABLES' );
-	}
+	} else {
+		$scope = get_flag_value( $assoc_args, 'scope', 'all' );
 
-	$prefix = $network ? $wpdb->base_prefix : $wpdb->prefix;
-	// '_' is a special wildcard for MySQL LIKE queries
-	// so it needs to be escaped with '\', but then '\' needs to be escaped as well
-	$sql_prefix = str_replace( '_', '\\_', $prefix );
-	$matching_tables = $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', $sql_prefix . '%' ) );
-
-	if ( 'all-tables-with-prefix' == $table_type ) {
-		return $matching_tables;
-	}
-
-	$filter_sitecategories = function( $matching_tables ) {
-		global $wpdb;
-		// Only include sitecategories when it's actually enabled.
-		if ( ! global_terms_enabled() ) {
-			$key = array_search( $wpdb->sitecategories, $matching_tables );
-			if ( false !== $key ) {
-				unset( $matching_tables[ $key ] );
-			}
-		}
-		return $matching_tables;
-	};
-
-	if ( $scope = get_flag_value( $assoc_args, 'scope' ) ) {
-		$matching_tables = $wpdb->tables( $scope );
-		$matching_tables = $filter_sitecategories( $matching_tables );
-		return $matching_tables;
-	}
-
-	$allowed_tables = array();
-	$allowed_table_types = array( 'tables', 'global_tables' );
-	if ( $network ) {
-		$allowed_table_types[] = 'ms_global_tables';
-	}
-	foreach ( $allowed_table_types as $table_type ) {
-		foreach ( $wpdb->$table_type as $table ) {
-			$allowed_tables[] = $prefix . $table;
-		}
-	}
-
-	// Given our matching tables, also allow site-specific tables on the network
-	foreach ( $matching_tables as $key => $matched_table ) {
-
-		if ( in_array( $matched_table, $allowed_tables ) ) {
-			continue;
-		}
-
-		if ( $network ) {
-			$valid_table = false;
-			foreach ( array_merge( $wpdb->tables, $wpdb->old_tables ) as $maybe_site_table ) {
-				if ( preg_match( "#{$prefix}([\d]+)_{$maybe_site_table}#", $matched_table ) ) {
-					$valid_table = true;
+		// Note: BC change 1.5.0, taking scope into consideration for network also.
+		if ( get_flag_value( $assoc_args, 'network' ) && is_multisite() ) {
+			$network_global_scope = in_array( $scope, array( 'all', 'global', 'ms_global' ), true ) ? ( 'all' === $scope ? 'global' : $scope ) : '';
+			$wp_tables = array_values( $wpdb->tables( $network_global_scope ) );
+			if ( in_array( $scope, array( 'all', 'blog' ), true ) ) {
+				// Do directly for compat with old WP versions. Note: private, deleted, archived sites are not excluded.
+				$blog_ids = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs WHERE site_id = $wpdb->siteid" );
+				foreach ( $blog_ids as $blog_id ) {
+					$wp_tables = array_merge( $wp_tables, array_values( $wpdb->tables( 'blog', true /*prefix*/, $blog_id ) ) );
 				}
 			}
-			if ( $valid_table ) {
-				continue;
-			}
+		} else {
+			$wp_tables = array_values( $wpdb->tables( $scope ) );
 		}
 
-		unset( $matching_tables[ $key ] );
+		if ( ! global_terms_enabled() ) {
+			// Only include sitecategories when it's actually enabled.
+			$wp_tables = array_values( array_diff( $wp_tables, array( $wpdb->sitecategories ) ) );
+		}
 
+		// Note: BC change 1.5.0, tables are sorted (via TABLES view).
+		$tables = $wpdb->get_col( sprintf( "SHOW TABLES WHERE %s IN ('%s')", esc_sql_ident( 'Tables_in_' . $wpdb->dbname ), implode( "', '", $wpdb->_escape( $wp_tables ) ) ) );
 	}
 
-	$filter_sitecategories( $matching_tables );
-	return array_values( $matching_tables );
+	// Filter by `$args`.
+	if ( $args ) {
+		$args_tables = array();
+		foreach ( $args as $arg ) {
+			if ( false !== strpos( $arg, '*' ) || false !== strpos( $arg, '?' ) ) {
+				$args_tables = array_merge( $args_tables, array_filter( $tables, function ( $v ) use ( $arg ) {
+					return fnmatch( $arg, $v );
+				} ) );
+			} else {
+				$args_tables[] = $arg;
+			}
+		}
+		$args_tables = array_values( array_unique( $args_tables ) );
+		if ( ! ( $tables = array_values( array_intersect( $tables, $args_tables ) ) ) ) {
+			\WP_CLI::error( sprintf( "Couldn't find any tables matching: %s", implode( ' ', $args ) ) );
+		}
+	}
+
+	return $tables;
 }

--- a/php/utils.php
+++ b/php/utils.php
@@ -1374,3 +1374,21 @@ function _proc_open_compat_win_env( $cmd, &$env ) {
 function esc_like( $text ) {
 	return addcslashes( $text, '_%\\' );
 }
+
+/**
+ * Escapes (backticks) MySQL identifiers (aka schema object names) - i.e. column names, table names, and database/index/alias/view etc names.
+ * See https://dev.mysql.com/doc/refman/5.5/en/identifiers.html
+ *
+ * @param string|array $idents A single identifier or an array of identifiers.
+ * @return string|array An escaped string if given a string, or an array of escaped strings if given an array of strings.
+ */
+function esc_sql_ident( $idents ) {
+	$backtick = function ( $v ) {
+		// Escape any backticks in the identifier by doubling.
+		return '`' . str_replace( '`', '``', $v ) . '`';
+	};
+	if ( is_string( $idents ) ) {
+		return $backtick( $idents );
+	}
+	return array_map( $backtick, $idents );
+}


### PR DESCRIPTION
See issue https://github.com/wp-cli/db-command/issues/73 and PRs https://github.com/wp-cli/db-command/pull/78 and https://github.com/wp-cli/wp-cli/pull/4606

Rewrites `Utils\wp_get_table_names()` to deal correctly with wildcards by getting the WP tables first and then filtering through the `$args`.

It's a backward compatibility (BC) change in that various buggy behaviours no longer happen, eg `wp db tables no_such_table` will return an error rather than `no_such_table`.

Also introduces some avoidable BC breaks:

- `scope` is not ignored when `network` given (it doesn't make sense to me that it should be).
- the tables are always returned sorted (rather than in `wpdb` order currently if not given `all-tables` or `all-tables-with-prefix`).

Also adds `Utils\esc_sql_ident()` from `DB_Command` to `utils.php`.

(May fail phpcs at the moment - let's see!)

Edit: will break tests for `db-command/features/db-search.feature` and `db-command/features/db-tables.feature` and `search-replace-command/features/search-replace-export.feature` and `search-replace-command/features/search-replace.feature` until they're adjusted.