### PR TITLE
Support launching system editor with specific temp file extension

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -355,14 +355,14 @@ function pick_fields( $item, $fields ) {
  * @param  string  $ext      Extension to use with the temp file.
  * @return string|bool       Edited text, if file is saved from editor; false, if no change to file.
  */
-function launch_editor_for_input( $input, $filename = 'WP-CLI', $ext = 'tmp' ) {
+function launch_editor_for_input( $input, $title = 'WP-CLI', $ext = 'tmp' ) {
 
 	check_proc_available( 'launch_editor_for_input' );
 
 	$tmpdir = get_temp_dir();
 
 	do {
-		$tmpfile = basename( $filename );
+		$tmpfile = basename( $title );
 		$tmpfile = preg_replace( '|\.[^.]*$|', '', $tmpfile );
 		$tmpfile .= '-' . substr( md5( mt_rand() ), 0, 6 );
 		$tmpfile = $tmpdir . $tmpfile . '.' . $ext;

--- a/php/utils.php
+++ b/php/utils.php
@@ -351,9 +351,11 @@ function pick_fields( $item, $fields ) {
  * @category Input
  *
  * @param  string  $content  Some form of text to edit (e.g. post content)
+ * @param  string  $title    Title to display in the editor.
+ * @param  string  $ext      Extension to use with the temp file.
  * @return string|bool       Edited text, if file is saved from editor; false, if no change to file.
  */
-function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
+function launch_editor_for_input( $input, $filename = 'WP-CLI', $ext = 'tmp' ) {
 
 	check_proc_available( 'launch_editor_for_input' );
 
@@ -363,7 +365,7 @@ function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
 		$tmpfile = basename( $filename );
 		$tmpfile = preg_replace( '|\.[^.]*$|', '', $tmpfile );
 		$tmpfile .= '-' . substr( md5( mt_rand() ), 0, 6 );
-		$tmpfile = $tmpdir . $tmpfile . '.tmp';
+		$tmpfile = $tmpdir . $tmpfile . '.' . $ext;
 		$fp = fopen( $tmpfile, 'xb' );
 		if ( ! $fp && is_writable( $tmpdir ) && file_exists( $tmpfile ) ) {
 			$tmpfile = '';


### PR DESCRIPTION
If the editor does some amount of syntax highlighting, it probably needs
the extension to enable the highlighting.

See https://github.com/wp-cli/config-command/pull/48