### PR TITLE
Only check staged files during the pre-commit PHPCS verification

### DIFF
--- a/utils/git-pre-commit-script
+++ b/utils/git-pre-commit-script
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-if REV=$(git rev-parse -q --verify HEAD)
-then
+if REV=$(git rev-parse -q --verify HEAD); then
     against=HEAD
 else
     # Initial commit: diff against an empty tree object

--- a/utils/git-pre-commit-script
+++ b/utils/git-pre-commit-script
@@ -10,7 +10,7 @@ fi
 FILES=$(git diff-index --name-only --cached --diff-filter=ACMR $against -- )
 
 if [ "$FILES" == "" ]; then
-	echo "No files to check with PHPCS.\n"
+	echo "No files to check with PHPCS."
 	exit 0
 fi
 

--- a/utils/git-pre-commit-script
+++ b/utils/git-pre-commit-script
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 if REV=$(git rev-parse -q --verify HEAD); then
-    against=HEAD
+	against=HEAD
 else
-    # Initial commit: diff against an empty tree object
-    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+	# Initial commit: diff against an empty tree object
+	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
 
 FILES=$(git diff-index --name-only --cached --diff-filter=ACMR $against -- )
 
 if [ "$FILES" == "" ]; then
 	echo "No files to check with PHPCS.\n"
-    exit 0
+	exit 0
 fi
 
 set -ex

--- a/utils/git-pre-commit-script
+++ b/utils/git-pre-commit-script
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if REV=$(git rev-parse -q --verify HEAD)
+then
+    against=HEAD
+else
+    # Initial commit: diff against an empty tree object
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+FILES=$(git diff-index --name-only --cached --diff-filter=ACMR $against -- )
+
+if [ "$FILES" == "" ]; then
+	echo "No files to check with PHPCS.\n"
+    exit 0
+fi
+
+set -ex
+
+{{PHPCS_BIN}} -s $FILES

--- a/utils/git-setup-pre-commit-hook
+++ b/utils/git-setup-pre-commit-hook
@@ -25,7 +25,7 @@ fi
 pre_commit_file="$(git rev-parse --git-dir)/hooks/pre-commit"
 
 if [[ ! -f "$pre_commit_file" ]]; then
-	echo -e "#!/bin/bash\nset -ex\n$phpcs_bin" > $pre_commit_file
+	cat utils/git-pre-commit-script | sed 's|{{PHPCS_BIN}}|'$phpcs_bin'|' > $pre_commit_file
 	chmod +x $pre_commit_file
 elif ! grep -q "phpcs" $pre_commit_file; then
 	echo -e "hook file already exists: $pre_commit_file\n\nplease add the below command to your pre-commit file:\n\n$phpcs_bin"


### PR DESCRIPTION
This avoids causing unnecessary delays when committing files.

See https://github.com/wp-cli/wp-cli/pull/4622#issuecomment-366789280