### PR TITLE
PHPCS: fix up the code base [7] - closure declaration

### DIFF
--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -523,7 +523,10 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$expand_globs_no_glob_brace = getenv( 'WP_CLI_TEST_EXPAND_GLOBS_NO_GLOB_BRACE' );
 
 		$dir      = __DIR__ . '/data/expand_globs/';
-		$expected = array_map( function ( $v ) use ( $dir ) { return $dir . $v; }, $expected );
+		$concat   = function ( $v ) use ( $dir ) {
+			return $dir . $v;
+		};
+		$expected = array_map( $concat, $expected );
 		sort( $expected );
 
 		putenv( 'WP_CLI_TEST_EXPAND_GLOBS_NO_GLOB_BRACE=0' );


### PR DESCRIPTION
Whether a full-blown function or a closure, the body of a function has to start on a new line, once indented and the close brace has to be on its own line.

As this would make the function call in which this closure was wrapped multi-line, I've moved the closure declaration to a variable declared before the function call and pass the variable in instead.