### PR TITLE
Add sibling `vendor` folder location

### DIFF
--- a/php/wp-cli.php
+++ b/php/wp-cli.php
@@ -9,6 +9,8 @@ if ( file_exists( WP_CLI_ROOT . '/vendor/autoload.php' ) ) {
 	define( 'WP_CLI_VENDOR_DIR', WP_CLI_ROOT . '/vendor' );
 } elseif ( file_exists( dirname( dirname( WP_CLI_ROOT ) ) . '/autoload.php' ) ) {
 	define( 'WP_CLI_VENDOR_DIR', dirname( dirname( WP_CLI_ROOT ) ) );
+} elseif ( file_exists( dirname( WP_CLI_ROOT ) . '/vendor/autoload.php' ) ) {
+	define( 'WP_CLI_VENDOR_DIR', dirname( WP_CLI_ROOT ) . '/vendor' );
 } else {
 	define( 'WP_CLI_VENDOR_DIR', WP_CLI_ROOT . '/vendor' );
 }


### PR DESCRIPTION
For the development use case where all repositories are checked out into a flat folder hierarchy (mirroring the GitHub org), the `vendor` folder will end up being a sibling to the `wp-cli` framework folder.

The bootstrapping code needs to allow for this setup as well.