### PR TITLE
Update regex to be more accurate

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -945,7 +945,7 @@ function report_batch_operation_results( $noun, $verb, $total, $successes, $fail
  * @return array
  */
 function parse_str_to_argv( $arguments ) {
-	preg_match_all( '/(?:[^\s]*(?:(["|\']).*?(?<!\\\)\1))|(?:[^\s]+)/', $arguments, $matches );
+	preg_match_all( '/(?:[^\s\"]*\".+?(?<!\\\\)\"[^\s\"]*|[^\s\']*\'(.+?)(?<!\\\\)\'[^\s\']*|[^\s]+)/', $arguments, $matches );
 	$argv = isset( $matches[0] ) ? $matches[0] : array();
 	$argv = array_map(
 		function( $arg ) {

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -289,6 +289,15 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			"--post_title='Escaped \'single \'quotes!'",
 		);
 		$this->assertEquals( $expected, Utils\parse_str_to_argv( "post create --post_title='Escaped \'single \'quotes!'" ) );
+
+		$expected = array(
+			'search-replace',
+			'//old-domain.com',
+			'//new-domain.com',
+			'specifictable',
+			'--all-tables',
+		);
+		$this->assertEquals( $expected, Utils\parse_str_to_argv( 'search-replace "//old-domain.com" "//new-domain.com" "specifictable" --all-tables' ) );
 	}
 
 	public function testAssocArgsToString() {


### PR DESCRIPTION
Summary:

While building a command that run other commands, i realized that there's a bug with the `parse_str_to_argv` function that's used in `WP_CLI::runcommand`.

This is a seemingly valid string to be sent to the function which fails to properly be parsed in the current version

`command subcommand "param with space" "paramnotspaced" "param spaced with \" quotes escaped" --param="string with spaces" --param="string with \" quotes escaped" --param='single quotes'`

This string is not properly parsed or get the quotes escaped accordingly.

This issue was introduced somewhere around the last 4 months when this regex was modified. I've tested this in 2.0.0-alpha something and it was not present.

Hopefully this can be fixed for the next version.