### PR TITLE
Rename camelCase properties to snake_case

### DIFF
--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -13,15 +13,15 @@ class DocParser {
 	/**
 	 * @var string $docComment PHPdoc command for the command.
 	 */
-	protected $docComment;
+	protected $doc_comment;
 
 	/**
 	 * @param string $doc_comment
 	 */
 	public function __construct( $doc_comment ) {
 		/* Make sure we have a known line ending in document */
-		$doc_comment      = str_replace( "\r\n", "\n", $doc_comment );
-		$this->docComment = self::remove_decorations( $doc_comment );
+		$doc_comment       = str_replace( "\r\n", "\n", $doc_comment );
+		$this->doc_comment = self::remove_decorations( $doc_comment );
 	}
 
 	/**
@@ -44,7 +44,7 @@ class DocParser {
 	 * @return string
 	 */
 	public function get_shortdesc() {
-		if ( ! preg_match( '|^([^@][^\n]+)\n*|', $this->docComment, $matches ) ) {
+		if ( ! preg_match( '|^([^@][^\n]+)\n*|', $this->doc_comment, $matches ) ) {
 			return '';
 		}
 
@@ -62,7 +62,7 @@ class DocParser {
 			return '';
 		}
 
-		$longdesc = substr( $this->docComment, strlen( $shortdesc ) );
+		$longdesc = substr( $this->doc_comment, strlen( $shortdesc ) );
 
 		$lines = array();
 		foreach ( explode( "\n", $longdesc ) as $line ) {
@@ -84,7 +84,7 @@ class DocParser {
 	 * @return string
 	 */
 	public function get_tag( $name ) {
-		if ( preg_match( '|^@' . $name . '\s+([a-z-_0-9]+)|m', $this->docComment, $matches ) ) {
+		if ( preg_match( '|^@' . $name . '\s+([a-z-_0-9]+)|m', $this->doc_comment, $matches ) ) {
 			return $matches[1];
 		}
 
@@ -97,7 +97,7 @@ class DocParser {
 	 * @return string
 	 */
 	public function get_synopsis() {
-		if ( ! preg_match( '|^@synopsis\s+(.+)|m', $this->docComment, $matches ) ) {
+		if ( ! preg_match( '|^@synopsis\s+(.+)|m', $this->doc_comment, $matches ) ) {
 			return '';
 		}
 
@@ -112,7 +112,7 @@ class DocParser {
 	 */
 	public function get_arg_desc( $name ) {
 
-		if ( preg_match( "/\[?<{$name}>.+\n: (.+?)(\n|$)/", $this->docComment, $matches ) ) {
+		if ( preg_match( "/\[?<{$name}>.+\n: (.+?)(\n|$)/", $this->doc_comment, $matches ) ) {
 			return $matches[1];
 		}
 
@@ -138,7 +138,7 @@ class DocParser {
 	 */
 	public function get_param_desc( $key ) {
 
-		if ( preg_match( "/\[?--{$key}=.+\n: (.+?)(\n|$)/", $this->docComment, $matches ) ) {
+		if ( preg_match( "/\[?--{$key}=.+\n: (.+?)(\n|$)/", $this->doc_comment, $matches ) ) {
 			return $matches[1];
 		}
 
@@ -162,7 +162,7 @@ class DocParser {
 	 * @return array|null Interpreted YAML document, or null.
 	 */
 	private function get_arg_or_param_args( $regex ) {
-		$bits       = explode( "\n", $this->docComment );
+		$bits       = explode( "\n", $this->doc_comment );
 		$within_arg = false;
 		$within_doc = false;
 		$document   = array();

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -35,7 +35,7 @@ class FileCache {
 	/**
 	 * @var int max total size
 	 */
-	protected $maxSize;
+	protected $max_size;
 	/**
 	 * @var string key allowed chars (regex class)
 	 */
@@ -50,7 +50,7 @@ class FileCache {
 	public function __construct( $cache_dir, $ttl, $max_size, $whitelist = 'a-z0-9._-' ) {
 		$this->root      = Utils\trailingslashit( $cache_dir );
 		$this->ttl       = (int) $ttl;
-		$this->maxSize   = (int) $max_size;
+		$this->max_size  = (int) $max_size;
 		$this->whitelist = $whitelist;
 
 		if ( ! $this->ensure_dir_exists( $this->root ) ) {
@@ -216,7 +216,7 @@ class FileCache {
 		}
 
 		$ttl      = $this->ttl;
-		$max_size = $this->maxSize;
+		$max_size = $this->max_size;
 
 		// unlink expired files
 		if ( $ttl > 0 ) {


### PR DESCRIPTION
`DocParser::$docComment` -> `DocParser::$doc_comment`
`FileCache::$maxSize` -> `FileCache::$max_size`

Technically, both of these are breaking changes, as they are both protected, not private. However, neither a plugin search nor a GitHub search could find any instance where these classes were extended in third-party code.

Related #5166