### PR TITLE
Fix FileCache::export() not ensuring parent directories exist for $target

### DIFF
--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -178,7 +178,7 @@ class FileCache {
 	public function export( $key, $target, $ttl = null ) {
 		$filename = $this->has( $key, $ttl );
 
-		if ( $filename ) {
+		if ( $filename && $this->ensure_dir_exists( dirname( $target ) ) ) {
 			return copy( $filename, $target );
 		}
 

--- a/tests/test-file-cache.php
+++ b/tests/test-file-cache.php
@@ -81,4 +81,25 @@ class FileCacheTest extends PHPUnit_Framework_TestCase {
 		rmdir( $cache_dir );
 		$class_wp_cli_logger->setValue( $prev_logger );
 	}
+
+	public function test_export() {
+		$max_size   = 32;
+		$ttl        = 60;
+		$cache_dir  = Utils\get_temp_dir() . uniqid( 'wp-cli-test-file-cache', true );
+		$target_dir = Utils\get_temp_dir() . uniqid( 'wp-cli-test-file-cache-export/nonexistant-subdirectory', true );
+		$target     = $target_dir . '/foo';
+		$key        = 'foo';
+		$contents   = 'bar';
+		$cache      = new FileCache( $cache_dir, $ttl, $max_size );
+
+		// Assert subdirectory is created.
+		$cache->write( $key, $contents );
+		$cache->export( $key, $target );
+		$this->assertEquals( $contents, file_get_contents( $target ) );
+
+		// Clean up.
+		$cache->clear();
+		unlink( $target );
+		rmdir( $target_dir );
+	}
 }


### PR DESCRIPTION
Fixes #5050 .