### PR TITLE
Introducing `\WP_CLI\Utils\normalize_path` function. Using it for ABSPATH constant.

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -232,7 +232,7 @@ class Runner {
 	 * @param string $path
 	 */
 	private static function set_wp_root( $path ) {
-		define( 'ABSPATH', Utils\trailingslashit( $path ) );
+		define( 'ABSPATH', Utils\normalize_path( Utils\trailingslashit( $path ) ) );
 		WP_CLI::debug( 'ABSPATH defined: ' . ABSPATH, 'bootstrap' );
 
 		$_SERVER['DOCUMENT_ROOT'] = realpath( $path );

--- a/php/utils.php
+++ b/php/utils.php
@@ -777,12 +777,14 @@ function trailingslashit( $string ) {
 /**
  * Normalize a filesystem path.
  *
- * On windows systems, replaces backslashes with forward slashes
+ * On Windows systems, replaces backslashes with forward slashes
  * and forces upper-case drive letters.
  * Allows for two leading slashes for Windows network shares, but
- * ensures that all other duplicate slashes are reduced to a single.
+ * ensures that all other duplicate slashes are reduced to a single one.
  * Ensures upper-case drive letters on Windows systems.
- * Allows for Windows network shares.
+ *
+ * @access public
+ * @category System
  *
  * @param string $path Path to normalize.
  * @return string Normalized path.

--- a/php/utils.php
+++ b/php/utils.php
@@ -775,6 +775,29 @@ function trailingslashit( $string ) {
 }
 
 /**
+ * Normalize a filesystem path.
+ *
+ * On windows systems, replaces backslashes with forward slashes
+ * and forces upper-case drive letters.
+ * Allows for two leading slashes for Windows network shares, but
+ * ensures that all other duplicate slashes are reduced to a single.
+ * Ensures upper-case drive letters on Windows systems.
+ * Allows for Windows network shares.
+ *
+ * @param string $path Path to normalize.
+ * @return string Normalized path.
+ */
+function normalize_path( $path ) {
+	$path = str_replace( '\\', '/', $path );
+	$path = preg_replace( '|(?<=.)/+|', '/', $path );
+	if ( ':' === substr( $path, 1, 1 ) ) {
+		$path = ucfirst( $path );
+	}
+	return $path;
+}
+
+
+/**
  * Convert Windows EOLs to *nix.
  *
  * @param string $str String to convert.

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -326,6 +326,26 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame( 'a/', Utils\trailingslashit( 'a\\//\\' ) );
 	}
 
+	public function testNormalizePath() {
+		$this->assertSame( '', Utils\normalize_path( '' ) );
+		// Windows paths
+		$this->assertSame( 'C:/www/path/', Utils\normalize_path( 'C:\\www\\path\\' ) );
+		$this->assertSame( 'C:/www/path/', Utils\normalize_path( 'C:\\www\\\\path\\' ) );
+		$this->assertSame( 'C:', Utils\normalize_path( 'c:' ) ); // uppercase driver letter
+		$this->assertSame( 'C:/', Utils\normalize_path( 'c:\\' ) );
+		$this->assertSame( 'C:/www/path', Utils\normalize_path( 'c:/www/path' ) );
+		$this->assertSame( 'C:/www/path/', Utils\normalize_path( 'c:\\www\\path\\' ) );
+		$this->assertSame( 'C:/www/path/', Utils\normalize_path( 'c:\\\\www\\path\\' ) );
+		$this->assertSame( '//Domain/DFSRoots/share/path/', Utils\normalize_path( '\\\\Domain\\DFSRoots\\share\\path\\' ) );
+		$this->assertSame( '//Server/share/path', Utils\normalize_path( '\\\\Server\\share\\path' ) );
+		$this->assertSame( '//Server/share', Utils\normalize_path( '\\\\Server\\share' ) );
+		// Linux paths
+		$this->assertSame( '/', Utils\normalize_path( '/' ) );
+		$this->assertSame( '/www/path/', Utils\normalize_path( '/www/path/' ) );
+		$this->assertSame( '/www/path/', Utils\normalize_path( '/www/path/////' ) );
+		$this->assertSame( '/www/path', Utils\normalize_path( '/www/path' ) );
+	}
+
 	public function testNormalizeEols() {
 		$this->assertSame( "\na\ra\na\n", Utils\normalize_eols( "\r\na\ra\r\na\r\n" ) );
 	}

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -326,24 +326,34 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame( 'a/', Utils\trailingslashit( 'a\\//\\' ) );
 	}
 
-	public function testNormalizePath() {
-		$this->assertSame( '', Utils\normalize_path( '' ) );
-		// Windows paths
-		$this->assertSame( 'C:/www/path/', Utils\normalize_path( 'C:\\www\\path\\' ) );
-		$this->assertSame( 'C:/www/path/', Utils\normalize_path( 'C:\\www\\\\path\\' ) );
-		$this->assertSame( 'C:', Utils\normalize_path( 'c:' ) ); // uppercase driver letter
-		$this->assertSame( 'C:/', Utils\normalize_path( 'c:\\' ) );
-		$this->assertSame( 'C:/www/path', Utils\normalize_path( 'c:/www/path' ) );
-		$this->assertSame( 'C:/www/path/', Utils\normalize_path( 'c:\\www\\path\\' ) );
-		$this->assertSame( 'C:/www/path/', Utils\normalize_path( 'c:\\\\www\\path\\' ) );
-		$this->assertSame( '//Domain/DFSRoots/share/path/', Utils\normalize_path( '\\\\Domain\\DFSRoots\\share\\path\\' ) );
-		$this->assertSame( '//Server/share/path', Utils\normalize_path( '\\\\Server\\share\\path' ) );
-		$this->assertSame( '//Server/share', Utils\normalize_path( '\\\\Server\\share' ) );
-		// Linux paths
-		$this->assertSame( '/', Utils\normalize_path( '/' ) );
-		$this->assertSame( '/www/path/', Utils\normalize_path( '/www/path/' ) );
-		$this->assertSame( '/www/path/', Utils\normalize_path( '/www/path/////' ) );
-		$this->assertSame( '/www/path', Utils\normalize_path( '/www/path' ) );
+	/**
+	 * @dataProvider dataNormalizePath
+	 */
+	public function testNormalizePath( $path, $expected ) {
+		$this->assertEquals( $expected, Utils\normalize_path( $path ) );
+	}
+
+	public function dataNormalizePath() {
+		return array(
+			array( '', '' ),
+			// Windows paths
+			array( 'C:\\www\\path\\', 'C:/www/path/' ),
+			array( 'C:\\www\\\\path\\', 'C:/www/path/' ),
+			array( 'c:/www/path', 'C:/www/path' ),
+			array( 'c:\\www\\path\\', 'C:/www/path/' ), // uppercase drive letter
+			array( 'c:', 'C:' ),
+			array( 'c:\\', 'C:/' ),
+			array( 'c:\\\\www\\path\\', 'C:/www/path/' ),
+			array( '\\\\Domain\\DFSRoots\\share\\path\\', '//Domain/DFSRoots/share/path/' ),
+			array( '\\\\Server\\share\\path', '//Server/share/path' ),
+			array( '\\\\Server\\share', '//Server/share' ),
+			// Linux paths
+			array( '/', '/' ),
+			array( '/www/path/', '/www/path/' ),
+			array( '/www/path/////', '/www/path/' ),
+			array( '/www/path', '/www/path' ),
+			array( '/www/path', '/www/path' ),
+		);
 	}
 
 	public function testNormalizeEols() {


### PR DESCRIPTION
As discussed with @gitlost here: https://github.com/wp-cli/checksum-command/pull/39
Introducing `normalize_path` function (copied it from latest the WP Core :) ), and applied it to the `ABSPATH` constant, so that path concatenations of it have (more or less) consistent path separators.