### PR TITLE
Remove access to inexistent `$STDERR` property

### DIFF
--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -110,8 +110,7 @@ class Process {
 	public function run_check() {
 		$r = $this->run();
 
-		// $r->STDERR is incorrect, but kept incorrect for backwards-compat
-		if ( $r->return_code || ! empty( $r->STDERR ) ) {
+		if ( $r->return_code ) {
 			throw new \RuntimeException( $r );
 		}
 


### PR DESCRIPTION
I don't see any valid reason why that one was kept in.

Related #5166