### PR TITLE
PHPCS Config Refresh

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
 		"phpunit/phpunit": "3.7.*",
 		"roave/security-advisories": "dev-master",
         "phpcompatibility/phpcompatibility-wp": "^1",
-		"wp-coding-standards/wpcs": "^0.13.1"
+		"wp-coding-standards/wpcs": "^1"
 	},
 	"suggest": {
 		"psy/psysh": "Enhanced `wp shell` functionality"

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
 		"phpunit/phpunit": "3.7.*",
 		"roave/security-advisories": "dev-master",
-		"wimg/php-compatibility": "^8.0",
+        "phpcompatibility/phpcompatibility-wp": "^1",
 		"wp-coding-standards/wpcs": "^0.13.1"
 	},
 	"suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc0810f2e7c1640f66669be4620d4325",
+    "content-hash": "5b3032f9ed818e3d27e6a02ee0d84c0d",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3950,24 +3950,27 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.13.1",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "1f64b1a0b5b789822d0303436ee4e30e0135e4dc"
+                "reference": "539c6d74e6207daa22b7ea754d6f103e9abb2755"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/1f64b1a0b5b789822d0303436ee4e30e0135e4dc",
-                "reference": "1f64b1a0b5b789822d0303436ee4e30e0135e4dc",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/539c6d74e6207daa22b7ea754d6f103e9abb2755",
+                "reference": "539c6d74e6207daa22b7ea754d6f103e9abb2755",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3",
                 "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
             },
