### PR TITLE
PHPCS: fix up the code base [26] - rename a local variable

### DIFF
--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -16,12 +16,12 @@ class DocParser {
 	protected $docComment;
 
 	/**
-	 * @param string $docComment
+	 * @param string $doc_comment
 	 */
-	public function __construct( $docComment ) {
+	public function __construct( $doc_comment ) {
 		/* Make sure we have a known line ending in document */
-		$docComment       = str_replace( "\r\n", "\n", $docComment );
-		$this->docComment = self::remove_decorations( $docComment );
+		$doc_comment      = str_replace( "\r\n", "\n", $doc_comment );
+		$this->docComment = self::remove_decorations( $doc_comment );
 	}
 
 	/**


### PR DESCRIPTION
Variable names should be in `snake_case`.

As this is a function local variable, it can be safely renamed without BC.