### PR TITLE
Whitelist commented-out code

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -611,6 +611,8 @@ class Runner {
 			}
 		}
 
+		// phpcs:disable Squiz.PHP.CommentedOutCode.Found
+
 		// *-meta  ->  * meta
 		if ( ! empty( $args ) && preg_match( '/(post|comment|user|network)-meta/', $args[0], $matches ) ) {
 			array_shift( $args );
@@ -767,6 +769,8 @@ class Runner {
 				$args[1] = 'list';
 			}
 		}
+
+		// phpcs:enable
 
 		return array( $args, $assoc_args );
 	}


### PR DESCRIPTION
This allows for the back-compat conversion to be explained in logical shorthand.

Related #5166

Related #5179