### PR TITLE
PHPCS: fix up the code base [17] - require vs include

### DIFF
--- a/php/boot-fs.php
+++ b/php/boot-fs.php
@@ -14,5 +14,5 @@ if ( version_compare( PHP_VERSION, '5.3.0', '<' ) ) {
 
 define( 'WP_CLI_ROOT', dirname( __DIR__ ) );
 
-include_once WP_CLI_ROOT . '/php/wp-cli.php';
+require_once WP_CLI_ROOT . '/php/wp-cli.php';
 


### PR DESCRIPTION
When an include fails, you'll receive a `warning` and PHP will try to continue execution. When a `require` fails, this causes a fatal error, which considering this statement is trying to load the main file, is more appropriate.