### PR TITLE
PHPCS: fix up the code base [1] - whitespace

### DIFF
--- a/php/WP_CLI/Completions.php
+++ b/php/WP_CLI/Completions.php
@@ -99,7 +99,8 @@ class Completions {
 	}
 
 	private function get_command( $words ) {
-		$positional_args = $assoc_args = array();
+		$positional_args = array();
+		$assoc_args      = array();
 
 		foreach ( $words as $arg ) {
 			if ( preg_match( '|^--([^=]+)=?|', $arg, $matches ) ) {

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -130,10 +130,14 @@ class Configurator {
 	 * @return array(array)
 	 */
 	public static function extract_assoc( $arguments ) {
-		$positional_args = $assoc_args = $global_assoc = $local_assoc = array();
+		$positional_args = array();
+		$assoc_args      = array();
+		$global_assoc    = array();
+		$local_assoc     = array();
 
 		foreach ( $arguments as $arg ) {
-			$positional_arg = $assoc_arg = null;
+			$positional_arg = null;
+			$assoc_arg      = null;
 
 			if ( preg_match( '|^--no-([^=]+)$|', $arg, $matches ) ) {
 				$assoc_arg = array( $matches[1], false );
@@ -167,7 +171,8 @@ class Configurator {
 	 * @return array
 	 */
 	private function unmix_assoc_args( $mixed_args, $global_assoc = array(), $local_assoc = array() ) {
-		$assoc_args = $runtime_config = array();
+		$assoc_args     = array();
+		$runtime_config = array();
 
 		if ( getenv( 'WP_CLI_STRICT_ARGS_MODE' ) ) {
 			foreach ( $global_assoc as $tmp ) {

--- a/php/WP_CLI/Dispatcher/CommandFactory.php
+++ b/php/WP_CLI/Dispatcher/CommandFactory.php
@@ -89,7 +89,7 @@ class CommandFactory {
 
 		$when_invoked = function ( $args, $assoc_args ) use ( $callable ) {
 			if ( is_array( $callable ) ) {
-				$callable[0] = is_object( $callable[0] ) ? $callable[0] : new $callable[0];
+				$callable[0] = is_object( $callable[0] ) ? $callable[0] : new $callable[0]();
 				call_user_func( array( $callable[0], $callable[1] ), $args, $assoc_args );
 			} else {
 				call_user_func( $callable, $args, $assoc_args );
@@ -181,7 +181,8 @@ class CommandFactory {
 		if ( isset( self::$file_contents[ $filename ] ) ) {
 			$contents = self::$file_contents[ $filename ];
 		} elseif ( is_readable( $filename ) && ( $contents = file_get_contents( $filename ) ) ) {
-			self::$file_contents[ $filename ] = $contents = explode( "\n", $contents );
+			$contents                         = explode( "\n", $contents );
+			self::$file_contents[ $filename ] = $contents;
 		} else {
 			\WP_CLI::debug( "Could not read contents for filename '{$filename}'.", 'commandfactory' );
 			return null;

--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -304,4 +304,3 @@ class CompositeCommand {
 		return Utils\mustache_render( 'man-params.mustache', $binding );
 	}
 }
-

--- a/php/WP_CLI/Dispatcher/RootCommand.php
+++ b/php/WP_CLI/Dispatcher/RootCommand.php
@@ -47,4 +47,3 @@ class RootCommand extends CompositeCommand {
 		return $this->subcommands[ $command ];
 	}
 }
-

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -453,4 +453,3 @@ class Subcommand extends CompositeCommand {
 		return array_unique( array_merge( $local_parameters, $global_parameters ) );
 	}
 }
-

--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -163,7 +163,8 @@ class DocParser {
 	 */
 	private function get_arg_or_param_args( $regex ) {
 		$bits       = explode( "\n", $this->docComment );
-		$within_arg = $within_doc = false;
+		$within_arg = false;
+		$within_doc = false;
 		$document   = array();
 		foreach ( $bits as $bit ) {
 			if ( preg_match( $regex, $bit ) ) {

--- a/php/WP_CLI/Inflector.php
+++ b/php/WP_CLI/Inflector.php
@@ -437,7 +437,8 @@ class Inflector {
 			}
 
 			if ( 'plural' === $type ) {
-				self::$cache['pluralize'] = self::$cache['tableize'] = array();
+				self::$cache['pluralize'] = array();
+				self::$cache['tableize']  = array();
 			} elseif ( 'singular' === $type ) {
 				self::$cache['singularize'] = array();
 			}

--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -50,7 +50,7 @@ class Process {
 	 * @return Process
 	 */
 	public static function create( $command, $cwd = null, $env = array() ) {
-		$proc = new self;
+		$proc = new self();
 
 		$proc->command = $command;
 		$proc->cwd     = $cwd;

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -786,7 +786,7 @@ class Runner {
 
 	public function init_logger() {
 		if ( $this->config['quiet'] ) {
-			$logger = new \WP_CLI\Loggers\Quiet;
+			$logger = new \WP_CLI\Loggers\Quiet();
 		} else {
 			$logger = new \WP_CLI\Loggers\Regular( $this->in_color() );
 		}
@@ -1450,7 +1450,7 @@ class Runner {
 				'init',
 				function() use ( $config ) {
 					if ( isset( $config['user'] ) ) {
-						$fetcher = new \WP_CLI\Fetchers\User;
+						$fetcher = new \WP_CLI\Fetchers\User();
 						$user    = $fetcher->get_check( $config['user'] );
 						wp_set_current_user( $user->ID );
 					} else {

--- a/php/WP_CLI/WpHttpCacheManager.php
+++ b/php/WP_CLI/WpHttpCacheManager.php
@@ -2,6 +2,7 @@
 
 
 namespace WP_CLI;
+
 use WP_CLI;
 
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -51,7 +51,7 @@ class WP_CLI {
 		static $root;
 
 		if ( ! $root ) {
-			$root = new Dispatcher\RootCommand;
+			$root = new Dispatcher\RootCommand();
 		}
 
 		return $root;
@@ -61,7 +61,7 @@ class WP_CLI {
 		static $runner;
 
 		if ( ! $runner ) {
-			$runner = new WP_CLI\Runner;
+			$runner = new WP_CLI\Runner();
 		}
 
 		return $runner;
@@ -1249,7 +1249,7 @@ class WP_CLI {
 			list( $args, $assoc_args, $runtime_config ) = $configurator->parse_args( $argv );
 			if ( $return ) {
 				$existing_logger = self::$logger;
-				self::$logger    = new WP_CLI\Loggers\Execution;
+				self::$logger    = new WP_CLI\Loggers\Execution();
 				self::$logger->ob_start();
 			}
 			if ( ! $exit_error ) {

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -73,7 +73,7 @@ function replace_wp_die_handler() {
 	\add_filter(
 		'wp_die_handler',
 		function() {
-			return __NAMESPACE__ . '\\' . 'wp_die_handler';
+			return __NAMESPACE__ . '\\wp_die_handler';
 		}
 	);
 }
@@ -92,7 +92,8 @@ function wp_die_handler( $message ) {
  * Clean HTML error message so suitable for text display.
  */
 function wp_clean_error_message( $message ) {
-	$original_message = $message = trim( $message );
+	$original_message = trim( $message );
+	$message          = $original_message;
 	if ( preg_match( '|^\<h1>(.+?)</h1>|', $original_message, $matches ) ) {
 		$message = $matches[1] . '.';
 	}
@@ -132,7 +133,7 @@ function get_upgrader( $class ) {
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 	}
 
-	return new $class( new \WP_CLI\UpgraderSkin );
+	return new $class( new \WP_CLI\UpgraderSkin() );
 }
 
 /**

--- a/php/utils.php
+++ b/php/utils.php
@@ -528,7 +528,7 @@ function mustache_render( $template_name, $data = array() ) {
  */
 function make_progress_bar( $message, $count, $interval = 100 ) {
 	if ( \cli\Shell::isPiped() ) {
-		return new \WP_CLI\NoOp;
+		return new \WP_CLI\NoOp();
 	}
 
 	return new \cli\progress\Bar( $message, $count, $interval );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,9 +12,9 @@ if ( class_exists( 'PHPUnit\Runner\Version' ) ) {
 }
 
 if ( file_exists( WP_CLI_ROOT . '/vendor/autoload.php' ) ) {
-	define( 'WP_CLI_VENDOR_DIR' , WP_CLI_ROOT . '/vendor' );
+	define( 'WP_CLI_VENDOR_DIR', WP_CLI_ROOT . '/vendor' );
 } elseif ( file_exists( dirname( dirname( WP_CLI_ROOT ) ) . '/autoload.php' ) ) {
-	define( 'WP_CLI_VENDOR_DIR' , dirname( dirname( WP_CLI_ROOT ) ) );
+	define( 'WP_CLI_VENDOR_DIR', dirname( dirname( WP_CLI_ROOT ) ) );
 }
 
 require_once WP_CLI_VENDOR_DIR . '/autoload.php';

--- a/tests/test-arg-validation.php
+++ b/tests/test-arg-validation.php
@@ -27,14 +27,21 @@ class ArgValidationTests extends PHPUnit_Framework_TestCase {
 	function testUnknownAssocEmpty() {
 		$validator = new SynopsisValidator( '' );
 
-		$assoc_args = array( 'foo' => true, 'bar' => false );
+		$assoc_args = array(
+			'foo' => true,
+			'bar' => false,
+		);
 		$this->assertEquals( array_keys( $assoc_args ), $validator->unknown_assoc( $assoc_args ) );
 	}
 
 	function testUnknownAssoc() {
 		$validator = new SynopsisValidator( '--type=<type> [--brand=<brand>] [--flag]' );
 
-		$assoc_args = array( 'type' => 'analog', 'brand' => true, 'flag' => true );
+		$assoc_args = array(
+			'type'  => 'analog',
+			'brand' => true,
+			'flag'  => true,
+		);
 		$this->assertEmpty( $validator->unknown_assoc( $assoc_args ) );
 
 		$assoc_args['another'] = true;
@@ -44,7 +51,10 @@ class ArgValidationTests extends PHPUnit_Framework_TestCase {
 	function testMissingAssoc() {
 		$validator = new SynopsisValidator( '--type=<type> [--brand=<brand>] [--flag]' );
 
-		$assoc_args = array( 'brand' => true, 'flag' => true );
+		$assoc_args                = array(
+			'brand' => true,
+			'flag'  => true,
+		);
 		list( $errors, $to_unset ) = $validator->validate_assoc( $assoc_args );
 
 		$this->assertCount( 1, $errors['fatal'] );
@@ -54,7 +64,7 @@ class ArgValidationTests extends PHPUnit_Framework_TestCase {
 	function testAssocWithOptionalValue() {
 		$validator = new SynopsisValidator( '[--network[=<id>]]' );
 
-		$assoc_args = array( 'network' => true );
+		$assoc_args                = array( 'network' => true );
 		list( $errors, $to_unset ) = $validator->validate_assoc( $assoc_args );
 
 		$this->assertCount( 0, $errors['fatal'] );

--- a/tests/test-commandfactory.php
+++ b/tests/test-commandfactory.php
@@ -50,40 +50,40 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 
 	function dataProviderExtractLastDocComment() {
 		return array(
-			array( "", false ),
-			array( "*/", false ),
-			array( "/*/  ", false ),
-			array( "/**/", false ),
-			array( "/***/ */", false ),
-			array( "/***/", "/***/" ),
+			array( '', false ),
+			array( '*/', false ),
+			array( '/*/  ', false ),
+			array( '/**/', false ),
+			array( '/***/ */', false ),
+			array( '/***/', '/***/' ),
 			array( "\n /**\n  \n  \t\n  */ \t\n \n ", "/**\n  \n  \t\n  */" ),
 			array( "\r\n /**\r\n  \r\n  \t\r\n  */ \t\r\n \r\n ", "/**\r\n  \r\n  \t\r\n  */" ),
-			array( "/**/ /***/ /***/", "/***/" ),
-			array( "asdfasdf/** /** */", "/** /** */" ),
-			array( "*//** /** */", "/** /** */" ),
-			array( "/** *//** /** */", "/** /** */" ),
-			array( "*//** */ /** /** */", "/** /** */" ),
-			array( "*//** *//** /** /** */", "/** /** /** */" ),
+			array( '/**/ /***/ /***/', '/***/' ),
+			array( 'asdfasdf/** /** */', '/** /** */' ),
+			array( '*//** /** */', '/** /** */' ),
+			array( '/** *//** /** */', '/** /** */' ),
+			array( '*//** */ /** /** */', '/** /** */' ),
+			array( '*//** *//** /** /** */', '/** /** /** */' ),
 
-			array( "/** */class qwer", "/** */" ),
-			array( "/**1*/class qwer{}/**2*/class asdf", "/**2*/" ),
+			array( '/** */class qwer', '/** */' ),
+			array( '/**1*/class qwer{}/**2*/class asdf', '/**2*/' ),
 			array( "/** */class qwer {}\nclass asdf", false ),
 			array( "/** */class qwer {}\r\nclass asdf", false ),
 
-			array( "/** */function qwer", "/** */" ),
-			array( "/** */function qwer( \$function ) {}", "/** */" ),
-			array( "/**1*/function qwer() {}/**2*/function asdf()", "/**2*/" ),
+			array( '/** */function qwer', '/** */' ),
+			array( '/** */function qwer( $function ) {}', '/** */' ),
+			array( '/**1*/function qwer() {}/**2*/function asdf()', '/**2*/' ),
 			array( "/** */function qwer() {}\nfunction asdf()", false ),
 			array( "/** */function qwer() {}\r\nfunction asdf()", false ),
-			array( "/** */function qwer() {}function asdf()", false ),
-			array( "/** */function qwer() {};function asdf( \$function )", false ),
+			array( '/** */function qwer() {}function asdf()', false ),
+			array( '/** */function qwer() {};function asdf( $function )', false ),
 		);
 	}
 
 	function testGetDocComment() {
 		// Save and set test env var.
 		$get_doc_comment = getenv( 'WP_CLI_TEST_GET_DOC_COMMENT' );
-		$is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
+		$is_windows      = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
 
 		putenv( 'WP_CLI_TEST_GET_DOC_COMMENT=1' );
 		putenv( 'WP_CLI_TEST_IS_WINDOWS=0' );
@@ -102,7 +102,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class 1
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_1_Command' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -110,7 +110,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 1
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command1' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -118,7 +118,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 2
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command2' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -126,7 +126,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 3
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command3' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -134,7 +134,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 4
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command4' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -143,7 +143,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class 1 Windows
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -151,7 +151,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 1
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command1' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -159,7 +159,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 2
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command2' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -167,7 +167,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 3
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command3' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -175,7 +175,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 4
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command4' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -184,7 +184,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class 2
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_2_Command' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -192,7 +192,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 1
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_2_Command', 'command1' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -201,7 +201,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class 2 Windows
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_2_Command_Win' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -209,7 +209,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 1
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_2_Command_Win', 'command1' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -222,7 +222,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Function 1
 
 		$reflection = new \ReflectionFunction( 'commandfactorytests_get_doc_comment_func_1' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -230,7 +230,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Function 2
 
 		$reflection = new \ReflectionFunction( 'commandfactorytests_get_doc_comment_func_2' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -238,7 +238,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Function 3
 
 		$reflection = new \ReflectionFunction( $commandfactorytests_get_doc_comment_func_3 );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -251,7 +251,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 	function testGetDocCommentWin() {
 		// Save and set test env var.
 		$get_doc_comment = getenv( 'WP_CLI_TEST_GET_DOC_COMMENT' );
-		$is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
+		$is_windows      = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
 
 		putenv( 'WP_CLI_TEST_GET_DOC_COMMENT=1' );
 		putenv( 'WP_CLI_TEST_IS_WINDOWS=1' );
@@ -270,7 +270,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class 1
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_1_Command' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -278,7 +278,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 1
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command1' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -286,7 +286,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 2
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command2' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -294,7 +294,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 3
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command3' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -302,7 +302,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 4
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command4' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -311,7 +311,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class 1 Windows
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -319,7 +319,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 1
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command1' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -327,7 +327,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 2
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command2' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -335,7 +335,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 3
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command3' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -343,7 +343,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 4
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command4' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -352,7 +352,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class 2
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_2_Command' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -360,7 +360,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 1
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_2_Command', 'command1' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -369,7 +369,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class 2 Windows
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_2_Command_Win' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -377,7 +377,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Class method 1
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_2_Command_Win', 'command1' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -390,7 +390,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Function 1 Windows
 
 		$reflection = new \ReflectionFunction( 'commandfactorytests_get_doc_comment_func_1_win' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -398,7 +398,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Function 2
 
 		$reflection = new \ReflectionFunction( 'commandfactorytests_get_doc_comment_func_2_win' );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
@@ -406,7 +406,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		// Function 3
 
 		$reflection = new \ReflectionFunction( $commandfactorytests_get_doc_comment_func_3_win );
-		$expected = $reflection->getDocComment();
+		$expected   = $reflection->getDocComment();
 
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );

--- a/tests/test-configurator.php
+++ b/tests/test-configurator.php
@@ -4,62 +4,62 @@ use WP_CLI\Configurator;
 
 class ConfiguratorTest extends PHPUnit_Framework_TestCase {
 
-  function testExtractAssoc() {
-    $args = Configurator::extract_assoc( array( 'foo', '--bar', '--baz=text' ) );
+	function testExtractAssoc() {
+		$args = Configurator::extract_assoc( array( 'foo', '--bar', '--baz=text' ) );
 
-    $this->assertCount( 1, $args[0] );
-    $this->assertCount( 2, $args[1] );
+		$this->assertCount( 1, $args[0] );
+		$this->assertCount( 2, $args[1] );
 
-    $this->assertEquals( 'foo', $args[0][0] );
+		$this->assertEquals( 'foo', $args[0][0] );
 
-    $this->assertEquals( 'bar', $args[1][0][0] );
-    $this->assertTrue( $args[1][0][1] );
+		$this->assertEquals( 'bar', $args[1][0][0] );
+		$this->assertTrue( $args[1][0][1] );
 
-    $this->assertEquals( 'baz', $args[1][1][0] );
-    $this->assertEquals( 'text', $args[1][1][1] );
+		$this->assertEquals( 'baz', $args[1][1][0] );
+		$this->assertEquals( 'text', $args[1][1][1] );
 
-  }
+	}
 
-  function testExtractAssocNoValue() {
-    $args = Configurator::extract_assoc( array( 'foo', '--bar=', '--baz=text' ) );
+	function testExtractAssocNoValue() {
+		$args = Configurator::extract_assoc( array( 'foo', '--bar=', '--baz=text' ) );
 
-    $this->assertCount( 1, $args[0] );
-    $this->assertCount( 2, $args[1] );
+		$this->assertCount( 1, $args[0] );
+		$this->assertCount( 2, $args[1] );
 
-    $this->assertEquals( 'foo', $args[0][0] );
+		$this->assertEquals( 'foo', $args[0][0] );
 
-    $this->assertEquals( 'bar', $args[1][0][0] );
-    $this->assertEmpty( $args[1][0][1] );
+		$this->assertEquals( 'bar', $args[1][0][0] );
+		$this->assertEmpty( $args[1][0][1] );
 
-    $this->assertEquals( 'baz', $args[1][1][0] );
-    $this->assertEquals( 'text', $args[1][1][1] );
+		$this->assertEquals( 'baz', $args[1][1][0] );
+		$this->assertEquals( 'text', $args[1][1][1] );
 
-  }
+	}
 
-  function testExtractAssocGlobalLocal() {
-    $args = Configurator::extract_assoc( array( '--url=foo.dev', '--path=wp', 'foo', '--bar=', '--baz=text', '--url=bar.dev' ) );
+	function testExtractAssocGlobalLocal() {
+		$args = Configurator::extract_assoc( array( '--url=foo.dev', '--path=wp', 'foo', '--bar=', '--baz=text', '--url=bar.dev' ) );
 
-    $this->assertCount( 1, $args[0] );
-    $this->assertCount( 5, $args[1] );
-    $this->assertCount( 2, $args[2] );
-    $this->assertCount( 3, $args[3] );
+		$this->assertCount( 1, $args[0] );
+		$this->assertCount( 5, $args[1] );
+		$this->assertCount( 2, $args[2] );
+		$this->assertCount( 3, $args[3] );
 
-    $this->assertEquals( 'url', $args[2][0][0] );
-    $this->assertEquals( 'foo.dev', $args[2][0][1] );
-    $this->assertEquals( 'url', $args[3][2][0] );
-    $this->assertEquals( 'bar.dev', $args[3][2][1] );
-  }
+		$this->assertEquals( 'url', $args[2][0][0] );
+		$this->assertEquals( 'foo.dev', $args[2][0][1] );
+		$this->assertEquals( 'url', $args[3][2][0] );
+		$this->assertEquals( 'bar.dev', $args[3][2][1] );
+	}
 
-  function testExtractAssocDoubleDashInValue() {
-    $args = Configurator::extract_assoc( array( '--test=text--text' ) );
+	function testExtractAssocDoubleDashInValue() {
+		$args = Configurator::extract_assoc( array( '--test=text--text' ) );
 
-    $this->assertCount( 0, $args[0] );
-    $this->assertCount( 1, $args[1] );
+		$this->assertCount( 0, $args[0] );
+		$this->assertCount( 1, $args[1] );
 
-    $this->assertEquals( 'test', $args[1][0][0] );
-    $this->assertEquals( 'text--text', $args[1][0][1] );
+		$this->assertEquals( 'test', $args[1][0][0] );
+		$this->assertEquals( 'text--text', $args[1][0][1] );
 
-  }
+	}
 
 
 }

--- a/tests/test-doc-parser.php
+++ b/tests/test-doc-parser.php
@@ -10,7 +10,7 @@ class DocParserTests extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( '', $doc->get_shortdesc() );
 		$this->assertEquals( '', $doc->get_longdesc() );
 		$this->assertEquals( '', $doc->get_synopsis() );
-		$this->assertEquals( '', $doc->get_tag('alias') );
+		$this->assertEquals( '', $doc->get_tag( 'alias' ) );
 	}
 
 	function test_only_tags() {
@@ -25,9 +25,9 @@ EOB
 		$this->assertEquals( '', $doc->get_shortdesc() );
 		$this->assertEquals( '', $doc->get_longdesc() );
 		$this->assertEquals( '', $doc->get_synopsis() );
-		$this->assertEquals( '', $doc->get_tag('foo') );
-		$this->assertEquals( 'rock-on', $doc->get_tag('alias') );
-		$this->assertEquals( 'revoke-md5-passwords', $doc->get_tag('subcommand') );
+		$this->assertEquals( '', $doc->get_tag( 'foo' ) );
+		$this->assertEquals( 'rock-on', $doc->get_tag( 'alias' ) );
+		$this->assertEquals( 'revoke-md5-passwords', $doc->get_tag( 'subcommand' ) );
 	}
 
 	function test_no_longdesc() {
@@ -42,7 +42,7 @@ EOB
 		$this->assertEquals( 'Rock and roll!', $doc->get_shortdesc() );
 		$this->assertEquals( '', $doc->get_longdesc() );
 		$this->assertEquals( '', $doc->get_synopsis() );
-		$this->assertEquals( 'rock-on', $doc->get_tag('alias') );
+		$this->assertEquals( 'rock-on', $doc->get_tag( 'alias' ) );
 	}
 
 	function test_complete() {
@@ -75,7 +75,7 @@ EOB
 		$this->assertEquals( '[--volume=<number>]', $doc->get_synopsis() );
 		$this->assertEquals( 'Start with one or more genres.', $doc->get_arg_desc( 'genre' ) );
 		$this->assertEquals( 'Sets the volume.', $doc->get_param_desc( 'volume' ) );
-		$this->assertEquals( 'rock-on', $doc->get_tag('alias') );
+		$this->assertEquals( 'rock-on', $doc->get_tag( 'alias' ) );
 
 		$longdesc = <<<EOB
 ## OPTIONS
@@ -92,8 +92,7 @@ EOB
 ## EXAMPLES
 
 wp rock-on --volume=11
-EOB
-		;
+EOB;
 		$this->assertEquals( $longdesc, $doc->get_longdesc() );
 	}
 
@@ -131,6 +130,7 @@ default: 10
 wp rock-on electronic --volume=11
 
 EOB;
+
 		$doc = new DocParser( $longdesc );
 		$this->assertEquals( 'Start with one or more genres.', $doc->get_arg_desc( 'genre' ) );
 		$this->assertEquals( 'Sets the volume.', $doc->get_param_desc( 'volume' ) );
@@ -162,6 +162,7 @@ options:
   - yaml
 ---
 EOB;
+
 		$doc = new DocParser( $longdesc );
 		$this->assertEquals( array(
 			'default' => 'table',
@@ -188,6 +189,7 @@ options:
   - yaml
 ---
 EOB;
+
 		$doc = new DocParser( $longdesc );
 		$this->assertEquals( array(
 			'default' => 'table',
@@ -197,4 +199,3 @@ EOB;
 	}
 
 }
-

--- a/tests/test-extractor.php
+++ b/tests/test-extractor.php
@@ -21,7 +21,7 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 		'xmlrpc8.php',
 	);
 
-	static $logger = null;
+	static $logger      = null;
 	static $prev_logger = null;
 
 	public function setUp() {
@@ -32,7 +32,7 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 		$class_wp_cli_logger->setAccessible( true );
 		self::$prev_logger = $class_wp_cli_logger->getValue();
 
-		self::$logger = new \WP_CLI\Loggers\Execution;
+		self::$logger = new \WP_CLI\Loggers\Execution();
 		WP_CLI::set_logger( self::$logger );
 
 		// Remove any failed tests detritus.
@@ -106,11 +106,11 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 
 		list( $temp_dir, $src_dir, $wp_dir ) = self::create_test_directory_structure();
 
-		$tarball = $temp_dir . '/test.tar.gz';
+		$tarball  = $temp_dir . '/test.tar.gz';
 		$dest_dir = $temp_dir . '/dest';
 
 		// Create test tarball.
-		$output = array();
+		$output     = array();
 		$return_var = -1;
 		// Need --force-local for Windows to avoid "C:" being interpreted as being on remote machine, and redirect for Mac as outputs verbosely on STDERR.
 		$cmd = 'tar czvf %1$s' . ( Utils\is_windows() ? ' --force-local' : '' ) . ' --directory=%2$s/src wordpress 2>&1';
@@ -155,7 +155,9 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( 0 === strpos( self::$logger->stderr, 'Warning: PharData failed' ) );
 		$this->assertTrue( false !== strpos( self::$logger->stderr, 'no-such-tar' ) );
 
-		self::$logger->stderr = self::$logger->stdout = ''; // Reset logger.
+		// Reset logger.
+		self::$logger->stderr = '';
+		self::$logger->stdout = '';
 
 		// Zero-length.
 		$zero_tar = Utils\get_temp_dir() . 'zero-tar.tar.gz';
@@ -179,11 +181,11 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 
 		list( $temp_dir, $src_dir, $wp_dir ) = self::create_test_directory_structure();
 
-		$zipfile = $temp_dir . '/test.zip';
+		$zipfile  = $temp_dir . '/test.zip';
 		$dest_dir = $temp_dir . '/dest';
 
 		// Create test zip.
-		$zip = new ZipArchive;
+		$zip    = new ZipArchive();
 		$result = $zip->open( $zipfile, ZipArchive::CREATE );
 		$this->assertTrue( $result );
 		$files = self::recursive_scandir( $src_dir );
@@ -224,7 +226,9 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( false !== strpos( $msg, 'no-such-zip' ) );
 		$this->assertTrue( empty( self::$logger->stderr ) );
 
-		self::$logger->stderr = self::$logger->stdout = ''; // Reset logger.
+		// Reset logger.
+		self::$logger->stderr = '';
+		self::$logger->stdout = '';
 
 		// Zero-length.
 		$zero_zip = Utils\get_temp_dir() . 'zero-zip.zip';
@@ -276,10 +280,10 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 		$ret = array();
 		foreach ( array_diff( scandir( $dir ), array( '.', '..' ) ) as $file ) {
 			if ( is_dir( $dir . '/' . $file ) ) {
-				$ret[] = ( $prefix_dir ? ( $prefix_dir . '/'. $file ) : $file ) . '/';
-				$ret = array_merge( $ret, self::recursive_scandir( $dir . '/' . $file, $prefix_dir ? ( $prefix_dir . '/' . $file ) : $file ) );
+				$ret[] = ( $prefix_dir ? ( $prefix_dir . '/' . $file ) : $file ) . '/';
+				$ret   = array_merge( $ret, self::recursive_scandir( $dir . '/' . $file, $prefix_dir ? ( $prefix_dir . '/' . $file ) : $file ) );
 			} else {
-				$ret[] = $prefix_dir ? ( $prefix_dir . '/'. $file ) : $file;
+				$ret[] = $prefix_dir ? ( $prefix_dir . '/' . $file ) : $file;
 			}
 		}
 		return $ret;

--- a/tests/test-file-cache.php
+++ b/tests/test-file-cache.php
@@ -12,7 +12,7 @@ class FileCacheTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testGetRoot() {
 		$max_size = 32;
-		$ttl = 60;
+		$ttl      = 60;
 
 		$cache_dir = Utils\get_temp_dir() . uniqid( 'wp-cli-test-file-cache', true );
 
@@ -36,16 +36,16 @@ class FileCacheTest extends PHPUnit_Framework_TestCase {
 		$class_wp_cli_logger->setAccessible( true );
 		$prev_logger = $class_wp_cli_logger->getValue();
 
-		$logger = new WP_CLI\Loggers\Execution;
+		$logger = new WP_CLI\Loggers\Execution();
 		WP_CLI::set_logger( $logger );
 
-		$max_size = 32;
-		$ttl = 60;
+		$max_size  = 32;
+		$ttl       = 60;
 		$cache_dir = Utils\get_temp_dir() . uniqid( 'wp-cli-test-file-cache', true );
 
-		$cache = new FileCache( $cache_dir, $ttl, $max_size );
+		$cache      = new FileCache( $cache_dir, $ttl, $max_size );
 		$test_class = new ReflectionClass( $cache );
-		$method = $test_class->getMethod( 'ensure_dir_exists' );
+		$method     = $test_class->getMethod( 'ensure_dir_exists' );
 		$method->setAccessible( true );
 
 		// Cache directory should be created.
@@ -62,7 +62,7 @@ class FileCacheTest extends PHPUnit_Framework_TestCase {
 			// It should be failed because permission denied.
 			$logger->stderr = '';
 			chmod( $cache_dir . '/test1', 0000 );
-			$result = $method->invokeArgs( $cache, array( $cache_dir . '/test1/error' ) );
+			$result   = $method->invokeArgs( $cache, array( $cache_dir . '/test1/error' ) );
 			$expected = "/^Warning: Failed to create directory '.+': mkdir\(\): Permission denied\.$/";
 			$this->assertRegexp( $expected, $logger->stderr );
 		}
@@ -70,7 +70,7 @@ class FileCacheTest extends PHPUnit_Framework_TestCase {
 		// It should be failed because file exists.
 		$logger->stderr = '';
 		file_put_contents( $cache_dir . '/test2', '' );
-		$result = $method->invokeArgs( $cache, array( $cache_dir . '/test2' ) );
+		$result   = $method->invokeArgs( $cache, array( $cache_dir . '/test2' ) );
 		$expected = "/^Warning: Failed to create directory '.+': mkdir\(\): File exists\.$/";
 		$this->assertRegexp( $expected, $logger->stderr );
 

--- a/tests/test-help.php
+++ b/tests/test-help.php
@@ -10,13 +10,13 @@ class HelpTest extends PHPUnit_Framework_TestCase {
 
 	public function test_parse_reference_links() {
 		$test_class = new ReflectionClass( 'Help_Command' );
-		$method = $test_class->getMethod( 'parse_reference_links' );
+		$method     = $test_class->getMethod( 'parse_reference_links' );
 		$method->setAccessible( true );
 
-		$desc = 'This is a [reference link](https://wordpress.org/). It should be displayed very nice!';
+		$desc   = 'This is a [reference link](https://wordpress.org/). It should be displayed very nice!';
 		$result = $method->invokeArgs( null, array( $desc ) );
 
-		$expected =<<<EOL
+		$expected = <<<EOL
 This is a [reference link][1]. It should be displayed very nice!
 
 ---
@@ -24,10 +24,10 @@ This is a [reference link][1]. It should be displayed very nice!
 EOL;
 		$this->assertSame( $expected, $result );
 
-		$desc = 'This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/). It should be displayed very nice!';
+		$desc   = 'This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/). It should be displayed very nice!';
 		$result = $method->invokeArgs( null, array( $desc ) );
 
-		$expected =<<<EOL
+		$expected = <<<EOL
 This is a [reference link][1] and [second link][2]. It should be displayed very nice!
 
 ---
@@ -36,13 +36,13 @@ This is a [reference link][1] and [second link][2]. It should be displayed very 
 EOL;
 		$this->assertSame( $expected, $result );
 
-		$desc =<<<EOL
+		$desc   = <<<EOL
 This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/).
 It should be displayed very nice!
 EOL;
 		$result = $method->invokeArgs( null, array( $desc ) );
 
-		$expected =<<<EOL
+		$expected = <<<EOL
 This is a [reference link][1] and [second link][2].
 It should be displayed very nice!
 
@@ -53,7 +53,7 @@ EOL;
 
 		$this->assertSame( $expected, $result );
 
-		$desc =<<<EOL
+		$desc   = <<<EOL
 This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/).
 It should be displayed very nice!
 
@@ -63,7 +63,7 @@ It doesn't expect to be link here like [reference link](https://wordpress.org/).
 EOL;
 		$result = $method->invokeArgs( null, array( $desc ) );
 
-		$expected =<<<EOL
+		$expected = <<<EOL
 This is a [reference link][1] and [second link][2].
 It should be displayed very nice!
 
@@ -78,14 +78,14 @@ EOL;
 
 		$this->assertSame( $expected, $result );
 
-		$desc =<<<EOL
+		$desc   = <<<EOL
 ## Example
 
 It doesn't expect to be link here like [reference link](https://wordpress.org/).
 EOL;
 		$result = $method->invokeArgs( null, array( $desc ) );
 
-		$expected =<<<EOL
+		$expected = <<<EOL
 ## Example
 
 It doesn't expect to be link here like [reference link](https://wordpress.org/).
@@ -93,7 +93,7 @@ EOL;
 
 		$this->assertSame( $expected, $result );
 
-		$desc =<<<EOL
+		$desc   = <<<EOL
 This is a long description.
 It doesn't have any link.
 
@@ -103,7 +103,7 @@ It doesn't expect to be link here like [reference link](https://wordpress.org/).
 EOL;
 		$result = $method->invokeArgs( null, array( $desc ) );
 
-		$expected =<<<EOL
+		$expected = <<<EOL
 This is a long description.
 It doesn't have any link.
 

--- a/tests/test-logging.php
+++ b/tests/test-logging.php
@@ -3,10 +3,10 @@
 class MockRegularLogger extends WP_CLI\Loggers\Regular {
 
 	protected function get_runner() {
-		return (object) array (
-			'config' => array (
-				'debug' => true
-			)
+		return (object) array(
+			'config' => array(
+				'debug' => true,
+			),
 		);
 	}
 
@@ -18,10 +18,10 @@ class MockRegularLogger extends WP_CLI\Loggers\Regular {
 class MockQuietLogger extends WP_CLI\Loggers\Quiet {
 
 	protected function get_runner() {
-		return (object) array (
-			'config' => array (
-				'debug' => true
-			)
+		return (object) array(
+			'config' => array(
+				'debug' => true,
+			),
 		);
 	}
 }
@@ -51,7 +51,7 @@ class LoggingTests extends PHPUnit_Framework_TestCase {
 
 	function testExecutionLogger() {
 		// Save Runner config.
-		$runner = WP_CLI::get_runner();
+		$runner        = WP_CLI::get_runner();
 		$runner_config = new \ReflectionProperty( $runner, 'config' );
 		$runner_config->setAccessible( true );
 
@@ -60,7 +60,7 @@ class LoggingTests extends PHPUnit_Framework_TestCase {
 		// Set debug.
 		$runner_config->setValue( $runner, array( 'debug' => true ) );
 
-		$logger = new WP_CLI\Loggers\Execution;
+		$logger = new WP_CLI\Loggers\Execution();
 
 		// Standard use.
 
@@ -72,9 +72,9 @@ class LoggingTests extends PHPUnit_Framework_TestCase {
 		$logger->success( 'success2' );
 		$logger->warning( 'warning2' );
 		$logger->debug( 'debug', 'group' );
-		$logger->error_multi_line( array( "line11", "line12", "line13" ) );
+		$logger->error_multi_line( array( 'line11', 'line12', 'line13' ) );
 		$logger->error( 'error2' );
-		$logger->error_multi_line( array( "line21" ) );
+		$logger->error_multi_line( array( 'line21' ) );
 		$logger->debug( 'debug2', 'group2' );
 
 		$this->assertSame( "info\ninfo2\nSuccess: success\nSuccess: success2\n", $logger->stdout );
@@ -84,13 +84,14 @@ class LoggingTests extends PHPUnit_Framework_TestCase {
 			. 'Error:\nline11\nline12\nline13\n---------\n\nError: error2\n'
 			. 'Error:\nline21\n---------\n\nDebug \(group2\): debug2 \([0-9.]+s\)$/', $logger->stderr ) );
 
-		$logger->stdout = $logger->stderr = '';
+		$logger->stdout = '';
+		$logger->stderr = '';
 
 		// With output buffering.
 
 		$logger->ob_start();
 
-		echo "echo";
+		echo 'echo';
 		$logger->info( 'info' );
 		print "print\n";
 		$logger->success( 'success' );
@@ -98,14 +99,15 @@ class LoggingTests extends PHPUnit_Framework_TestCase {
 		$logger->error( 'error' );
 		echo "echo3\n";
 		$logger->success( 'success2' );
-		echo "echo4";
+		echo 'echo4';
 
 		$logger->ob_end();
 
 		$this->assertSame( "echoinfo\nprint\nSuccess: success\necho2\necho3\nSuccess: success2\necho4", $logger->stdout );
 		$this->assertSame( "Error: error\n", $logger->stderr );
 
-		$logger->stdout = $logger->stderr = '';
+		$logger->stdout = '';
+		$logger->stderr = '';
 
 		// Restore.
 		$runner_config->setValue( $runner, $prev_config );

--- a/tests/test-process.php
+++ b/tests/test-process.php
@@ -11,7 +11,7 @@ class ProcessTests extends PHPUnit_Framework_TestCase {
 	function test_process_env( $cmd_prefix, $env, $expected_env_vars, $expected_out ) {
 		$code = vsprintf( str_repeat( 'echo getenv( \'%s\' );', count( $expected_env_vars ) ), $expected_env_vars );
 
-		$cmd = $cmd_prefix . ' ' . escapeshellarg( Utils\get_php_binary() ) . ' -r ' . escapeshellarg( $code );
+		$cmd         = $cmd_prefix . ' ' . escapeshellarg( Utils\get_php_binary() ) . ' -r ' . escapeshellarg( $code );
 		$process_run = Process::create( $cmd, null /*cwd*/, $env )->run();
 
 		$this->assertSame( $process_run->stdout, $expected_out );

--- a/tests/test-synopsis.php
+++ b/tests/test-synopsis.php
@@ -160,7 +160,7 @@ class SynopsisParserTest extends PHPUnit_Framework_TestCase {
 				'type'        => 'assoc',
 				'description' => 'If you are hungry between meals, you should snack.',
 				'optional'    => true,
-			)
+			),
 		);
 		$this->assertEquals( '<message> [<secrets>...] --meal=<meal> [--snack=<snack>]', SynopsisParser::render( $a ) );
 	}

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -137,7 +137,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( array(
 			'host' => 'foo.com',
 			'path' => '~/path/to/dir',
-			'port' => '2222'
+			'port' => '2222',
 		), Utils\parse_ssh_url( $testcase ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
@@ -149,9 +149,9 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$testcase = 'ssh:bar@foo.com:~/path/to/dir';
 		$this->assertEquals( array(
 			'scheme' => 'ssh',
-			'user' => 'bar',
-			'host' => 'foo.com',
-			'path' => '~/path/to/dir',
+			'user'   => 'bar',
+			'host'   => 'foo.com',
+			'path'   => '~/path/to/dir',
 		), Utils\parse_ssh_url( $testcase ) );
 		$this->assertEquals( 'ssh', Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
 		$this->assertEquals( 'bar', Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
@@ -163,7 +163,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$testcase = 'docker:wordpress';
 		$this->assertEquals( array(
 			'scheme' => 'docker',
-			'host' => 'wordpress',
+			'host'   => 'wordpress',
 		), Utils\parse_ssh_url( $testcase ) );
 		$this->assertEquals( 'docker', Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
@@ -175,8 +175,8 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$testcase = 'docker:bar@wordpress';
 		$this->assertEquals( array(
 			'scheme' => 'docker',
-			'user' => 'bar',
-			'host' => 'wordpress',
+			'user'   => 'bar',
+			'host'   => 'wordpress',
 		), Utils\parse_ssh_url( $testcase ) );
 		$this->assertEquals( 'docker', Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
 		$this->assertEquals( 'bar', Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
@@ -188,9 +188,9 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$testcase = 'docker-compose:bar@wordpress:~/path/to/dir';
 		$this->assertEquals( array(
 			'scheme' => 'docker-compose',
-			'user' => 'bar',
-			'host' => 'wordpress',
-			'path' => '~/path/to/dir',
+			'user'   => 'bar',
+			'host'   => 'wordpress',
+			'path'   => '~/path/to/dir',
 		), Utils\parse_ssh_url( $testcase ) );
 		$this->assertEquals( 'docker-compose', Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
 		$this->assertEquals( 'bar', Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
@@ -202,7 +202,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$testcase = 'vagrant:default';
 		$this->assertEquals( array(
 			'scheme' => 'vagrant',
-			'host' => 'default',
+			'host'   => 'default',
 		), Utils\parse_ssh_url( $testcase ) );
 		$this->assertEquals( 'vagrant', Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
@@ -277,22 +277,22 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		};
 
 		$expected = " --url='foo.dev' --porcelain --apple='banana'";
-		$actual = Utils\assoc_args_to_str( array(
+		$actual   = Utils\assoc_args_to_str( array(
 			'url'       => 'foo.dev',
 			'porcelain' => true,
-			'apple'     => 'banana'
+			'apple'     => 'banana',
 		) );
 		$this->assertSame( $strip_quotes( $expected ), $strip_quotes( $actual ) );
 
 		$expected = " --url='foo.dev' --require='file-a.php' --require='file-b.php' --porcelain --apple='banana'";
-		$actual = Utils\assoc_args_to_str( array(
+		$actual   = Utils\assoc_args_to_str( array(
 			'url'       => 'foo.dev',
 			'require'   => array(
 				'file-a.php',
 				'file-b.php',
 			),
 			'porcelain' => true,
-			'apple'     => 'banana'
+			'apple'     => 'banana',
 		) );
 		$this->assertSame( $strip_quotes( $expected ), $strip_quotes( $actual ) );
 	}
@@ -314,12 +314,12 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 	public function testGetHomeDir() {
 
 		// save environments
-		$home = getenv( 'HOME' );
+		$home      = getenv( 'HOME' );
 		$homedrive = getenv( 'HOMEDRIVE' );
-		$homepath = getenv( 'HOMEPATH' );
+		$homepath  = getenv( 'HOMEPATH' );
 
 		putenv( 'HOME=/home/user' );
-		$this->assertSame('/home/user', Utils\get_home_dir() );
+		$this->assertSame( '/home/user', Utils\get_home_dir() );
 
 		putenv( 'HOME' );
 
@@ -391,13 +391,13 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$class_wp_cli_capture_exit = new \ReflectionProperty( 'WP_CLI', 'capture_exit' );
 		$class_wp_cli_capture_exit->setAccessible( true );
 
-		$prev_logger = $class_wp_cli_logger->getValue();
+		$prev_logger       = $class_wp_cli_logger->getValue();
 		$prev_capture_exit = $class_wp_cli_capture_exit->getValue();
 
 		// Enable exit exception.
 		$class_wp_cli_capture_exit->setValue( true );
 
-		$logger = new \WP_CLI\Loggers\Execution;
+		$logger = new \WP_CLI\Loggers\Execution();
 		WP_CLI::set_logger( $logger );
 
 		$exception = null;
@@ -429,15 +429,15 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$prev_logger = $class_wp_cli_logger->getValue();
 
 		$have_bad_cacert = false;
-		$created_dirs = array();
+		$created_dirs    = array();
 
 		// Hack to create bad CAcert, using Utils\get_vendor_paths() preference for a path as part of a Composer-installed larger project.
-		$vendor_dir = WP_CLI_ROOT . '/../../../vendor';
-		$cert_path = '/rmccue/requests/library/Requests/Transport/cacert.pem';
+		$vendor_dir      = WP_CLI_ROOT . '/../../../vendor';
+		$cert_path       = '/rmccue/requests/library/Requests/Transport/cacert.pem';
 		$bad_cacert_path = $vendor_dir . $cert_path;
 		if ( ! file_exists( $bad_cacert_path ) ) {
 			// Capture any directories created so can clean up.
-			$dirs = array_merge( array( 'vendor' ), array_filter( explode( '/', dirname( $cert_path ) ) ) );
+			$dirs        = array_merge( array( 'vendor' ), array_filter( explode( '/', dirname( $cert_path ) ) ) );
 			$current_dir = dirname( $vendor_dir );
 			foreach ( $dirs as $dir ) {
 				if ( ! file_exists( $current_dir . '/' . $dir ) ) {
@@ -460,7 +460,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			$this->markTestSkipped( 'Unable to create bad CAcert.' );
 		}
 
-		$logger = new \WP_CLI\Loggers\Execution;
+		$logger = new \WP_CLI\Loggers\Execution();
 		WP_CLI::set_logger( $logger );
 
 		Utils\http_request( 'GET', 'https://example.com' );
@@ -522,7 +522,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 	public function testExpandGlobs( $path, $expected ) {
 		$expand_globs_no_glob_brace = getenv( 'WP_CLI_TEST_EXPAND_GLOBS_NO_GLOB_BRACE' );
 
-		$dir = __DIR__ . '/data/expand_globs/';
+		$dir      = __DIR__ . '/data/expand_globs/';
 		$expected = array_map( function ( $v ) use ( $dir ) { return $dir . $v; }, $expected );
 		sort( $expected );
 
@@ -544,12 +544,12 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		return array(
 			array( 'foo.ab1', array( 'foo.ab1' ) ),
 			array( '{foo,bar}.ab1', array( 'foo.ab1', 'bar.ab1' ) ),
-			array( '{foo,baz}.a{b,c}1', array( 'foo.ab1', 'baz.ab1' , 'baz.ac1' ) ),
-			array( '{foo,baz}.{ab,ac}1', array( 'foo.ab1', 'baz.ab1' , 'baz.ac1' ) ),
+			array( '{foo,baz}.a{b,c}1', array( 'foo.ab1', 'baz.ab1', 'baz.ac1' ) ),
+			array( '{foo,baz}.{ab,ac}1', array( 'foo.ab1', 'baz.ab1', 'baz.ac1' ) ),
 			array( '{foo,bar}.{ab1,efg1}', array( 'foo.ab1', 'foo.efg1', 'bar.ab1' ) ),
 			array( '{foo,bar,baz}.{ab,ac,efg}1', array( 'foo.ab1', 'foo.efg1', 'bar.ab1', 'baz.ab1', 'baz.ac1' ) ),
 			array( '{foo,ba{r,z}}.ab1', array( 'foo.ab1', 'bar.ab1', 'baz.ab1' ) ),
-			array( '{foo,ba{r,z}}.{ab1,efg1}', array( 'foo.ab1', 'foo.efg1', 'bar.ab1', 'baz.ab1') ),
+			array( '{foo,ba{r,z}}.{ab1,efg1}', array( 'foo.ab1', 'foo.efg1', 'bar.ab1', 'baz.ab1' ) ),
 			array( '{foo,bar}.{ab{1,2},efg1}', array( 'foo.ab1', 'foo.ab2', 'foo.efg1', 'bar.ab1', 'bar.ab2' ) ),
 			array( '{foo,ba{r,z}}.{a{b,c}{1,2},efg{1,2}}', array( 'foo.ab1', 'foo.ab2', 'foo.efg1', 'foo.efg2', 'bar.ab1', 'bar.ab2', 'baz.ab1', 'baz.ac1', 'baz.efg2' ) ),
 
@@ -567,13 +567,13 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$class_wp_cli_capture_exit = new \ReflectionProperty( 'WP_CLI', 'capture_exit' );
 		$class_wp_cli_capture_exit->setAccessible( true );
 
-		$prev_logger = $class_wp_cli_logger->getValue();
+		$prev_logger       = $class_wp_cli_logger->getValue();
 		$prev_capture_exit = $class_wp_cli_capture_exit->getValue();
 
 		// Enable exit exception.
 		$class_wp_cli_capture_exit->setValue( true );
 
-		$logger = new \WP_CLI\Loggers\Execution;
+		$logger = new \WP_CLI\Loggers\Execution();
 		WP_CLI::set_logger( $logger );
 
 		$exception = null;
@@ -611,7 +611,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetPHPBinary() {
 		$env_php_used = getenv( 'WP_CLI_PHP_USED' );
-		$env_php = getenv( 'WP_CLI_PHP' );
+		$env_php      = getenv( 'WP_CLI_PHP' );
 
 		putenv( 'WP_CLI_PHP_USED' );
 		putenv( 'WP_CLI_PHP' );

--- a/utils/contrib-list.php
+++ b/utils/contrib-list.php
@@ -32,28 +32,28 @@ class Contrib_List_Command {
 	 */
 	public function __invoke( $_, $assoc_args ) {
 
-		$contributors = array();
-		$contributor_count = 0;
+		$contributors       = array();
+		$contributor_count  = 0;
 		$pull_request_count = 0;
 
 		// Get the contributors to the current open large project milestones
-		foreach( array( 'wp-cli/wp-cli', 'wp-cli/handbook', 'wp-cli/wp-cli.github.com' ) as $repo ) {
+		foreach ( array( 'wp-cli/wp-cli', 'wp-cli/handbook', 'wp-cli/wp-cli.github.com' ) as $repo ) {
 			$milestones = self::get_project_milestones( $repo );
 			// Cheap way to get the latest milestone
 			$milestone = array_shift( $milestones );
 			WP_CLI::log( 'Current open ' . $repo . ' milestone: ' . $milestone->title );
-			$pull_requests = self::get_project_milestone_pull_requests( $repo, $milestone->number );
+			$pull_requests     = self::get_project_milestone_pull_requests( $repo, $milestone->number );
 			$repo_contributors = self::parse_contributors_from_pull_requests( $pull_requests );
 			WP_CLI::log( ' - Contributors: ' . count( $repo_contributors ) );
 			WP_CLI::log( ' - Pull requests: ' . count( $pull_requests ) );
 			$pull_request_count += count( $pull_requests );
-			$contributors = array_merge( $contributors, $repo_contributors );
+			$contributors        = array_merge( $contributors, $repo_contributors );
 		}
 
 		// Identify all command dependencies and their contributors
 		$milestones = self::get_project_milestones( 'wp-cli/wp-cli', array( 'state' => 'closed' ) );
 		// Cheap way to get the latest closed milestone
-		$milestone = array_shift( $milestones );
+		$milestone         = array_shift( $milestones );
 		$composer_lock_url = sprintf( 'https://raw.githubusercontent.com/wp-cli/wp-cli/v%s/composer.lock', $milestone->title );
 		WP_CLI::log( 'Fetching ' . $composer_lock_url );
 		$response = Utils\http_request( 'GET', $composer_lock_url );
@@ -61,21 +61,21 @@ class Contrib_List_Command {
 			WP_CLI::error( sprintf( 'Could not fetch composer.json (HTTP code %d)', $response->status_code ) );
 		}
 		$composer_json = json_decode( $response->body, true );
-		foreach( $composer_json['packages'] as $package ) {
-			$package_name = $package['name'];
+		foreach ( $composer_json['packages'] as $package ) {
+			$package_name       = $package['name'];
 			$version_constraint = str_replace( 'v', '', $package['version'] );
 			if ( ! preg_match( '#^wp-cli/.+-command$#', $package_name ) ) {
 				continue;
 			}
 			// Closed milestones denote a tagged release
-			$milestones = self::get_project_milestones( $package_name, array( 'state' => 'closed' ) );
-			$milestone_ids = array();
+			$milestones       = self::get_project_milestones( $package_name, array( 'state' => 'closed' ) );
+			$milestone_ids    = array();
 			$milestone_titles = array();
-			foreach( $milestones as $milestone ) {
+			foreach ( $milestones as $milestone ) {
 				if ( ! version_compare( $milestone->title, $version_constraint, '>' ) ) {
 					continue;
 				}
-				$milestone_ids[] = $milestone->number;
+				$milestone_ids[]    = $milestone->number;
 				$milestone_titles[] = $milestone->title;
 			}
 			// No shipped releases for this milestone.
@@ -83,13 +83,13 @@ class Contrib_List_Command {
 				continue;
 			}
 			WP_CLI::log( 'Closed ' . $package_name . ' milestone(s): ' . implode( ', ', $milestone_titles ) );
-			foreach( $milestone_ids as $milestone_id ) {
-				$pull_requests = self::get_project_milestone_pull_requests( $package_name, $milestone_id );
+			foreach ( $milestone_ids as $milestone_id ) {
+				$pull_requests     = self::get_project_milestone_pull_requests( $package_name, $milestone_id );
 				$repo_contributors = self::parse_contributors_from_pull_requests( $pull_requests );
 				WP_CLI::log( ' - Contributors: ' . count( $repo_contributors ) );
 				WP_CLI::log( ' - Pull requests: ' . count( $pull_requests ) );
 				$pull_request_count += count( $pull_requests );
-				$contributors = array_merge( $contributors, $repo_contributors );
+				$contributors        = array_merge( $contributors, $repo_contributors );
 			}
 		}
 
@@ -100,7 +100,7 @@ class Contrib_List_Command {
 		asort( $contributors, SORT_NATURAL | SORT_FLAG_CASE );
 		if ( in_array( $assoc_args['format'], array( 'markdown', 'html' ), true ) ) {
 			$contrib_list = '';
-			foreach( $contributors as $url => $login ) {
+			foreach ( $contributors as $url => $login ) {
 				if ( 'markdown' === $assoc_args['format'] ) {
 					$contrib_list .= '[' . $login . '](' . $url . '), ';
 				} elseif ( 'html' === $assoc_args['format'] ) {
@@ -119,7 +119,7 @@ class Contrib_List_Command {
 	 * @return array
 	 */
 	private static function get_project_milestones( $project, $args = array() ) {
-		$request_url = sprintf( 'https://api.github.com/repos/%s/milestones', $project );
+		$request_url            = sprintf( 'https://api.github.com/repos/%s/milestones', $project );
 		list( $body, $headers ) = self::make_github_api_request( $request_url, $args );
 		return $body;
 	}
@@ -132,33 +132,33 @@ class Contrib_List_Command {
 	 * @return array
 	 */
 	private static function get_project_milestone_pull_requests( $project, $milestone_id ) {
-		$request_url = sprintf( 'https://api.github.com/repos/%s/issues', $project );
-		$args = array(
+		$request_url   = sprintf( 'https://api.github.com/repos/%s/issues', $project );
+		$args          = array(
 			'milestone' => $milestone_id,
 			'state'     => 'all',
 		);
 		$pull_requests = array();
 		do {
 			list( $body, $headers ) = self::make_github_api_request( $request_url, $args );
-			foreach( $body as $issue ) {
+			foreach ( $body as $issue ) {
 				if ( ! empty( $issue->pull_request ) ) {
 					$pull_requests[] = $issue;
 				}
 			}
-			$args = array();
+			$args        = array();
 			$request_url = false;
 			// Set $request_url to 'rel="next" if present'
 			if ( ! empty( $headers['Link'] ) ) {
 				$bits = trim( explode( ',', $headers['Link'] ) );
-				foreach( $bits as $bit ) {
+				foreach ( $bits as $bit ) {
 					if ( false !== stripos( $bit, 'rel="next"' ) ) {
-						$hrefandrel = explode( '; ', $bit );
+						$hrefandrel  = explode( '; ', $bit );
 						$request_url = trim( $hrefandrel[0], '<>' );
 						break;
 					}
 				}
 			}
-		} while( $request_url );
+		} while ( $request_url );
 		return $pull_requests;
 	}
 
@@ -170,7 +170,7 @@ class Contrib_List_Command {
 	 */
 	private static function parse_contributors_from_pull_requests( $pull_requests ) {
 		$contributors = array();
-		foreach( $pull_requests as $pull_request ) {
+		foreach ( $pull_requests as $pull_request ) {
 			if ( ! empty( $pull_request->user ) ) {
 				$contributors[ $pull_request->user->html_url ] = $pull_request->user->login;
 			}

--- a/utils/get-package-require-from-composer.php
+++ b/utils/get-package-require-from-composer.php
@@ -3,7 +3,7 @@
 $file = $argv[1];
 if ( ! file_exists( $file ) ) {
 	echo 'File does not exist.';
-	exit(1);
+	exit( 1 );
 }
 
 $contents = file_get_contents( $file );
@@ -11,13 +11,13 @@ $composer = json_decode( $contents );
 
 if ( empty( $composer ) || ! is_object( $composer ) ) {
 	echo 'Invalid composer.json for package.';
-	exit(1);
+	exit( 1 );
 }
 
 if ( empty( $composer->autoload->files ) ) {
 	echo 'composer.json must specify valid "autoload" => "files"';
-	exit(1);
+	exit( 1 );
 }
 
 echo implode( PHP_EOL, $composer->autoload->files );
-exit(0);
+exit( 0 );


### PR DESCRIPTION
Simple, mostly whitespace related, fixes to make the code comply with the WPCliCS rules.

Fixes relate to the following rules:
* Align the equality operators in assignment blocks.
* No multiple assignments in one statement.
* One space between a control structure keyword and the open parenthesis.
* No space between a function call/language contruct keyword and the open parenthesis.
* One space on the inside of open/close parenthesis when there is content between them.
* Always use parenthesis when instantiating a new object.
* One space after equality operators.
* One space before and after concatenation operators.
* Don't use concatenation when it isn't necessary.
* There should be no space before a comma.
* Associative arrays with more than one item, should be multi-line.
* The double arrow in multi-line arrays should be aligned.
* Each array item in a multi-line array should be followed by a comma.
* Use single quoted strings when the string doesn't contain a single quote or variables.
* There should be one blank line after a namespace statement.
* Use tabs for indentation, spaces for inline alignment.
* Files should end on a new line character.