### PR TITLE
PHPCS: fix up the code base [20] - strict array comparisons

### DIFF
--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -332,13 +332,13 @@ class Subcommand extends CompositeCommand {
 				if ( isset( $spec_args['options'] ) ) {
 					if ( ! empty( $spec['repeating'] ) ) {
 						do {
-							if ( isset( $args[ $i ] ) && ! in_array( $args[ $i ], $spec_args['options'] ) ) {
+							if ( isset( $args[ $i ] ) && ! in_array( $args[ $i ], $spec_args['options'], true ) ) {
 								\WP_CLI::error( 'Invalid value specified for positional arg.' );
 							}
 							$i++;
 						} while ( isset( $args[ $i ] ) );
 					} else {
-						if ( isset( $args[ $i ] ) && ! in_array( $args[ $i ], $spec_args['options'] ) ) {
+						if ( isset( $args[ $i ] ) && ! in_array( $args[ $i ], $spec_args['options'], true ) ) {
 							\WP_CLI::error( 'Invalid value specified for positional arg.' );
 						}
 					}
@@ -352,7 +352,7 @@ class Subcommand extends CompositeCommand {
 					}
 				}
 				if ( isset( $assoc_args[ $spec['name'] ] ) && isset( $spec_args['options'] ) ) {
-					if ( ! in_array( $assoc_args[ $spec['name'] ], $spec_args['options'] ) ) {
+					if ( ! in_array( $assoc_args[ $spec['name'] ], $spec_args['options'], true ) ) {
 						$errors['fatal'][ $spec['name'] ] = "Invalid value specified for '{$spec['name']}'";
 					}
 				}


### PR DESCRIPTION
Fixes relate to the following rules:
* Use the `$strict` parameter when calling `in_array()`.

N.B.: These should be reviewed critically!