### PR TITLE
Replace or justify the usage of the `parse_url()` function

### DIFF
--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -357,10 +357,7 @@ class FileCache {
 	 * @return string relative filename
 	 */
 	protected function validate_key( $key ) {
-		$url_parts = function_exists( 'wp_parse_url' )
-			? wp_parse_url( $key )
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- Fallback.
-			: parse_url( $key );
+		$url_parts = Utils\parse_url( $key, -1, false );
 		if ( ! empty( $url_parts['scheme'] ) ) { // is url
 			$parts   = array( 'misc' );
 			$parts[] = $url_parts['scheme'] . '-' . $url_parts['host'] .

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -357,7 +357,10 @@ class FileCache {
 	 * @return string relative filename
 	 */
 	protected function validate_key( $key ) {
-		$url_parts = Utils\parse_url( $key );
+		$url_parts = function_exists( 'wp_parse_url' )
+			? wp_parse_url( $key )
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- Fallback.
+			: parse_url( $key );
 		if ( ! empty( $url_parts['scheme'] ) ) { // is url
 			$parts   = array( 'misc' );
 			$parts[] = $url_parts['scheme'] . '-' . $url_parts['host'] .

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -14,6 +14,7 @@
 namespace WP_CLI;
 
 use Symfony\Component\Finder\Finder;
+use WP_CLI\Utils;
 
 /**
  * Reads/writes to a filesystem cache
@@ -356,7 +357,7 @@ class FileCache {
 	 * @return string relative filename
 	 */
 	protected function validate_key( $key ) {
-		$url_parts = parse_url( $key );
+		$url_parts = Utils\parse_url( $key );
 		if ( ! empty( $url_parts['scheme'] ) ) { // is url
 			$parts   = array( 'misc' );
 			$parts[] = $url_parts['scheme'] . '-' . $url_parts['host'] .

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1470,7 +1470,7 @@ class Runner {
 			'wp_mail_from',
 			function( $from_email ) {
 				if ( 'wordpress@' === $from_email ) {
-					$sitename = strtolower( parse_url( site_url(), PHP_URL_HOST ) );
+					$sitename = strtolower( Utils\parse_url( site_url(), PHP_URL_HOST ) );
 					if ( substr( $sitename, 0, 4 ) === 'www.' ) {
 						$sitename = substr( $sitename, 4 );
 					}

--- a/php/WP_CLI/WpHttpCacheManager.php
+++ b/php/WP_CLI/WpHttpCacheManager.php
@@ -4,7 +4,7 @@
 namespace WP_CLI;
 
 use WP_CLI;
-
+use WP_CLI\Utils;
 
 /**
  * Manage caching with whitelisting
@@ -102,7 +102,7 @@ class WpHttpCacheManager {
 	 * @param int    $ttl
 	 */
 	public function whitelist_package( $url, $group, $slug, $version, $ttl = null ) {
-		$ext = pathinfo( parse_url( $url, PHP_URL_PATH ), PATHINFO_EXTENSION );
+		$ext = pathinfo( Utils\parse_url( $url, PHP_URL_PATH ), PATHINFO_EXTENSION );
 		$key = "$group/$slug-$version.$ext";
 		$this->whitelist_url( $url, $key, $ttl );
 		wp_update_plugins();

--- a/php/utils.php
+++ b/php/utils.php
@@ -543,16 +543,32 @@ function make_progress_bar( $message, $count, $interval = 100 ) {
 	return new \cli\progress\Bar( $message, $count, $interval );
 }
 
-function parse_url( $url ) {
+/**
+ * Helper function to use wp_parse_url when available or fall back to PHP's
+ * parse_url if not.
+ *
+ * Additionally, this adds 'http://' to the URL if no scheme was found.
+ *
+ * @param string $url       The URL to parse.
+ * @param int    $component The specific component to retrieve. Use one of the
+ *                          PHP predefined constants to specify which one.
+ *                          Defaults to -1 (= return all parts as an array).
+ * @return mixed False on parse failure; Array of URL components on success;
+ *               When a specific component has been requested: null if the
+ *               component doesn't exist in the given URL; a string or - in the
+ *               case of PHP_URL_PORT - integer when it does. See parse_url()'s
+ *               return values.
+ */
+function parse_url( $url, $component = - 1 ) {
 	if ( function_exists( 'wp_parse_url' ) ) {
-		$url_parts = wp_parse_url( $url );
+		$url_parts = wp_parse_url( $url, $component );
 	} else {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- Fallback.
-		$url_parts = \parse_url( $url );
+		$url_parts = \parse_url( $url, $component );
 	}
 
 	if ( ! isset( $url_parts['scheme'] ) ) {
-		$url_parts = WP_CLI\Utils\parse_url( 'http://' . $url );
+		$url_parts = WP_CLI\Utils\parse_url( 'http://' . $url, $component );
 	}
 
 	return $url_parts;

--- a/php/utils.php
+++ b/php/utils.php
@@ -549,21 +549,24 @@ function make_progress_bar( $message, $count, $interval = 100 ) {
  *
  * Additionally, this adds 'http://' to the URL if no scheme was found.
  *
- * @param string $url       The URL to parse.
- * @param int    $component The specific component to retrieve. Use one of the
- *                          PHP predefined constants to specify which one.
- *                          Defaults to -1 (= return all parts as an array).
+ * @param string $url           The URL to parse.
+ * @param int $component        Optional. The specific component to retrieve.
+ *                              Use one of the PHP predefined constants to
+ *                              specify which one. Defaults to -1 (= return
+ *                              all parts as an array).
+ * @param bool $auto_add_scheme Optional. Automatically add an http:// scheme if
+ *                              none was found. Defaults to true.
  * @return mixed False on parse failure; Array of URL components on success;
  *               When a specific component has been requested: null if the
  *               component doesn't exist in the given URL; a string or - in the
  *               case of PHP_URL_PORT - integer when it does. See parse_url()'s
  *               return values.
  */
-function parse_url( $url, $component = - 1 ) {
+function parse_url( $url, $component = - 1, $auto_add_scheme = true ) {
 	if (
 		function_exists( 'wp_parse_url' )
 		&& (
-			$component === -1
+			-1 === $component
 			|| wp_version_compare( '4.7', '>=' )
 		)
 	) {
@@ -573,7 +576,7 @@ function parse_url( $url, $component = - 1 ) {
 		$url_parts = \parse_url( $url, $component );
 	}
 
-	if ( ! isset( $url_parts['scheme'] ) ) {
+	if ( $auto_add_scheme && ! isset( $url_parts['scheme'] ) ) {
 		$url_parts = WP_CLI\Utils\parse_url( 'http://' . $url, $component );
 	}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -577,7 +577,7 @@ function parse_url( $url, $component = - 1, $auto_add_scheme = true ) {
 	}
 
 	if ( $auto_add_scheme && ! isset( $url_parts['scheme'] ) ) {
-		$url_parts = WP_CLI\Utils\parse_url( 'http://' . $url, $component );
+		$url_parts = namespace\parse_url( 'http://' . $url, $component, false );
 	}
 
 	return $url_parts;

--- a/php/utils.php
+++ b/php/utils.php
@@ -560,7 +560,13 @@ function make_progress_bar( $message, $count, $interval = 100 ) {
  *               return values.
  */
 function parse_url( $url, $component = - 1 ) {
-	if ( function_exists( 'wp_parse_url' ) ) {
+	if (
+		function_exists( 'wp_parse_url' )
+		&& (
+			$component === -1
+			|| wp_version_compare( '4.7', '>=' )
+		)
+	) {
 		$url_parts = wp_parse_url( $url, $component );
 	} else {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- Fallback.

--- a/php/utils.php
+++ b/php/utils.php
@@ -7,7 +7,6 @@ namespace WP_CLI\Utils;
 use Composer\Semver\Comparator;
 use Composer\Semver\Semver;
 use WP_CLI;
-use WP_CLI\Dispatcher;
 use WP_CLI\Inflector;
 use WP_CLI\Iterators\Transform;
 
@@ -545,10 +544,15 @@ function make_progress_bar( $message, $count, $interval = 100 ) {
 }
 
 function parse_url( $url ) {
-	$url_parts = \parse_url( $url );
+	if ( function_exists( 'wp_parse_url' ) ) {
+		$url_parts = wp_parse_url( $url );
+	} else {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- Fallback.
+		$url_parts = \parse_url( $url );
+	}
 
 	if ( ! isset( $url_parts['scheme'] ) ) {
-		$url_parts = parse_url( 'http://' . $url );
+		$url_parts = WP_CLI\Utils\parse_url( 'http://' . $url );
 	}
 
 	return $url_parts;


### PR DESCRIPTION
The  `WP_CLI\Utils\parse_url` helper now uses `wp_parse_url` if available, and falls back to the PHP `parse_url` otherwise.

Related #5166

Related #5179