### PR TITLE
Use "installation" instead of "install" in documentation

### DIFF
--- a/features/utils-wp.feature
+++ b/features/utils-wp.feature
@@ -42,7 +42,7 @@ Feature: Utilities that depend on WordPress code
        * : Can be all, global, ms_global, blog, or old tables. Defaults to all.
        *
        * [--network]
-       * : List all the tables in a multisite install. Overrides --scope=<scope>.
+       * : List all the tables in a multisite installation. Overrides --scope=<scope>.
        *
        * [--all-tables-with-prefix]
        * : List all tables that match the table prefix even if not registered on $wpdb. Overrides --network.
@@ -313,7 +313,7 @@ Feature: Utilities that depend on WordPress code
        * : Can be all, global, ms_global, blog, or old tables. Defaults to all.
        *
        * [--network]
-       * : List all the tables in a multisite install. Overrides --scope=<scope>.
+       * : List all the tables in a multisite installation. Overrides --scope=<scope>.
        *
        * [--all-tables-with-prefix]
        * : List all tables that match the table prefix even if not registered on $wpdb. Overrides --network.

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -224,7 +224,7 @@ class WP_CLI {
 	 * WP_CLI::add_command( 'network meta', 'Network_Meta_Command', array(
 	 *    'before_invoke' => function () {
 	 *        if ( !is_multisite() ) {
-	 *            WP_CLI::error( 'This is not a multisite install.' );
+	 *            WP_CLI::error( 'This is not a multisite installation.' );
 	 *        }
 	 *    }
 	 * ) );

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -553,7 +553,7 @@ class CLI_Command extends WP_CLI_Command {
 	/**
 	 * List available WP-CLI aliases.
 	 *
-	 * Aliases are shorthand references to WordPress installs. For instance,
+	 * Aliases are shorthand references to WordPress installations. For instance,
 	 * `@dev` could refer to a development installation and `@prod` could refer
 	 * to a production installation. This command gives you visibility in what
 	 * registered aliases you have available.


### PR DESCRIPTION
This PR uses the noun where appropriate. Please note only documentation is addressed, not code or tests. PR is a response to https://twitter.com/wpcli/status/1047158732805853184

#Hacktoberfest