### PR TITLE
Bump PHP version check in bootstrap code to v5.4+

### DIFF
--- a/php/boot-fs.php
+++ b/php/boot-fs.php
@@ -7,8 +7,8 @@ if ( 'cli' !== PHP_SAPI ) {
 	die( -1 );
 }
 
-if ( version_compare( PHP_VERSION, '5.3.0', '<' ) ) {
-	printf( "Error: WP-CLI requires PHP %s or newer. You are running version %s.\n", '5.3.0', PHP_VERSION );
+if ( version_compare( PHP_VERSION, '5.4.0', '<' ) ) {
+	printf( "Error: WP-CLI requires PHP %s or newer. You are running version %s.\n", '5.4.0', PHP_VERSION );
 	die( -1 );
 }
 


### PR DESCRIPTION
fixes https://github.com/wp-cli/wp-cli/issues/5037