### PR TITLE
Use custom autoloader to load framework

### DIFF
--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -1,5 +1,12 @@
 Feature: Bootstrap WP-CLI
 
+  Background:
+    When I run `wp package path`
+    And save STDOUT as {PACKAGE_PATH}
+    And I run `rm -rf {PACKAGE_PATH}/vendor`
+    And I run `rm -rf {PACKAGE_PATH}/composer.json`
+    And I run `rm -rf {PACKAGE_PATH}/composer.lock`
+
   @require-opcache-save-comments
   Scenario: Basic Composer stack
     Given an empty directory

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -34,7 +34,7 @@
 
 	<!-- For help in understanding this testVersion:
 		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.3-"/>
+	<config name="testVersion" value="5.4-"/>
 
 	<!-- Ignore php_uname mode issue, we're conditionally providing a callback -->
 	<rule ref="PHPCompatibility.PHP.NewFunctionParameters.php_uname_modeFound">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -34,7 +34,7 @@
 
 	<!-- For help in understanding this testVersion:
 		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.4-"/>
+	<config name="testVersion" value="5.3-"/>
 
 	<!-- Ignore php_uname mode issue, we're conditionally providing a callback -->
 	<rule ref="PHPCompatibility.PHP.NewFunctionParameters.php_uname_modeFound">


### PR DESCRIPTION
This decouples the framework from the Composer autoloader, so that framework and bundled commands can be controlled independently, allowing overrides.

Fixes #4987

Depends on #5014 