### PR TITLE
PHPCS: fix up the code base [12] - assignment within function call

### DIFF
--- a/php/WP_CLI/Bootstrap/IncludePackageAutoloader.php
+++ b/php/WP_CLI/Bootstrap/IncludePackageAutoloader.php
@@ -18,7 +18,7 @@ final class IncludePackageAutoloader extends AutoloaderStep {
 	 *                        to skip.
 	 */
 	protected function get_autoloader_paths() {
-		if ( $this->state->getValue( BootstrapState::IS_PROTECTED_COMMAND, $fallback = false ) ) {
+		if ( $this->state->getValue( BootstrapState::IS_PROTECTED_COMMAND, false ) ) {
 			return false;
 		}
 

--- a/php/WP_CLI/Bootstrap/LoadRequiredCommand.php
+++ b/php/WP_CLI/Bootstrap/LoadRequiredCommand.php
@@ -22,7 +22,7 @@ final class LoadRequiredCommand implements BootstrapStep {
 	 * @return BootstrapState Modified state to pass to the next step.
 	 */
 	public function process( BootstrapState $state ) {
-		if ( $state->getValue( BootstrapState::IS_PROTECTED_COMMAND, $fallback = false ) ) {
+		if ( $state->getValue( BootstrapState::IS_PROTECTED_COMMAND, false ) ) {
 			return $state;
 		}
 


### PR DESCRIPTION
PHP does not have a concept of named parameters, so assigning a parameter being passed in a function call to a variable within that call does not have a function, especially if that variable is not used anywhere within the same function (as it isn't in these cases).