### PR TITLE
Update Composer dependencies (2018-10-15)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1683,12 +1683,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "e889aa8db63daf82a357d10abce7547dc5e11e4f"
+                "reference": "80391a9571af37a87675d6dc12d59d050cedc5f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/e889aa8db63daf82a357d10abce7547dc5e11e4f",
-                "reference": "e889aa8db63daf82a357d10abce7547dc5e11e4f",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/80391a9571af37a87675d6dc12d59d050cedc5f7",
+                "reference": "80391a9571af37a87675d6dc12d59d050cedc5f7",
                 "shasum": ""
             },
             "conflict": {
@@ -1807,7 +1807,7 @@
                 "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
                 "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7",
                 "thelia/backoffice-default-template": ">=2.1,<2.1.2",
-                "thelia/thelia": ">=2.1.0-beta1,<2.1.3|>=2.1,<2.1.2",
+                "thelia/thelia": ">=2.1,<2.1.2|>=2.1.0-beta1,<2.1.3",
                 "theonedemon/phpwhois": "<=4.2.5",
                 "titon/framework": ">=0,<9.9.99",
                 "truckersmp/phpwhois": "<=4.3.1",
@@ -1863,7 +1863,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2018-10-11T11:25:15+00:00"
+            "time": "2018-10-12T22:19:58+00:00"
         },
         {
             "name": "sebastian/comparator",


### PR DESCRIPTION
```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
Writing lock file
Generating autoload files
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/phpcompatibility-wp/,../../wp-coding-standards/wpcs/,../../phpcompatibility/php-compatibility/
```