### PR TITLE
Fix `var_export` return in `WP_CLI::print_value`

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -936,7 +936,7 @@ class WP_CLI {
 		} elseif ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'format' ) === 'yaml' ) {
 			$value = Spyc::YAMLDump( $value, 2, 0 );
 		} elseif ( is_array( $value ) || is_object( $value ) ) {
-			$value = var_export( $value );
+			$value = var_export( $value, true );
 		}
 
 		echo $value . "\n";


### PR DESCRIPTION
By default `var_export` will dump its output to stdout. Set the return
parameter to true to save it into the `$value` variable for further
processing as expected.