### PR TITLE
Match the way WordPress Core locates `wp-config.php`

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -227,7 +227,7 @@ function esc_cmd( $cmd ) {
 }
 
 /**
- * Gets path to Wordpress configuration.
+ * Gets path to WordPress configuration.
  *
  * @return string
  */
@@ -239,8 +239,8 @@ function locate_wp_config() {
 
 		if ( file_exists( ABSPATH . 'wp-config.php' ) ) {
 			$path = ABSPATH . 'wp-config.php';
-    } elseif ( @file_exists( dirname( ABSPATH ) . '/wp-config.php' ) && ! @file_exists( dirname( ABSPATH ) . '/wp-settings.php' ) ) {
-      $path = dirname( ABSPATH ) . '/wp-config.php';
+		} elseif ( @file_exists( dirname( ABSPATH ) . '/wp-config.php' ) && ! @file_exists( dirname( ABSPATH ) . '/wp-settings.php' ) ) {
+			$path = dirname( ABSPATH ) . '/wp-config.php';
 		}
 
 		if ( $path ) {

--- a/php/utils.php
+++ b/php/utils.php
@@ -226,6 +226,11 @@ function esc_cmd( $cmd ) {
 	return vsprintf( $cmd, array_map( 'escapeshellarg', $args ) );
 }
 
+/**
+ * Gets path to Wordpress configuration.
+ *
+ * @return string
+ */
 function locate_wp_config() {
 	static $path;
 
@@ -234,8 +239,8 @@ function locate_wp_config() {
 
 		if ( file_exists( ABSPATH . 'wp-config.php' ) ) {
 			$path = ABSPATH . 'wp-config.php';
-		} elseif ( file_exists( ABSPATH . '../wp-config.php' ) && ! file_exists( ABSPATH . '/../wp-settings.php' ) ) {
-			$path = ABSPATH . '../wp-config.php';
+    } elseif ( @file_exists( dirname( ABSPATH ) . '/wp-config.php' ) && ! @file_exists( dirname( ABSPATH ) . '/wp-settings.php' ) ) {
+      $path = dirname( ABSPATH ) . '/wp-config.php';
 		}
 
 		if ( $path ) {


### PR DESCRIPTION
Fix for #4856 Updated locate_wp_config() to match core.
