### PR TITLE
Validate that global configuration does exists

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -67,6 +67,7 @@ Feature: `wp cli` tasks
       """
       Global configuration `url` does exists.
       """
+
     When I run `wp --require=custom-cmd.php custom-command`
     Then STDOUT should be:
       """

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -62,7 +62,6 @@ Feature: `wp cli` tasks
                   WP_CLI::log( "Global configuration '{$args[0]}' does not exist." );
               }
           }
-
       }
       WP_CLI::add_command( 'custom-command', 'Custom_Command' );
       """

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -40,7 +40,7 @@ Feature: `wp cli` tasks
     And STDERR should be empty
     And the return code should be 0
 
-  Scenario: Ability to detect a global configuration does exists or not
+  Scenario: Checking whether a global configuration parameter exists or not
     Given a WP installation
     And a custom-cmd.php file:
       """

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -48,13 +48,18 @@ Feature: `wp cli` tasks
       class Custom_Command extends WP_CLI_Command {
 
           /**
+           * Custom Command to validate a global configuration does exists or not.
+           *
+           * <config>
+           * : Config name to validate.
+           *
            * @when after_wp_load
            */
-          public function __invoke() {
-              if ( WP_CLI::has_config( 'user' ) ) {
-                  WP_CLI::log( 'Global configuration `user` does exists.' );
+          public function __invoke( $args ) {
+              if ( WP_CLI::has_config( $args[0] ) ) {
+                  WP_CLI::log( 'Global configuration `url` does exists.' );
               } else {
-                  WP_CLI::log( 'Global configuration `user` does not exists.' );
+                  WP_CLI::log( 'Global configuration `dummy` does not exists.' );
               }
           }
 
@@ -62,14 +67,14 @@ Feature: `wp cli` tasks
       WP_CLI::add_command( 'custom-command', 'Custom_Command' );
       """
 
-    When I run `wp --require=custom-cmd.php custom-command --user=1`
+    When I run `wp --require=custom-cmd.php custom-command url`
     Then STDOUT should be:
       """
-      Global configuration `user` does exists.
+      Global configuration `url` does exists.
       """
 
