### PR TITLE
Allow WP_CLI::confirm to be sent to stderr

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -819,7 +819,11 @@ class WP_CLI {
 	 * @param array $assoc_args Skips prompt if 'yes' is provided.
 	 */
 	public static function confirm( $question, $assoc_args = array() ) {
-		switch ( $assoc_args['out'] ) {
+		$args = wp_parse_args( $assoc_args, array(
+			'out' => 'stdout',
+		) );
+		
+		switch ( $args['out'] ) {
 			case 'stderr':
 				$out = STDERR;
 				break;

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -819,17 +819,17 @@ class WP_CLI {
 	 * @param array $assoc_args Skips prompt if 'yes' is provided.
 	 */
 	public static function confirm( $question, $assoc_args = array() ) {
-		switch( $assoc_args[ 'out' ] ) {
+		switch ( $assoc_args['out'] ) {
 			case 'stderr':
 				$out = STDERR;
 				break;
-				
+
 			case 'stdout':
 			default:
 				$out = STDOUT;
 				break;
 		}
-		
+
 		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'yes' ) ) {
 			fwrite( $out, $question . ' [y/n] ' );
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -819,8 +819,19 @@ class WP_CLI {
 	 * @param array $assoc_args Skips prompt if 'yes' is provided.
 	 */
 	public static function confirm( $question, $assoc_args = array() ) {
+		switch( $assoc_args[ 'out' ] ) {
+			case 'stderr':
+				$out = STDERR;
+				break;
+				
+			case 'stdout':
+			default:
+				$out = STDOUT;
+				break;
+		}
+		
 		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'yes' ) ) {
-			fwrite( STDOUT, $question . ' [y/n] ' );
+			fwrite( $out, $question . ' [y/n] ' );
 
 			$answer = strtolower( trim( fgets( STDIN ) ) );
 


### PR DESCRIPTION
Some scripts produce a lot of output and it's useful to redirect stdout to a file. In that case, we need to send the confirmation prompt to stderr, else it also is redirected to the file and the script hangs waiting for input.

Fixes #4732