### PR TITLE
Fix phpunit extractor, glob, behat tests.

### DIFF
--- a/tests/test-behat-tags.php
+++ b/tests/test-behat-tags.php
@@ -121,8 +121,8 @@ class BehatTagsTest extends PHPUnit_Framework_TestCase {
 		if ( ! extension_loaded( 'imagick' ) ) {
 			$expecteds[] = '~@require-extension-imagick';
 		}
-		if ( ! extension_loaded( 'intl' ) ) {
-			$expecteds[] = '~@require-extension-intl';
+		if ( ! extension_loaded( 'curl' ) ) {
+			$expecteds[] = '~@require-extension-curl';
 		}
 		$expected = '--tags=' . implode( '&&', array_merge( array( '~@github-api', '~@broken' ), $expecteds ) );
 		$output = exec( "cd {$this->temp_dir}; php $behat_tags" );

--- a/tests/test-extractor.php
+++ b/tests/test-extractor.php
@@ -113,7 +113,8 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 		$output = array();
 		$return_var = -1;
 		// Need --force-local for Windows to avoid "C:" being interpreted as being on remote machine.
-		exec( Utils\esc_cmd( 'tar czvf %1$s --force-local --directory=%2$s/src wordpress', $tarball, $temp_dir ), $output, $return_var );
+		$cmd = 'tar czvf %1$s' . ( Utils\is_windows() ? ' --force-local' : '' ) . ' --directory=%2$s/src wordpress';
+		exec( Utils\esc_cmd( $cmd, $tarball, $temp_dir ), $output, $return_var );
 		$this->assertSame( 0, $return_var );
 		$this->assertFalse( empty( $output ) );
 		sort( $output );

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -528,13 +528,16 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 
 		$dir = __DIR__ . '/data/expand_globs/';
 		$expected = array_map( function ( $v ) use ( $dir ) { return $dir . $v; }, $expected );
+		sort( $expected );
 
 		putenv( 'WP_CLI_TEST_EXPAND_GLOBS_NO_GLOB_BRACE=0' );
 		$out = Utils\expand_globs( $dir . $path );
+		sort( $out );
 		$this->assertSame( $expected, $out );
 
 		putenv( 'WP_CLI_TEST_EXPAND_GLOBS_NO_GLOB_BRACE=1' );
 		$out = Utils\expand_globs( $dir . $path );
+		sort( $out );
 		$this->assertSame( $expected, $out );
 
 		putenv( false === $expand_globs_no_glob_brace ? 'WP_CLI_TEST_EXPAND_GLOBS_NO_GLOB_BRACE' : "WP_CLI_TEST_EXPAND_GLOBS_NO_GLOB_BRACE=$expand_globs_no_glob_brace" );


### PR DESCRIPTION
Fixes #4671 

Checks for correct extension in `test_behat_tags_extension()`.

Uses `--force-local` on Windows only in `test_extract_tarball()`.

Sorts expected/actual in `testExpandGlobs()` to allow for different filesystem glob order.

