### PR TITLE
Use `dirname()` instead of `..` to locate `wp-config.php` to match Core behavior

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -234,7 +234,7 @@ function locate_wp_config() {
 
 		if ( file_exists( ABSPATH . 'wp-config.php' ) ) {
 			$path = ABSPATH . 'wp-config.php';
-		} elseif ( file_exists( ABSPATH . '../wp-config.php' ) && ! file_exists( ABSPATH . '/../wp-settings.php' ) ) {
+		} elseif ( file_exists( dirname( ABSPATH ) . '../wp-config.php' ) && ! file_exists( dirname( ABSPATH ) . '/../wp-settings.php' ) ) {
 			$path = ABSPATH . '../wp-config.php';
 		}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -234,7 +234,7 @@ function locate_wp_config() {
 
 		if ( file_exists( ABSPATH . 'wp-config.php' ) ) {
 			$path = ABSPATH . 'wp-config.php';
-		} elseif ( file_exists( dirname( ABSPATH ) . '../wp-config.php' ) && ! file_exists( dirname( ABSPATH ) . '/../wp-settings.php' ) ) {
+		} elseif ( file_exists( dirname( ABSPATH ) . '/wp-config.php' ) && ! file_exists( dirname( ABSPATH ) . '/wp-settings.php' ) ) {
 			$path = ABSPATH . '../wp-config.php';
 		}
 


### PR DESCRIPTION
fix for #4856 to add dirname when searching for wp-config inline with WordPress