### PR TITLE
PHPCS: fix up the code base [22] - no \ prefixed use statements

### DIFF
--- a/php/WP_CLI/ComposerIO.php
+++ b/php/WP_CLI/ComposerIO.php
@@ -2,8 +2,8 @@
 
 namespace WP_CLI;
 
-use \Composer\IO\NullIO;
-use \WP_CLI;
+use Composer\IO\NullIO;
+use WP_CLI;
 
 /**
  * A Composer IO class so we can provide some level of interactivity from WP-CLI

--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -2,7 +2,7 @@
 
 namespace WP_CLI\Dispatcher;
 
-use \WP_CLI\Utils;
+use WP_CLI\Utils;
 
 /**
  * A non-leaf node in the command tree.

--- a/php/WP_CLI/Dispatcher/RootCommand.php
+++ b/php/WP_CLI/Dispatcher/RootCommand.php
@@ -2,7 +2,7 @@
 
 namespace WP_CLI\Dispatcher;
 
-use \WP_CLI\Utils;
+use WP_CLI\Utils;
 
 /**
  * The root node in the command tree.

--- a/php/WP_CLI/PackageManagerEventSubscriber.php
+++ b/php/WP_CLI/PackageManagerEventSubscriber.php
@@ -2,11 +2,11 @@
 
 namespace WP_CLI;
 
-use \Composer\DependencyResolver\Rule;
-use \Composer\EventDispatcher\EventSubscriberInterface;
-use \Composer\Installer\PackageEvent;
+use Composer\DependencyResolver\Rule;
+use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\Installer\PackageEvent;
 use Composer\Installer\PackageEvents;
-use \WP_CLI;
+use WP_CLI;
 
 /**
  * A Composer Event subscriber so we can keep track of what's happening inside Composer

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1,12 +1,12 @@
 <?php
 
-use \WP_CLI\ExitException;
-use \WP_CLI\Dispatcher;
-use \WP_CLI\FileCache;
-use \WP_CLI\Process;
+use WP_CLI\ExitException;
+use WP_CLI\Dispatcher;
+use WP_CLI\FileCache;
+use WP_CLI\Process;
 use WP_CLI\ProcessRun;
-use \WP_CLI\WpHttpCacheManager;
-use \WP_CLI\Utils;
+use WP_CLI\WpHttpCacheManager;
+use WP_CLI\Utils;
 use Mustangostang\Spyc;
 
 /**

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -1,7 +1,7 @@
 <?php
 
-use \Composer\Semver\Comparator;
-use \WP_CLI\Utils;
+use Composer\Semver\Comparator;
+use WP_CLI\Utils;
 
 /**
  * Review current WP-CLI info, check for updates, or see defined aliases.

--- a/php/utils.php
+++ b/php/utils.php
@@ -4,12 +4,12 @@
 
 namespace WP_CLI\Utils;
 
-use \Composer\Semver\Comparator;
-use \Composer\Semver\Semver;
-use \WP_CLI;
-use \WP_CLI\Dispatcher;
-use \WP_CLI\Inflector;
-use \WP_CLI\Iterators\Transform;
+use Composer\Semver\Comparator;
+use Composer\Semver\Semver;
+use WP_CLI;
+use WP_CLI\Dispatcher;
+use WP_CLI\Inflector;
+use WP_CLI\Iterators\Transform;
 
 const PHAR_STREAM_PREFIX = 'phar://';
 

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -3,7 +3,7 @@
  * A modified version of wp-settings.php, tailored for CLI use.
  */
 
-use \WP_CLI\Utils;
+use WP_CLI\Utils;
 
 /**
  * Stores the location of the WordPress directory of functions, classes, and core content.


### PR DESCRIPTION
Import `use` statements should always be fully qualified, so a leading backslash is unnecessary and explicitly recommended against.

Ref: https://www.php.net/manual/en/language.namespaces.importing.php