### PR TITLE
Handle old config syntax gracefully

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -731,13 +731,13 @@ class Runner {
 		// config get --[global|constant]=<global|constant> --> config get <name> --type=constant|variable
 		// config get --> config list
 		if ( count( $args ) === 2
-		     && 'config' === $args[0]
-		     && 'get' === $args[1] ) {
+			&& 'config' === $args[0]
+			&& 'get' === $args[1] ) {
 			if ( isset( $assoc_args['global'] ) ) {
 				$name = $assoc_args['global'];
 				$type = 'variable';
 				unset( $assoc_args['global'] );
-			} else if ( isset( $assoc_args['constant'] ) ) {
+			} elseif ( isset( $assoc_args['constant'] ) ) {
 				$name = $assoc_args['constant'];
 				$type = 'constant';
 				unset( $assoc_args['constant'] );

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -728,6 +728,29 @@ class Runner {
 			}
 		}
 
+		// config get --[global|constant]=<global|constant> --> config get <name> --type=constant|variable
+		// config get --> config list
+		if ( count( $args ) === 2
+		     && 'config' === $args[0]
+		     && 'get' === $args[1] ) {
+			if ( isset( $assoc_args['global'] ) ) {
+				$name = $assoc_args['global'];
+				$type = 'variable';
+				unset( $assoc_args['global'] );
+			} else if ( isset( $assoc_args['constant'] ) ) {
+				$name = $assoc_args['constant'];
+				$type = 'constant';
+				unset( $assoc_args['constant'] );
+			}
+			if ( ! empty( $name ) && ! empty( $type ) ) {
+				$args[] = $name;
+				$assoc_args['type'] = $type;
+			} else {
+				// We had a 'config get' without a '<name>', so assume 'list' was wanted.
+				$args[1] = 'list';
+			}
+		}
+
 		return array( $args, $assoc_args );
 	}
 


### PR DESCRIPTION
`wp config get --global=<global>` => `wp config get <name> --type=variable`
`wp config get --constant=<constant>` => `wp config get <name> --type=constant`
`wp config get` => `wp config list`

Fixes https://github.com/wp-cli/config-command/issues/43