### PR TITLE
PHPCS: fix up the code base [13] - assignments in conditions

### DIFF
--- a/php/WP_CLI/Bootstrap/IncludeFallbackAutoloader.php
+++ b/php/WP_CLI/Bootstrap/IncludeFallbackAutoloader.php
@@ -23,7 +23,8 @@ final class IncludeFallbackAutoloader extends AutoloaderStep {
 			WP_CLI_VENDOR_DIR . '/autoload.php',
 		);
 
-		if ( $custom_vendor = $this->get_custom_vendor_folder() ) {
+		$custom_vendor = $this->get_custom_vendor_folder();
+		if ( false !== $custom_vendor ) {
 			array_unshift(
 				$autoloader_paths,
 				WP_CLI_ROOT . '/../../../' . $custom_vendor . '/autoload.php'

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -92,7 +92,8 @@ class Configurator {
 	 * @return array
 	 */
 	public function get_aliases() {
-		if ( $runtime_alias = getenv( 'WP_CLI_RUNTIME_ALIAS' ) ) {
+		$runtime_alias = getenv( 'WP_CLI_RUNTIME_ALIAS' );
+		if ( false !== $runtime_alias ) {
 			$returned_aliases = array();
 			foreach ( json_decode( $runtime_alias, true ) as $key => $value ) {
 				if ( preg_match( '#' . self::ALIAS_REGEX . '#', $key ) ) {

--- a/php/WP_CLI/Dispatcher/CommandFactory.php
+++ b/php/WP_CLI/Dispatcher/CommandFactory.php
@@ -206,12 +206,14 @@ class CommandFactory {
 		if ( preg_match_all( '/(?:^|[\s;}])(?:class|function)\s+/', substr( $content, $comment_end_pos + 2 ), $dummy /*needed for PHP 5.3*/ ) > 1 ) {
 			return false;
 		}
-		$content = substr( $content, 0, $comment_end_pos + 2 );
-		if ( false === ( $comment_start_pos = strrpos( $content, '/**' ) ) || $comment_start_pos + 2 === $comment_end_pos ) {
+		$content           = substr( $content, 0, $comment_end_pos + 2 );
+		$comment_start_pos = strrpos( $content, '/**' );
+		if ( false === $comment_start_pos || $comment_start_pos + 2 === $comment_end_pos ) {
 			return false;
 		}
 		// Make sure comment start belongs to this comment end.
-		if ( false !== ( $comment_end2_pos = strpos( substr( $content, $comment_start_pos ), '*/' ) ) && $comment_start_pos + $comment_end2_pos < $comment_end_pos ) {
+		$comment_end2_pos = strpos( substr( $content, $comment_start_pos ), '*/' );
+		if ( false !== $comment_end2_pos && $comment_start_pos + $comment_end2_pos < $comment_end_pos ) {
 			return false;
 		}
 		// Allow for '/**' within doc comment.

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -367,7 +367,8 @@ class Subcommand extends CompositeCommand {
 			$out = 'Parameter errors:';
 			foreach ( $errors['fatal'] as $key => $error ) {
 				$out .= "\n {$error}";
-				if ( $desc = $docparser->get_param_desc( $key ) ) {
+				$desc = $docparser->get_param_desc( $key );
+				if ( '' !== $desc ) {
 					$out .= " ({$desc})";
 				}
 			}

--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -212,7 +212,8 @@ class Extractor {
 	 */
 	public static function tar_error_msg( $process_run ) {
 		$stderr = trim( $process_run->stderr );
-		if ( false !== ( $nl_pos = strpos( $stderr, "\n" ) ) ) {
+		$nl_pos = strpos( $stderr, "\n" );
+		if ( false !== $nl_pos ) {
 			$stderr = trim( substr( $stderr, 0, $nl_pos ) );
 		}
 		if ( $stderr ) {

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -214,7 +214,8 @@ class Runner {
 			}
 
 			if ( file_exists( "$dir/index.php" ) ) {
-				if ( $path = self::extract_subdir_path( "$dir/index.php" ) ) {
+				$path = self::extract_subdir_path( "$dir/index.php" );
+				if ( ! empty( $path ) ) {
 					return $path;
 				}
 			}
@@ -1007,7 +1008,8 @@ class Runner {
 			if ( isset( $this->aliases[ $this->alias ][0] ) ) {
 				$group_aliases = $this->aliases[ $this->alias ];
 				$all_aliases   = array_keys( $this->aliases );
-				if ( $diff = array_diff( $group_aliases, $all_aliases ) ) {
+				$diff          = array_diff( $group_aliases, $all_aliases );
+				if ( ! empty( $diff ) ) {
 					WP_CLI::error( "Group '{$this->alias}' contains one or more invalid aliases: " . implode( ', ', $diff ) );
 				}
 				$this->run_alias_group( $group_aliases );

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -371,7 +371,8 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 			}
 		}
 		$args_tables = array_values( array_unique( $args_tables ) );
-		if ( ! ( $tables = array_values( array_intersect( $tables, $args_tables ) ) ) ) {
+		$tables      = array_values( array_intersect( $tables, $args_tables ) );
+		if ( empty( $tables ) ) {
 			\WP_CLI::error( sprintf( "Couldn't find any tables matching: %s", implode( ' ', $args ) ) );
 		}
 	}

--- a/php/utils.php
+++ b/php/utils.php
@@ -550,7 +550,8 @@ function parse_url( $url ) {
  * @return bool
  */
 function is_windows() {
-	return false !== ( $test_is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' ) ) ? (bool) $test_is_windows : strtoupper( substr( PHP_OS, 0, 3 ) ) === 'WIN';
+	$test_is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
+	return false !== $test_is_windows ? (bool) $test_is_windows : strtoupper( substr( PHP_OS, 0, 3 ) ) === 'WIN';
 }
 
 /**
@@ -1093,7 +1094,8 @@ function glob_brace( $pattern, $dummy_flags = null ) {
 	}
 
 	// Find comma or matching closing brace.
-	if ( null === ( $next = $next_brace_sub( $pattern, $begin + 1 ) ) ) {
+	$next = $next_brace_sub( $pattern, $begin + 1 );
+	if ( null === $next ) {
 		return glob( $pattern );
 	}
 
@@ -1101,7 +1103,8 @@ function glob_brace( $pattern, $dummy_flags = null ) {
 
 	// Point `$rest` to matching closing brace.
 	while ( '}' !== $pattern[ $rest ] ) {
-		if ( null === ( $rest = $next_brace_sub( $pattern, $rest + 1 ) ) ) {
+		$rest = $next_brace_sub( $pattern, $rest + 1 );
+		if ( null === $rest ) {
 			return glob( $pattern );
 		}
 	}
@@ -1115,7 +1118,8 @@ function glob_brace( $pattern, $dummy_flags = null ) {
 					. substr( $pattern, $p, $next - $p )
 					. substr( $pattern, $rest + 1 );
 
-		if ( $result = glob_brace( $subpattern ) ) {
+		$result = glob_brace( $subpattern );
+		if ( ! empty( $result ) ) {
 			$paths = array_merge( $paths, $result );
 		}
 
@@ -1337,11 +1341,13 @@ function past_tense_verb( $verb ) {
  * @return string
  */
 function get_php_binary() {
-	if ( $wp_cli_php_used = getenv( 'WP_CLI_PHP_USED' ) ) {
+	$wp_cli_php_used = getenv( 'WP_CLI_PHP_USED' );
+	if ( false !== $wp_cli_php_used ) {
 		return $wp_cli_php_used;
 	}
 
-	if ( $wp_cli_php = getenv( 'WP_CLI_PHP' ) ) {
+	$wp_cli_php = getenv( 'WP_CLI_PHP' );
+	if ( false !== $wp_cli_php ) {
 		return $wp_cli_php;
 	}
 

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -430,7 +430,8 @@ do_action( 'init' );
 // Check site status
 # if ( is_multisite() ) {  // WP-CLI
 if ( is_multisite() && ! defined( 'WP_INSTALLING' ) ) {
-	if ( true !== ( $file = ms_site_check() ) ) {
+	$file = ms_site_check();
+	if ( true !== $file ) {
 		require $file;
 		die();
 	}


### PR DESCRIPTION
Fixes relate to the following rules:
* No assignments in conditions.

Where there was no doubt about what the possible output types could be, I've also adjusted the conditions from loose comparisons to strict.