### PR TITLE
Whitelist urlencode

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -982,6 +982,7 @@ function parse_str_to_argv( $arguments ) {
  * @return string
  */
 function basename( $path, $suffix = '' ) {
+	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode -- Format required by wordpress.org API.
 	return urldecode( \basename( str_replace( array( '%2F', '%5C' ), '/', urlencode( $path ) ), $suffix ) );
 }
 


### PR DESCRIPTION
It produces the format that the wordpress.org API requires.

Related #5166

Related #5179