-    When I run `wp --require=custom-cmd.php custom-command`
+    When I run `wp --require=custom-cmd.php custom-command dummy`
     Then STDOUT should be:
       """
-      Global configuration `user` does not exists.
+      Global configuration `dummy` does not exists.
       """

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -57,7 +57,7 @@ Feature: `wp cli` tasks
            */
           public function __invoke( $args ) {
               if ( WP_CLI::has_config( $args[0] ) ) {
-                  WP_CLI::log( 'Global configuration `url` does exists.' );
+                  WP_CLI::log( "Global configuration '{$args[0]}' does exist." );
               } else {
                   WP_CLI::log( "Global configuration '{$args[0]}' does not exist." );
               }

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -48,7 +48,7 @@ Feature: `wp cli` tasks
       class Custom_Command extends WP_CLI_Command {
 
           /**
-           * Custom Command to validate a global configuration does exists or not.
+           * Custom command to validate a global configuration does exist or not.
            *
            * <config>
            * : Configuration parameter name to check for.

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -59,7 +59,7 @@ Feature: `wp cli` tasks
               if ( WP_CLI::has_config( $args[0] ) ) {
                   WP_CLI::log( 'Global configuration `url` does exists.' );
               } else {
-                  WP_CLI::log( 'Global configuration `dummy` does not exists.' );
+                  WP_CLI::log( "Global configuration '{$args[0]}' does not exist." );
               }
           }
 

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -69,7 +69,7 @@ Feature: `wp cli` tasks
     When I run `wp --require=custom-cmd.php custom-command url`
     Then STDOUT should be:
       """
-      Global configuration `url` does exists.
+      Global configuration 'url' does exist.
       """
 
     When I run `wp --require=custom-cmd.php custom-command dummy`

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -40,7 +40,7 @@ Feature: `wp cli` tasks
     And STDERR should be empty
     And the return code should be 0
 
-  Scenario: Ability to detect a globgal configuration does exists or not
+  Scenario: Ability to detect a global configuration does exists or not
     Given a WP installation
     And a custom-cmd.php file:
       """
@@ -62,12 +62,12 @@ Feature: `wp cli` tasks
       WP_CLI::add_command( 'custom-command', 'Custom_Command' );
       """
 
-    When I run `wp custom-command --url=example.com`
+    When I run `wp --require=custom-cmd.php custom-command --url=example.com`
     Then STDOUT should be:
       """
       Global configuration `url` does exists.
       """
-    When I run `wp custom-command`
+    When I run `wp --require=custom-cmd.php custom-command`
     Then STDOUT should be:
       """
       Global configuration `url` does not exists.

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -51,10 +51,10 @@ Feature: `wp cli` tasks
            * @when after_wp_load
            */
           public function __invoke() {
-              if ( WP_CLI::has_config( 'url' ) ) {
-                  WP_CLI::log( 'Global configuration `url` does exists.' );
+              if ( WP_CLI::has_config( 'dummy' ) ) {
+                  WP_CLI::log( 'Configuration `dummy` does exists.' );
               } else {
-                  WP_CLI::log( 'Global configuration `url` does not exists.' );
+                  WP_CLI::log( 'Configuration `dummy` does not exists.' );
               }
           }
 
@@ -62,14 +62,14 @@ Feature: `wp cli` tasks
       WP_CLI::add_command( 'custom-command', 'Custom_Command' );
       """
 
-    When I run `wp --require=custom-cmd.php custom-command --url=example.com`
+    When I run `wp --require=custom-cmd.php custom-command --dummy=example.com`
     Then STDOUT should be:
       """
-      Global configuration `url` does exists.
+      Configuration `dummy` does exists.
       """
 
     When I run `wp --require=custom-cmd.php custom-command`
     Then STDOUT should be:
       """
-      Global configuration `url` does not exists.
+      Configuration `dummy` does not exists.
       """

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -51,10 +51,10 @@ Feature: `wp cli` tasks
            * @when after_wp_load
            */
           public function __invoke() {
-              if ( WP_CLI::has_config( 'quiet' ) ) {
-                  WP_CLI::log( 'Global configuration `quiet` does exists.' );
+              if ( WP_CLI::has_config( 'user' ) ) {
+                  WP_CLI::log( 'Global configuration `user` does exists.' );
               } else {
-                  WP_CLI::log( 'Global configuration `quiet` does not exists.' );
+                  WP_CLI::log( 'Global configuration `user` does not exists.' );
               }
           }
 
@@ -62,14 +62,14 @@ Feature: `wp cli` tasks
       WP_CLI::add_command( 'custom-command', 'Custom_Command' );
       """
 
-    When I run `wp --require=custom-cmd.php custom-command --quiet`
+    When I run `wp --require=custom-cmd.php custom-command --user=1`
     Then STDOUT should be:
       """
-      Global configuration `quiet` does exists.
+      Global configuration `user` does exists.
       """
 
     When I run `wp --require=custom-cmd.php custom-command`
     Then STDOUT should be:
       """
-      Global configuration `quiet` does not exists.
+      Global configuration `user` does not exists.
       """

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -51,7 +51,7 @@ Feature: `wp cli` tasks
            * Custom Command to validate a global configuration does exists or not.
            *
            * <config>
-           * : Config name to validate.
+           * : Configuration parameter name to check for.
            *
            * @when after_wp_load
            */

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -39,3 +39,36 @@ Feature: `wp cli` tasks
       """
     And STDERR should be empty
     And the return code should be 0
+
+  Scenario: Ability to detect a globgal configuration does exists or not
+    Given a WP installation
+    And a custom-cmd.php file:
+      """
+      <?php
+      class Custom_Command extends WP_CLI_Command {
+
+          /**
+           * @when after_wp_load
+           */
+          public function __invoke() {
+              if ( WP_CLI::has_config( 'url' ) ) {
+                  WP_CLI::log( 'Global configuration `url` does exists.' );
+              } else {
+                  WP_CLI::log( 'Global configuration `url` does not exists.' );
+              }
+          }
+
+      }
+      WP_CLI::add_command( 'custom-command', 'Custom_Command' );
+      """
+
+    When I try `wp custom-command --url=example.com`
+    Then STDOUT should be:
+      """
+      Global configuration `url` does exists.
+      """
+    When I try `wp custom-command`
+    Then STDOUT should be:
+      """
+      Global configuration `url` does not exists.
+      """

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -51,10 +51,10 @@ Feature: `wp cli` tasks
            * @when after_wp_load
            */
           public function __invoke() {
-              if ( WP_CLI::has_config( 'dummy' ) ) {
-                  WP_CLI::log( 'Configuration `dummy` does exists.' );
+              if ( WP_CLI::has_config( 'quiet' ) ) {
+                  WP_CLI::log( 'Global configuration `quiet` does exists.' );
               } else {
-                  WP_CLI::log( 'Configuration `dummy` does not exists.' );
+                  WP_CLI::log( 'Global configuration `quiet` does not exists.' );
               }
           }
 
@@ -62,14 +62,14 @@ Feature: `wp cli` tasks
       WP_CLI::add_command( 'custom-command', 'Custom_Command' );
       """
 
-    When I run `wp --require=custom-cmd.php custom-command --dummy=example.com`
+    When I run `wp --require=custom-cmd.php custom-command --quiet`
     Then STDOUT should be:
       """
-      Configuration `dummy` does exists.
+      Global configuration `url` does exists.
       """
 
     When I run `wp --require=custom-cmd.php custom-command`
     Then STDOUT should be:
       """
-      Configuration `dummy` does not exists.
+      Global configuration `url` does not exists.
       """

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -62,12 +62,12 @@ Feature: `wp cli` tasks
       WP_CLI::add_command( 'custom-command', 'Custom_Command' );
       """
 
-    When I try `wp custom-command --url=example.com`
+    When I run `wp custom-command --url=example.com`
     Then STDOUT should be:
       """
       Global configuration `url` does exists.
       """
-    When I try `wp custom-command`
+    When I run `wp custom-command`
     Then STDOUT should be:
       """
       Global configuration `url` does not exists.

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -76,5 +76,5 @@ Feature: `wp cli` tasks
     When I run `wp --require=custom-cmd.php custom-command dummy`
     Then STDOUT should be:
       """
-      Global configuration `dummy` does not exists.
+      Global configuration 'dummy' does not exist.
       """

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -65,11 +65,11 @@ Feature: `wp cli` tasks
     When I run `wp --require=custom-cmd.php custom-command --quiet`
     Then STDOUT should be:
       """
-      Global configuration `url` does exists.
+      Global configuration `quiet` does exists.
       """
 
     When I run `wp --require=custom-cmd.php custom-command`
     Then STDOUT should be:
       """
-      Global configuration `url` does not exists.
+      Global configuration `quiet` does not exists.
       """

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1118,7 +1118,7 @@ class WP_CLI {
 	 * @access public
 	 * @category Input
 	 *
-	 * @param null $key Check if the config does exists.
+	 * @param string $key Config parameter key to check.
 	 *
 	 * @return bool
 	 */

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1122,7 +1122,7 @@ class WP_CLI {
 	 *
 	 * @return bool
 	 */
-	public static function has_config( $key = null ) {
+	public static function has_config( $key ) {
 		return array_key_exists( $key, self::get_runner()->config );
 	}
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1113,7 +1113,7 @@ class WP_CLI {
 	}
 
 	/**
-	 * Confirm that global configuration parameters does exists.
+	 * Confirm that a global configuration parameter does exist.
 	 *
 	 * @access public
 	 * @category Input

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1113,6 +1113,20 @@ class WP_CLI {
 	}
 
 	/**
+	 * Confirm that global configuration parameters does exists.
+	 *
+	 * @access public
+	 * @category Input
+	 *
+	 * @param null $key Check if the config does exists.
+	 *
+	 * @return bool
+	 */
+	public static function has_config( $key = null ) {
+		return array_key_exists( $key, self::get_runner()->config );
+	}
+
+	/**
 	 * Get values of global configuration parameters.
 	 *
 	 * Provides access to `--path=<path>`, `--url=<url>`, and other values of


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

New wp cli api to validate that a global configuration does exists.

Related #4954 