### PR TITLE
Differentiate commands and namespace

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -592,7 +592,11 @@ class WP_CLI {
 
 		if ( ! empty( $parent ) ) {
 			$sub_command = trim( str_replace( $parent, '', $name ) );
-			self::debug( "Adding namespace: {$parent}", 'commands' );
+
+			if ( $leaf_command instanceof Dispatcher\CommandNamespace ) {
+				self::debug( "Adding namespace: {$parent}", 'commands' );
+			}
+
 			self::debug( "Adding command: {$sub_command} to namespace {$parent}", 'commands' );
 		} else {
 			self::debug( "Adding command: {$name}", 'commands' );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -592,7 +592,8 @@ class WP_CLI {
 
 		if ( ! empty( $parent ) ) {
 			$sub_command = trim( str_replace( $parent, '', $name ) );
-			self::debug( "Adding command: {$sub_command} in {$parent} Namespace", 'commands' );
+			self::debug( "Adding namespace: {$parent}", 'commands' );
+			self::debug( "Adding command: {$sub_command} to namespace {$parent}", 'commands' );
 		} else {
 			self::debug( "Adding command: {$name}", 'commands' );
 		}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -519,6 +519,10 @@ class WP_CLI {
 			return false;
 		}
 
+		if ( ! empty( $parent ) && $leaf_command instanceof Dispatcher\CommandNamespace ) {
+			self::debug( "Adding namespace: {$parent}", 'commands' );
+		}
+
 		// Reattach commands attached to namespace to real command.
 		$subcommand_name  = (array) $leaf_name;
 		$existing_command = $command->find_subcommand( $subcommand_name );
@@ -592,10 +596,6 @@ class WP_CLI {
 
 		if ( ! empty( $parent ) ) {
 			$sub_command = trim( str_replace( $parent, '', $name ) );
-
-			if ( $leaf_command instanceof Dispatcher\CommandNamespace ) {
-				self::debug( "Adding namespace: {$parent}", 'commands' );
-			}
 
 			self::debug( "Adding command: {$sub_command} to namespace {$parent}", 'commands' );
 		} else {


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

--debug showing a message to differentiate the namespace from the command.

Resolve: #4937