### PR TITLE
Fix: Limit ranges of PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "homepage": "https://wp-cli.org",
     "license": "MIT",
     "require": {
-        "php": ">=5.4",
+        "php": "^5.4 || ^7.0",
         "ext-curl": "*",
         "mustache/mustache": "~2.4",
         "rmccue/requests": "~1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eaf85123c00bd6c78c12591623df60b5",
+    "content-hash": "724ebd3482de16592cdeb06eaacb6d75",
     "packages": [
         {
             "name": "mustache/mustache",
@@ -3752,7 +3752,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4",
+        "php": "^5.4 || ^7.0",
         "ext-curl": "*"
     },
     "platform-dev": [],


### PR DESCRIPTION
This PR

* [x] limits the ranges of PHP versions this project can be installed with

💁‍♂️ We don't know yet whether this project will work with PHP 9000.