### PR TITLE
Add dev-master branch alias.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,9 +80,9 @@
 		"psr-4": { "": "php/commands/src" }
 	},
 	"extra": {
-        "branch-alias": {
-            "dev-master": "1.5.x-dev"
-        },
+		"branch-alias": {
+			"dev-master": "1.5.x-dev"
+		},
 		"autoload-splitter": {
 			"splitter-logic": "WP_CLI\\AutoloadSplitter",
 			"splitter-location": "php/WP_CLI/AutoloadSplitter.php",

--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,9 @@
 		"psr-4": { "": "php/commands/src" }
 	},
 	"extra": {
+        "branch-alias": {
+            "dev-master": "1.5.x-dev"
+        },
 		"autoload-splitter": {
 			"splitter-logic": "WP_CLI\\AutoloadSplitter",
 			"splitter-location": "php/WP_CLI/AutoloadSplitter.php",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/4625

Adds dev-master branch alias `1.5.x-dev` as per https://github.com/wp-cli/db-command/pull/79#issuecomment-357967577.