### PR TITLE
Bump lowest PHP version to test to 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,7 @@ jobs:
       env: WP_VERSION=3.7.11
     - stage: test
       script: ./ci/test.sh
-      php: 5.3
-      dist: precise
+      php: 5.4
       env: WP_VERSION=3.7.11
     - stage: deploy
       env: DEPLOY_BRANCH=master


### PR DESCRIPTION
The build for testing WP-CLI is currently broken on PHP 5.3. Given that:

- the current version v2.x is supposed to drop PHP 5.3 support;
- PHP 5.3 only runs on Travis within a separate distro, which might not get the same care;
- efforts in https://github.com/wp-cli/wp-cli/issues/4791 to fix the PHP 5.3 build have failed;
- no bug reports were provided for the issue the tests on PHP 5.3 flag;

=> I've decided to just bump the minimum tested version to PHP 5.4 now.

Fixes #4791