### PR TITLE
PHPCS: fix up the code base [3] - strict comparisons

### DIFF
--- a/php/WP_CLI/Completions.php
+++ b/php/WP_CLI/Completions.php
@@ -51,7 +51,7 @@ class Completions {
 
 		if ( $command->can_have_subcommands() ) {
 			// add completion when command is `wp` and alias isn't set.
-			if ( 'wp' === $command->get_name() && false === $is_alias && false == $is_help ) {
+			if ( 'wp' === $command->get_name() && false === $is_alias && false === $is_help ) {
 				$aliases = \WP_CLI::get_configurator()->get_aliases();
 				foreach ( $aliases as $name => $_ ) {
 					$this->add( "$name " );
@@ -62,7 +62,7 @@ class Completions {
 			}
 		} else {
 			foreach ( $spec as $arg ) {
-				if ( in_array( $arg['type'], array( 'flag', 'assoc' ) ) ) {
+				if ( in_array( $arg['type'], array( 'flag', 'assoc' ), true ) ) {
 					if ( isset( $assoc_args[ $arg['name'] ] ) ) {
 						continue;
 					}
@@ -110,7 +110,7 @@ class Completions {
 		}
 
 		$r = \WP_CLI::get_runner()->find_command_to_run( $positional_args );
-		if ( ! is_array( $r ) && array_pop( $positional_args ) == $this->cur_word ) {
+		if ( ! is_array( $r ) && array_pop( $positional_args ) === $this->cur_word ) {
 			$r = \WP_CLI::get_runner()->find_command_to_run( $positional_args );
 		}
 

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -275,7 +275,7 @@ class Configurator {
 			if ( false !== $details['runtime'] && isset( $config[ $key ] ) ) {
 				$value = $config[ $key ];
 
-				if ( 'require' == $key ) {
+				if ( 'require' === $key ) {
 					$value = \WP_CLI\Utils\expand_globs( $value );
 				}
 

--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -268,7 +268,7 @@ class CompositeCommand {
 		$binding                 = array();
 		$binding['root_command'] = $root_command;
 
-		if ( ! $this->can_have_subcommands() || ( is_object( $this->parent ) && get_class( $this->parent ) == 'WP_CLI\Dispatcher\CompositeCommand' ) ) {
+		if ( ! $this->can_have_subcommands() || ( is_object( $this->parent ) && get_class( $this->parent ) === 'WP_CLI\Dispatcher\CompositeCommand' ) ) {
 			$binding['is_subcommand'] = true;
 		}
 

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -147,7 +147,7 @@ class Subcommand extends CompositeCommand {
 		$spec = array_filter(
 			\WP_CLI\SynopsisParser::parse( $synopsis ),
 			function( $spec_arg ) {
-				return in_array( $spec_arg['type'], array( 'generic', 'positional', 'assoc', 'flag' ) );
+				return in_array( $spec_arg['type'], array( 'generic', 'positional', 'assoc', 'flag' ), true );
 			}
 		);
 
@@ -178,7 +178,7 @@ class Subcommand extends CompositeCommand {
 			$default        = $spec_arg['optional'] ? '' : false;
 
 			// 'generic' permits arbitrary key=value (e.g. [--<field>=<value>] )
-			if ( 'generic' == $spec_arg['type'] ) {
+			if ( 'generic' === $spec_arg['type'] ) {
 
 				list( $key_token, $value_token ) = explode( '=', $spec_arg['token'] );
 
@@ -215,7 +215,7 @@ class Subcommand extends CompositeCommand {
 			} else {
 
 				$prompt = $current_prompt . $spec_arg['token'];
-				if ( 'flag' == $spec_arg['type'] ) {
+				if ( 'flag' === $spec_arg['type'] ) {
 					$prompt .= ' (Y/n)';
 				}
 
@@ -238,7 +238,7 @@ class Subcommand extends CompositeCommand {
 							$assoc_args[ $spec_arg['name'] ] = $response;
 							break;
 						case 'flag':
-							if ( 'Y' == strtoupper( $response ) ) {
+							if ( 'Y' === strtoupper( $response ) ) {
 								$assoc_args[ $spec_arg['name'] ] = true;
 							}
 							break;

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -68,7 +68,7 @@ class Formatter {
 		if ( $this->args['field'] ) {
 			$this->show_single_field( $items, $this->args['field'] );
 		} else {
-			if ( in_array( $this->args['format'], array( 'csv', 'json', 'table' ) ) ) {
+			if ( in_array( $this->args['format'], array( 'csv', 'json', 'table' ), true ) ) {
 				$item = is_array( $items ) && ! empty( $items ) ? array_shift( $items ) : false;
 				if ( $item && ! empty( $this->args['fields'] ) ) {
 					foreach ( $this->args['fields'] as &$field ) {
@@ -78,7 +78,7 @@ class Formatter {
 				}
 			}
 
-			if ( in_array( $this->args['format'], array( 'table', 'csv' ) ) ) {
+			if ( in_array( $this->args['format'], array( 'table', 'csv' ), true ) ) {
 				if ( is_object( $items ) && is_a( $items, 'Iterator' ) ) {
 					$items = \WP_CLI\Utils\iterator_map( $items, array( $this, 'transform_item_values_to_json' ) );
 				} else {
@@ -101,7 +101,7 @@ class Formatter {
 			$item  = (object) $item;
 			$key   = $this->find_item_key( $item, $this->args['field'] );
 			$value = $item->$key;
-			if ( in_array( $this->args['format'], array( 'table', 'csv' ) ) && ( is_object( $value ) || is_array( $value ) ) ) {
+			if ( in_array( $this->args['format'], array( 'table', 'csv' ), true ) && ( is_object( $value ) || is_array( $value ) ) ) {
 				$value = json_encode( $value );
 			}
 			\WP_CLI::print_value(
@@ -188,7 +188,7 @@ class Formatter {
 				$key = $this->find_item_key( $item, $field );
 			}
 
-			if ( 'json' == $this->args['format'] ) {
+			if ( 'json' === $this->args['format'] ) {
 				$values[] = $item->$key;
 			} else {
 				\WP_CLI::print_value(
@@ -200,7 +200,7 @@ class Formatter {
 			}
 		}
 
-		if ( 'json' == $this->args['format'] ) {
+		if ( 'json' === $this->args['format'] ) {
 			echo json_encode( $values );
 		}
 	}
@@ -258,9 +258,9 @@ class Formatter {
 			case 'csv':
 				$rows   = $this->assoc_array_to_rows( $data );
 				$fields = array( 'Field', 'Value' );
-				if ( 'table' == $format ) {
+				if ( 'table' === $format ) {
 					self::show_table( $rows, $fields, $ascii_pre_colorized );
-				} elseif ( 'csv' == $format ) {
+				} elseif ( 'csv' === $format ) {
 					\WP_CLI\Utils\write_csv( STDOUT, $rows, $fields );
 				}
 				break;

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -550,7 +550,7 @@ class Runner {
 	 */
 	public function is_command_disabled( $command ) {
 		$path = implode( ' ', array_slice( \WP_CLI\Dispatcher\get_path( $command ), 1 ) );
-		return in_array( $path, $this->config['disabled_commands'] );
+		return in_array( $path, $this->config['disabled_commands'], true );
 	}
 
 	/**
@@ -599,7 +599,7 @@ class Runner {
 		);
 		if ( count( $args ) > 0 ) {
 			foreach ( $top_level_aliases as $old => $new ) {
-				if ( $old == $args[0] ) {
+				if ( $old === $args[0] ) {
 					$args[0] = $new;
 					break;
 				}
@@ -614,27 +614,27 @@ class Runner {
 		}
 
 		// core (multsite-)install --admin_name=  ->  --admin_user=
-		if ( count( $args ) > 0 && 'core' == $args[0] && isset( $assoc_args['admin_name'] ) ) {
+		if ( count( $args ) > 0 && 'core' === $args[0] && isset( $assoc_args['admin_name'] ) ) {
 			$assoc_args['admin_user'] = $assoc_args['admin_name'];
 			unset( $assoc_args['admin_name'] );
 		}
 
 		// core config  ->  config create
-		if ( array( 'core', 'config' ) == array_slice( $args, 0, 2 ) ) {
+		if ( array( 'core', 'config' ) === array_slice( $args, 0, 2 ) ) {
 			list( $args[0], $args[1] ) = array( 'config', 'create' );
 		}
 		// core language  ->  language core
-		if ( array( 'core', 'language' ) == array_slice( $args, 0, 2 ) ) {
+		if ( array( 'core', 'language' ) === array_slice( $args, 0, 2 ) ) {
 			list( $args[0], $args[1] ) = array( 'language', 'core' );
 		}
 
 		// checksum core  ->  core verify-checksums
-		if ( array( 'checksum', 'core' ) == array_slice( $args, 0, 2 ) ) {
+		if ( array( 'checksum', 'core' ) === array_slice( $args, 0, 2 ) ) {
 			list( $args[0], $args[1] ) = array( 'core', 'verify-checksums' );
 		}
 
 		// checksum plugin  ->  plugin verify-checksums
-		if ( array( 'checksum', 'plugin' ) == array_slice( $args, 0, 2 ) ) {
+		if ( array( 'checksum', 'plugin' ) === array_slice( $args, 0, 2 ) ) {
 			list( $args[0], $args[1] ) = array( 'plugin', 'verify-checksums' );
 		}
 
@@ -645,7 +645,7 @@ class Runner {
 		}
 
 		// {plugin|theme} update-all  ->  {plugin|theme} update --all
-		if ( count( $args ) > 1 && in_array( $args[0], array( 'plugin', 'theme' ) )
+		if ( count( $args ) > 1 && in_array( $args[0], array( 'plugin', 'theme' ), true )
 			&& 'update-all' === $args[1]
 		) {
 			$args[1]           = 'update';
@@ -665,7 +665,7 @@ class Runner {
 		}
 
 		// plugin scaffold  ->  scaffold plugin
-		if ( array( 'plugin', 'scaffold' ) == array_slice( $args, 0, 2 ) ) {
+		if ( array( 'plugin', 'scaffold' ) === array_slice( $args, 0, 2 ) ) {
 			list( $args[0], $args[1] ) = array( $args[1], $args[0] );
 		}
 
@@ -676,7 +676,7 @@ class Runner {
 		}
 
 		// {post|user} list --ids  ->  {post|user} list --format=ids
-		if ( count( $args ) > 1 && in_array( $args[0], array( 'post', 'user' ) )
+		if ( count( $args ) > 1 && in_array( $args[0], array( 'post', 'user' ), true )
 			&& 'list' === $args[1]
 			&& isset( $assoc_args['ids'] )
 		) {
@@ -703,7 +703,7 @@ class Runner {
 		}
 
 		// (post|comment|site|term) url  --> (post|comment|site|term) list --*__in --field=url
-		if ( count( $args ) >= 2 && in_array( $args[0], array( 'post', 'comment', 'site', 'term' ) ) && 'url' === $args[1] ) {
+		if ( count( $args ) >= 2 && in_array( $args[0], array( 'post', 'comment', 'site', 'term' ), true ) && 'url' === $args[1] ) {
 			switch ( $args[0] ) {
 				case 'post':
 					$post_ids                = array_slice( $args, 2 );
@@ -989,7 +989,7 @@ class Runner {
 
 			if ( '@all' === $this->alias && is_string( $this->aliases['@all'] ) ) {
 				$aliases = array_keys( $this->aliases );
-				$k       = array_search( '@all', $aliases );
+				$k       = array_search( '@all', $aliases, true );
 				unset( $aliases[ $k ] );
 				$this->run_alias_group( $aliases );
 				exit;
@@ -1079,7 +1079,7 @@ class Runner {
 		if (
 			count( $this->arguments ) >= 2 &&
 			'core' === $this->arguments[0] &&
-			in_array( $this->arguments[1], array( 'install', 'multisite-install' ) )
+			in_array( $this->arguments[1], array( 'install', 'multisite-install' ), true )
 		) {
 			define( 'WP_INSTALLING', true );
 
@@ -1089,7 +1089,7 @@ class Runner {
 				\WP_CLI::set_url( $url );
 			}
 
-			if ( 'multisite-install' == $this->arguments[1] ) {
+			if ( 'multisite-install' === $this->arguments[1] ) {
 				// need to fake some globals to skip the checks in wp-includes/ms-settings.php
 				$url_parts = Utils\parse_url( $url );
 				self::fake_current_site_blog( $url_parts );
@@ -1465,7 +1465,7 @@ class Runner {
 			function( $from_email ) {
 				if ( 'wordpress@' === $from_email ) {
 					$sitename = strtolower( parse_url( site_url(), PHP_URL_HOST ) );
-					if ( substr( $sitename, 0, 4 ) == 'www.' ) {
+					if ( substr( $sitename, 0, 4 ) === 'www.' ) {
 						$sitename = substr( $sitename, 4 );
 					}
 					$from_email = 'wordpress@' . $sitename;
@@ -1571,7 +1571,7 @@ class Runner {
 				$checked_value = get_option( 'stylesheet' );
 			}
 
-			if ( '' === $checked_value || in_array( $checked_value, $skipped_themes ) ) {
+			if ( '' === $checked_value || in_array( $checked_value, $skipped_themes, true ) ) {
 				return '';
 			}
 			return $value;

--- a/php/WP_CLI/SynopsisParser.php
+++ b/php/WP_CLI/SynopsisParser.php
@@ -142,7 +142,7 @@ class SynopsisParser {
 	 * @return array
 	 */
 	private static function is_optional( $token ) {
-		if ( '[' == substr( $token, 0, 1 ) && ']' == substr( $token, -1 ) ) {
+		if ( '[' === substr( $token, 0, 1 ) && ']' === substr( $token, -1 ) ) {
 			return array( true, substr( $token, 1, -1 ) );
 		}
 

--- a/php/WP_CLI/SynopsisValidator.php
+++ b/php/WP_CLI/SynopsisValidator.php
@@ -141,7 +141,7 @@ class SynopsisValidator {
 		$known_assoc = array();
 
 		foreach ( $this->spec as $param ) {
-			if ( in_array( $param['type'], array( 'assoc', 'flag' ) ) ) {
+			if ( in_array( $param['type'], array( 'assoc', 'flag' ), true ) ) {
 				$known_assoc[] = $param['name'];
 			}
 		}
@@ -169,9 +169,9 @@ class SynopsisValidator {
 				}
 			}
 
-			if ( ( 'AND' == $operator && $matched == $count )
-				|| ( 'OR' == $operator && $matched > 0 )
-				|| ( 'NOT' == $operator && 0 == $matched ) ) {
+			if ( ( 'AND' === $operator && $matched === $count )
+				|| ( 'OR' === $operator && $matched > 0 )
+				|| ( 'NOT' === $operator && 0 === $matched ) ) {
 					$filtered[ $key ] = $to_match;
 			}
 		}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -895,7 +895,7 @@ class WP_CLI {
 
 			$answer = strtolower( trim( fgets( STDIN ) ) );
 
-			if ( 'y' != $answer ) {
+			if ( 'y' !== $answer ) {
 				exit;
 			}
 		}

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -221,7 +221,7 @@ class CLI_Command extends WP_CLI_Command {
 				array( 'version', 'update_type', 'package_url' )
 			);
 			$formatter->display_items( $updates );
-		} elseif ( empty( $assoc_args['format'] ) || 'table' == $assoc_args['format'] ) {
+		} elseif ( empty( $assoc_args['format'] ) || 'table' === $assoc_args['format'] ) {
 			$update_type = $this->get_update_type_str( $assoc_args );
 			WP_CLI::success( "WP-CLI is at the latest{$update_type}version." );
 		}
@@ -323,7 +323,7 @@ class CLI_Command extends WP_CLI_Command {
 		Utils\http_request( 'GET', $download_url, null, $headers, $options );
 
 		$md5_response = Utils\http_request( 'GET', $md5_url );
-		if ( 20 != substr( $md5_response->status_code, 0, 2 ) ) {
+		if ( '20' !== substr( $md5_response->status_code, 0, 2 ) ) {
 			WP_CLI::error( "Couldn't access md5 hash for release (HTTP code {$md5_response->status_code})." );
 		}
 		$md5_file     = md5_file( $temp );
@@ -445,7 +445,7 @@ class CLI_Command extends WP_CLI_Command {
 				WP_CLI::error( sprintf( 'Failed to get current nightly version (HTTP code %d)', $response->status_code ) );
 			}
 			$nightly_version = trim( $response->body );
-			if ( WP_CLI_VERSION != $nightly_version ) {
+			if ( WP_CLI_VERSION !== $nightly_version ) {
 				$updates['nightly'] = array(
 					'version'     => $nightly_version,
 					'update_type' => 'nightly',

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -160,7 +160,7 @@ function is_plugin_skipped( $file ) {
 		$skipped_plugins = explode( ',', $skipped_plugins );
 	}
 
-	return in_array( $name, array_filter( $skipped_plugins ) );
+	return in_array( $name, array_filter( $skipped_plugins ), true );
 }
 
 function get_theme_name( $path ) {
@@ -179,7 +179,7 @@ function is_theme_skipped( $path ) {
 		$skipped_themes = explode( ',', $skipped_themes );
 	}
 
-	return in_array( $name, array_filter( $skipped_themes ) );
+	return in_array( $name, array_filter( $skipped_themes ), true );
 }
 
 /**

--- a/php/utils.php
+++ b/php/utils.php
@@ -424,7 +424,7 @@ function mysql_host_to_cli_args( $raw_host ) {
 	$assoc_args = array();
 
 	$host_parts = explode( ':', $raw_host );
-	if ( count( $host_parts ) == 2 ) {
+	if ( count( $host_parts ) === 2 ) {
 		list( $assoc_args['host'], $extra ) = $host_parts;
 		$extra                              = trim( $extra );
 		if ( is_numeric( $extra ) ) {

--- a/utils/contrib-list.php
+++ b/utils/contrib-list.php
@@ -98,7 +98,7 @@ class Contrib_List_Command {
 
 		// Sort and render the contributor list
 		asort( $contributors, SORT_NATURAL | SORT_FLAG_CASE );
-		if ( in_array( $assoc_args['format'], array( 'markdown', 'html' ) ) ) {
+		if ( in_array( $assoc_args['format'], array( 'markdown', 'html' ), true ) ) {
 			$contrib_list = '';
 			foreach( $contributors as $url => $login ) {
 				if ( 'markdown' === $assoc_args['format'] ) {


### PR DESCRIPTION
Fixes relate to the following rules:
* Use strict comparisons.
* Use the `$strict` parameter when calling `in_array()`.

Note: as there were quite a few occurances of this in this codebase: please remember that _strings_, generally speaking, have the lowest precedence when doing a loose comparison, i.e. the string will be juggled and this can lead to _**very**_ unexpected results.
Think `if ( 0 == 'text' ) { print 'success!'; } // Result: success!`.
So, while using strict comparisons should be the rule anyway, it is all the more important when doing comparisons involving strings.