### PR TITLE
PHPCS: fix up the code base [23] - touch up inline comment

### DIFF
--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -279,7 +279,7 @@ class FileCache {
 			return false;
 		}
 
-		/* @var Finder $finder */
+		/** @var Finder $finder */
 		$finder = $this->get_finder()->sortByName();
 
 		$files_to_delete = array();

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -534,7 +534,7 @@ class WP_CLI {
 			}
 		}
 
-		/* @var $leaf_command Dispatcher\Subcommand|Dispatcher\CompositeCommand|Dispatcher\CommandNamespace */
+		/** @var $leaf_command Dispatcher\Subcommand|Dispatcher\CompositeCommand|Dispatcher\CommandNamespace */
 
 		if ( ! $command->can_have_subcommands() ) {
 			throw new Exception(


### PR DESCRIPTION
Inline `@var` comments should use docblock format. This will also prevent them from being incorrectly marked as commented out code.