### PR TITLE
Add a missing accepted output format to `wp cli alias`

### DIFF
--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -551,6 +551,7 @@ class CLI_Command extends WP_CLI_Command {
 	 * options:
 	 *   - yaml
 	 *   - json
+	 *   - var_export
 	 * ---
 	 *
 	 * ## EXAMPLES


### PR DESCRIPTION
This format is accepted already, it's just not documented and therefore isn't usable.