### PR TITLE
Update Composer dependencies (2018-05-28)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -702,7 +702,7 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.8.40",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
@@ -759,7 +759,7 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.40",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
@@ -820,7 +820,7 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v2.8.40",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
@@ -877,7 +877,7 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.8.40",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
@@ -940,7 +940,7 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.40",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -1000,7 +1000,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.8.40",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -1050,7 +1050,7 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v2.8.40",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -1213,7 +1213,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.40",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -1262,7 +1262,7 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v2.8.40",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
@@ -1326,7 +1326,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.40",
+            "version": "v2.8.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",


### PR DESCRIPTION
```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 10 updates, 0 removals
  - Updating symfony/filesystem (v2.8.40 => v2.8.41):  Checking out 1ed4b26555
  - Updating symfony/config (v2.8.40 => v2.8.41):  Checking out 93bdf96d0e
  - Updating symfony/debug (v2.8.40 => v2.8.41):  Checking out fe8838e11c
  - Updating symfony/console (v2.8.40 => v2.8.41):  Checking out e8e59b74ad
  - Updating symfony/dependency-injection (v2.8.40 => v2.8.41):	 Checking out 3d7cbf34cd
  - Updating symfony/event-dispatcher (v2.8.40 => v2.8.41):  Checking out 9b69aad7d4
  - Updating symfony/finder (v2.8.40 => v2.8.41):  Checking out 79764d2116
  - Updating symfony/process (v2.8.40 => v2.8.41):  Checking out 713952f2cc
  - Updating symfony/translation (v2.8.40 => v2.8.41):	Checking out c6a27966a9
  - Updating symfony/yaml (v2.8.40 => v2.8.41):	 Checking out 51356b7a2f
Writing lock file
Generating autoload files
```