### PR TITLE
get_config shall thrown a debug message instead warning

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1125,7 +1125,7 @@ class WP_CLI {
 		}
 
 		if ( ! isset( self::get_runner()->config[ $key ] ) ) {
-			self::warning( "Unknown config option '$key'." );
+			self::debug( "Unknown config option '$key'." );
 			return null;
 		}
 


### PR DESCRIPTION
The function get_config shall thrown a debug message instead warning.

Related with: #3220