### PR TITLE
Fix parsing of arguments for `WP_CLI::runcommand()` with `launch=false`

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -944,7 +944,7 @@ function report_batch_operation_results( $noun, $verb, $total, $successes, $fail
  * @return array
  */
 function parse_str_to_argv( $arguments ) {
-	preg_match_all( '/(?<=^|\s)([\'"]?)(.+?)(?<!\\\\)\1(?=$|\s)/', $arguments, $matches );
+	preg_match_all( '/(?:(?:\'[^\']+?\')|(?:"[^"]+?")|[^\s])+/', $arguments, $matches );
 	$argv = isset( $matches[0] ) ? $matches[0] : array();
 	$argv = array_map(
 		function( $arg ) {

--- a/php/utils.php
+++ b/php/utils.php
@@ -944,7 +944,7 @@ function report_batch_operation_results( $noun, $verb, $total, $successes, $fail
  * @return array
  */
 function parse_str_to_argv( $arguments ) {
-	preg_match_all( '/(?:(?:\'[^\']+?\')|(?:"[^"]+?")|[^\s])+/', $arguments, $matches );
+	preg_match_all( '/(?:[^\s]*(?:(?:".*?(?<!\\\)")|[^\s]*(?:\'.*?(?<!\\\)\')))|(?:[^\s]+)/', $arguments, $matches );
 	$argv = isset( $matches[0] ) ? $matches[0] : array();
 	$argv = array_map(
 		function( $arg ) {

--- a/php/utils.php
+++ b/php/utils.php
@@ -944,7 +944,7 @@ function report_batch_operation_results( $noun, $verb, $total, $successes, $fail
  * @return array
  */
 function parse_str_to_argv( $arguments ) {
-	preg_match_all( '/(?:[^\s]*(?:(?:".*?(?<!\\\)")|[^\s]*(?:\'.*?(?<!\\\)\')))|(?:[^\s]+)/', $arguments, $matches );
+	preg_match_all( '/(?:[^\s]*(?:(["|\']).*?(?<!\\\)\1))|(?:[^\s]+)/', $arguments, $matches );
 	$argv = isset( $matches[0] ) ? $matches[0] : array();
 	$argv = array_map(
 		function( $arg ) {

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -248,6 +248,12 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			'eval',
 			'echo wp_get_current_user()->user_login;',
 		), Utils\parse_str_to_argv( 'eval "echo wp_get_current_user()->user_login;"' ) );
+		$this->assertEquals( array(
+			'post',
+			'create',
+			'--post_title="Hello world!"',
+			'--post_content=\'mixed "quotes are working" hopefully\'',
+		), Utils\parse_str_to_argv( 'post create --post_title="Hello world!" --post_content=\'mixed "quotes are working" hopefully\'' ) );
 	}
 
 	public function testAssocArgsToString() {

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -252,8 +252,22 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			'post',
 			'create',
 			'--post_title="Hello world!"',
-			'--post_content=\'mixed "quotes are working" hopefully\'',
-		), Utils\parse_str_to_argv( 'post create --post_title="Hello world!" --post_content=\'mixed "quotes are working" hopefully\'' ) );
+		), Utils\parse_str_to_argv( 'post create --post_title="Hello world!"' ) );
+		$this->assertEquals( array(
+			'post',
+			'create',
+			'--post_title=\'Mixed "quotes are working" hopefully\'',
+		), Utils\parse_str_to_argv( 'post create --post_title=\'Mixed "quotes are working" hopefully\'' ) );
+		$this->assertEquals( array(
+			'post',
+			'create',
+			'--post_title="Escaped \"double \"quotes!"',
+		), Utils\parse_str_to_argv( 'post create --post_title="Escaped \"double \"quotes!"' ) );
+		$this->assertEquals( array(
+			'post',
+			'create',
+			"--post_title='Escaped \'single \'quotes!'",
+		), Utils\parse_str_to_argv( "post create --post_title='Escaped \'single \'quotes!'" ) );
 	}
 
 	public function testAssocArgsToString() {


### PR DESCRIPTION
I added unit tests for the broken cases and modified the regular expression so that it correctly parses these cases as well.

Fixes #4741 