### PR TITLE
PHPCS: fix up the code base [2] - scope modifiers

### DIFF
--- a/php/WP_CLI/Loggers/Execution.php
+++ b/php/WP_CLI/Loggers/Execution.php
@@ -20,7 +20,7 @@ class Execution extends Regular {
 	/**
 	 * @param bool $in_color Whether or not to Colorize strings.
 	 */
-	function __construct( $in_color = false ) {
+	public function __construct( $in_color = false ) {
 		parent::__construct( $in_color );
 	}
 

--- a/tests/test-arg-validation.php
+++ b/tests/test-arg-validation.php
@@ -4,7 +4,7 @@ use WP_CLI\SynopsisValidator;
 
 class ArgValidationTests extends PHPUnit_Framework_TestCase {
 
-	function testMissingPositional() {
+	public function testMissingPositional() {
 		$validator = new SynopsisValidator( '<foo> <bar> [<baz>]' );
 
 		$this->assertFalse( $validator->enough_positionals( array() ) );
@@ -14,7 +14,7 @@ class ArgValidationTests extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( array( 4 ), $validator->unknown_positionals( array( 1, 2, 3, 4 ) ) );
 	}
 
-	function testRepeatingPositional() {
+	public function testRepeatingPositional() {
 		$validator = new SynopsisValidator( '<foo> [<bar>...]' );
 
 		$this->assertFalse( $validator->enough_positionals( array() ) );
@@ -24,7 +24,7 @@ class ArgValidationTests extends PHPUnit_Framework_TestCase {
 		$this->assertEmpty( $validator->unknown_positionals( array( 1, 2, 3 ) ) );
 	}
 
-	function testUnknownAssocEmpty() {
+	public function testUnknownAssocEmpty() {
 		$validator = new SynopsisValidator( '' );
 
 		$assoc_args = array(
@@ -34,7 +34,7 @@ class ArgValidationTests extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( array_keys( $assoc_args ), $validator->unknown_assoc( $assoc_args ) );
 	}
 
-	function testUnknownAssoc() {
+	public function testUnknownAssoc() {
 		$validator = new SynopsisValidator( '--type=<type> [--brand=<brand>] [--flag]' );
 
 		$assoc_args = array(
@@ -48,7 +48,7 @@ class ArgValidationTests extends PHPUnit_Framework_TestCase {
 		$this->assertContains( 'another', $validator->unknown_assoc( $assoc_args ) );
 	}
 
-	function testMissingAssoc() {
+	public function testMissingAssoc() {
 		$validator = new SynopsisValidator( '--type=<type> [--brand=<brand>] [--flag]' );
 
 		$assoc_args                = array(
@@ -61,7 +61,7 @@ class ArgValidationTests extends PHPUnit_Framework_TestCase {
 		$this->assertCount( 1, $errors['warning'] );
 	}
 
-	function testAssocWithOptionalValue() {
+	public function testAssocWithOptionalValue() {
 		$validator = new SynopsisValidator( '[--network[=<id>]]' );
 
 		$assoc_args                = array( 'network' => true );

--- a/tests/test-commandfactory.php
+++ b/tests/test-commandfactory.php
@@ -9,7 +9,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider dataProviderExtractLastDocComment
 	 */
-	function testExtractLastDocComment( $content, $expected ) {
+	public function testExtractLastDocComment( $content, $expected ) {
 		// Save and set test env var.
 		$is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
 		putenv( 'WP_CLI_TEST_IS_WINDOWS=0' );
@@ -30,7 +30,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider dataProviderExtractLastDocComment
 	 */
-	function testExtractLastDocCommentWin( $content, $expected ) {
+	public function testExtractLastDocCommentWin( $content, $expected ) {
 		// Save and set test env var.
 		$is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
 		putenv( 'WP_CLI_TEST_IS_WINDOWS=1' );
@@ -48,7 +48,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		putenv( false === $is_windows ? 'WP_CLI_TEST_IS_WINDOWS' : "WP_CLI_TEST_IS_WINDOWS=$is_windows" );
 	}
 
-	function dataProviderExtractLastDocComment() {
+	public function dataProviderExtractLastDocComment() {
 		return array(
 			array( '', false ),
 			array( '*/', false ),
@@ -80,7 +80,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		);
 	}
 
-	function testGetDocComment() {
+	public function testGetDocComment() {
 		// Save and set test env var.
 		$get_doc_comment = getenv( 'WP_CLI_TEST_GET_DOC_COMMENT' );
 		$is_windows      = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
@@ -248,7 +248,7 @@ class CommandFactoryTests extends PHPUnit_Framework_TestCase {
 		putenv( false === $is_windows ? 'WP_CLI_TEST_IS_WINDOWS' : "WP_CLI_TEST_IS_WINDOWS=$is_windows" );
 	}
 
-	function testGetDocCommentWin() {
+	public function testGetDocCommentWin() {
 		// Save and set test env var.
 		$get_doc_comment = getenv( 'WP_CLI_TEST_GET_DOC_COMMENT' );
 		$is_windows      = getenv( 'WP_CLI_TEST_IS_WINDOWS' );

--- a/tests/test-configurator.php
+++ b/tests/test-configurator.php
@@ -4,7 +4,7 @@ use WP_CLI\Configurator;
 
 class ConfiguratorTest extends PHPUnit_Framework_TestCase {
 
-	function testExtractAssoc() {
+	public function testExtractAssoc() {
 		$args = Configurator::extract_assoc( array( 'foo', '--bar', '--baz=text' ) );
 
 		$this->assertCount( 1, $args[0] );
@@ -20,7 +20,7 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase {
 
 	}
 
-	function testExtractAssocNoValue() {
+	public function testExtractAssocNoValue() {
 		$args = Configurator::extract_assoc( array( 'foo', '--bar=', '--baz=text' ) );
 
 		$this->assertCount( 1, $args[0] );
@@ -36,7 +36,7 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase {
 
 	}
 
-	function testExtractAssocGlobalLocal() {
+	public function testExtractAssocGlobalLocal() {
 		$args = Configurator::extract_assoc( array( '--url=foo.dev', '--path=wp', 'foo', '--bar=', '--baz=text', '--url=bar.dev' ) );
 
 		$this->assertCount( 1, $args[0] );
@@ -50,7 +50,7 @@ class ConfiguratorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'bar.dev', $args[3][2][1] );
 	}
 
-	function testExtractAssocDoubleDashInValue() {
+	public function testExtractAssocDoubleDashInValue() {
 		$args = Configurator::extract_assoc( array( '--test=text--text' ) );
 
 		$this->assertCount( 0, $args[0] );

--- a/tests/test-doc-parser.php
+++ b/tests/test-doc-parser.php
@@ -4,7 +4,7 @@ use WP_CLI\DocParser;
 
 class DocParserTests extends PHPUnit_Framework_TestCase {
 
-	function test_empty() {
+	public function test_empty() {
 		$doc = new DocParser( '' );
 
 		$this->assertEquals( '', $doc->get_shortdesc() );
@@ -13,7 +13,7 @@ class DocParserTests extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( '', $doc->get_tag( 'alias' ) );
 	}
 
-	function test_only_tags() {
+	public function test_only_tags() {
 		$doc = new DocParser( <<<EOB
 /**
  * @alias rock-on
@@ -30,7 +30,7 @@ EOB
 		$this->assertEquals( 'revoke-md5-passwords', $doc->get_tag( 'subcommand' ) );
 	}
 
-	function test_no_longdesc() {
+	public function test_no_longdesc() {
 		$doc = new DocParser( <<<EOB
 /**
  * Rock and roll!
@@ -45,7 +45,7 @@ EOB
 		$this->assertEquals( 'rock-on', $doc->get_tag( 'alias' ) );
 	}
 
-	function test_complete() {
+	public function test_complete() {
 		$doc = new DocParser( <<<EOB
 /**
  * Rock and roll!

--- a/tests/test-extractor.php
+++ b/tests/test-extractor.php
@@ -5,9 +5,9 @@ use WP_CLI\Utils;
 
 class Extractor_Test extends PHPUnit_Framework_TestCase {
 
-	static $copy_overwrite_files_prefix = 'wp-cli-test-utils-copy-overwrite-files-';
+	public static $copy_overwrite_files_prefix = 'wp-cli-test-utils-copy-overwrite-files-';
 
-	static $expected_wp = array(
+	public static $expected_wp = array(
 		'index1.php',
 		'license2.php',
 		'wp-admin/',
@@ -21,8 +21,8 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 		'xmlrpc8.php',
 	);
 
-	static $logger      = null;
-	static $prev_logger = null;
+	public static $logger      = null;
+	public static $prev_logger = null;
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/test-inflector.php
+++ b/tests/test-inflector.php
@@ -5,11 +5,11 @@ use WP_CLI\Inflector;
 class InflectorTest extends PHPUnit_Framework_TestCase {
 
 	/** @dataProvider dataProviderPluralize */
-	function testPluralize( $singular, $expected ) {
+	public function testPluralize( $singular, $expected ) {
 		$this->assertEquals( $expected, Inflector::pluralize( $singular ) );
 	}
 
-	function dataProviderPluralize() {
+	public function dataProviderPluralize() {
 		return array(
 			array( 'string', 'strings' ), // regular
 			array( 'person', 'people' ),  // irregular
@@ -18,11 +18,11 @@ class InflectorTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/** @dataProvider dataProviderSingularize */
-	function testSingularize( $singular, $expected ) {
+	public function testSingularize( $singular, $expected ) {
 		$this->assertEquals( $expected, Inflector::singularize( $singular ) );
 	}
 
-	function dataProviderSingularize() {
+	public function dataProviderSingularize() {
 		return array(
 			array( 'strings', 'string' ), // regular
 			array( 'people', 'person' ),  // irregular

--- a/tests/test-logging.php
+++ b/tests/test-logging.php
@@ -28,7 +28,7 @@ class MockQuietLogger extends WP_CLI\Loggers\Quiet {
 
 class LoggingTests extends PHPUnit_Framework_TestCase {
 
-	function testLogDebug() {
+	public function testLogDebug() {
 		$message = 'This is a test message.';
 
 		$regularLogger = new MockRegularLogger( false );
@@ -40,7 +40,7 @@ class LoggingTests extends PHPUnit_Framework_TestCase {
 		$quietLogger->debug( $message );
 	}
 
-	function testLogEscaping() {
+	public function testLogEscaping() {
 		$logger = new MockRegularLogger( false );
 
 		$message = 'foo%20bar';
@@ -49,7 +49,7 @@ class LoggingTests extends PHPUnit_Framework_TestCase {
 		$logger->success( $message );
 	}
 
-	function testExecutionLogger() {
+	public function testExecutionLogger() {
 		// Save Runner config.
 		$runner        = WP_CLI::get_runner();
 		$runner_config = new \ReflectionProperty( $runner, 'config' );

--- a/tests/test-process.php
+++ b/tests/test-process.php
@@ -8,7 +8,7 @@ class ProcessTests extends PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider data_process_env
 	 */
-	function test_process_env( $cmd_prefix, $env, $expected_env_vars, $expected_out ) {
+	public function test_process_env( $cmd_prefix, $env, $expected_env_vars, $expected_out ) {
 		$code = vsprintf( str_repeat( 'echo getenv( \'%s\' );', count( $expected_env_vars ) ), $expected_env_vars );
 
 		$cmd         = $cmd_prefix . ' ' . escapeshellarg( Utils\get_php_binary() ) . ' -r ' . escapeshellarg( $code );
@@ -17,7 +17,7 @@ class ProcessTests extends PHPUnit_Framework_TestCase {
 		$this->assertSame( $process_run->stdout, $expected_out );
 	}
 
-	function data_process_env() {
+	public function data_process_env() {
 		return array(
 			array( '', array(), array(), '' ),
 			array( 'ENV=blah', array(), array( 'ENV' ), 'blah' ),

--- a/tests/test-synopsis.php
+++ b/tests/test-synopsis.php
@@ -4,13 +4,13 @@ use WP_CLI\SynopsisParser;
 
 class SynopsisParserTest extends PHPUnit_Framework_TestCase {
 
-	function testEmpty() {
+	public function testEmpty() {
 		$r = SynopsisParser::parse( ' ' );
 
 		$this->assertEmpty( $r );
 	}
 
-	function testPositional() {
+	public function testPositional() {
 		$r = SynopsisParser::parse( '<plugin|zip> [<bar>]' );
 
 		$this->assertCount( 2, $r );
@@ -24,7 +24,7 @@ class SynopsisParserTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $param['optional'] );
 	}
 
-	function testFlag() {
+	public function testFlag() {
 		$r = SynopsisParser::parse( '[--foo]' );
 
 		$this->assertCount( 1, $r );
@@ -42,7 +42,7 @@ class SynopsisParserTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'unknown', $param['type'] );
 	}
 
-	function testGeneric() {
+	public function testGeneric() {
 		$r = SynopsisParser::parse( '--<field>=<value> [--<field>=<value>] --<field>[=<value>] [--<field>[=<value>]]' );
 
 		$this->assertCount( 4, $r );
@@ -62,7 +62,7 @@ class SynopsisParserTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'unknown', $param['type'] );
 	}
 
-	function testAssoc() {
+	public function testAssoc() {
 		$r = SynopsisParser::parse( '--foo=<value> [--bar=<value>] [--bar[=<value>]]' );
 
 		$this->assertCount( 3, $r );
@@ -81,7 +81,7 @@ class SynopsisParserTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $param['value']['optional'] );
 	}
 
-	function testInvalidAssoc() {
+	public function testInvalidAssoc() {
 		$r = SynopsisParser::parse( '--bar[=<value>] --bar=[<value>] --count=100' );
 
 		$this->assertCount( 3, $r );
@@ -91,7 +91,7 @@ class SynopsisParserTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'unknown', $r[2]['type'] );
 	}
 
-	function testRepeating() {
+	public function testRepeating() {
 		$r = SynopsisParser::parse( '<positional>... [--<field>=<value>...]' );
 
 		$this->assertCount( 2, $r );
@@ -105,7 +105,7 @@ class SynopsisParserTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( $param['repeating'] );
 	}
 
-	function testCombined() {
+	public function testCombined() {
 		$r = SynopsisParser::parse( '<positional> --assoc=<someval> --<field>=<value> [--flag]' );
 
 		$this->assertCount( 4, $r );
@@ -116,7 +116,7 @@ class SynopsisParserTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'flag', $r[3]['type'] );
 	}
 
-	function testAllowedValueCharacters() {
+	public function testAllowedValueCharacters() {
 		$r = SynopsisParser::parse( '--capitals=<VALUE> --hyphen=<val-ue> --combined=<VAL-ue> --disallowed=<wrong:char>' );
 
 		$this->assertCount( 4, $r );
@@ -136,7 +136,7 @@ class SynopsisParserTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 'unknown', $r[3]['type'] );
 	}
 
-	function testRender() {
+	public function testRender() {
 		$a = array(
 			array(
 				'name'        => 'message',
@@ -165,14 +165,14 @@ class SynopsisParserTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( '<message> [<secrets>...] --meal=<meal> [--snack=<snack>]', SynopsisParser::render( $a ) );
 	}
 
-	function testParseThenRender() {
+	public function testParseThenRender() {
 		$o = '<positional> --assoc=<assoc> --<field>=<value> [--flag]';
 		$a = SynopsisParser::parse( $o );
 		$r = SynopsisParser::render( $a );
 		$this->assertEquals( $o, $r );
 	}
 
-	function testParseThenRenderNumeric() {
+	public function testParseThenRenderNumeric() {
 		$o = '<p1ositional> --a2ssoc=<assoc> --<field>=<value> [--f3lag]';
 		$a = SynopsisParser::parse( $o );
 		$this->assertEquals( 'p1ositional', $a[0]['name'] );

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -6,7 +6,7 @@ require_once dirname( __DIR__ ) . '/php/class-wp-cli.php';
 
 class UtilsTest extends PHPUnit_Framework_TestCase {
 
-	function testIncrementVersion() {
+	public function testIncrementVersion() {
 		// keyword increments
 		$this->assertEquals(
 			Utils\increment_version( '1.2.3-pre', 'same' ),
@@ -650,7 +650,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		putenv( false === $env_is_windows ? 'WP_CLI_TEST_IS_WINDOWS' : "WP_CLI_TEST_IS_WINDOWS=$env_is_windows" );
 	}
 
-	function dataProcOpenCompatWinEnv() {
+	public function dataProcOpenCompatWinEnv() {
 		return array(
 			array( 'echo', array(), 'echo', array() ),
 			array( 'ENV=blah echo', array(), 'echo', array( 'ENV' => 'blah' ) ),
@@ -674,7 +674,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Copied from core "tests/phpunit/tests/db.php" (adapted to not use `$wpdb`).
 	 */
-	function test_esc_like() {
+	public function test_esc_like() {
 		$inputs   = array(
 			'howdy%', //Single Percent
 			'howdy_', //Single Underscore


### PR DESCRIPTION
Fixes relate to the following rules:
* Always specify visibility for all class properties and methods.