### PR TITLE
PHPCS: fix up the code base [14] - assignments in conditions

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1068,7 +1068,11 @@ class WP_CLI {
 		foreach ( $reused_runtime_args as $key ) {
 			if ( isset( $runtime_args[ $key ] ) ) {
 				$assoc_args[ $key ] = $runtime_args[ $key ];
-			} elseif ( $value = self::get_runner()->config[ $key ] ) {
+				continue;
+			}
+
+			$value = self::get_runner()->config[ $key ];
+			if ( $value ) {
 				$assoc_args[ $key ] = $value;
 			}
 		}


### PR DESCRIPTION
Fixes relate to the following rules:
* No assignments in conditions.

As this was an assignment in an `elseif`, the logic of the code needed some tweaking as well to turn the `elseif` into an `if`.