### PR TITLE
Bug fix for Issue #5109

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -423,6 +423,14 @@ function launch_editor_for_input( $input, $title = 'WP-CLI', $ext = 'tmp' ) {
 function mysql_host_to_cli_args( $raw_host ) {
 	$assoc_args = array();
 
+	/**
+	 * If the host string begins with 'p:' for a persistent db connection,
+	 * replace 'p:' with nothing.
+	 */
+	if ( substr( $raw_host, 0, 2 ) == 'p:' ) {
+		$raw_host = substr_replace( $raw_host, '', 0, 2 );
+	}
+
 	$host_parts = explode( ':', $raw_host );
 	if ( count( $host_parts ) === 2 ) {
 		list( $assoc_args['host'], $extra ) = $host_parts;

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -329,6 +329,41 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame( $strip_quotes( $expected ), $strip_quotes( $actual ) );
 	}
 
+	public function testMysqlHostToCLIArgs() {
+		// Test hostname only, with and without 'p:' modifier
+		$expected = array(
+			'hostname'
+		);
+		$testcase = 'hostname';
+		$this->assertEquals( $expected, Utils\mysql_host_to_cli_args( $testcase ) );
+
+		$testcase = 'p:hostname';
+		$this->assertEquals( $expected, Utils\mysql_host_to_cli_args( $testcase ) );
+
+		// Test hostname with port number, with and without 'p:' modifier
+		$expected = array(
+			'hostname',
+			3306,
+			'tcp'
+		);
+		$testcase = 'hostname:3306';
+		$this->assertEquals( $expected, Utils\mysql_host_to_cli_args( $testcase ) );
+
+		$testcase = 'p:hostname:3306';
+		$this->assertEquals( $expected, Utils\mysql_host_to_cli_args( $testcase ) );
+
+		// Test hostname with socket path, with and without 'p:' modifier
+		$expected = array(
+			'hostname',
+			'/path/to/socket'
+		);
+		$testcase = 'hostname:/path/to/socket';
+		$this->assertEquals( $expected, Utils\mysql_host_to_cli_args( $testcase ) );
+
+		$testcase = 'p:hostname:/path/to/socket';
+		$this->assertEquals( $expected, Utils\mysql_host_to_cli_args( $testcase ) );
+	}
+
 	public function testForceEnvOnNixSystems() {
 		$env_is_windows = getenv( 'WP_CLI_TEST_IS_WINDOWS' );
 

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -332,7 +332,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 	public function testMysqlHostToCLIArgs() {
 		// Test hostname only, with and without 'p:' modifier
 		$expected = array(
-			'hostname'
+			'host' => 'hostname'
 		);
 		$testcase = 'hostname';
 		$this->assertEquals( $expected, Utils\mysql_host_to_cli_args( $testcase ) );
@@ -342,9 +342,9 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 
 		// Test hostname with port number, with and without 'p:' modifier
 		$expected = array(
-			'hostname',
-			3306,
-			'tcp'
+			'host' => 'hostname',
+			'port' => 3306,
+			'protocol' => 'tcp'
 		);
 		$testcase = 'hostname:3306';
 		$this->assertEquals( $expected, Utils\mysql_host_to_cli_args( $testcase ) );
@@ -354,8 +354,8 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 
 		// Test hostname with socket path, with and without 'p:' modifier
 		$expected = array(
-			'hostname',
-			'/path/to/socket'
+			'host' => 'hostname',
+			'socket' => '/path/to/socket'
 		);
 		$testcase = 'hostname:/path/to/socket';
 		$this->assertEquals( $expected, Utils\mysql_host_to_cli_args( $testcase ) );


### PR DESCRIPTION
Added support for DB_HOST strings that include 'p:' for persistent DB connections. If present, the 'p:' modifier is replaced with '' to allow the correct parsing of the remaining host string.
