### PR TITLE
Move phpunit PHP directive tests to behat.

### DIFF
--- a/features/class-wp-cli.feature
+++ b/features/class-wp-cli.feature
@@ -1,0 +1,17 @@
+Feature: Various utilities for WP-CLI commands
+
+  Scenario Outline: Check that `proc_open()` and `proc_close()` aren't disabled for `WP_CLI::launch()`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--ddisable_functions=<func>} --skip-wordpress eval 'WP_CLI::launch( null );'`
+    Then STDERR should contain:
+      """
+      Error: Cannot do 'launch': The PHP functions `proc_open()` and/or `proc_close()` are disabled
+      """
+    And STDOUT should be empty
+    And the return code should be 1
+
+    Examples:
+      | func       |
+      | proc_open  |
+      | proc_close |
+
+

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -1,0 +1,52 @@
+Feature: Utilities that do NOT depend on WordPress code
+
+  Scenario Outline: Check that `proc_open()` and `proc_close()` aren't disabled for `Utils\run_mysql_command()`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--ddisable_functions=<func>} --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( null, array() );'`
+    Then STDERR should contain:
+      """
+      Error: Cannot do 'run_mysql_command': The PHP functions `proc_open()` and/or `proc_close()` are disabled
+      """
+    And STDOUT should be empty
+    And the return code should be 1
+
+    Examples:
+      | func       |
+      | proc_open  |
+      | proc_close |
+
+  Scenario Outline: Check that `proc_open()` and `proc_close()` aren't disabled for `Utils\launch_editor_for_input()`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--ddisable_functions=<func>} --skip-wordpress eval 'WP_CLI\Utils\launch_editor_for_input( null, null );'`
+    Then STDERR should contain:
+      """
+      Error: Cannot do 'launch_editor_for_input': The PHP functions `proc_open()` and/or `proc_close()` are disabled
+      """
+    And STDOUT should be empty
+    And the return code should be 1
+
+    Examples:
+      | func       |
+      | proc_open  |
+      | proc_close |
+
+  # INI directive `sys_temp_dir` introduced PHP 5.5.0.
+  @require-php-5.5
+  Scenario: Check `Utils\get_temp_dir()` when `sys_temp_dir` directive set
+    # `sys_temp_dir` set to unwritable.
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dsys_temp_dir=\\tmp\\} --skip-wordpress eval 'echo WP_CLI\Utils\get_temp_dir();'`
+    Then STDERR should contain:
+      """
+      Warning: Temp directory isn't writable
+      """
+    And STDERR should contain:
+      """
+      \tmp/
+      """
+    And STDOUT should be:
+      """
+      \tmp/
+      """
+    And the return code should be 0
+
+    # `sys_temp_dir` unset.
+    When I run `{INVOKE_WP_CLI_WITH_PHP_ARGS--dsys_temp_dir=} --skip-wordpress eval 'echo WP_CLI\Utils\get_temp_dir();'`
+    Then STDOUT should match /\/$/

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -332,28 +332,6 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetTempDir() {
 		$this->assertTrue( '/' === substr( Utils\get_temp_dir(), -1 ) );
-
-		// INI directive `sys_temp_dir` introduced PHP 5.5.0.
-		if ( version_compare( PHP_VERSION, '5.5.0', '>=' ) ) {
-
-			// `sys_temp_dir` set to unwritable.
-
-			$cmd = 'php ' . escapeshellarg( '-dsys_temp_dir=\\tmp\\' ) . ' php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'echo WP_CLI\\Utils\\get_temp_dir();' ) . ' 2>&1';
-			$output = array();
-			exec( $cmd, $output );
-			$output = trim( implode( "\n", $output ) );
-			$this->assertTrue( false !== strpos( $output, 'Warning' ) );
-			$this->assertTrue( false !== strpos( $output, 'writable' ) );
-			$this->assertTrue( false !== strpos( $output, '\\tmp/' ) );
-
-			// `sys_temp_dir` unset.
-
-			$cmd = 'php ' . escapeshellarg( '-dsys_temp_dir=' ) . ' php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'echo WP_CLI\\Utils\\get_temp_dir();' ) . ' 2>&1';
-			$output = array();
-			exec( $cmd, $output );
-			$output = trim( implode( "\n", $output ) );
-			$this->assertTrue( '/' === substr( $output, -1 ) );
-		}
 	}
 
 	public function testHttpRequestBadAddress() {
@@ -449,38 +427,6 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 
 		// Restore.
 		$class_wp_cli_logger->setValue( $prev_logger );
-	}
-
-	public function testRunMysqlCommandProcDisabled() {
-		$err_msg = 'Error: Cannot do \'run_mysql_command\': The PHP functions `proc_open()` and/or `proc_close()` are disabled';
-
-		$cmd = 'php -ddisable_functions=proc_open php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI\\Utils\\run_mysql_command( null, array() );' ) . ' 2>&1';
-		$output = array();
-		exec( $cmd, $output );
-		$output = trim( implode( "\n", $output ) );
-		$this->assertTrue( false !== strpos( $output, $err_msg ) );
-
-		$cmd = 'php -ddisable_functions=proc_close php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI\\Utils\\run_mysql_command( null, array() );' ) . ' 2>&1';
-		$output = array();
-		exec( $cmd, $output );
-		$output = trim( implode( "\n", $output ) );
-		$this->assertTrue( false !== strpos( $output, $err_msg ) );
-	}
-
-	public function testLaunchEditorForInputProcDisabled() {
-		$err_msg = 'Error: Cannot do \'launch_editor_for_input\': The PHP functions `proc_open()` and/or `proc_close()` are disabled';
-
-		$cmd = 'php -ddisable_functions=proc_open php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI\\Utils\\launch_editor_for_input( null, null );' ) . ' 2>&1';
-		$output = array();
-		exec( $cmd, $output );
-		$output = trim( implode( "\n", $output ) );
-		$this->assertTrue( false !== strpos( $output, $err_msg ) );
-
-		$cmd = 'php -ddisable_functions=proc_close php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI\\Utils\\launch_editor_for_input( null, null );' ) . ' 2>&1';
-		$output = array();
-		exec( $cmd, $output );
-		$output = trim( implode( "\n", $output ) );
-		$this->assertTrue( false !== strpos( $output, $err_msg ) );
 	}
 
 	/**

--- a/tests/test-wp-cli.php
+++ b/tests/test-wp-cli.php
@@ -2,22 +2,6 @@
 
 class WP_CLI_Test extends PHPUnit_Framework_TestCase {
 
-	public function testLaunchProcDisabled() {
-		$err_msg = 'Error: Cannot do \'launch\': The PHP functions `proc_open()` and/or `proc_close()` are disabled';
-
-		$cmd = 'php -ddisable_functions=proc_open php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI::launch( null );' ) . ' 2>&1';
-		$output = array();
-		exec( $cmd, $output );
-		$output = trim( implode( "\n", $output ) );
-		$this->assertTrue( false !== strpos( $output, $err_msg ) );
-
-		$cmd = 'php -ddisable_functions=proc_close php/boot-fs.php --skip-wordpress eval ' . escapeshellarg( 'WP_CLI::launch( null );' ) . ' 2>&1';
-		$output = array();
-		exec( $cmd, $output );
-		$output = trim( implode( "\n", $output ) );
-		$this->assertTrue( false !== strpos( $output, $err_msg ) );
-	}
-
 	public function testGetPHPBinary() {
 		$this->assertSame( WP_CLI\Utils\get_php_binary(), WP_CLI::get_php_binary() );
 	}


### PR DESCRIPTION
Closes #4673 

Moves remaining (see https://github.com/wp-cli/wp-cli/pull/4597) phpunit tests invoking PHP with directive to behat `INVOKE_WP_CLI_WITH_PHP_ARGS` tests.