### PR TITLE
PHPCS: fix up the code base [4] - remove redundant function

### DIFF
--- a/php/WP_CLI/Dispatcher/RootCommand.php
+++ b/php/WP_CLI/Dispatcher/RootCommand.php
@@ -46,14 +46,5 @@ class RootCommand extends CompositeCommand {
 
 		return $this->subcommands[ $command ];
 	}
-
-	/**
-	 * Get all registered subcommands.
-	 *
-	 * @return array
-	 */
-	public function get_subcommands() {
-		return parent::get_subcommands();
-	}
 }
 


### PR DESCRIPTION
This code doesn't add any value as the parent version would have been called anyway.