### PR TITLE
Revert "update `wp cli info`"

### DIFF
--- a/features/cli-info.feature
+++ b/features/cli-info.feature
@@ -26,7 +26,7 @@ Feature: Review CLI information
     When I run `wp cli info`
     Then STDOUT should contain:
       """
-      WP-CLI packages dir
+      WP-CLI packages dir:
       """
 
   Scenario: Packages directory path should be slashed correctly

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -130,29 +130,18 @@ class CLI_Command extends WP_CLI_Command {
 
 			WP_CLI::line( json_encode( $info ) );
 		} else {
-
-			$info = array(
-				array( 'OS', $system_os ),
-				array( 'Shell', $shell ),
-				array( 'PHP binary', $php_bin ),
-				array( 'PHP version', PHP_VERSION ),
-				array( 'php.ini used', get_cfg_var( 'cfg_file_path' ) ),
-				array( 'WP-CLI root dir', WP_CLI_ROOT ),
-				array( 'WP-CLI vendor dir', WP_CLI_VENDOR_DIR ),
-				array( 'WP_CLI phar path', ( defined( 'WP_CLI_PHAR_PATH' ) ? WP_CLI_PHAR_PATH : '' ) ),
-				array( 'WP-CLI packages dir', $packages_dir ),
-				array( 'WP-CLI global config', $runner->global_config_path ),
-				array( 'WP-CLI project config', $runner->project_config_path ),
-				array( 'WP-CLI version', WP_CLI_VERSION ),
-			);
-
-			$info_table = new \cli\Table();
-			$info_table->setRows( $info );
-			$info_table->setRenderer( new \cli\table\Ascii() );
-			$lines = array_slice( $info_table->getDisplayLines(), 2 );
-			foreach ( $lines as $line ) {
-				\WP_CLI::line( $line );
-			}
+			WP_CLI::line( "OS:\t" . $system_os );
+			WP_CLI::line( "Shell:\t" . $shell );
+			WP_CLI::line( "PHP binary:\t" . $php_bin );
+			WP_CLI::line( "PHP version:\t" . PHP_VERSION );
+			WP_CLI::line( "php.ini used:\t" . get_cfg_var( 'cfg_file_path' ) );
+			WP_CLI::line( "WP-CLI root dir:\t" . WP_CLI_ROOT );
+			WP_CLI::line( "WP-CLI vendor dir:\t" . WP_CLI_VENDOR_DIR );
+			WP_CLI::line( "WP_CLI phar path:\t" . ( defined( 'WP_CLI_PHAR_PATH' ) ? WP_CLI_PHAR_PATH : '' ) );
+			WP_CLI::line( "WP-CLI packages dir:\t" . $packages_dir );
+			WP_CLI::line( "WP-CLI global config:\t" . $runner->global_config_path );
+			WP_CLI::line( "WP-CLI project config:\t" . $runner->project_config_path );
+			WP_CLI::line( "WP-CLI version:\t" . WP_CLI_VERSION );
 		}
 	}
 


### PR DESCRIPTION
Reverts wp-cli/wp-cli#4613

See https://github.com/wp-cli/wp-cli/issues/4701 where it breaks self-updating.

Plus unnecessary BC break, less readable, my fault, apologies and thanks to @thrijith for the work.