### PR TITLE
Skip pre-commit hook in auto-composer-update

### DIFF
--- a/utils/auto-composer-update.sh
+++ b/utils/auto-composer-update.sh
@@ -43,7 +43,7 @@ MESSAGE="Update Composer dependencies ($DATE)
 \`\`\`
 $UPDATE
 \`\`\`"
-git commit -m "$MESSAGE"
+git commit -m -n "$MESSAGE"
 
 # Push and pull request
 git push origin $BRANCH

--- a/utils/auto-composer-update.sh
+++ b/utils/auto-composer-update.sh
@@ -43,7 +43,7 @@ MESSAGE="Update Composer dependencies ($DATE)
 \`\`\`
 $UPDATE
 \`\`\`"
-git commit -m -n "$MESSAGE"
+git commit -n -m "$MESSAGE"
 
 # Push and pull request
 git push origin $BRANCH


### PR DESCRIPTION
When our bot gets rejected because of PHPCS violations, it doesn't know
what to do. It's better the pull request is submitted.