+            "require-dev": {
+                "phpcompatibility/php-compatibility": "*"
+            },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -3986,7 +3989,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2017-08-05T16:08:58+00:00"
+            "time": "2018-07-25T18:10:35+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f7842c55102768e34d9d48b187ab0b7",
+    "content-hash": "dc0810f2e7c1640f66669be4620d4325",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3232,6 +3232,105 @@
             "time": "2017-12-06T16:27:17+00:00"
         },
         {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "8.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "PHPCompatibility\\": "PHPCompatibility/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-07-17T13:42:26+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "b26c84df3ec1d4850d0f22264a4a16482a171996"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b26c84df3ec1d4850d0f22264a4a16482a171996",
+                "reference": "b26c84df3ec1d4850d0f22264a4a16482a171996",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^8.1"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility for WordPress projects.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2018-07-16T22:10:02+00:00"
+        },
+        {
             "name": "phpunit/php-code-coverage",
             "version": "1.2.18",
             "source": {
@@ -3848,59 +3947,6 @@
                 "standards"
             ],
             "time": "2017-05-22T02:43:20+00:00"
-        },
-        {
-            "name": "wimg/php-compatibility",
-            "version": "8.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
-            },
-            "conflict": {
-                "squizlabs/php_codesniffer": "2.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
-                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-            },
-            "type": "phpcodesniffer-standard",
-            "autoload": {
-                "psr-4": {
-                    "PHPCompatibility\\": "PHPCompatibility/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Wim Godden",
-                    "role": "lead"
-                }
-            ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
-            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
-            "keywords": [
-                "compatibility",
-                "phpcs",
-                "standards"
-            ],
-            "time": "2018-07-17T13:42:26+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/php/WP_CLI/Bootstrap/LoadRequiredCommand.php
+++ b/php/WP_CLI/Bootstrap/LoadRequiredCommand.php
@@ -33,7 +33,7 @@ final class LoadRequiredCommand implements BootstrapStep {
 
 		foreach ( $runner()->config['require'] as $path ) {
 			if ( ! file_exists( $path ) ) {
-				$context = '';
+				$context        = '';
 				$required_files = $runner()->get_required_files();
 				foreach ( array( 'global', 'project', 'runtime' ) as $scope ) {
 					if ( in_array( $path, $required_files[ $scope ], true ) ) {

--- a/php/WP_CLI/Completions.php
+++ b/php/WP_CLI/Completions.php
@@ -21,7 +21,7 @@ class Completions {
 		}
 
 		$is_alias = false;
-		$is_help = false;
+		$is_help  = false;
 		if ( ! empty( $this->words[0] ) && preg_match( '/^@/', $this->words[0] ) ) {
 			array_shift( $this->words );
 			// `wp @al` is false, but `wp @all ` is true.

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -54,10 +54,10 @@ class Configurator {
 		$this->spec = include $path;
 
 		$defaults = array(
-			'runtime' => false,
-			'file' => false,
+			'runtime'  => false,
+			'file'     => false,
 			'synopsis' => '',
-			'default' => null,
+			'default'  => null,
 			'multiple' => false,
 		);
 
@@ -118,7 +118,7 @@ class Configurator {
 	 */
 	public function parse_args( $arguments ) {
 		list( $positional_args, $mixed_args, $global_assoc, $local_assoc ) = self::extract_assoc( $arguments );
-		list( $assoc_args, $runtime_config ) = $this->unmix_assoc_args( $mixed_args, $global_assoc, $local_assoc );
+		list( $assoc_args, $runtime_config )                               = $this->unmix_assoc_args( $mixed_args, $global_assoc, $local_assoc );
 		return array( $positional_args, $assoc_args, $runtime_config );
 	}
 
@@ -224,14 +224,14 @@ class Configurator {
 		foreach ( $yaml as $key => $value ) {
 			if ( preg_match( '#' . self::ALIAS_REGEX . '#', $key ) ) {
 				$this->aliases[ $key ] = array();
-				$is_alias = false;
+				$is_alias              = false;
 				foreach ( self::$alias_spec as $i ) {
 					if ( isset( $value[ $i ] ) ) {
 						if ( 'path' === $i && ! isset( $value['ssh'] ) ) {
 							self::absolutize( $value[ $i ], $yml_file_dir );
 						}
 						$this->aliases[ $key ][ $i ] = $value[ $i ];
-						$is_alias = true;
+						$is_alias                    = true;
 					}
 				}
 				// If it's not an alias, it might be a group of aliases

--- a/php/WP_CLI/Dispatcher/CommandAddition.php
+++ b/php/WP_CLI/Dispatcher/CommandAddition.php
@@ -34,7 +34,7 @@ final class CommandAddition {
 	 * @param string $reason Reason as to why the addition was aborted.
 	 */
 	public function abort( $reason = '' ) {
-		$this->abort = true;
+		$this->abort  = true;
 		$this->reason = (string) $reason;
 	}
 

--- a/php/WP_CLI/Dispatcher/CommandFactory.php
+++ b/php/WP_CLI/Dispatcher/CommandFactory.php
@@ -24,10 +24,10 @@ class CommandFactory {
 		if ( ( is_object( $callable ) && ( $callable instanceof \Closure ) )
 			|| ( is_string( $callable ) && function_exists( $callable ) ) ) {
 			$reflection = new \ReflectionFunction( $callable );
-			$command = self::create_subcommand( $parent, $name, $callable, $reflection );
+			$command    = self::create_subcommand( $parent, $name, $callable, $reflection );
 		} elseif ( is_array( $callable ) && is_callable( $callable ) ) {
 			$reflection = new \ReflectionClass( $callable[0] );
-			$command = self::create_subcommand(
+			$command    = self::create_subcommand(
 				$parent, $name, array( $callable[0], $callable[1] ),
 				$reflection->getMethod( $callable[1] )
 			);
@@ -36,7 +36,7 @@ class CommandFactory {
 			if ( $reflection->isSubclassOf( '\WP_CLI\Dispatcher\CommandNamespace' ) ) {
 				$command = self::create_namespace( $parent, $name, $callable );
 			} elseif ( $reflection->hasMethod( '__invoke' ) ) {
-				$class = is_object( $callable ) ? $callable : $reflection->name;
+				$class   = is_object( $callable ) ? $callable : $reflection->name;
 				$command = self::create_subcommand(
 					$parent, $name, array( $class, '__invoke' ),
 					$reflection->getMethod( '__invoke' )
@@ -68,7 +68,7 @@ class CommandFactory {
 	 */
 	private static function create_subcommand( $parent, $name, $callable, $reflection ) {
 		$doc_comment = self::get_doc_comment( $reflection );
-		$docparser = new \WP_CLI\DocParser( $doc_comment );
+		$docparser   = new \WP_CLI\DocParser( $doc_comment );
 
 		if ( is_array( $callable ) ) {
 			if ( ! $name ) {
@@ -103,7 +103,7 @@ class CommandFactory {
 	 * @param mixed $callable
 	 */
 	private static function create_composite_command( $parent, $name, $callable ) {
-		$reflection = new \ReflectionClass( $callable );
+		$reflection  = new \ReflectionClass( $callable );
 		$doc_comment = self::get_doc_comment( $reflection );
 		if ( ! $doc_comment ) {
 			\WP_CLI::debug( null === $doc_comment ? "Failed to get doc comment for {$name}." : "No doc comment for {$name}.", 'commandfactory' );
@@ -117,7 +117,7 @@ class CommandFactory {
 				continue;
 			}
 
-			$class = is_object( $callable ) ? $callable : $reflection->name;
+			$class      = is_object( $callable ) ? $callable : $reflection->name;
 			$subcommand = self::create_subcommand( $container, false, array( $class, $method->name ), $method );
 
 			$subcommand_name = $subcommand->get_name();
@@ -136,7 +136,7 @@ class CommandFactory {
 	 * @param mixed $callable
 	 */
 	private static function create_namespace( $parent, $name, $callable ) {
-		$reflection = new \ReflectionClass( $callable );
+		$reflection  = new \ReflectionClass( $callable );
 		$doc_comment = self::get_doc_comment( $reflection );
 		if ( ! $doc_comment ) {
 			\WP_CLI::debug( null === $doc_comment ? "Failed to get doc comment for {$name}." : "No doc comment for {$name}.", 'commandfactory' );
@@ -193,7 +193,7 @@ class CommandFactory {
 	 * @return string|bool The last doc comment if any, or false if none.
 	 */
 	private static function extract_last_doc_comment( $content ) {
-		$content = trim( $content );
+		$content         = trim( $content );
 		$comment_end_pos = strrpos( $content, '*/' );
 		if ( false === $comment_end_pos ) {
 			return false;
@@ -214,7 +214,7 @@ class CommandFactory {
 		$subcontent = substr( $content, 0, $comment_start_pos );
 		while ( false !== ( $comment_start2_pos = strrpos( $subcontent, '/**' ) ) && false === strpos( $subcontent, '*/', $comment_start2_pos ) ) {
 			$comment_start_pos = $comment_start2_pos;
-			$subcontent = substr( $subcontent, 0, $comment_start_pos );
+			$subcontent        = substr( $subcontent, 0, $comment_start_pos );
 		}
 		return substr( $content, $comment_start_pos, $comment_end_pos + 2 );
 	}

--- a/php/WP_CLI/Dispatcher/CommandNamespace.php
+++ b/php/WP_CLI/Dispatcher/CommandNamespace.php
@@ -24,7 +24,7 @@ class CommandNamespace extends CompositeCommand {
 	public function show_usage() {
 		$methods = $this->get_subcommands();
 
-		$i = 0;
+		$i     = 0;
 		$count = 0;
 
 		foreach ( $methods as $name => $subcommand ) {
@@ -39,7 +39,7 @@ class CommandNamespace extends CompositeCommand {
 		}
 
 		$cmd_name = implode( ' ', array_slice( get_path( $this ), 1 ) );
-		$message = $count > 0
+		$message  = $count > 0
 			? "See 'wp help $cmd_name <command>' for more information on a specific command."
 			: "The namespace $cmd_name does not contain any usable commands in the current context.";
 

--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -29,7 +29,7 @@ class CompositeCommand {
 		$this->name = $name;
 
 		$this->shortdesc = $docparser->get_shortdesc();
-		$this->longdesc = $docparser->get_longdesc();
+		$this->longdesc  = $docparser->get_longdesc();
 		$this->docparser = $docparser;
 
 		$when_to_invoke = $docparser->get_tag( 'when' );
@@ -265,7 +265,7 @@ class CompositeCommand {
 	 * @return string
 	 */
 	protected function get_global_params( $root_command = false ) {
-		$binding = array();
+		$binding                 = array();
 		$binding['root_command'] = $root_command;
 
 		if ( ! $this->can_have_subcommands() || ( is_object( $this->parent ) && get_class( $this->parent ) == 'WP_CLI\Dispatcher\CompositeCommand' ) ) {
@@ -293,7 +293,7 @@ class CompositeCommand {
 
 			$binding['parameters'][] = array(
 				'synopsis' => $synopsis,
-				'desc' => $details['desc'],
+				'desc'     => $details['desc'],
 			);
 		}
 

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -175,7 +175,7 @@ class Subcommand extends CompositeCommand {
 			}
 
 			$current_prompt = ( $key + 1 ) . '/' . count( $spec ) . ' ';
-			$default = $spec_arg['optional'] ? '' : false;
+			$default        = $spec_arg['optional'] ? '' : false;
 
 			// 'generic' permits arbitrary key=value (e.g. [--<field>=<value>] )
 			if ( 'generic' == $spec_arg['type'] ) {
@@ -197,7 +197,7 @@ class Subcommand extends CompositeCommand {
 
 					if ( $key ) {
 						$key_prompt_count = strlen( $key_prompt ) - strlen( $value_token ) - 1;
-						$value_prompt = str_repeat( ' ', $key_prompt_count ) . '=' . $value_token;
+						$value_prompt     = str_repeat( ' ', $key_prompt_count ) . '=' . $value_token;
 
 						$value = $this->prompt( $value_prompt, $default );
 						if ( false === $value ) {
@@ -293,15 +293,15 @@ class Subcommand extends CompositeCommand {
 		}
 
 		$synopsis_spec = \WP_CLI\SynopsisParser::parse( $synopsis );
-		$i = 0;
-		$errors = array(
-			'fatal' => array(),
+		$i             = 0;
+		$errors        = array(
+			'fatal'   => array(),
 			'warning' => array(),
 		);
-		$mock_doc = array( $this->get_shortdesc(), '' );
-		$mock_doc = array_merge( $mock_doc, explode( "\n", $this->get_longdesc() ) );
-		$mock_doc = '/**' . PHP_EOL . '* ' . implode( PHP_EOL . '* ', $mock_doc ) . PHP_EOL . '*/';
-		$docparser = new \WP_CLI\DocParser( $mock_doc );
+		$mock_doc      = array( $this->get_shortdesc(), '' );
+		$mock_doc      = array_merge( $mock_doc, explode( "\n", $this->get_longdesc() ) );
+		$mock_doc      = '/**' . PHP_EOL . '* ' . implode( PHP_EOL . '* ', $mock_doc ) . PHP_EOL . '*/';
+		$docparser     = new \WP_CLI\DocParser( $mock_doc );
 		foreach ( $synopsis_spec as $spec ) {
 			if ( 'positional' === $spec['type'] ) {
 				$spec_args = $docparser->get_arg_args( $spec['name'] );
@@ -349,7 +349,7 @@ class Subcommand extends CompositeCommand {
 
 		if ( 'help' !== $this->name ) {
 			foreach ( $validator->unknown_assoc( $assoc_args ) as $key ) {
-				$suggestion = Utils\get_suggestion(
+				$suggestion    = Utils\get_suggestion(
 					$key,
 					$this->get_parameters( $synopsis_spec ),
 					$threshold = 2
@@ -392,8 +392,8 @@ class Subcommand extends CompositeCommand {
 		static $prompted_once = false;
 		if ( \WP_CLI::get_config( 'prompt' ) && ! $prompted_once ) {
 			list( $_args, $assoc_args ) = $this->prompt_args( $args, $assoc_args );
-			$args = array_merge( $args, $_args );
-			$prompted_once = true;
+			$args                       = array_merge( $args, $_args );
+			$prompted_once              = true;
 		}
 
 		$extra_positionals = array();
@@ -413,9 +413,9 @@ class Subcommand extends CompositeCommand {
 			unset( $assoc_args[ $key ] );
 		}
 
-		$path = get_path( $this->get_parent() );
+		$path   = get_path( $this->get_parent() );
 		$parent = implode( ' ', array_slice( $path, 1 ) );
-		$cmd = $this->name;
+		$cmd    = $this->name;
 		if ( $parent ) {
 			WP_CLI::do_hook( "before_invoke:{$parent}" );
 			$cmd = $parent . ' ' . $cmd;
@@ -439,7 +439,7 @@ class Subcommand extends CompositeCommand {
 	 * @return array Array of parameter names
 	 */
 	private function get_parameters( $spec = array() ) {
-		$local_parameters = array_column( $spec, 'name' );
+		$local_parameters  = array_column( $spec, 'name' );
 		$global_parameters = array_column(
 			WP_CLI\SynopsisParser::parse( $this->get_global_params() ),
 			'name'

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -20,7 +20,7 @@ class DocParser {
 	 */
 	public function __construct( $docComment ) {
 		/* Make sure we have a known line ending in document */
-		$docComment = str_replace( "\r\n", "\n", $docComment );
+		$docComment       = str_replace( "\r\n", "\n", $docComment );
 		$this->docComment = self::remove_decorations( $docComment );
 	}
 
@@ -162,9 +162,9 @@ class DocParser {
 	 * @return array|null Interpreted YAML document, or null.
 	 */
 	private function get_arg_or_param_args( $regex ) {
-		$bits = explode( "\n", $this->docComment );
+		$bits       = explode( "\n", $this->docComment );
 		$within_arg = $within_doc = false;
-		$document = array();
+		$document   = array();
 		foreach ( $bits as $bit ) {
 			if ( preg_match( $regex, $bit ) ) {
 				$within_arg = true;

--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -73,7 +73,7 @@ class Extractor {
 
 		if ( class_exists( 'PharData' ) ) {
 			try {
-				$phar = new PharData( $tarball );
+				$phar    = new PharData( $tarball );
 				$tempdir = implode(
 					DIRECTORY_SEPARATOR,
 					array(
@@ -95,7 +95,7 @@ class Extractor {
 			}
 		}
 		// Note: directory must exist for tar --directory to work.
-		$cmd = Utils\esc_cmd( 'tar xz --strip-components=1 --directory=%s -f %s', $dest, $tarball );
+		$cmd         = Utils\esc_cmd( 'tar xz --strip-components=1 --directory=%s -f %s', $dest, $tarball );
 		$process_run = WP_CLI::launch( $cmd, false /*exit_on_error*/, true /*return_detailed*/ );
 		if ( 0 !== $process_run->return_code ) {
 			throw new \Exception( sprintf( 'Failed to execute `%s`: %s.', $cmd, self::tar_error_msg( $process_run ) ) );
@@ -172,30 +172,30 @@ class Extractor {
 	public static function zip_error_msg( $error_code ) {
 		// From https://github.com/php/php-src/blob/php-5.3.0/ext/zip/php_zip.c#L2623-L2646
 		static $zip_err_msgs = array(
-			ZipArchive::ER_OK => 'No error',
-			ZipArchive::ER_MULTIDISK => 'Multi-disk zip archives not supported',
-			ZipArchive::ER_RENAME => 'Renaming temporary file failed',
-			ZipArchive::ER_CLOSE => 'Closing zip archive failed',
-			ZipArchive::ER_SEEK => 'Seek error',
-			ZipArchive::ER_READ => 'Read error',
-			ZipArchive::ER_WRITE => 'Write error',
-			ZipArchive::ER_CRC => 'CRC error',
-			ZipArchive::ER_ZIPCLOSED => 'Containing zip archive was closed',
-			ZipArchive::ER_NOENT => 'No such file',
-			ZipArchive::ER_EXISTS => 'File already exists',
-			ZipArchive::ER_OPEN => 'Can\'t open file',
-			ZipArchive::ER_TMPOPEN => 'Failure to create temporary file',
-			ZipArchive::ER_ZLIB => 'Zlib error',
-			ZipArchive::ER_MEMORY => 'Malloc failure',
-			ZipArchive::ER_CHANGED => 'Entry has been changed',
+			ZipArchive::ER_OK          => 'No error',
+			ZipArchive::ER_MULTIDISK   => 'Multi-disk zip archives not supported',
+			ZipArchive::ER_RENAME      => 'Renaming temporary file failed',
+			ZipArchive::ER_CLOSE       => 'Closing zip archive failed',
+			ZipArchive::ER_SEEK        => 'Seek error',
+			ZipArchive::ER_READ        => 'Read error',
+			ZipArchive::ER_WRITE       => 'Write error',
+			ZipArchive::ER_CRC         => 'CRC error',
+			ZipArchive::ER_ZIPCLOSED   => 'Containing zip archive was closed',
+			ZipArchive::ER_NOENT       => 'No such file',
+			ZipArchive::ER_EXISTS      => 'File already exists',
+			ZipArchive::ER_OPEN        => 'Can\'t open file',
+			ZipArchive::ER_TMPOPEN     => 'Failure to create temporary file',
+			ZipArchive::ER_ZLIB        => 'Zlib error',
+			ZipArchive::ER_MEMORY      => 'Malloc failure',
+			ZipArchive::ER_CHANGED     => 'Entry has been changed',
 			ZipArchive::ER_COMPNOTSUPP => 'Compression method not supported',
-			ZipArchive::ER_EOF => 'Premature EOF',
-			ZipArchive::ER_INVAL => 'Invalid argument',
-			ZipArchive::ER_NOZIP => 'Not a zip archive',
-			ZipArchive::ER_INTERNAL => 'Internal error',
-			ZipArchive::ER_INCONS => 'Zip archive inconsistent',
-			ZipArchive::ER_REMOVE => 'Can\'t remove file',
-			ZipArchive::ER_DELETED => 'Entry has been deleted',
+			ZipArchive::ER_EOF         => 'Premature EOF',
+			ZipArchive::ER_INVAL       => 'Invalid argument',
+			ZipArchive::ER_NOZIP       => 'Not a zip archive',
+			ZipArchive::ER_INTERNAL    => 'Internal error',
+			ZipArchive::ER_INCONS      => 'Zip archive inconsistent',
+			ZipArchive::ER_REMOVE      => 'Can\'t remove file',
+			ZipArchive::ER_DELETED     => 'Entry has been deleted',
 		);
 
 		if ( isset( $zip_err_msgs[ $error_code ] ) ) {

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -48,9 +48,9 @@ class FileCache {
 	 * @param string $whitelist  List of characters that are allowed in path names (used in a regex character class)
 	 */
 	public function __construct( $cacheDir, $ttl, $maxSize, $whitelist = 'a-z0-9._-' ) {
-		$this->root = Utils\trailingslashit( $cacheDir );
-		$this->ttl = (int) $ttl;
-		$this->maxSize = (int) $maxSize;
+		$this->root      = Utils\trailingslashit( $cacheDir );
+		$this->ttl       = (int) $ttl;
+		$this->maxSize   = (int) $maxSize;
 		$this->whitelist = $whitelist;
 
 		if ( ! $this->ensure_dir_exists( $this->root ) ) {
@@ -215,7 +215,7 @@ class FileCache {
 			return false;
 		}
 
-		$ttl = $this->ttl;
+		$ttl     = $this->ttl;
 		$maxSize = $this->maxSize;
 
 		// unlink expired files
@@ -297,13 +297,13 @@ class FileCache {
 	protected function validate_key( $key ) {
 		$url_parts = parse_url( $key );
 		if ( ! empty( $url_parts['scheme'] ) ) { // is url
-			$parts = array( 'misc' );
+			$parts   = array( 'misc' );
 			$parts[] = $url_parts['scheme'] . '-' . $url_parts['host'] .
 				( empty( $url_parts['port'] ) ? '' : '-' . $url_parts['port'] );
 			$parts[] = substr( $url_parts['path'], 1 ) .
 				( empty( $url_parts['query'] ) ? '' : '-' . $url_parts['query'] );
 		} else {
-			$key = str_replace( '\\', '/', $key );
+			$key   = str_replace( '\\', '/', $key );
 			$parts = explode( '/', ltrim( $key ) );
 		}
 

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -28,7 +28,7 @@ class Formatter {
 		$format_args = array(
 			'format' => 'table',
 			'fields' => $fields,
-			'field' => null,
+			'field'  => null,
 		);
 
 		foreach ( array( 'format', 'fields', 'field' ) as $key ) {
@@ -44,7 +44,7 @@ class Formatter {
 
 		$format_args['fields'] = array_map( 'trim', $format_args['fields'] );
 
-		$this->args = $format_args;
+		$this->args   = $format_args;
 		$this->prefix = $prefix;
 	}
 
@@ -98,8 +98,8 @@ class Formatter {
 	 */
 	public function display_item( $item, $ascii_pre_colorized = false ) {
 		if ( isset( $this->args['field'] ) ) {
-			$item = (object) $item;
-			$key = $this->find_item_key( $item, $this->args['field'] );
+			$item  = (object) $item;
+			$key   = $this->find_item_key( $item, $this->args['field'] );
 			$value = $item->$key;
 			if ( in_array( $this->args['format'], array( 'table', 'csv' ) ) && ( is_object( $value ) || is_array( $value ) ) ) {
 				$value = json_encode( $value );
@@ -178,7 +178,7 @@ class Formatter {
 	 * @param string The field to show
 	 */
 	private function show_single_field( $items, $field ) {
-		$key = null;
+		$key    = null;
 		$values = array();
 
 		foreach ( $items as $item ) {
@@ -256,7 +256,7 @@ class Formatter {
 
 			case 'table':
 			case 'csv':
-				$rows = $this->assoc_array_to_rows( $data );
+				$rows   = $this->assoc_array_to_rows( $data );
 				$fields = array( 'Field', 'Value' );
 				if ( 'table' == $format ) {
 					self::show_table( $rows, $fields, $ascii_pre_colorized );
@@ -347,7 +347,7 @@ class Formatter {
 	public function transform_item_values_to_json( $item ) {
 		foreach ( $this->args['fields'] as $field ) {
 			$true_field = $this->find_item_key( $item, $field );
-			$value = is_object( $item ) ? $item->$true_field : $item[ $true_field ];
+			$value      = is_object( $item ) ? $item->$true_field : $item[ $true_field ];
 			if ( is_array( $value ) || is_object( $value ) ) {
 				if ( is_object( $item ) ) {
 					$item->$true_field = json_encode( $value );

--- a/php/WP_CLI/Iterators/Query.php
+++ b/php/WP_CLI/Iterators/Query.php
@@ -10,16 +10,16 @@ namespace WP_CLI\Iterators;
 class Query implements \Iterator {
 
 	private $chunk_size;
-	private $query = '';
+	private $query       = '';
 	private $count_query = '';
 
-	private $global_index = 0;
+	private $global_index     = 0;
 	private $index_in_results = 0;
-	private $results = array();
-	private $row_count = 0;
-	private $offset = 0;
-	private $db = null;
-	private $depleted = false;
+	private $results          = array();
+	private $row_count        = 0;
+	private $offset           = 0;
+	private $db               = null;
+	private $depleted         = false;
 
 	/**
 	 * Creates a new query iterator
@@ -71,7 +71,7 @@ class Query implements \Iterator {
 	private function load_items_from_db() {
 		$this->adjust_offset_for_shrinking_result_set();
 
-		$query = $this->query . sprintf( ' LIMIT %d OFFSET %d', $this->chunk_size, $this->offset );
+		$query         = $this->query . sprintf( ' LIMIT %d OFFSET %d', $this->chunk_size, $this->offset );
 		$this->results = $this->db->get_results( $query );
 
 		if ( ! $this->results ) {
@@ -100,11 +100,11 @@ class Query implements \Iterator {
 	}
 
 	public function rewind() {
-		$this->results = array();
-		$this->global_index = 0;
+		$this->results          = array();
+		$this->global_index     = 0;
 		$this->index_in_results = 0;
-		$this->offset = 0;
-		$this->depleted = false;
+		$this->offset           = 0;
+		$this->depleted         = false;
 	}
 
 	public function valid() {

--- a/php/WP_CLI/Iterators/Table.php
+++ b/php/WP_CLI/Iterators/Table.php
@@ -40,19 +40,19 @@ class Table extends Query {
 	 */
 	public function __construct( $args = array() ) {
 		$defaults = array(
-			'fields' => '*',
-			'where' => array(),
-			'append' => '',
-			'table' => null,
+			'fields'     => '*',
+			'where'      => array(),
+			'append'     => '',
+			'table'      => null,
 			'chunk_size' => 500,
 		);
-		$table = $args['table'];
-		$args = array_merge( $defaults, $args );
+		$table    = $args['table'];
+		$args     = array_merge( $defaults, $args );
 
-		$fields = self::build_fields( $args['fields'] );
+		$fields     = self::build_fields( $args['fields'] );
 		$conditions = self::build_where_conditions( $args['where'] );
-		$where_sql = $conditions ? " WHERE $conditions" : '';
-		$query = "SELECT $fields FROM `$table` $where_sql {$args['append']}";
+		$where_sql  = $conditions ? " WHERE $conditions" : '';
+		$query      = "SELECT $fields FROM `$table` $where_sql {$args['append']}";
 
 		parent::__construct( $query, $args['chunk_size'] );
 	}
@@ -79,7 +79,7 @@ class Table extends Query {
 			$conditions = array();
 			foreach ( $where as $key => $value ) {
 				if ( is_array( $value ) ) {
-					$conditions[]  = $key . ' IN (' . esc_sql( implode( ',', $value ) ) . ')';
+					$conditions[] = $key . ' IN (' . esc_sql( implode( ',', $value ) ) . ')';
 				} elseif ( is_numeric( $key ) ) {
 					$conditions[] = $value;
 				} else {

--- a/php/WP_CLI/Loggers/Base.php
+++ b/php/WP_CLI/Loggers/Base.php
@@ -43,7 +43,7 @@ abstract class Base {
 		if ( true !== $debug && $group !== $debug ) {
 			return;
 		}
-		$time = round( microtime( true ) - ( defined( 'WP_CLI_START_MICROTIME' ) ? WP_CLI_START_MICROTIME : $start_time ), 3 );
+		$time   = round( microtime( true ) - ( defined( 'WP_CLI_START_MICROTIME' ) ? WP_CLI_START_MICROTIME : $start_time ), 3 );
 		$prefix = 'Debug';
 		if ( $group && true === $debug ) {
 			$prefix = 'Debug (' . $group . ')';

--- a/php/WP_CLI/Loggers/Regular.php
+++ b/php/WP_CLI/Loggers/Regular.php
@@ -72,7 +72,7 @@ class Regular extends Base {
 
 		foreach ( $message_lines as $line ) {
 			$padding = str_repeat( ' ', $longest - strlen( $line ) );
-			$line = \cli\Colors::colorize( "%w%1 $line $padding%n" );
+			$line    = \cli\Colors::colorize( "%w%1 $line $padding%n" );
 			$this->write( STDERR, "\t$line\n" );
 		}
 

--- a/php/WP_CLI/PackageManagerEventSubscriber.php
+++ b/php/WP_CLI/PackageManagerEventSubscriber.php
@@ -16,7 +16,7 @@ class PackageManagerEventSubscriber implements EventSubscriberInterface {
 	public static function getSubscribedEvents() {
 
 		return array(
-			PackageEvents::PRE_PACKAGE_INSTALL => 'pre_install',
+			PackageEvents::PRE_PACKAGE_INSTALL  => 'pre_install',
 			PackageEvents::POST_PACKAGE_INSTALL => 'post_install',
 		);
 	}
@@ -29,7 +29,7 @@ class PackageManagerEventSubscriber implements EventSubscriberInterface {
 	public static function post_install( PackageEvent $event ) {
 
 		$operation = $event->getOperation();
-		$reason = $operation->getReason();
+		$reason    = $operation->getReason();
 		if ( $reason instanceof Rule ) {
 
 			switch ( $reason->getReason() ) {

--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -53,8 +53,8 @@ class Process {
 		$proc = new self;
 
 		$proc->command = $command;
-		$proc->cwd = $cwd;
-		$proc->env = $env;
+		$proc->cwd     = $cwd;
+		$proc->env     = $env;
 
 		return $proc;
 	}
@@ -91,13 +91,13 @@ class Process {
 
 		return new ProcessRun(
 			array(
-				'stdout' => $stdout,
-				'stderr' => $stderr,
+				'stdout'      => $stdout,
+				'stderr'      => $stderr,
 				'return_code' => $return_code,
-				'command' => $this->command,
-				'cwd' => $this->cwd,
-				'env' => $this->env,
-				'run_time' => $run_time,
+				'command'     => $this->command,
+				'cwd'         => $this->cwd,
+				'env'         => $this->env,
+				'run_time'    => $run_time,
 			)
 		);
 	}

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -64,7 +64,7 @@ class Runner {
 
 		// Search the value of @when from the command method.
 		$real_when = '';
-		$r = $this->find_command_to_run( $this->arguments );
+		$r         = $this->find_command_to_run( $this->arguments );
 		if ( is_array( $r ) ) {
 			list( $command, $final_args, $cmd_path ) = $r;
 
@@ -94,10 +94,10 @@ class Runner {
 	public function get_global_config_path() {
 
 		if ( getenv( 'WP_CLI_CONFIG_PATH' ) ) {
-			$config_path = getenv( 'WP_CLI_CONFIG_PATH' );
+			$config_path                     = getenv( 'WP_CLI_CONFIG_PATH' );
 			$this->_global_config_path_debug = 'Using global config from WP_CLI_CONFIG_PATH env var: ' . $config_path;
 		} else {
-			$config_path = Utils\get_home_dir() . '/.wp-cli/config.yml';
+			$config_path                     = Utils\get_home_dir() . '/.wp-cli/config.yml';
 			$this->_global_config_path_debug = 'Using default global config: ' . $config_path;
 		}
 
@@ -130,7 +130,7 @@ class Runner {
 			getcwd(),
 			function ( $dir ) {
 				static $wp_load_count = 0;
-				$wp_load_path = $dir . DIRECTORY_SEPARATOR . 'wp-load.php';
+				$wp_load_path         = $dir . DIRECTORY_SEPARATOR . 'wp-load.php';
 				if ( file_exists( $wp_load_path ) ) {
 					++ $wp_load_count;
 				}
@@ -176,7 +176,7 @@ class Runner {
 
 		$wp_path_src = $matches[1] . $matches[2];
 		$wp_path_src = Utils\replace_path_consts( $wp_path_src, $index_path );
-		$wp_path = eval( "return $wp_path_src;" );
+		$wp_path     = eval( "return $wp_path_src;" );
 
 		if ( ! Utils\is_path_absolute( $wp_path ) ) {
 			$wp_path = dirname( $index_path ) . "/$wp_path";
@@ -235,10 +235,12 @@ class Runner {
 		if ( ! defined( 'ABSPATH' ) ) {
 			define( 'ABSPATH', Utils\normalize_path( Utils\trailingslashit( $path ) ) );
 		} elseif ( ! is_null( $path ) ) {
-			WP_CLI::error_multi_line( array(
-				'The --path parameter cannot be used when ABSPATH is already defined elsewhere',
-				'ABSPATH is defined as: "' . ABSPATH . '"',
-			) );
+			WP_CLI::error_multi_line(
+				array(
+					'The --path parameter cannot be used when ABSPATH is already defined elsewhere',
+					'ABSPATH is defined as: "' . ABSPATH . '"',
+				)
+			);
 		}
 		WP_CLI::debug( 'ABSPATH defined: ' . ABSPATH, 'bootstrap' );
 
@@ -289,15 +291,15 @@ class Runner {
 
 		while ( ! empty( $args ) && $command->can_have_subcommands() ) {
 			$cmd_path[] = $args[0];
-			$full_name = implode( ' ', $cmd_path );
+			$full_name  = implode( ' ', $cmd_path );
 
 			$subcommand = $command->find_subcommand( $args );
 
 			if ( ! $subcommand ) {
 				if ( count( $cmd_path ) > 1 ) {
-					$child = array_pop( $cmd_path );
+					$child       = array_pop( $cmd_path );
 					$parent_name = implode( ' ', $cmd_path );
-					$suggestion = $this->get_subcommand_suggestion( $child, $command );
+					$suggestion  = $this->get_subcommand_suggestion( $child, $command );
 					return sprintf(
 						"'%s' is not a registered subcommand of '%s'. See 'wp help %s' for available subcommands.%s",
 						$child,
@@ -422,7 +424,7 @@ class Runner {
 		}
 
 		$wp_binary = 'wp';
-		$wp_args = array_slice( $GLOBALS['argv'], 1 );
+		$wp_args   = array_slice( $GLOBALS['argv'], 1 );
 
 		if ( $this->alias && ! empty( $wp_args[0] ) && $this->alias === $wp_args[0] ) {
 			array_shift( $wp_args );
@@ -439,7 +441,7 @@ class Runner {
 						$this->alias => $runtime_alias,
 					)
 				);
-				$wp_binary = "WP_CLI_RUNTIME_ALIAS='{$encoded_alias}' {$wp_binary} {$this->alias}";
+				$wp_binary     = "WP_CLI_RUNTIME_ALIAS='{$encoded_alias}' {$wp_binary} {$this->alias}";
 			}
 		}
 
@@ -449,7 +451,7 @@ class Runner {
 			}
 		}
 
-		$wp_command = $pre_cmd . $env_vars . $wp_binary . ' ' . implode( ' ', array_map( 'escapeshellarg', $wp_args ) );
+		$wp_command      = $pre_cmd . $env_vars . $wp_binary . ' ' . implode( ' ', array_map( 'escapeshellarg', $wp_args ) );
 		$escaped_command = $this->generate_ssh_command( $bits, $wp_command );
 
 		passthru( $escaped_command, $exit_code );
@@ -589,7 +591,7 @@ class Runner {
 	 */
 	private static function back_compat_conversions( $args, $assoc_args ) {
 		$top_level_aliases = array(
-			'sql' => 'db',
+			'sql'  => 'db',
 			'blog' => 'site',
 		);
 		if ( count( $args ) > 0 ) {
@@ -643,19 +645,19 @@ class Runner {
 		if ( count( $args ) > 1 && in_array( $args[0], array( 'plugin', 'theme' ) )
 			&& 'update-all' === $args[1]
 		) {
-			$args[1] = 'update';
+			$args[1]           = 'update';
 			$assoc_args['all'] = true;
 		}
 
 		// transient delete-expired  ->  transient delete --expired
 		if ( count( $args ) > 1 && 'transient' === $args[0] && 'delete-expired' === $args[1] ) {
-			$args[1] = 'delete';
+			$args[1]               = 'delete';
 			$assoc_args['expired'] = true;
 		}
 
 		// transient delete-all  ->  transient delete --all
 		if ( count( $args ) > 1 && 'transient' === $args[0] && 'delete-all' === $args[1] ) {
-			$args[1] = 'delete';
+			$args[1]           = 'delete';
 			$assoc_args['all'] = true;
 		}
 
@@ -701,36 +703,36 @@ class Runner {
 		if ( count( $args ) >= 2 && in_array( $args[0], array( 'post', 'comment', 'site', 'term' ) ) && 'url' === $args[1] ) {
 			switch ( $args[0] ) {
 				case 'post':
-					$post_ids = array_slice( $args, 2 );
-					$args = array( 'post', 'list' );
-					$assoc_args['post__in'] = implode( ',', $post_ids );
+					$post_ids                = array_slice( $args, 2 );
+					$args                    = array( 'post', 'list' );
+					$assoc_args['post__in']  = implode( ',', $post_ids );
 					$assoc_args['post_type'] = 'any';
-					$assoc_args['orderby'] = 'post__in';
-					$assoc_args['field'] = 'url';
+					$assoc_args['orderby']   = 'post__in';
+					$assoc_args['field']     = 'url';
 					break;
 				case 'comment':
-					$comment_ids = array_slice( $args, 2 );
-					$args = array( 'comment', 'list' );
+					$comment_ids               = array_slice( $args, 2 );
+					$args                      = array( 'comment', 'list' );
 					$assoc_args['comment__in'] = implode( ',', $comment_ids );
-					$assoc_args['orderby'] = 'comment__in';
-					$assoc_args['field'] = 'url';
+					$assoc_args['orderby']     = 'comment__in';
+					$assoc_args['field']       = 'url';
 					break;
 				case 'site':
-					$site_ids = array_slice( $args, 2 );
-					$args = array( 'site', 'list' );
+					$site_ids               = array_slice( $args, 2 );
+					$args                   = array( 'site', 'list' );
 					$assoc_args['site__in'] = implode( ',', $site_ids );
-					$assoc_args['field'] = 'url';
+					$assoc_args['field']    = 'url';
 					break;
 				case 'term':
 					$taxonomy = '';
 					if ( isset( $args[2] ) ) {
 						$taxonomy = $args[2];
 					}
-					$term_ids = array_slice( $args, 3 );
-					$args = array( 'term', 'list', $taxonomy );
+					$term_ids              = array_slice( $args, 3 );
+					$args                  = array( 'term', 'list', $taxonomy );
 					$assoc_args['include'] = implode( ',', $term_ids );
 					$assoc_args['orderby'] = 'include';
-					$assoc_args['field'] = 'url';
+					$assoc_args['field']   = 'url';
 					break;
 			}
 		}
@@ -750,7 +752,7 @@ class Runner {
 				unset( $assoc_args['constant'] );
 			}
 			if ( ! empty( $name ) && ! empty( $type ) ) {
-				$args[] = $name;
+				$args[]             = $name;
 				$assoc_args['type'] = $type;
 			} else {
 				// We had a 'config get' without a '<name>', so assume 'list' was wanted.
@@ -811,12 +813,12 @@ class Runner {
 	}
 
 	private function check_wp_version() {
-		$wp_exists = $this->wp_exists();
+		$wp_exists      = $this->wp_exists();
 		$wp_is_readable = $this->wp_is_readable();
 		if ( ! $wp_exists || ! $wp_is_readable ) {
 			$this->show_synopsis_if_composite_command();
 			// If the command doesn't exist use as error.
-			$args = $this->cmd_starts_with( array( 'help' ) ) ? array_slice( $this->arguments, 1 ) : $this->arguments;
+			$args                   = $this->cmd_starts_with( array( 'help' ) ) ? array_slice( $this->arguments, 1 ) : $this->arguments;
 			$suggestion_or_disabled = $this->find_command_to_run( $args );
 			if ( is_string( $suggestion_or_disabled ) ) {
 				if ( ! preg_match( '/disabled from the config file.$/', $suggestion_or_disabled ) ) {
@@ -864,14 +866,14 @@ class Runner {
 
 		// File config
 		{
-			$this->global_config_path = $this->get_global_config_path();
+			$this->global_config_path  = $this->get_global_config_path();
 			$this->project_config_path = $this->get_project_config_path();
 
 			$configurator->merge_yml( $this->global_config_path, $this->alias );
-			$config = $configurator->to_array();
+			$config                          = $configurator->to_array();
 			$this->_required_files['global'] = $config[0]['require'];
 			$configurator->merge_yml( $this->project_config_path, $this->alias );
-			$config = $configurator->to_array();
+			$config                           = $configurator->to_array();
 			$this->_required_files['project'] = $config[0]['require'];
 		}
 
@@ -887,11 +889,11 @@ class Runner {
 		}
 
 		list( $this->config, $this->extra_config ) = $configurator->to_array();
-		$this->aliases = $configurator->get_aliases();
+		$this->aliases                             = $configurator->get_aliases();
 		if ( count( $this->aliases ) && ! isset( $this->aliases['@all'] ) ) {
-			$this->aliases = array_reverse( $this->aliases );
+			$this->aliases         = array_reverse( $this->aliases );
 			$this->aliases['@all'] = 'Run command against every registered alias.';
-			$this->aliases = array_reverse( $this->aliases );
+			$this->aliases         = array_reverse( $this->aliases );
 		}
 		$this->_required_files['runtime'] = $this->config['require'];
 	}
@@ -945,17 +947,17 @@ class Runner {
 
 		foreach ( $aliases as $alias ) {
 			WP_CLI::log( $alias );
-			$args = implode( ' ', array_map( 'escapeshellarg', $this->arguments ) );
-			$assoc_args = Utils\assoc_args_to_str( $this->assoc_args );
+			$args           = implode( ' ', array_map( 'escapeshellarg', $this->arguments ) );
+			$assoc_args     = Utils\assoc_args_to_str( $this->assoc_args );
 			$runtime_config = Utils\assoc_args_to_str( $this->runtime_config );
-			$full_command = "WP_CLI_CONFIG_PATH={$config_path} {$php_bin} {$script_path} {$alias} {$args}{$assoc_args}{$runtime_config}";
-			$proc = Utils\proc_open_compat( $full_command, array( STDIN, STDOUT, STDERR ), $pipes );
+			$full_command   = "WP_CLI_CONFIG_PATH={$config_path} {$php_bin} {$script_path} {$alias} {$args}{$assoc_args}{$runtime_config}";
+			$proc           = Utils\proc_open_compat( $full_command, array( STDIN, STDOUT, STDERR ), $pipes );
 			proc_close( $proc );
 		}
 	}
 
 	private function set_alias( $alias ) {
-		$orig_config = $this->config;
+		$orig_config  = $this->config;
 		$alias_config = $this->aliases[ $this->alias ];
 		$this->config = array_merge( $orig_config, $alias_config );
 		foreach ( $alias_config as $key => $_ ) {
@@ -983,14 +985,14 @@ class Runner {
 
 			if ( '@all' === $this->alias && is_string( $this->aliases['@all'] ) ) {
 				$aliases = array_keys( $this->aliases );
-				$k = array_search( '@all', $aliases );
+				$k       = array_search( '@all', $aliases );
 				unset( $aliases[ $k ] );
 				$this->run_alias_group( $aliases );
 				exit;
 			}
 
 			if ( ! array_key_exists( $this->alias, $this->aliases ) ) {
-				$error_msg = "Alias '{$this->alias}' not found.";
+				$error_msg  = "Alias '{$this->alias}' not found.";
 				$suggestion = Utils\get_suggestion( $this->alias, array_keys( $this->aliases ), $threshold = 2 );
 				if ( $suggestion ) {
 					$error_msg .= PHP_EOL . "Did you mean '{$suggestion}'?";
@@ -1000,7 +1002,7 @@ class Runner {
 			// Numerically indexed means a group of aliases
 			if ( isset( $this->aliases[ $this->alias ][0] ) ) {
 				$group_aliases = $this->aliases[ $this->alias ];
-				$all_aliases = array_keys( $this->aliases );
+				$all_aliases   = array_keys( $this->aliases );
 				if ( $diff = array_diff( $group_aliases, $all_aliases ) ) {
 					WP_CLI::error( "Group '{$this->alias}' contains one or more invalid aliases: " . implode( ', ', $diff ) );
 				}
@@ -1215,25 +1217,25 @@ class Runner {
 		}
 
 		$current_site = (object) array(
-			'id' => 1,
-			'blog_id' => 1,
-			'domain' => $url_parts['host'],
-			'path' => $url_parts['path'],
+			'id'            => 1,
+			'blog_id'       => 1,
+			'domain'        => $url_parts['host'],
+			'path'          => $url_parts['path'],
 			'cookie_domain' => $url_parts['host'],
-			'site_name' => 'Fake Site',
+			'site_name'     => 'Fake Site',
 		);
 
 		$current_blog = (object) array(
-			'blog_id' => 1,
-			'site_id' => 1,
-			'domain' => $url_parts['host'],
-			'path' => $url_parts['path'],
-			'public' => '1',
+			'blog_id'  => 1,
+			'site_id'  => 1,
+			'domain'   => $url_parts['host'],
+			'path'     => $url_parts['path'],
+			'public'   => '1',
 			'archived' => '0',
-			'mature' => '0',
-			'spam' => '0',
-			'deleted' => '0',
-			'lang_id' => '0',
+			'mature'   => '0',
+			'spam'     => '0',
+			'deleted'  => '0',
+			'lang_id'  => '0',
 		);
 	}
 
@@ -1315,12 +1317,12 @@ class Runner {
 		// Get rid of warnings when converting single site to multisite
 		if ( defined( 'WP_INSTALLING' ) && $this->is_multisite() ) {
 			$values = array(
-				'ms_files_rewriting' => null,
-				'active_sitewide_plugins' => array(),
-				'_site_transient_update_core' => null,
-				'_site_transient_update_themes' => null,
+				'ms_files_rewriting'             => null,
+				'active_sitewide_plugins'        => array(),
+				'_site_transient_update_core'    => null,
+				'_site_transient_update_themes'  => null,
 				'_site_transient_update_plugins' => null,
-				'WPLANG' => '',
+				'WPLANG'                         => '',
 			);
 			foreach ( $values as $key => $value ) {
 				WP_CLI::add_wp_hook(
@@ -1397,10 +1399,10 @@ class Runner {
 			WP_CLI::add_wp_hook(
 				'ms_site_not_found',
 				function( $current_site, $domain, $path ) {
-					$url = $domain . $path;
-					$message = $url ? "Site '{$url}' not found." : 'Site not found.';
-					$has_param = isset( WP_CLI::get_runner()->config['url'] );
-					$has_const = defined( 'DOMAIN_CURRENT_SITE' );
+					$url         = $domain . $path;
+					$message     = $url ? "Site '{$url}' not found." : 'Site not found.';
+					$has_param   = isset( WP_CLI::get_runner()->config['url'] );
+					$has_const   = defined( 'DOMAIN_CURRENT_SITE' );
 					$explanation = '';
 					if ( $has_param ) {
 						$explanation = 'Verify `--url=<url>` matches an existing site.';
@@ -1441,7 +1443,7 @@ class Runner {
 				function() use ( $config ) {
 					if ( isset( $config['user'] ) ) {
 						$fetcher = new \WP_CLI\Fetchers\User;
-						$user = $fetcher->get_check( $config['user'] );
+						$user    = $fetcher->get_check( $config['user'] );
 						wp_set_current_user( $user->ID );
 					} else {
 						add_action( 'init', 'kses_remove_filters', 11 );
@@ -1487,9 +1489,11 @@ class Runner {
 		);
 
 		// Set up hook for plugins and themes to conditionally add WP-CLI commands.
-		WP_CLI::add_wp_hook( 'init', function () {
-			do_action( 'cli_init' );
-		} );
+		WP_CLI::add_wp_hook(
+			'init', function () {
+				do_action( 'cli_init' );
+			}
+		);
 	}
 
 	/**
@@ -1649,7 +1653,7 @@ class Runner {
 			$days_between_checks = 1;
 		}
 
-		$cache = WP_CLI::get_cache();
+		$cache     = WP_CLI::get_cache();
 		$cache_key = 'wp-cli-update-check';
 		// Bail early on the first check, so we don't always check on an unwritable cache.
 		if ( ! $cache->has( $cache_key ) ) {

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -176,7 +176,7 @@ class Runner {
 
 		$wp_path_src = $matches[1] . $matches[2];
 		$wp_path_src = Utils\replace_path_consts( $wp_path_src, $index_path );
-		$wp_path     = eval( "return $wp_path_src;" );
+		$wp_path     = eval( "return $wp_path_src;" ); // phpcs:ignore Squiz.PHP.Eval.Discouraged -- @codingStandardsIgnoreLine
 
 		if ( ! Utils\is_path_absolute( $wp_path ) ) {
 			$wp_path = dirname( $index_path ) . "/$wp_path";
@@ -1143,7 +1143,7 @@ class Runner {
 
 		// Load wp-config.php code, in the global scope
 		$wp_cli_original_defined_vars = get_defined_vars();
-		eval( $this->get_wp_config_code() );
+		eval( $this->get_wp_config_code() ); // phpcs:ignore Squiz.PHP.Eval.Discouraged -- @codingStandardsIgnoreLine
 		foreach ( get_defined_vars() as $key => $var ) {
 			if ( array_key_exists( $key, $wp_cli_original_defined_vars ) || 'wp_cli_original_defined_vars' === $key ) {
 				continue;

--- a/php/WP_CLI/SynopsisParser.php
+++ b/php/WP_CLI/SynopsisParser.php
@@ -28,7 +28,7 @@ class SynopsisParser {
 			}
 
 			$param['token'] = $token;
-			$params[] = $param;
+			$params[]       = $param;
 		}
 
 		return $params;
@@ -44,9 +44,9 @@ class SynopsisParser {
 		}
 		$bits = array(
 			'positional' => '',
-			'assoc' => '',
-			'generic' => '',
-			'flag' => '',
+			'assoc'      => '',
+			'generic'    => '',
+			'flag'       => '',
 		);
 		foreach ( $bits as $key => &$value ) {
 			foreach ( $synopsis as $arg ) {
@@ -62,7 +62,7 @@ class SynopsisParser {
 				if ( 'positional' === $key ) {
 					$rendered_arg = "<{$arg['name']}>";
 				} elseif ( 'assoc' === $key ) {
-					$arg_value = isset( $arg['value']['name'] ) ? $arg['value']['name'] : $arg['name'];
+					$arg_value    = isset( $arg['value']['name'] ) ? $arg['value']['name'] : $arg['name'];
 					$rendered_arg = "--{$arg['name']}=<{$arg_value}>";
 				} elseif ( 'generic' === $key ) {
 					$rendered_arg = '--<field>=<value>';
@@ -96,10 +96,10 @@ class SynopsisParser {
 	private static function classify_token( $token ) {
 		$param = array();
 
-		list( $param['optional'], $token ) = self::is_optional( $token );
+		list( $param['optional'], $token )  = self::is_optional( $token );
 		list( $param['repeating'], $token ) = self::is_repeating( $token );
 
-		$p_name = '([a-z-_0-9]+)';
+		$p_name  = '([a-z-_0-9]+)';
 		$p_value = '([a-zA-Z-_|,0-9]+)';
 
 		if ( '--<field>=<value>' === $token ) {

--- a/php/WP_CLI/SynopsisValidator.php
+++ b/php/WP_CLI/SynopsisValidator.php
@@ -43,7 +43,7 @@ class SynopsisValidator {
 	public function enough_positionals( $args ) {
 		$positional = $this->query_spec(
 			array(
-				'type' => 'positional',
+				'type'     => 'positional',
 				'optional' => false,
 			)
 		);
@@ -60,7 +60,7 @@ class SynopsisValidator {
 	public function unknown_positionals( $args ) {
 		$positional_repeating = $this->query_spec(
 			array(
-				'type' => 'positional',
+				'type'      => 'positional',
 				'repeating' => true,
 			)
 		);
@@ -72,7 +72,7 @@ class SynopsisValidator {
 
 		$positional = $this->query_spec(
 			array(
-				'type' => 'positional',
+				'type'      => 'positional',
 				'repeating' => false,
 			)
 		);
@@ -94,7 +94,7 @@ class SynopsisValidator {
 		);
 
 		$errors = array(
-			'fatal' => array(),
+			'fatal'   => array(),
 			'warning' => array(),
 		);
 
@@ -109,7 +109,7 @@ class SynopsisValidator {
 				}
 			} else {
 				if ( true === $assoc_args[ $key ] && ! $param['value']['optional'] ) {
-					$error_type = ( ! $param['optional'] ) ? 'fatal' : 'warning';
+					$error_type                    = ( ! $param['optional'] ) ? 'fatal' : 'warning';
 					$errors[ $error_type ][ $key ] = "--$key parameter needs a value";
 
 					$to_unset[] = $key;
@@ -157,7 +157,7 @@ class SynopsisValidator {
 	 */
 	private function query_spec( $args, $operator = 'AND' ) {
 		$operator = strtoupper( $operator );
-		$count = count( $args );
+		$count    = count( $args );
 		$filtered = array();
 
 		foreach ( $this->spec as $key => $to_match ) {

--- a/php/WP_CLI/WpHttpCacheManager.php
+++ b/php/WP_CLI/WpHttpCacheManager.php
@@ -53,7 +53,7 @@ class WpHttpCacheManager {
 				// simulate successful download response
 				return array(
 					'response' => array(
-						'code' => 200,
+						'code'    => 200,
 						'message' => 'OK',
 					),
 					'filename' => $args['filename'],
@@ -115,7 +115,7 @@ class WpHttpCacheManager {
 	 * @param int    $ttl
 	 */
 	public function whitelist_url( $url, $key = null, $ttl = null ) {
-		$key = $key ? : $url;
+		$key                     = $key ? : $url;
 		$this->whitelist[ $url ] = compact( 'key', 'ttl' );
 	}
 

--- a/php/bootstrap.php
+++ b/php/bootstrap.php
@@ -72,6 +72,6 @@ function bootstrap() {
 	foreach ( get_bootstrap_steps() as $step ) {
 		/** @var \WP_CLI\Bootstrap\BootstrapStep $step_instance */
 		$step_instance = new $step();
-		$state = $step_instance->process( $state );
+		$state         = $step_instance->process( $state );
 	}
 }

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -75,7 +75,7 @@ class WP_CLI {
 
 		if ( ! $cache ) {
 			$home = Utils\get_home_dir();
-			$dir = getenv( 'WP_CLI_CACHE_DIR' ) ? : "$home/.wp-cli/cache";
+			$dir  = getenv( 'WP_CLI_CACHE_DIR' ) ? : "$home/.wp-cli/cache";
 
 			// 6 months, 300mb
 			$cache = new FileCache( $dir, 15552000, 314572800 );
@@ -120,8 +120,8 @@ class WP_CLI {
 			$_SERVER['SERVER_NAME'] = $url_parts['host'];
 		}
 
-		$_SERVER['REQUEST_URI'] = $f( 'path' ) . ( isset( $url_parts['query'] ) ? '?' . $url_parts['query'] : '' );
-		$_SERVER['SERVER_PORT'] = \WP_CLI\Utils\get_flag_value( $url_parts, 'port', '80' );
+		$_SERVER['REQUEST_URI']  = $f( 'path' ) . ( isset( $url_parts['query'] ) ? '?' . $url_parts['query'] : '' );
+		$_SERVER['SERVER_PORT']  = \WP_CLI\Utils\get_flag_value( $url_parts, 'port', '80' );
 		$_SERVER['QUERY_STRING'] = $f( 'query' );
 	}
 
@@ -296,9 +296,9 @@ class WP_CLI {
 		if ( function_exists( 'add_filter' ) ) {
 			add_filter( $tag, $function_to_add, $priority, $accepted_args );
 		} else {
-			$idx = self::wp_hook_build_unique_id( $tag, $function_to_add, $priority );
+			$idx                                    = self::wp_hook_build_unique_id( $tag, $function_to_add, $priority );
 			$wp_filter[ $tag ][ $priority ][ $idx ] = array(
-				'function' => $function_to_add,
+				'function'      => $function_to_add,
 				'accepted_args' => $accepted_args,
 			);
 			unset( $merged_filters[ $tag ] );
@@ -338,7 +338,7 @@ class WP_CLI {
 				if ( false === $priority ) {
 					return false;
 				}
-				$obj_idx .= isset( $wp_filter[ $tag ][ $priority ] ) ? count( (array) $wp_filter[ $tag ][ $priority ] ) : $filter_id_count;
+				$obj_idx                  .= isset( $wp_filter[ $tag ][ $priority ] ) ? count( (array) $wp_filter[ $tag ][ $priority ] ) : $filter_id_count;
 				$function[0]->wp_filter_id = $filter_id_count;
 				++$filter_id_count;
 			} else {
@@ -422,7 +422,7 @@ class WP_CLI {
 		if ( ! $valid ) {
 			if ( is_array( $callable ) ) {
 				$callable[0] = is_object( $callable[0] ) ? get_class( $callable[0] ) : $callable[0];
-				$callable = array( $callable[0], $callable[1] );
+				$callable    = array( $callable[0], $callable[1] );
 			}
 			WP_CLI::error( sprintf( 'Callable %s does not exist, and cannot be registered as `wp %s`.', json_encode( $callable ), $name ) );
 		}
@@ -450,8 +450,8 @@ class WP_CLI {
 
 		while ( ! empty( $path ) ) {
 			$subcommand_name = $path[0];
-			$parent = implode( ' ', $path );
-			$subcommand = $command->find_subcommand( $path );
+			$parent          = implode( ' ', $path );
+			$subcommand      = $command->find_subcommand( $path );
 
 			// Parent not found. Defer addition or create an empty container as
 			// needed.
@@ -488,7 +488,7 @@ class WP_CLI {
 			throw new Exception(
 				sprintf(
 					"'%s' can't have subcommands.",
-					implode( ' ' , Dispatcher\get_path( $command ) )
+					implode( ' ', Dispatcher\get_path( $command ) )
 				)
 			);
 		}
@@ -508,7 +508,7 @@ class WP_CLI {
 				$synopsis = \WP_CLI\SynopsisParser::render( $args['synopsis'] );
 				$leaf_command->set_synopsis( $synopsis );
 				$long_desc = '';
-				$bits = explode( ' ', $synopsis );
+				$bits      = explode( ' ', $synopsis );
 				foreach ( $args['synopsis'] as $key => $arg ) {
 					$long_desc .= $bits[ $key ] . "\n";
 					if ( ! empty( $arg['description'] ) ) {
@@ -557,7 +557,7 @@ class WP_CLI {
 	 * @param array  $args     Optional. See `WP_CLI::add_command()` for details.
 	 */
 	private static function defer_command_addition( $name, $parent, $callable, $args = array() ) {
-		$args['is_deferred'] = true;
+		$args['is_deferred']               = true;
 		self::$deferred_additions[ $name ] = array(
 			'parent'   => $parent,
 			'callable' => $callable,
@@ -947,7 +947,7 @@ class WP_CLI {
 	public static function launch( $command, $exit_on_error = true, $return_detailed = false ) {
 		Utils\check_proc_available( 'launch' );
 
-		$proc = Process::create( $command );
+		$proc    = Process::create( $command );
 		$results = $proc->run();
 
 		if ( -1 == $results->return_code ) {
@@ -1013,7 +1013,7 @@ class WP_CLI {
 		}
 		$config_path = escapeshellarg( $config_path );
 
-		$args = implode( ' ', array_map( 'escapeshellarg', $args ) );
+		$args       = implode( ' ', array_map( 'escapeshellarg', $args ) );
 		$assoc_args = \WP_CLI\Utils\assoc_args_to_str( $assoc_args );
 
 		$full_command = "WP_CLI_CONFIG_PATH={$config_path} {$php_bin} {$script_path} {$command} {$args} {$assoc_args}";
@@ -1095,18 +1095,18 @@ class WP_CLI {
 	 * @return mixed
 	 */
 	public static function runcommand( $command, $options = array() ) {
-		$defaults = array(
+		$defaults   = array(
 			'launch'     => true, // Launch a new process, or reuse the existing.
 			'exit_error' => true, // Exit on error by default.
 			'return'     => false, // Capture and return output, or render in realtime.
 			'parse'      => false, // Parse returned output as a particular format.
 		);
-		$options = array_merge( $defaults, $options );
-		$launch = $options['launch'];
+		$options    = array_merge( $defaults, $options );
+		$launch     = $options['launch'];
 		$exit_error = $options['exit_error'];
-		$return = $options['return'];
-		$parse = $options['parse'];
-		$retval = null;
+		$return     = $options['return'];
+		$parse      = $options['parse'];
+		$retval     = null;
 		if ( $launch ) {
 			Utils\check_proc_available( 'launch option' );
 
@@ -1124,12 +1124,12 @@ class WP_CLI {
 				);
 			}
 
-			$php_bin = escapeshellarg( Utils\get_php_binary() );
+			$php_bin     = escapeshellarg( Utils\get_php_binary() );
 			$script_path = $GLOBALS['argv'][0];
 
 			// Persist runtime arguments unless they've been specified otherwise.
-			$configurator = \WP_CLI::get_configurator();
-			$argv = array_slice( $GLOBALS['argv'], 1 );
+			$configurator                   = \WP_CLI::get_configurator();
+			$argv                           = array_slice( $GLOBALS['argv'], 1 );
 			list( $_, $_, $runtime_config ) = $configurator->parse_args( $argv );
 			foreach ( $runtime_config as $k => $v ) {
 				if ( preg_match( "|^--{$k}=?$|", $command ) ) {
@@ -1168,12 +1168,12 @@ class WP_CLI {
 				);
 			}
 		} else {
-			$configurator = self::get_configurator();
-			$argv = Utils\parse_str_to_argv( $command );
+			$configurator                               = self::get_configurator();
+			$argv                                       = Utils\parse_str_to_argv( $command );
 			list( $args, $assoc_args, $runtime_config ) = $configurator->parse_args( $argv );
 			if ( $return ) {
 				$existing_logger = self::$logger;
-				self::$logger = new WP_CLI\Loggers\Execution;
+				self::$logger    = new WP_CLI\Loggers\Execution;
 				self::$logger->ob_start();
 			}
 			if ( ! $exit_error ) {
@@ -1193,8 +1193,8 @@ class WP_CLI {
 				$execution_logger = self::$logger;
 				$execution_logger->ob_end();
 				self::$logger = $existing_logger;
-				$stdout = $execution_logger->stdout;
-				$stderr = $execution_logger->stderr;
+				$stdout       = $execution_logger->stdout;
+				$stderr       = $execution_logger->stderr;
 				if ( true === $return || 'stdout' === $return ) {
 					$retval = trim( $stdout );
 				} elseif ( 'stderr' === $return ) {

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -36,12 +36,12 @@ class Help_Command extends WP_CLI_Command {
 		$out = self::get_initial_markdown( $command );
 
 		// Remove subcommands if in columns - will wordwrap separately.
-		$subcommands = '';
+		$subcommands       = '';
 		$column_subpattern = '[ \t]+[^\t]+\t+';
 		if ( preg_match( '/(^## SUBCOMMANDS[^\n]*\n+' . $column_subpattern . '.+?)(?:^##|\z)/ms', $out, $matches, PREG_OFFSET_CAPTURE ) ) {
-			$subcommands = $matches[1][0];
+			$subcommands        = $matches[1][0];
 			$subcommands_header = "## SUBCOMMANDS\n";
-			$out = substr_replace( $out, $subcommands_header, $matches[1][1], strlen( $subcommands ) );
+			$out                = substr_replace( $out, $subcommands_header, $matches[1][1], strlen( $subcommands ) );
 		}
 
 		$out .= self::parse_reference_links( $command->get_longdesc() );
@@ -74,10 +74,10 @@ class Help_Command extends WP_CLI_Command {
 				'/^(' . $column_subpattern . ')([^\n]+)\n/m',
 				function ( $matches ) use ( $wordwrap_width, $tab ) {
 					// Need to de-tab for wordwrapping to work properly.
-					$matches[1] = str_replace( "\t", $tab, $matches[1] );
-					$matches[2] = str_replace( "\t", $tab, $matches[2] );
+					$matches[1]  = str_replace( "\t", $tab, $matches[1] );
+					$matches[2]  = str_replace( "\t", $tab, $matches[2] );
 					$padding_len = strlen( $matches[1] );
-					$padding = str_repeat( ' ', $padding_len );
+					$padding     = str_repeat( ' ', $padding_len );
 					return $matches[1] . str_replace( "\n", "\n$padding", wordwrap( $matches[2], $wordwrap_width - $padding_len ) ) . "\n";
 				},
 				$subcommands
@@ -95,7 +95,7 @@ class Help_Command extends WP_CLI_Command {
 
 	private static function rewrap_param_desc( $matches ) {
 		$param = $matches[1];
-		$desc = self::indent( "\t\t", $matches[2] );
+		$desc  = self::indent( "\t\t", $matches[2] );
 		return "\t$param\n$desc\n\n";
 	}
 
@@ -144,7 +144,7 @@ class Help_Command extends WP_CLI_Command {
 		$name = implode( ' ', Dispatcher\get_path( $command ) );
 
 		$binding = array(
-			'name' => $name,
+			'name'      => $name,
 			'shortdesc' => $command->get_shortdesc(),
 		);
 
@@ -212,23 +212,27 @@ class Help_Command extends WP_CLI_Command {
 
 		// Fires if it has description text at the head of `$longdesc`.
 		if ( $description ) {
-			$links = array(); // An array of URLs from the description.
+			$links   = array(); // An array of URLs from the description.
 			$pattern = '/\[.+?\]\((https?:\/\/.+?)\)/';
-			$newdesc = preg_replace_callback( $pattern, function( $matches ) use ( &$links ) {
-				static $count = 0;
-				$count++;
-				$links[] = $matches[1];
-				return str_replace( '(' . $matches[1] . ')', '[' . $count . ']', $matches[0] );
-			}, $description );
+			$newdesc = preg_replace_callback(
+				$pattern,
+				function( $matches ) use ( &$links ) {
+					static $count = 0;
+					$count++;
+					$links[] = $matches[1];
+					return str_replace( '(' . $matches[1] . ')', '[' . $count . ']', $matches[0] );
+				},
+				$description
+			);
 
 			$footnote = '';
 			for ( $i = 0; $i < count( $links ); $i++ ) {
-				$n = $i + 1;
+				$n         = $i + 1;
 				$footnote .= '[' . $n . '] ' . $links[ $i ] . "\n";
 			}
 
 			if ( $footnote ) {
-				$newdesc = trim( $newdesc ) . "\n\n---\n" . $footnote;
+				$newdesc  = trim( $newdesc ) . "\n\n---\n" . $footnote;
 				$longdesc = str_replace( trim( $description ), trim( $newdesc ), $longdesc );
 			}
 		}

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -29,9 +29,9 @@ class CLI_Command extends WP_CLI_Command {
 
 	private function command_to_array( $command ) {
 		$dump = array(
-			'name' => $command->get_name(),
+			'name'        => $command->get_name(),
 			'description' => $command->get_shortdesc(),
-			'longdesc' => $command->get_longdesc(),
+			'longdesc'    => $command->get_longdesc(),
 		);
 
 		foreach ( $command->get_subcommands() as $subcommand ) {
@@ -283,11 +283,11 @@ class CLI_Command extends WP_CLI_Command {
 		if ( Utils\get_flag_value( $assoc_args, 'nightly' ) ) {
 			WP_CLI::confirm( sprintf( 'You have version %s. Would you like to update to the latest nightly?', WP_CLI_VERSION ), $assoc_args );
 			$download_url = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar';
-			$md5_url = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar.md5';
+			$md5_url      = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar.md5';
 		} elseif ( Utils\get_flag_value( $assoc_args, 'stable' ) ) {
 			WP_CLI::confirm( sprintf( 'You have version %s. Would you like to update to the latest stable release?', WP_CLI_VERSION ), $assoc_args );
 			$download_url = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar';
-			$md5_url = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar.md5';
+			$md5_url      = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar.md5';
 		} else {
 
 			$updates = $this->get_updates( $assoc_args );
@@ -303,7 +303,7 @@ class CLI_Command extends WP_CLI_Command {
 			WP_CLI::confirm( sprintf( 'You have version %s. Would you like to update to %s?', WP_CLI_VERSION, $newest['version'] ), $assoc_args );
 
 			$download_url = $newest['package_url'];
-			$md5_url = str_replace( '.phar', '.phar.md5', $download_url );
+			$md5_url      = str_replace( '.phar', '.phar.md5', $download_url );
 		}
 
 		WP_CLI::log( sprintf( 'Downloading from %s...', $download_url ) );
@@ -312,7 +312,7 @@ class CLI_Command extends WP_CLI_Command {
 
 		$headers = array();
 		$options = array(
-			'timeout' => 600,  // 10 minutes ought to be enough for everybody.
+			'timeout'  => 600,  // 10 minutes ought to be enough for everybody.
 			'filename' => $temp,
 		);
 
@@ -322,7 +322,7 @@ class CLI_Command extends WP_CLI_Command {
 		if ( 20 != substr( $md5_response->status_code, 0, 2 ) ) {
 			WP_CLI::error( "Couldn't access md5 hash for release (HTTP code {$md5_response->status_code})." );
 		}
-		$md5_file = md5_file( $temp );
+		$md5_file     = md5_file( $temp );
 		$release_hash = trim( $md5_response->body );
 		if ( $md5_file === $release_hash ) {
 			WP_CLI::log( 'md5 hash verified: ' . $release_hash );
@@ -332,8 +332,8 @@ class CLI_Command extends WP_CLI_Command {
 
 		$allow_root = WP_CLI::get_runner()->config['allow-root'] ? '--allow-root' : '';
 		$php_binary = Utils\get_php_binary();
-		$process = WP_CLI\Process::create( "{$php_binary} $temp --info {$allow_root}" );
-		$result = $process->run();
+		$process    = WP_CLI\Process::create( "{$php_binary} $temp --info {$allow_root}" );
+		$result     = $process->run();
 		if ( 0 !== $result->return_code || false === stripos( $result->stdout, 'WP-CLI version' ) ) {
 			$multi_line = explode( PHP_EOL, $result->stderr );
 			WP_CLI::error_multi_line( $multi_line );
@@ -390,9 +390,9 @@ class CLI_Command extends WP_CLI_Command {
 		$release_data = json_decode( $response->body );
 
 		$updates = array(
-			'major'      => false,
-			'minor'      => false,
-			'patch'      => false,
+			'major' => false,
+			'minor' => false,
+			'patch' => false,
 		);
 		foreach ( $release_data as $release ) {
 
@@ -412,7 +412,7 @@ class CLI_Command extends WP_CLI_Command {
 			}
 
 			$updates[ $update_type ] = array(
-				'version' => $release_version,
+				'version'     => $release_version,
 				'update_type' => $update_type,
 				'package_url' => $release->assets[0]->browser_download_url,
 			);
@@ -432,16 +432,16 @@ class CLI_Command extends WP_CLI_Command {
 
 		if ( empty( $updates ) && preg_match( '#-alpha-(.+)$#', WP_CLI_VERSION, $matches ) ) {
 			$version_url = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/NIGHTLY_VERSION';
-			$response = Utils\http_request( 'GET', $version_url );
+			$response    = Utils\http_request( 'GET', $version_url );
 			if ( ! $response->success || 200 !== $response->status_code ) {
 				WP_CLI::error( sprintf( 'Failed to get current nightly version (HTTP code %d)', $response->status_code ) );
 			}
 			$nightly_version = trim( $response->body );
 			if ( WP_CLI_VERSION != $nightly_version ) {
 				$updates['nightly'] = array(
-					'version'        => $nightly_version,
-					'update_type'    => 'nightly',
-					'package_url'    => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar',
+					'version'     => $nightly_version,
+					'update_type' => 'nightly',
+					'package_url' => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar',
 				);
 			}
 		}
@@ -541,7 +541,7 @@ class CLI_Command extends WP_CLI_Command {
 	 *     eval-file
 	 */
 	public function completions( $_, $assoc_args ) {
-		$line = substr( $assoc_args['line'], 0, $assoc_args['point'] );
+		$line  = substr( $assoc_args['line'], 0, $assoc_args['point'] );
 		$compl = new \WP_CLI\Completions( $line );
 		$compl->render();
 	}

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -1,115 +1,115 @@
 <?php
 
 return array(
-	'path' => array(
+	'path'              => array(
 		'runtime' => '=<path>',
-		'file' => '<path>',
-		'desc' => 'Path to the WordPress files.',
+		'file'    => '<path>',
+		'desc'    => 'Path to the WordPress files.',
 	),
 
-	'url' => array(
+	'url'               => array(
 		'runtime' => '=<url>',
-		'file' => '<url>',
-		'desc' => 'Pretend request came from given URL. In multisite, this argument is how the target site is specified.',
+		'file'    => '<url>',
+		'desc'    => 'Pretend request came from given URL. In multisite, this argument is how the target site is specified.',
 	),
 
-	'ssh' => array(
+	'ssh'               => array(
 		'runtime' => '=[<scheme>:][<user>@]<host|container>[:<port>][<path>]',
-		'file' => '[<scheme>:][<user>@]<host|container>[:<port>][<path>]',
-		'desc' => 'Perform operation against a remote server over SSH (or a container using scheme of "docker", "docker-compose", "vagrant").',
+		'file'    => '[<scheme>:][<user>@]<host|container>[:<port>][<path>]',
+		'desc'    => 'Perform operation against a remote server over SSH (or a container using scheme of "docker", "docker-compose", "vagrant").',
 	),
 
-	'http' => array(
+	'http'              => array(
 		'runtime' => '=<http>',
-		'file' => '<http>',
-		'desc' => 'Perform operation against a remote WordPress install over HTTP.',
+		'file'    => '<http>',
+		'desc'    => 'Perform operation against a remote WordPress install over HTTP.',
 	),
 
-	'blog' => array(
+	'blog'              => array(
 		'deprecated' => 'Use --url instead.',
-		'runtime' => '=<url>',
+		'runtime'    => '=<url>',
 	),
 
-	'user' => array(
+	'user'              => array(
 		'runtime' => '=<id|login|email>',
-		'file' => '<id|login|email>',
-		'desc' => 'Set the WordPress user.',
+		'file'    => '<id|login|email>',
+		'desc'    => 'Set the WordPress user.',
 	),
 
-	'skip-plugins' => array(
+	'skip-plugins'      => array(
 		'runtime' => '[=<plugins>]',
-		'file' => '<list>',
-		'desc' => 'Skip loading all plugins, or a comma-separated list of plugins. Note: mu-plugins are still loaded.',
+		'file'    => '<list>',
+		'desc'    => 'Skip loading all plugins, or a comma-separated list of plugins. Note: mu-plugins are still loaded.',
 		'default' => '',
 	),
 
-	'skip-themes' => array(
+	'skip-themes'       => array(
 		'runtime' => '[=<themes>]',
-		'file' => '<list>',
-		'desc' => 'Skip loading all themes, or a comma-separated list of themes.',
+		'file'    => '<list>',
+		'desc'    => 'Skip loading all themes, or a comma-separated list of themes.',
 		'default' => '',
 	),
 
-	'skip-packages' => array(
-		'runtime'   => '',
-		'file'      => '<bool>',
-		'desc'      => 'Skip loading all installed packages.',
-		'default'   => false,
+	'skip-packages'     => array(
+		'runtime' => '',
+		'file'    => '<bool>',
+		'desc'    => 'Skip loading all installed packages.',
+		'default' => false,
 	),
 
-	'require' => array(
-		'runtime' => '=<path>',
-		'file' => '<path>',
-		'desc' => 'Load PHP file before running the command (may be used more than once).',
+	'require'           => array(
+		'runtime'  => '=<path>',
+		'file'     => '<path>',
+		'desc'     => 'Load PHP file before running the command (may be used more than once).',
 		'multiple' => true,
-		'default' => array(),
+		'default'  => array(),
 	),
 
 	'disabled_commands' => array(
-		'file' => '<list>',
+		'file'    => '<list>',
 		'default' => array(),
-		'desc' => '(Sub)commands to disable.',
+		'desc'    => '(Sub)commands to disable.',
 	),
 
-	'color' => array(
+	'color'             => array(
 		'runtime' => true,
-		'file' => '<bool>',
+		'file'    => '<bool>',
 		'default' => 'auto',
-		'desc' => 'Whether to colorize the output.',
+		'desc'    => 'Whether to colorize the output.',
 	),
 
-	'debug' => array(
+	'debug'             => array(
 		'runtime' => '[=<group>]',
-		'file' => '<group>',
+		'file'    => '<group>',
 		'default' => false,
-		'desc' => 'Show all PHP errors and add verbosity to WP-CLI output. Built-in groups include: bootstrap, commandfactory, and help.',
+		'desc'    => 'Show all PHP errors and add verbosity to WP-CLI output. Built-in groups include: bootstrap, commandfactory, and help.',
 	),
 
-	'prompt' => array(
+	'prompt'            => array(
 		'runtime' => '[=<assoc>]',
-		'file' => false,
+		'file'    => false,
 		'default' => false,
-		'desc' => 'Prompt the user to enter values for all command arguments, or a subset specified as comma-separated values.',
+		'desc'    => 'Prompt the user to enter values for all command arguments, or a subset specified as comma-separated values.',
 	),
 
-	'quiet' => array(
+	'quiet'             => array(
 		'runtime' => '',
-		'file' => '<bool>',
+		'file'    => '<bool>',
 		'default' => false,
-		'desc' => 'Suppress informational messages.',
+		'desc'    => 'Suppress informational messages.',
 	),
 
-	'apache_modules' => array(
-		'file' => '<list>',
-		'desc' => 'List of Apache Modules that are to be reported as loaded.',
+	'apache_modules'    => array(
+		'file'     => '<list>',
+		'desc'     => 'List of Apache Modules that are to be reported as loaded.',
 		'multiple' => true,
-		'default' => array(),
+		'default'  => array(),
 	),
 
 	# --allow-root => (NOT RECOMMENDED) Allow wp-cli to run as root. This poses
 	# a security risk, so you probably do not want to do this.
-	'allow-root' => array(
-		'file' => false, # Explicit. Just in case the default changes.
+	'allow-root'        => array(
+		'file'    => false, # Explicit. Just in case the default changes.
 		'runtime' => '',
 		'hidden'  => true,
 	),

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -7,7 +7,7 @@ namespace WP_CLI\Utils;
 function wp_not_installed() {
 	global $wpdb, $table_prefix;
 	if ( ! is_blog_installed() && ! defined( 'WP_INSTALLING' ) ) {
-		$tables = $wpdb->get_col( "SHOW TABLES LIKE '%_options'" );
+		$tables         = $wpdb->get_col( "SHOW TABLES LIKE '%_options'" );
 		$found_prefixes = array();
 		if ( count( $tables ) ) {
 			foreach ( $tables as $table ) {
@@ -18,7 +18,7 @@ function wp_not_installed() {
 			}
 		}
 		if ( count( $found_prefixes ) ) {
-			$prefix_list = implode( ', ', $found_prefixes );
+			$prefix_list   = implode( ', ', $found_prefixes );
 			$install_label = count( $found_prefixes ) > 1 ? 'installs' : 'install';
 			\WP_CLI::error(
 				"The site you have requested is not installed.\n" .
@@ -100,12 +100,12 @@ function wp_clean_error_message( $message ) {
 	}
 
 	$search_replace = array(
-		'<code>'    => '`',
-		'</code>'   => '`',
+		'<code>'  => '`',
+		'</code>' => '`',
 	);
-	$message = str_replace( array_keys( $search_replace ), array_values( $search_replace ), $message );
-	$message = strip_tags( $message );
-	$message = html_entity_decode( $message, ENT_COMPAT, 'UTF-8' );
+	$message        = str_replace( array_keys( $search_replace ), array_values( $search_replace ), $message );
+	$message        = strip_tags( $message );
+	$message        = html_entity_decode( $message, ENT_COMPAT, 'UTF-8' );
 
 	return $message;
 }
@@ -189,14 +189,14 @@ function wp_register_unused_sidebar() {
 
 	register_sidebar(
 		array(
-			'name' => __( 'Inactive Widgets' ),
-			'id' => 'wp_inactive_widgets',
-			'class' => 'inactive-sidebar',
-			'description' => __( 'Drag widgets here to remove them from the sidebar but keep their settings.' ),
+			'name'          => __( 'Inactive Widgets' ),
+			'id'            => 'wp_inactive_widgets',
+			'class'         => 'inactive-sidebar',
+			'description'   => __( 'Drag widgets here to remove them from the sidebar but keep their settings.' ),
 			'before_widget' => '',
-			'after_widget' => '',
-			'before_title' => '',
-			'after_title' => '',
+			'after_widget'  => '',
+			'before_title'  => '',
+			'after_title'   => '',
 		)
 	);
 
@@ -253,7 +253,7 @@ function wp_get_cache_type() {
 			$message = 'WP LCache';
 
 		} elseif ( function_exists( 'w3_instance' ) ) {
-			$config = w3_instance( 'W3_Config' );
+			$config  = w3_instance( 'W3_Config' );
 			$message = 'Unknown';
 
 			if ( $config->get_boolean( 'objectcache.enabled' ) ) {
@@ -329,7 +329,7 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 		// Note: BC change 1.5.0, taking scope into consideration for network also.
 		if ( get_flag_value( $assoc_args, 'network' ) && is_multisite() ) {
 			$network_global_scope = in_array( $scope, array( 'all', 'global', 'ms_global' ), true ) ? ( 'all' === $scope ? 'global' : $scope ) : '';
-			$wp_tables = array_values( $wpdb->tables( $network_global_scope ) );
+			$wp_tables            = array_values( $wpdb->tables( $network_global_scope ) );
 			if ( in_array( $scope, array( 'all', 'blog' ), true ) ) {
 				// Do directly for compat with old WP versions. Note: private, deleted, archived sites are not excluded.
 				$blog_ids = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs WHERE site_id = $wpdb->siteid" );
@@ -356,9 +356,15 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 		$args_tables = array();
 		foreach ( $args as $arg ) {
 			if ( false !== strpos( $arg, '*' ) || false !== strpos( $arg, '?' ) ) {
-				$args_tables = array_merge( $args_tables, array_filter( $tables, function ( $v ) use ( $arg ) {
-					return fnmatch( $arg, $v );
-				} ) );
+				$args_tables = array_merge(
+					$args_tables,
+					array_filter(
+						$tables,
+						function ( $v ) use ( $arg ) {
+							return fnmatch( $arg, $v );
+						}
+					)
+				);
 			} else {
 				$args_tables[] = $arg;
 			}

--- a/php/utils.php
+++ b/php/utils.php
@@ -66,7 +66,7 @@ function load_dependencies() {
 }
 
 function get_vendor_paths() {
-	$vendor_paths = array(
+	$vendor_paths        = array(
 		WP_CLI_ROOT . '/../../../vendor',  // part of a larger project / installed via Composer (preferred)
 		WP_CLI_ROOT . '/vendor',           // top-level project / installed as Git clone
 	);
@@ -247,7 +247,7 @@ function locate_wp_config() {
 
 function wp_version_compare( $since, $operator ) {
 	$wp_version = str_replace( '-src', '', $GLOBALS['wp_version'] );
-	$since = str_replace( '-src', '', $since );
+	$since      = str_replace( '-src', '', $since );
 	return version_compare( $wp_version, $since, $operator );
 }
 
@@ -298,7 +298,7 @@ function wp_version_compare( $since, $operator ) {
  */
 function format_items( $format, $items, $fields ) {
 	$assoc_args = compact( 'format', 'fields' );
-	$formatter = new \WP_CLI\Formatter( $assoc_args );
+	$formatter  = new \WP_CLI\Formatter( $assoc_args );
 	$formatter->display_items( $items );
 }
 
@@ -362,11 +362,11 @@ function launch_editor_for_input( $input, $title = 'WP-CLI', $ext = 'tmp' ) {
 	$tmpdir = get_temp_dir();
 
 	do {
-		$tmpfile = basename( $title );
-		$tmpfile = preg_replace( '|\.[^.]*$|', '', $tmpfile );
+		$tmpfile  = basename( $title );
+		$tmpfile  = preg_replace( '|\.[^.]*$|', '', $tmpfile );
 		$tmpfile .= '-' . substr( md5( mt_rand() ), 0, 6 );
-		$tmpfile = $tmpdir . $tmpfile . '.' . $ext;
-		$fp = fopen( $tmpfile, 'xb' );
+		$tmpfile  = $tmpdir . $tmpfile . '.' . $ext;
+		$fp       = fopen( $tmpfile, 'xb' );
 		if ( ! $fp && is_writable( $tmpdir ) && file_exists( $tmpfile ) ) {
 			$tmpfile = '';
 			continue;
@@ -389,8 +389,8 @@ function launch_editor_for_input( $input, $title = 'WP-CLI', $ext = 'tmp' ) {
 	}
 
 	$descriptorspec = array( STDIN, STDOUT, STDERR );
-	$process = proc_open_compat( "$editor " . escapeshellarg( $tmpfile ), $descriptorspec, $pipes );
-	$r = proc_close( $process );
+	$process        = proc_open_compat( "$editor " . escapeshellarg( $tmpfile ), $descriptorspec, $pipes );
+	$r              = proc_close( $process );
 	if ( $r ) {
 		exit( $r );
 	}
@@ -413,12 +413,12 @@ function launch_editor_for_input( $input, $title = 'WP-CLI', $ext = 'tmp' ) {
 function mysql_host_to_cli_args( $raw_host ) {
 	$assoc_args = array();
 
-	$host_parts = explode( ':',  $raw_host );
+	$host_parts = explode( ':', $raw_host );
 	if ( count( $host_parts ) == 2 ) {
 		list( $assoc_args['host'], $extra ) = $host_parts;
-		$extra = trim( $extra );
+		$extra                              = trim( $extra );
 		if ( is_numeric( $extra ) ) {
-			$assoc_args['port'] = (int) $extra;
+			$assoc_args['port']     = (int) $extra;
 			$assoc_args['protocol'] = 'tcp';
 		} elseif ( '' !== $extra ) {
 			$assoc_args['socket'] = $extra;
@@ -585,7 +585,7 @@ function replace_path_consts( $source, $path ) {
  */
 function http_request( $method, $url, $data = null, $headers = array(), $options = array() ) {
 
-	$cert_path = '/rmccue/requests/library/Requests/Transport/cacert.pem';
+	$cert_path     = '/rmccue/requests/library/Requests/Transport/cacert.pem';
 	$halt_on_error = ! isset( $options['halt_on_error'] ) || (bool) $options['halt_on_error'];
 	if ( inside_phar() ) {
 		// cURL can't read Phar archives
@@ -704,7 +704,7 @@ function get_named_sem_ver( $new_version, $original_version ) {
 	}
 
 	$parts = explode( '-', $original_version );
-	$bits = explode( '.', $parts[0] );
+	$bits  = explode( '.', $parts[0] );
 	$major = $bits[0];
 	if ( isset( $bits[1] ) ) {
 		$minor = $bits[1];
@@ -903,8 +903,8 @@ function parse_ssh_url( $url, $component = -1 ) {
  * @param null|integer $skips     Optional. Number of skipped operations. Default null (don't show skips).
  */
 function report_batch_operation_results( $noun, $verb, $total, $successes, $failures, $skips = null ) {
-	$plural_noun = $noun . 's';
-	$past_tense_verb = past_tense_verb( $verb );
+	$plural_noun           = $noun . 's';
+	$past_tense_verb       = past_tense_verb( $verb );
 	$past_tense_verb_upper = ucfirst( $past_tense_verb );
 	if ( $failures ) {
 		$failed_skipped_message = null === $skips ? '' : " ({$failures} failed" . ( $skips ? ", {$skips} skipped" : '' ) . ')';
@@ -987,7 +987,7 @@ function isPiped() {
 		return filter_var( $shellPipe, FILTER_VALIDATE_BOOLEAN );
 	}
 
-	return (function_exists( 'posix_isatty' ) && ! posix_isatty( STDOUT ));
+	return ( function_exists( 'posix_isatty' ) && ! posix_isatty( STDOUT ) );
 }
 
 /**
@@ -1046,8 +1046,8 @@ function glob_brace( $pattern, $dummy_flags = null ) {
 	if ( ! $next_brace_sub ) {
 		// Find the end of the subpattern in a brace expression.
 		$next_brace_sub = function ( $pattern, $current ) {
-			$length  = strlen( $pattern );
-			$depth   = 0;
+			$length = strlen( $pattern );
+			$depth  = 0;
 
 			while ( $current < $length ) {
 				if ( '\\' === $pattern[ $current ] ) {
@@ -1096,7 +1096,7 @@ function glob_brace( $pattern, $dummy_flags = null ) {
 	}
 
 	$paths = array();
-	$p = $begin + 1;
+	$p     = $begin + 1;
 
 	// For each comma-separated subpattern.
 	do {
@@ -1138,26 +1138,26 @@ function glob_brace( $pattern, $dummy_flags = null ) {
 function get_suggestion( $target, array $options, $threshold = 2 ) {
 
 	$suggestion_map = array(
-		'add' => 'create',
-		'check' => 'check-update',
+		'add'        => 'create',
+		'check'      => 'check-update',
 		'capability' => 'cap',
-		'clear' => 'flush',
-		'decrement' => 'decr',
-		'del' => 'delete',
-		'directory' => 'dir',
-		'exec' => 'eval',
-		'exec-file' => 'eval-file',
-		'increment' => 'incr',
-		'language' => 'locale',
-		'lang' => 'locale',
-		'new' => 'create',
-		'number' => 'count',
-		'remove' => 'delete',
-		'regen' => 'regenerate',
-		'rep' => 'replace',
-		'repl' => 'replace',
-		'trash' => 'delete',
-		'v' => 'version',
+		'clear'      => 'flush',
+		'decrement'  => 'decr',
+		'del'        => 'delete',
+		'directory'  => 'dir',
+		'exec'       => 'eval',
+		'exec-file'  => 'eval-file',
+		'increment'  => 'incr',
+		'language'   => 'locale',
+		'lang'       => 'locale',
+		'new'        => 'create',
+		'number'     => 'count',
+		'remove'     => 'delete',
+		'regen'      => 'regenerate',
+		'rep'        => 'replace',
+		'repl'       => 'replace',
+		'trash'      => 'delete',
+		'v'          => 'version',
 	);
 
 	if ( array_key_exists( $target, $suggestion_map ) && in_array( $suggestion_map[ $target ], $options, true ) ) {
@@ -1168,7 +1168,7 @@ function get_suggestion( $target, array $options, $threshold = 2 ) {
 		return '';
 	}
 	foreach ( $options as $option ) {
-		$distance = levenshtein( $option, $target );
+		$distance               = levenshtein( $option, $target );
 		$levenshtein[ $option ] = $distance;
 	}
 
@@ -1225,7 +1225,7 @@ function is_bundled_command( $command ) {
 	static $classes;
 
 	if ( null === $classes ) {
-		$classes = array();
+		$classes   = array();
 		$class_map = WP_CLI_VENDOR_DIR . '/composer/autoload_commands_classmap.php';
 		if ( file_exists( WP_CLI_VENDOR_DIR . '/composer/' ) ) {
 			$classes = include $class_map;
@@ -1250,7 +1250,7 @@ function is_bundled_command( $command ) {
  * @return string
  */
 function force_env_on_nix_systems( $command ) {
-	$env_prefix = '/usr/bin/env ';
+	$env_prefix     = '/usr/bin/env ';
 	$env_prefix_len = strlen( $env_prefix );
 	if ( is_windows() ) {
 		if ( 0 === strncmp( $command, $env_prefix, $env_prefix_len ) ) {

--- a/php/wp-cli.php
+++ b/php/wp-cli.php
@@ -16,8 +16,8 @@ if ( file_exists( WP_CLI_ROOT . '/vendor/autoload.php' ) ) {
 // Set common headers, to prevent warnings from plugins
 $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.0';
 $_SERVER['HTTP_USER_AGENT'] = '';
-$_SERVER['REQUEST_METHOD'] = 'GET';
-$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+$_SERVER['REQUEST_METHOD']  = 'GET';
+$_SERVER['REMOTE_ADDR']     = '127.0.0.1';
 
 require_once WP_CLI_ROOT . '/php/bootstrap.php';
 \WP_CLI\bootstrap();

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -42,7 +42,7 @@ wp_check_php_mysql_versions();
 
 // Disable magic quotes at runtime. Magic quotes are added using wpdb later in wp-settings.php.
 ini_set( 'magic_quotes_runtime', 0 );
-ini_set( 'magic_quotes_sybase',  0 );
+ini_set( 'magic_quotes_sybase', 0 );
 
 // WordPress calculates offsets from UTC.
 date_default_timezone_set( 'UTC' );
@@ -385,7 +385,7 @@ wp_templating_constants();
 // Load the default text localization domain.
 load_default_textdomain();
 
-$locale = get_locale();
+$locale      = get_locale();
 $locale_file = WP_LANG_DIR . "/$locale.php";
 if ( ( 0 === validate_file( $locale ) ) && is_readable( $locale_file ) ) {
 	require $locale_file;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -19,7 +19,7 @@
 	<exclude-pattern>*/utils/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
-	<rule ref="PHPCompatibility">
+	<rule ref="PHPCompatibilityWP">
 		<!-- Polyfill package is used so array_column() is available for PHP 5.4- -->
 		<exclude name="PHPCompatibility.PHP.NewFunctions.array_columnFound"/>
 		<!-- Both magic quotes directives set in wp-settings-cli.php to provide consistent starting point. -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,17 +1,14 @@
 <?xml version="1.0"?>
 <ruleset name="WP-CLI">
-	<description>WordPress Coding Standards for WP-CLI</description>
+	<description>Custom ruleset for WP-CLI</description>
 
-	<!-- Show sniff codes in all reports, and progress while running -->
-	<arg value="sp"/>
-	<!-- Check all PHP files in directory tree by default. -->
-	<arg name="extensions" value="php"/>
-	<!-- Run different reports -->
-	<arg name="report" value="full"/>
-	<arg name="report" value="summary"/>
-	<arg name="report" value="source"/>
+	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
 
+	<!-- What to scan -->
 	<file>.</file>
+	<!-- Ignoring Files and Folders:
+		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>*/ci/*</exclude-pattern>
 	<exclude-pattern>*/features/*</exclude-pattern>
 	<exclude-pattern>*/packages/*</exclude-pattern>
@@ -19,6 +16,13 @@
 	<exclude-pattern>*/utils/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
+	<!-- How to scan -->
+	<arg value="sp"/> <!-- Show sniff and progress -->
+	<arg name="colors"/> <!-- Show results with colors -->
+	<arg name="extensions" value="php"/> <!-- Limit to PHP files -->
+
+	<!-- Rules: Check PHP version compatibility - see
+		https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibilityWP">
 		<!-- Polyfill package is used so array_column() is available for PHP 5.4- -->
 		<exclude name="PHPCompatibility.PHP.NewFunctions.array_columnFound"/>
@@ -26,18 +30,27 @@
 		<exclude name="PHPCompatibility.PHP.DeprecatedIniDirectives.magic_quotes_runtimeDeprecatedRemoved"/>
 		<exclude name="PHPCompatibility.PHP.DeprecatedIniDirectives.magic_quotes_sybaseDeprecatedRemoved"/>
 	</rule>
+
+	<!-- For help in understanding this testVersion:
+		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
 	<config name="testVersion" value="5.3-"/>
+
 	<!-- Ignore php_uname mode issue, we're conditionally providing a callback -->
 	<rule ref="PHPCompatibility.PHP.NewFunctionParameters.php_uname_modeFound">
 		<exclude-pattern>*/php/commands/src/CLI_Command.php</exclude-pattern>
 	</rule>
 
+	<!-- Rules: WordPress Coding Standards - see
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<rule ref="WordPress-Core">
 		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.MemberNotSnakeCase" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" />
 	</rule>
+
+	<!-- For help in understanding these custom sniff properties:
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
 	<rule ref="WordPress.Files.FileName">
 		<properties>
 			<property name="strict_class_file_names" value="false"/>


### PR DESCRIPTION
See individual commits for more info.

Self-note: WP-CLI is pinned to PHP 5.3.29, so it's PHP_Codesniffer 2.9.1 that is installed. As such `parallel` and `basepath` args are not available.

Note, that none of the newly reported violations have yet been fixed in this PR, but I can do if desired. 374 violations are auto-fixable (mostly whitespace), and two are the use of `eval` ([1](https://github.com/wp-cli/wp-cli/blob/ba5ac9689da8ea1cc29a6ef14d4fcebbddf2c0db/php/WP_CLI/Runner.php#L179), [2](https://github.com/wp-cli/wp-cli/blob/ba5ac9689da8ea1cc29a6ef14d4fcebbddf2c0db/php/WP_CLI/Runner.php#L1144)).

Here's the source summary of violations:

```sh
> ~/code/wp-cli: phpcs --report=source
WW.W.W...W..................WWWWW.WW.W.WWW....E.W.W.WWWE...E 60 / 69 (87%)
WWE.WWW.W


PHP CODE SNIFFER VIOLATION SOURCE SUMMARY
----------------------------------------------------------------------
    SOURCE                                                       COUNT
----------------------------------------------------------------------
[x] Generic.Formatting.MultipleStatementAlignment.NotSameWarnin  207
[x] WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotA  161
[x] Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceA  2
[ ] Squiz.PHP.Eval.Discouraged                                   2
[x] WordPress.WhiteSpace.ArbitraryParenthesesSpacing.SpaceBefor  1
[x] WordPress.WhiteSpace.ArbitraryParenthesesSpacing.SpaceAfter  1
[x] Generic.Functions.FunctionCallArgumentSpacing.SpaceBeforeCo  1
[x] Generic.Formatting.MultipleStatementAlignment.IncorrectWarn  1
----------------------------------------------------------------------
A TOTAL OF 376 SNIFF VIOLATIONS WERE FOUND IN 8 SOURCES
----------------------------------------------------------------------
PHPCBF CAN FIX THE 7 MARKED SOURCES AUTOMATICALLY (374 VIOLATIONS IN TOTAL)
----------------------------------------------------------------------

Time: 9.35 secs; Memory: 30Mb
```