### PR TITLE
Add flags to include / exclude views in wp_get_table_names()

### DIFF
--- a/features/utils-wp.feature
+++ b/features/utils-wp.feature
@@ -95,7 +95,26 @@ Feature: Utilities that depend on WordPress code
     When I run `wp --require=table_names.php get_table_names --all-tables --base-tables-only`
     Then STDOUT should not contain:
       """
-      posts_view
+      wp_posts_view
+      """
+    But STDOUT should contain:
+      """
+      wp_commentmeta
+      wp_comments
+      wp_links
+      wp_options
+      wp_postmeta
+      wp_posts
+      wp_posts_xx
+      wp_term_relationships
+      wp_term_taxonomy
+      """
+  # Leave out wp_termmeta for old WP compat.
+    But STDOUT should contain:
+      """
+      wp_terms
+      wp_usermeta
+      wp_users
       """
 
     When I run `wp --require=table_names.php get_table_names --scope=all`

--- a/features/utils-wp.feature
+++ b/features/utils-wp.feature
@@ -86,10 +86,10 @@ Feature: Utilities that depend on WordPress code
       """
     And save STDOUT as {DEFAULT_STDOUT}
 
-    When I run `wp --require=table_names.php get_table_names --all-tables --views-only`
-    Then STDOUT should contain:
+    When I run `wp --require=table_names.php get_table_names --all-tables-with-prefix --views-only`
+    Then STDOUT should be:
       """
-      posts_view
+      wp_posts_view
       """
 
     When I run `wp --require=table_names.php get_table_names --all-tables --base-tables-only`

--- a/features/utils-wp.feature
+++ b/features/utils-wp.feature
@@ -27,6 +27,7 @@ Feature: Utilities that depend on WordPress code
     And I run `wp db query "CREATE TABLE wp_xx_posts ( id int );"`
     And I run `wp db query "CREATE TABLE wp_posts_xx ( id int );"`
     And I run `wp db query "CREATE TABLE wp_categories ( id int );"`
+    And I run `wp db query "CREATE VIEW posts_view AS ( SELECT ID from wp_posts );"`
     And a table_names.php file:
       """
       <?php
@@ -49,6 +50,12 @@ Feature: Utilities that depend on WordPress code
        *
        * [--all-tables]
        * : List all tables in the database, regardless of the prefix, and even if not registered on $wpdb. Overrides --all-tables-with-prefix.
+       *
+       * [--base-tables-only]
+       * : Restrict returned tables to those that are not views.
+       *
+       * [--views-only]
+       * : Restrict returned tables to those that are views.
        */
       function test_wp_get_table_names( $args, $assoc_args ) {
         if ( $tables = WP_CLI\Utils\wp_get_table_names( $args, $assoc_args ) ) {
@@ -78,6 +85,18 @@ Feature: Utilities that depend on WordPress code
       wp_users
       """
     And save STDOUT as {DEFAULT_STDOUT}
+
+    When I run `wp --require=table_names.php get_table_names --all-tables --views-only`
+    Then STDOUT should contain:
+      """
+      posts_view
+      """
+
+    When I run `wp --require=table_names.php get_table_names --all-tables --base-tables-only`
+    Then STDOUT should not contain:
+      """
+      posts_view
+      """
 
     When I run `wp --require=table_names.php get_table_names --scope=all`
     Then STDOUT should be:

--- a/features/utils-wp.feature
+++ b/features/utils-wp.feature
@@ -27,7 +27,7 @@ Feature: Utilities that depend on WordPress code
     And I run `wp db query "CREATE TABLE wp_xx_posts ( id int );"`
     And I run `wp db query "CREATE TABLE wp_posts_xx ( id int );"`
     And I run `wp db query "CREATE TABLE wp_categories ( id int );"`
-    And I run `wp db query "CREATE VIEW posts_view AS ( SELECT ID from wp_posts );"`
+    And I run `wp db query "CREATE VIEW wp_posts_view AS ( SELECT ID from wp_posts );"`
     And a table_names.php file:
       """
       <?php

--- a/features/utils-wp.feature
+++ b/features/utils-wp.feature
@@ -173,6 +173,7 @@ Feature: Utilities that depend on WordPress code
       wp_options
       wp_postmeta
       wp_posts
+      wp_posts_view
       wp_posts_xx
       wp_term_relationships
       wp_term_taxonomy
@@ -196,6 +197,7 @@ Feature: Utilities that depend on WordPress code
       wp_options
       wp_postmeta
       wp_posts
+      wp_posts_view
       wp_posts_xx
       wp_term_relationships
       wp_term_taxonomy
@@ -266,6 +268,7 @@ Feature: Utilities that depend on WordPress code
       """
       wp_postmeta
       wp_posts
+      wp_posts_view
       wp_posts_xx
       """
 
@@ -296,6 +299,7 @@ Feature: Utilities that depend on WordPress code
       """
       wp_postmeta
       wp_posts
+      wp_posts_view
       wp_posts_xx
       """
 

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -327,10 +327,10 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 
 	// Pre-load tables SQL query with Views restriction if needed.
 	if ( get_flag_value( $assoc_args, 'base-tables-only' ) ) {
-		$tables_sql = $wpdb->prepare( 'SHOW FULL TABLES WHERE Table_Type = %s', 'BASE TABLE' );
+		$tables_sql = 'SHOW FULL TABLES WHERE Table_Type = "BASE TABLE"';
 
 	} elseif ( get_flag_value( $assoc_args, 'views-only' ) ) {
-		$tables_sql = $wpdb->prepare( 'SHOW FULL TABLES WHERE Table_Type = %s', 'VIEW' );
+		$tables_sql = 'SHOW FULL TABLES WHERE Table_Type = "VIEW"';
 
 	}
 

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -320,6 +320,11 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 
 	$tables = array();
 
+	// Abort if incompatible args supplied.
+	if ( get_flag_value( $assoc_args, 'base-tables-only' ) && get_flag_value( $assoc_args, 'views-only' ) ) {
+		\WP_CLI::error( 'You cannot supply --base-tables-only and --views-only at the same time.' );
+	}
+
 	// Pre-load tables SQL query with Views restriction if needed.
 	if ( get_flag_value( $assoc_args, 'base-tables-only' ) ) {
 		$tables_sql = $wpdb->prepare( 'SHOW FULL TABLES WHERE Table_Type = %s', 'BASE TABLE' );

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -344,7 +344,7 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 		if ( empty( $tables_sql ) ) {
 			$tables_sql = $wpdb->prepare( 'SHOW TABLES LIKE %s', esc_like( $wpdb->get_blog_prefix() ) . '%' );
 		} else {
-			$tables_sql .= $wpdb->prepare( ' AND Tables_in_$wpdb->dbname LIKE %s', esc_like( $wpdb->get_blog_prefix() ) . '%' );
+			$tables_sql .= sprintf( " AND %s LIKE '%s'", esc_sql_ident( 'Tables_in_' . $wpdb->dbname ), esc_like( $wpdb->get_blog_prefix() ) . '%' );
 		}
 		$tables = $wpdb->get_col( $tables_sql, 0 ); // WPCS: unprepared SQL OK.
 


### PR DESCRIPTION
Part one of a feature discussed in [search-replace-command/issues/109](https://github.com/wp-cli/search-replace-command/issues/109) - adds new flags --views-only and --base-tables-only to restrict results.

Test coverage only included for use with --all-tables / --all-tables-with-prefix. This is because when these functions aren't passed wp_get_table_names() relies on retrieving tables names from $wpdb. I couldn't see how to register a view with / inject a view into $wpdb, so have left that test coverage out for now.