### PR TITLE
Append longdesc if given synopsis on WP_CLI::add_command().

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -807,6 +807,7 @@ Feature: WP-CLI Commands
                 array(
                     'type'      => 'positional',
                     'name'      => 'name',
+                    'description' => 'Name of person to greet.',
                     'optional'  => false,
                     'repeating' => false,
                 ),
@@ -824,7 +825,7 @@ Feature: WP-CLI Commands
                 ),
             ),
             'when' => 'after_wp_load',
-            'longdesc'    => "## EXAMPLES\n\n# Say hello to Newman\nwp example hello Newman\nSuccess: Hello, Newman!",
+            'longdesc'    => "\r\n## EXAMPLES\n\n# Say hello to Newman\nwp example hello Newman\nSuccess: Hello, Newman!",
       ) );
       """
 
@@ -846,6 +847,7 @@ Feature: WP-CLI Commands
       OPTIONS
 
         <name>
+          Name of person to greet.
 
         [--type=<type>]
         ---

--- a/features/command.feature
+++ b/features/command.feature
@@ -769,11 +769,102 @@ Feature: WP-CLI Commands
     When I run `wp help foo`
     Then STDOUT should contain:
       """
+      NAME
+
+        wp foo
+
+      DESCRIPTION
+
+        My awesome function command
+
+      SYNOPSIS
+
+        wp foo 
+
+      EXAMPLES 
+
+        # Run the custom foo command
+
+      GLOBAL PARAMETERS
+
+      """
+
+    # With synopsis, appended.
+    Given a hello-command.php file:
+      """
+      <?php
+        $hello_command = function( $args, $assoc_args ) {
+            list( $name ) = $args;
+            $type = $assoc_args['type'];
+            WP_CLI::$type( "Hello, $name!" );
+            if ( isset( $assoc_args['honk'] ) ) {
+                WP_CLI::log( 'Honk!' );
+            }
+        };
+        WP_CLI::add_command( 'example hello', $hello_command, array(
+            'shortdesc' => 'Prints a greeting.',
+            'synopsis' => array(
+                array(
+                    'type'      => 'positional',
+                    'name'      => 'name',
+                    'optional'  => false,
+                    'repeating' => false,
+                ),
+                array(
+                    'type'     => 'assoc',
+                    'name'     => 'type',
+                    'optional' => true,
+                    'default'  => 'success',
+                    'options'  => array( 'success', 'error' ),
+                ),
+                array(
+                    'type'     => 'flag',
+                    'name'     => 'honk',
+                    'optional' => true,
+                ),
+            ),
+            'when' => 'after_wp_load',
+            'longdesc'    => "## EXAMPLES\n\n# Say hello to Newman\nwp example hello Newman\nSuccess: Hello, Newman!",
+      ) );
+      """
+
+    When I run `wp --require=hello-command.php help example hello`
+    Then STDOUT should contain:
+      """
+      NAME
+
+        wp example hello
+
+      DESCRIPTION
+
+        Prints a greeting.
+
+      SYNOPSIS
+
+        wp example hello <name> [--type=<type>] [--honk]
+
+      OPTIONS
+
+        <name>
+
+        [--type=<type>]
+        ---
+        default: success
+        options:
+        - success
+        - error
+        ---
+
+        [--honk]
+
       EXAMPLES
