### PR TITLE
PHPCS: fix up the code base [16] - operator precedence

### DIFF
--- a/php/WP_CLI/Dispatcher/CommandFactory.php
+++ b/php/WP_CLI/Dispatcher/CommandFactory.php
@@ -208,12 +208,12 @@ class CommandFactory {
 		}
 		$content           = substr( $content, 0, $comment_end_pos + 2 );
 		$comment_start_pos = strrpos( $content, '/**' );
-		if ( false === $comment_start_pos || $comment_start_pos + 2 === $comment_end_pos ) {
+		if ( false === $comment_start_pos || ( $comment_start_pos + 2 ) === $comment_end_pos ) {
 			return false;
 		}
 		// Make sure comment start belongs to this comment end.
 		$comment_end2_pos = strpos( substr( $content, $comment_start_pos ), '*/' );
-		if ( false !== $comment_end2_pos && $comment_start_pos + $comment_end2_pos < $comment_end_pos ) {
+		if ( false !== $comment_end2_pos && ( $comment_start_pos + $comment_end2_pos ) < $comment_end_pos ) {
 			return false;
 		}
 		// Allow for '/**' within doc comment.

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -106,7 +106,7 @@ class FileCache {
 		}
 
 		//
-		if ( $ttl > 0 && filemtime( $filename ) + $ttl < time() ) {
+		if ( $ttl > 0 && ( filemtime( $filename ) + $ttl ) < time() ) {
 			if ( $this->ttl > 0 && $ttl >= $this->ttl ) {
 				unlink( $filename );
 			}
@@ -239,7 +239,7 @@ class FileCache {
 			$total = 0;
 
 			foreach ( $files as $file ) {
-				if ( $total + $file->getSize() <= $maxSize ) {
+				if ( ( $total + $file->getSize() ) <= $maxSize ) {
 					$total += $file->getSize();
 				} else {
 					unlink( $file->getRealPath() );

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1672,7 +1672,7 @@ class Runner {
 
 		// Bail if last check is still within our update check time period.
 		$last_check = (int) $cache->read( $cache_key );
-		if ( time() - ( 24 * 60 * 60 * $days_between_checks ) < $last_check ) {
+		if ( ( time() - ( 24 * 60 * 60 * $days_between_checks ) ) < $last_check ) {
 			return;
 		}
 


### PR DESCRIPTION
Use brackets to prevent confusion over operator precedence.