### PR TITLE
Remove : from cli update info check.

### DIFF
--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -333,7 +333,7 @@ class CLI_Command extends WP_CLI_Command {
 		$php_binary = Utils\get_php_binary();
 		$process = WP_CLI\Process::create( "{$php_binary} $temp --info {$allow_root}" );
 		$result = $process->run();
-		if ( 0 !== $result->return_code || false === stripos( $result->stdout, 'WP-CLI version:' ) ) {
+		if ( 0 !== $result->return_code || false === stripos( $result->stdout, 'WP-CLI version' ) ) {
 			$multi_line = explode( PHP_EOL, $result->stderr );
 			WP_CLI::error_multi_line( $multi_line );
 			WP_CLI::error( 'The downloaded PHAR is broken, try running wp cli update again.' );


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/pull/4692#issuecomment-366808983

Removes colon from cli update info check to get builds working again.

Will probably revert https://github.com/wp-cli/wp-cli/pull/4613 also as unnecessary BC break.