### PR TITLE
PHPCS: fix up the code base [18] - one property per statement

### DIFF
--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -12,9 +12,13 @@ use \WP_CLI\Utils;
  */
 class CompositeCommand {
 
-	protected $name, $shortdesc, $synopsis, $docparser;
+	protected $name;
+	protected $shortdesc;
+	protected $synopsis;
+	protected $docparser;
 
-	protected $parent, $subcommands = array();
+	protected $parent;
+	protected $subcommands = array();
 
 	/**
 	 * Instantiate a new CompositeCommand

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -14,15 +14,19 @@ use WP_CLI\Dispatcher\CompositeCommand;
  */
 class Runner {
 
-	private $global_config_path, $project_config_path;
+	private $global_config_path;
+	private $project_config_path;
 
-	private $config, $extra_config;
+	private $config;
+	private $extra_config;
 
 	private $alias;
 
 	private $aliases;
 
-	private $arguments, $assoc_args, $runtime_config;
+	private $arguments;
+	private $assoc_args;
+	private $runtime_config;
 
 	private $colorize = false;
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -18,7 +18,9 @@ class WP_CLI {
 
 	private static $logger;
 
-	private static $hooks = array(), $hooks_passed = array();
+	private static $hooks = array();
+
+	private static $hooks_passed = array();
 
 	private static $capture_exit = false;
 


### PR DESCRIPTION
Fixes relate to the following rules:
* Declare only one property per statement.