### PR TITLE
PHPCS: fix up the code base [9] - function calls in for condition

### DIFF
--- a/php/commands/src/Help_Command.php
+++ b/php/commands/src/Help_Command.php
@@ -225,8 +225,9 @@ class Help_Command extends WP_CLI_Command {
 				$description
 			);
 
-			$footnote = '';
-			for ( $i = 0; $i < count( $links ); $i++ ) {
+			$footnote   = '';
+			$link_count = count( $links );
+			for ( $i = 0; $i < $link_count; $i++ ) {
 				$n         = $i + 1;
 				$footnote .= '[' . $n . '] ' . $links[ $i ] . "\n";
 			}


### PR DESCRIPTION
The `$link_count` is not going to change during the loop, so there is no need to repeatedly call `count()`.
