### PR TITLE
Update Composer dependencies (2018-10-05)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3688,16 +3688,16 @@
         },
         {
             "name": "wp-cli/wp-config-transformer",
-            "version": "v1.2.1",
+            "version": "v1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-config-transformer.git",
-                "reference": "6ce0a9fae09d53145c9c9c79486a69684598488d"
+                "reference": "c469771d29279e5d7a8a2065f6be809ae66a47cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-config-transformer/zipball/6ce0a9fae09d53145c9c9c79486a69684598488d",
-                "reference": "6ce0a9fae09d53145c9c9c79486a69684598488d",
+                "url": "https://api.github.com/repos/wp-cli/wp-config-transformer/zipball/c469771d29279e5d7a8a2065f6be809ae66a47cc",
+                "reference": "c469771d29279e5d7a8a2065f6be809ae66a47cc",
                 "shasum": ""
             },
             "require": {
@@ -3725,7 +3725,7 @@
                 }
             ],
             "description": "Programmatically edit a wp-config.php file.",
-            "time": "2018-03-20T16:19:27+00:00"
+            "time": "2018-10-03T10:40:09+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",


### PR DESCRIPTION
```
Loading composer repositories with package information
Updating dependencies (including require-dev)
The "http://packagist.org/p/provider-2018-07%24bff2396d778869ecd4413810a6740d47f718b54e996a28f5e2ef065f1d677e79.json" file could not be downloaded: failed to open stream: Connection timed out
http://packagist.org could not be fully loaded, package information was loaded from the local cache and may be out of date
Package operations: 0 installs, 1 update, 0 removals
  - Updating wp-cli/wp-config-transformer (v1.2.1 => v1.2.2): Downloading (100%)
Writing lock file
Generating autoload files
PHP CodeSniffer Config installed_paths set to ../../wp-coding-standards/wpcs/,../../phpcompatibility/php-compatibility/,../../phpcompatibility/phpcompatibility-wp/
```