### PR TITLE
Skip associative arguments that were already provided on `--prompt`

### DIFF
--- a/features/prompt.feature
+++ b/features/prompt.feature
@@ -95,4 +95,73 @@ Feature: Prompt user for input
       wp foobar
       """
     And STDERR should be empty
-    
+
+  Scenario: Prompt should skip arguments that are already provided
+    Given an empty directory
+    And a cmd.php file:
+      """
+      <?php
+      /**
+       * Test that the flag prompt is case insensitive.
+       *
+       * ## OPTIONS
+       *
+       * <arg1>
+       * : A positional arg.
+       *
+       * <arg2>
+       * : A positional arg.
+       *
+       * [--flag1=<value>]
+       * : A flag.
+       *
+       * [--flag2=<value>]
+       * : A flag.
+       *
+       * [--flag3=<value>]
+       * : A flag.
+       *
+       * @when before_wp_load
+       */
+      WP_CLI::add_command( 'test-prompt', function( $args, $assoc_args ) {
+        WP_CLI::line( 'arg1: ' . $args[0] );
+        WP_CLI::line( 'arg2: ' . $args[1] );
+        WP_CLI::line( 'flag1: ' . $assoc_args['flag1'] );
+        WP_CLI::line( 'flag2: ' . $assoc_args['flag2'] );
+        WP_CLI::line( 'flag3: ' . $assoc_args['flag3'] );
+      } );
+      """
+    And a value-file file:
+      """
+      positional2
+      value2
+      """
+    And a wp-cli.yml file:
+      """
+      require:
+        - cmd.php
+      """
+
+    When I run `wp test-prompt positional1 --flag1=value1 --flag3=value3 --prompt < value-file`
+    Then the return code should be 0
+    And STDERR should be empty
+    And STDOUT should contain:
+      """
+      arg1: positional1
+      """
+    And STDOUT should contain:
+      """
+      arg2: positional2
+      """
+    And STDOUT should contain:
+      """
+      flag1: value1
+      """
+    And STDOUT should contain:
+      """
+      flag2: value2
+      """
+    And STDOUT should contain:
+      """
+      flag3: value3
+      """

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -146,8 +146,12 @@ class Subcommand extends CompositeCommand {
 
 		$spec = array_filter(
 			\WP_CLI\SynopsisParser::parse( $synopsis ),
-			function( $spec_arg ) {
-				return in_array( $spec_arg['type'], array( 'generic', 'positional', 'assoc', 'flag' ) );
+			function( $spec_arg ) use ( $assoc_args ) {
+				return in_array( $spec_arg['type'], [ 'generic', 'positional' ] )
+					|| (
+						in_array( $spec_arg['type'], [ 'assoc', 'flag' ] )
+						&& ! isset( $assoc_args[ $spec_arg['name'] ] )
+					);
 			}
 		);
 
@@ -213,7 +217,6 @@ class Subcommand extends CompositeCommand {
 				} while ( $repeat );
 
 			} else {
-
 				$prompt = $current_prompt . $spec_arg['token'];
 				if ( 'flag' == $spec_arg['type'] ) {
 					$prompt .= ' (Y/n)';


### PR DESCRIPTION
I'm ignoring positional arguments for now and concentrate on associative arguments, except the ones of type `generic` (`--<field>=<value>`).

The current PR seems to work as expected, however I'm not sure yet how to write a test for this functionality.

Fixes #4762