### PR TITLE
Whitelist `_line` method as it is being used in third-party code

### DIFF
--- a/php/WP_CLI/Loggers/Base.php
+++ b/php/WP_CLI/Loggers/Base.php
@@ -72,7 +72,7 @@ abstract class Base {
 	 * @param string $color Colorize label with a given color.
 	 * @param resource $handle Resource to write to. Defaults to STDOUT.
 	 */
-	protected function _line( $message, $label, $color, $handle = STDOUT ) {
+	protected function _line( $message, $label, $color, $handle = STDOUT ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore -- Used in third party extensions.
 		if ( class_exists( 'cli\Colors' ) ) {
 			$label = \cli\Colors::colorize( "$color$label:%n", $this->in_color );
 		} else {


### PR DESCRIPTION
Related #5166