### PR TITLE
PHPCS: fix up the code base [21] - use `self`

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1221,7 +1221,7 @@ class WP_CLI {
 			$script_path = $GLOBALS['argv'][0];
 
 			// Persist runtime arguments unless they've been specified otherwise.
-			$configurator = \WP_CLI::get_configurator();
+			$configurator = self::get_configurator();
 			$argv         = array_slice( $GLOBALS['argv'], 1 );
 
 			list( $ignore1, $ignore2, $runtime_config ) = $configurator->parse_args( $argv );


### PR DESCRIPTION
Use `self` when referencing a (static) class member from within the same class.