### PR TITLE
Update the Travis build to include PHP 7.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: trusty
 
 language: php
-php: 7.2
+php: 7.3
 
 notifications:
   email:
@@ -50,6 +50,9 @@ jobs:
         - composer lint
         - composer phpcs
       env: BUILD=sniff
+    - stage: test
+      php: 7.3
+      env: WP_VERSION=latest
     - stage: test
       php: 7.2
       env: WP_VERSION=latest


### PR DESCRIPTION
This PR:

- Changes the default version of PHP used on jobs to 7.3
- Adds a PHP 7.3 job to the list.

One thing I am not sure of yet is how this gets pushed to the other repositories. Please advise the best way to tackle this.