-      """
-    And STDOUT should contain:
-      """
-      # Run the custom foo command
+
+        # Say hello to Newman
+        wp example hello Newman
+        Success: Hello, Newman!
+
+      GLOBAL PARAMETERS
+
       """
 
   Scenario: Register a command with default and accepted arguments.

--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -117,7 +117,7 @@ class CompositeCommand {
 	 * @param string
 	 */
 	public function set_shortdesc( $shortdesc ) {
-		$this->shortdesc = $shortdesc;
+		$this->shortdesc = Utils\normalize_eols( $shortdesc );
 	}
 
 	/**
@@ -136,7 +136,7 @@ class CompositeCommand {
 	 * @param string
 	 */
 	public function set_longdesc( $longdesc ) {
-		$this->longdesc = $longdesc;
+		$this->longdesc = Utils\normalize_eols( $longdesc );
 	}
 
 	/**

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -510,9 +510,9 @@ class WP_CLI {
 				$long_desc = '';
 				$bits = explode( ' ', $synopsis );
 				foreach ( $args['synopsis'] as $key => $arg ) {
-					$long_desc .= $bits[ $key ] . PHP_EOL;
+					$long_desc .= $bits[ $key ] . "\n";
 					if ( ! empty( $arg['description'] ) ) {
-						$long_desc .= ': ' . $arg['description'] . PHP_EOL;
+						$long_desc .= ': ' . $arg['description'] . "\n";
 					}
 					$yamlify = array();
 					foreach ( array( 'default', 'options' ) as $key ) {
@@ -522,13 +522,16 @@ class WP_CLI {
 					}
 					if ( ! empty( $yamlify ) ) {
 						$long_desc .= Spyc::YAMLDump( $yamlify );
-						$long_desc .= '---' . PHP_EOL;
+						$long_desc .= '---' . "\n";
 					}
-					$long_desc .= PHP_EOL;
+					$long_desc .= "\n";
 				}
 				if ( ! empty( $long_desc ) ) {
-					$long_desc = rtrim( $long_desc, PHP_EOL );
-					$long_desc = '## OPTIONS' . PHP_EOL . PHP_EOL . $long_desc;
+					$long_desc = rtrim( $long_desc, "\n" );
+					$long_desc = '## OPTIONS' . "\n\n" . $long_desc;
+					if ( ! empty( $args['longdesc'] ) ) {
+						$long_desc .= "\n\n" . ltrim( $args['longdesc'], "\n" );
+					}
 					$leaf_command->set_longdesc( $long_desc );
 				}
 			}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -527,10 +527,10 @@ class WP_CLI {
 					$long_desc .= "\n";
 				}
 				if ( ! empty( $long_desc ) ) {
-					$long_desc = rtrim( $long_desc, "\n" );
+					$long_desc = rtrim( $long_desc, "\r\n" );
 					$long_desc = '## OPTIONS' . "\n\n" . $long_desc;
 					if ( ! empty( $args['longdesc'] ) ) {
-						$long_desc .= "\n\n" . ltrim( $args['longdesc'], "\n" );
+						$long_desc .= "\n\n" . ltrim( $args['longdesc'], "\r\n" );
 					}
 					$leaf_command->set_longdesc( $long_desc );
 				}

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -49,8 +49,8 @@ class Help_Command extends WP_CLI_Command {
 		// definition lists
 		$out = preg_replace_callback( '/([^\n]+)\n: (.+?)(\n\n|$)/s', array( __CLASS__, 'rewrap_param_desc' ), $out );
 
-		// Ensure all non-section headers are indented.
-		$out = preg_replace( '#^([^\s^\#])#m', "\t$1", $out );
+		// Ensure lines with no leading whitespace that aren't section headers are indented.
+		$out = preg_replace( '/^((?! |\t|##).)/m', "\t$1", $out );
 
 		$tab = str_repeat( ' ', 2 );
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -773,6 +773,16 @@ function trailingslashit( $string ) {
 }
 
 /**
+ * Convert Windows EOLs to *nix.
+ *
+ * @param string $str String to convert.
+ * @return string String with carriage return / newline pairs reduced to newlines.
+ */
+function normalize_eols( $str ) {
+	return str_replace( "\r\n", "\n", $str );
+}
+
+/**
  * Get the system's temp directory. Warns user if it isn't writable.
  *
  * @access public

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -326,6 +326,10 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame( 'a/', Utils\trailingslashit( 'a\\//\\' ) );
 	}
 
+	public function testNormalizeEols() {
+		$this->assertSame( "\na\ra\na\n", Utils\normalize_eols( "\r\na\ra\r\na\r\n" ) );
+	}
+
 	public function testGetTempDir() {
 		$this->assertTrue( '/' === substr( Utils\get_temp_dir(), -1 ) );
 


### PR DESCRIPTION
Related release checklist https://github.com/wp-cli/wp-cli/issues/4512 item "Document longdesc argument from #4513 in Commands Cookbook"

When attempting to do this, noticed a bug in that the `longdesc` arg to `WP_CLI\add_command()` is ignored (overwritten) if a synopsis is given as well.

So this PR appends the `longdesc` if given to the generated synopsis.

Also replaces the `PHP_EOL` appends with `"\n"` and trims with `"\r\n"` as `PHP_EOL` shouldn't be used in this instance (tested on WIndows 10).

Also adds `Utils\normalize_eols()` function and uses in `CompositeCommand::set_shortdesc()` and `set_longdesc()` in case given Windows input.

Also fixes the regex used to detect non-zero-length lines that aren't section headers and don't have leading spaces in `Help_Command::show_help()`, which caused adding example content with a leading `#` to be improperly indented.