### PR TITLE
Bugfix outdated links in ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -2,13 +2,13 @@
 
 Thanks for taking the time to help improve WP-CLI!
 
-Found a bug or want to suggest an enhancement to an existing command? Before creating an issue, please review our best practices: http://wp-cli.org/docs/bug-reports/
+Found a bug or want to suggest an enhancement to an existing command? Before creating an issue, please review our best practices: https://make.wordpress.org/cli/handbook/bug-reports/
 
 Have an idea for something new? Jump into the ideas repo: https://github.com/wp-cli/ideas
 
 Need help with something? Github issues aren't for general support questions, but there are other venues you can try: http://wp-cli.org/#support Make sure you're running the most recent version of WP-CLI! The current version is the only officially supported version.
 
-Want to suggest a feature? Check out the roadmap for how feature development happens: https://wp-cli.org/docs/roadmap/
+Want to suggest a feature? Check out the roadmap for how feature development happens: https://make.wordpress.org/cli/handbook/roadmap/
 
 Oh! It's worth noting WP-CLI represents a collection of sub-projects, each with their own issue tracker. One of these may be a better destination:
 


### PR DESCRIPTION
The links used to redirect to the new location (see https://web.archive.org/web/20170409053658/https://wp-cli.org/docs/bug-reports/). But now they return 404.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
