### PR TITLE
Check for readablity of WordPress core files (solves #4594)

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -763,11 +763,20 @@ class Runner {
 	 * @return bool
 	 */
 	private function wp_exists() {
+		return file_exists( ABSPATH . 'wp-includes/version.php' );
+	}
+
+	/**
+	 * Are WordPress core files readable?
+	 *
+	 * @return bool
+	 */
+	private function wp_is_readable() {
 		return is_readable( ABSPATH . 'wp-includes/version.php' );
 	}
 
 	private function check_wp_version() {
-		if ( ! $this->wp_exists() ) {
+		if ( ! $this->wp_exists() || ! $this->wp_is_readable() ) {
 			$this->show_synopsis_if_composite_command();
 			// If the command doesn't exist use as error.
 			$args = $this->cmd_starts_with( array( 'help' ) ) ? array_slice( $this->arguments, 1 ) : $this->arguments;
@@ -777,6 +786,12 @@ class Runner {
 					WP_CLI::warning( "No WordPress install found. If the command '" . implode( ' ', $args ) . "' is in a plugin or theme, pass --path=`path/to/wordpress`." );
 				}
 				WP_CLI::error( $suggestion_or_disabled );
+			}
+
+			if ( $this->wp_exists() && ! $this->wp_is_readable() ) {
+				WP_CLI::error(
+					'It seems, the WordPress core files do not have the proper file permissions.'
+				);
 			}
 			WP_CLI::error(
 				"This does not seem to be a WordPress install.\n" .

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -776,7 +776,9 @@ class Runner {
 	}
 
 	private function check_wp_version() {
-		if ( ! $this->wp_exists() || ! $this->wp_is_readable() ) {
+		$wp_exists = $this->wp_exists();
+		$wp_is_readable = $this->wp_is_readable();
+		if ( ! $wp_exists || ! $wp_is_readable ) {
 			$this->show_synopsis_if_composite_command();
 			// If the command doesn't exist use as error.
 			$args = $this->cmd_starts_with( array( 'help' ) ) ? array_slice( $this->arguments, 1 ) : $this->arguments;
@@ -788,7 +790,7 @@ class Runner {
 				WP_CLI::error( $suggestion_or_disabled );
 			}
 
-			if ( $this->wp_exists() && ! $this->wp_is_readable() ) {
+			if ( $wp_exists && ! $wp_is_readable ) {
 				WP_CLI::error(
 					'It seems, the WordPress core files do not have the proper file permissions.'
 				);


### PR DESCRIPTION
Hi,
this PR checks for the existing of WordPress with `file_exists( ABSPATH . '/wp-includes/version.php' )` and in a separate check for the readability of this file.

This way, we can give a more precise error message. If its a readability problem, this PR sends `It seems, the WordPress core files do not have the proper file permissions.` and otherwise the known error message.

This solves #4594 

Thank you :) 