### PR TITLE
Show help text even when `proc_(open|close)` aren't available

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -1010,6 +1010,7 @@ Feature: Get help about WP-CLI commands
       """
       Warning: check_proc_available() failed in pass_through_pager().
       """
+    And STDOUT should not be empty
     And the return code should be 0
 
     Examples:

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -110,8 +110,9 @@ class Help_Command extends WP_CLI_Command {
 	private static function pass_through_pager( $out ) {
 
 		if ( ! Utils\check_proc_available( null /*context*/, true /*return*/ ) ) {
+			WP_CLI::line( $out );
 			WP_CLI::debug( 'Warning: check_proc_available() failed in pass_through_pager().', 'help' );
-			return $out;
+			return -1;
 		}
 
 		if ( false === ( $pager = getenv( 'PAGER' ) ) ) {

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -82,7 +82,7 @@ return array(
 		'runtime' => '[=<group>]',
 		'file' => '<group>',
 		'default' => false,
-		'desc' => 'Show all PHP errors; add verbosity to WP-CLI bootstrap.',
+		'desc' => 'Show all PHP errors and add verbosity to WP-CLI output. Built-in groups include: bootstrap, commandfactory, and help.',
 	),
 
 	'prompt' => array(


### PR DESCRIPTION
When running `wp help` on an environment where `proc_open()` or `proc_close()` aren't available, the command silently fails with no output (unless the `--debug` flag is used).

The command should output the help text using stdout in this situation, so the user still sees help text.

This change also improves the corresponding description of the `--debug` flag, and switches to returning `-1` from `Help_Command::pass_through_pager()` so that its return value matches that of `proc_close()` when there's an error.