### PR TITLE
Add COMPOSER_VERSIONS file generated from composer.lock to phar.

### DIFF
--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -9,7 +9,7 @@ if ( file_exists( WP_CLI_ROOT . '/vendor/autoload.php' ) ) {
 	define( 'WP_CLI_BASE_PATH', dirname( dirname( dirname( WP_CLI_ROOT ) ) ) );
 	define( 'WP_CLI_VENDOR_DIR' , dirname( dirname( WP_CLI_ROOT ) ) );
 } else {
-	echo 'Missing vendor/autoload.php';
+	fwrite( STDERR, 'Missing vendor/autoload.php' . PHP_EOL );
 	exit(1);
 }
 require WP_CLI_VENDOR_DIR . '/autoload.php';
@@ -24,7 +24,7 @@ $configurator = new Configurator( WP_CLI_ROOT . '/utils/make-phar-spec.php' );
 list( $args, $assoc_args, $runtime_config ) = $configurator->parse_args( array_slice( $GLOBALS['argv'], 1 ) );
 
 if ( ! isset( $args[0] ) || empty( $args[0] ) ) {
-	echo "usage: php -dphar.readonly=0 $argv[0] <path> [--quiet] [--version=same|patch|minor|major|x.y.z] [--store-version]\n";
+	fwrite( STDERR, "usage: php -dphar.readonly=0 $argv[0] <path> [--quiet] [--version=same|patch|minor|major|x.y.z] [--store-version] [--build=cli]" . PHP_EOL );
 	exit(1);
 }
 
@@ -50,8 +50,9 @@ if ( isset( $runtime_config['version'] ) ) {
 function add_file( $phar, $path ) {
 	$key = str_replace( WP_CLI_BASE_PATH, '', $path );
 
-	if ( !BE_QUIET )
-		echo "$key - $path\n";
+	if ( ! BE_QUIET ) {
+		echo "$key - $path" . PHP_EOL;
+	}
 
 	$basename = basename( $path );
 	if ( 0 === strpos( $basename, 'autoload_' ) && preg_match( '/(?:classmap|files|namespaces|psr4|static)\.php$/', $basename ) ) {
@@ -60,11 +61,11 @@ function add_file( $phar, $path ) {
 		if ( null === $strip_res ) {
 			if ( 'cli' === BUILD ) {
 				$strips = array(
-					'\/(?:behat|composer|gherkin)\/src',
+					'\/(?:behat|composer|gherkin)\/src\/',
 					'\/phpunit\/',
-					'\/nb\/oxymel',
+					'\/nb\/oxymel\/',
 					'-command\/src\/',
-					'\/wp-cli\/[^\n]+-command\/',
+					'\/wp-cli\/[^\n]+?-command\/',
 					'\/symfony\/(?!finder|polyfill-mbstring)[^\/]+\/',
 					'\/(?:dealerdirect|squizlabs|wimg)\/',
 				);
@@ -91,10 +92,58 @@ function add_file( $phar, $path ) {
 function set_file_contents( $phar, $path, $content ) {
 	$key = str_replace( WP_CLI_BASE_PATH, '', $path );
 
-	if ( !BE_QUIET )
-		echo "$key - $path\n";
+	if ( ! BE_QUIET ) {
+		echo "$key - $path" . PHP_EOL;
+	}
 
 	$phar[ $key ] = $content;
+}
+
+function get_composer_versions( $current_version ) {
+	$composer_lock_path = WP_CLI_ROOT . '/composer.lock';
+	if ( ! ( $get_composer_lock = file_get_contents( $composer_lock_path ) ) || ! ( $composer_lock = json_decode( $get_composer_lock, true ) ) ) {
+		fwrite( STDERR, sprintf( "Warning: Failed to read '%s'." . PHP_EOL, $composer_lock_path ) );
+		return '';
+	}
+	if ( ! isset( $composer_lock['packages'] ) ) {
+		fwrite( STDERR, sprintf( "Warning: No packages in '%s'." . PHP_EOL, $composer_lock_path ) );
+		return '';
+	}
+	$vendor_versions = array( implode( ' ', array( 'wp-cli/wp-cli', $current_version, date( 'c' ) ) ) );
+	$missing_names = $missing_versions = $missing_references = 0;
+	foreach ( $composer_lock['packages'] as $package ) {
+		if ( isset( $package['name'] ) ) {
+			$vendor_version = array( $package['name'] );
+			if ( isset( $package['version'] ) ) {
+				$vendor_version[] = $package['version'];
+			} else {
+				$vendor_version[] = 'unknown_version';
+				$missing_versions++;
+			}
+			if ( isset( $package['source'] ) && isset( $package['source']['reference'] ) ) {
+				$vendor_version[] = $package['source']['reference'];
+			} elseif( isset( $package['dist'] ) && isset( $package['dist']['reference'] ) ) {
+				$vendor_version[] = $package['dist']['reference'];
+			} else {
+				$vendor_version[] = 'unknown_reference';
+				$missing_references++;
+			}
+			$vendor_versions[] = implode( ' ', $vendor_version );
+		} else {
+			$vendor_versions[] = implode( ' ', array( 'unknown_package', 'unknown_version', 'unknown_reference' ) );
+			$missing_names++;
+		}
+	}
+	if ( $missing_names ) {
+		fwrite( STDERR, sprintf( "Warning: %d package names missing from '%s'." . PHP_EOL, $missing_names, $composer_lock_path ) );
+	}
+	if ( $missing_versions ) {
+		fwrite( STDERR, sprintf( "Warning: %d package versions missing from '%s'." . PHP_EOL, $missing_versions, $composer_lock_path ) );
+	}
+	if ( $missing_references ) {
+		fwrite( STDERR, sprintf( "Warning: %d package references missing from '%s'." . PHP_EOL, $missing_references, $composer_lock_path ) );
+	}
+	return implode( "\n", $vendor_versions );
 }
 
 if ( file_exists( DEST_PATH ) ) {
@@ -149,6 +198,7 @@ if ( 'cli' === BUILD ) {
 		->in(WP_CLI_VENDOR_DIR . '/symfony/filesystem')
 		->in(WP_CLI_VENDOR_DIR . '/symfony/process')
 		->in(WP_CLI_VENDOR_DIR . '/justinrainbow/json-schema')
+		->exclude('demo')
 		->exclude('nb/oxymel/OxymelTest.php')
 		->exclude('composer/spdx-licenses')
 		->exclude('composer/composer/src/Composer/Command')
@@ -235,6 +285,7 @@ if ( 'cli' !== BUILD ) {
 }
 add_file( $phar, WP_CLI_VENDOR_DIR . '/rmccue/requests/library/Requests/Transport/cacert.pem' );
 
+set_file_contents( $phar, WP_CLI_ROOT . '/COMPOSER_VERSIONS', get_composer_versions( $current_version ) );
 set_file_contents( $phar, WP_CLI_ROOT . '/VERSION', $current_version );
 
 $phar_boot = str_replace( WP_CLI_BASE_PATH, '', WP_CLI_ROOT . '/php/boot-phar.php' );
@@ -253,5 +304,5 @@ $phar->stopBuffering();
 chmod( DEST_PATH, 0755 ); // Make executable.
 
 if ( ! BE_QUIET ) {
-	echo "Generated " . DEST_PATH . "\n";
+	echo "Generated " . DEST_PATH . PHP_EOL;
 }


### PR DESCRIPTION
For consideration/discussion.

This adds a `WP_CLI_ROOT/COMPOSER_VERSIONS` file to the phar (but doesn't create on disk) that lists the versions/gitrefs used from `composer.lock`, as a check to see what was used to build the phar.

Also updates usage and makes some strip regexs consistent (no functional change).

Also excludes `demo` folder (in `vendor/justinrainbow/json-schema`).

Also writes errors to STDERR and uses PHP_EOL for all messages.