### PR TITLE
Revert "Rename camelCase methods into snake_case"

### DIFF
--- a/php/WP_CLI/Bootstrap/BootstrapState.php
+++ b/php/WP_CLI/Bootstrap/BootstrapState.php
@@ -34,7 +34,8 @@ class BootstrapState {
 	 *
 	 * @return mixed
 	 */
-	public function get_value( $key, $fallback = null ) {
+	// @codingStandardsIgnoreLine
+	public function getValue( $key, $fallback = null ) {
 		return array_key_exists( $key, $this->state )
 			? $this->state[ $key ]
 			: $fallback;
@@ -48,7 +49,8 @@ class BootstrapState {
 	 *
 	 * @return void
 	 */
-	public function set_value( $key, $value ) {
+	// @codingStandardsIgnoreLine
+	public function setValue( $key, $value ) {
 		$this->state[ $key ] = $value;
 	}
 }

--- a/php/WP_CLI/Bootstrap/DefineProtectedCommands.php
+++ b/php/WP_CLI/Bootstrap/DefineProtectedCommands.php
@@ -25,7 +25,7 @@ final class DefineProtectedCommands implements BootstrapStep {
 
 		foreach ( $commands as $command ) {
 			if ( 0 === strpos( $current_command, $command ) ) {
-				$state->set_value( BootstrapState::IS_PROTECTED_COMMAND, true );
+				$state->setValue( BootstrapState::IS_PROTECTED_COMMAND, true );
 			}
 		}
 

--- a/php/WP_CLI/Bootstrap/IncludePackageAutoloader.php
+++ b/php/WP_CLI/Bootstrap/IncludePackageAutoloader.php
@@ -18,7 +18,7 @@ final class IncludePackageAutoloader extends AutoloaderStep {
 	 *                        to skip.
 	 */
 	protected function get_autoloader_paths() {
-		if ( $this->state->get_value( BootstrapState::IS_PROTECTED_COMMAND, false ) ) {
+		if ( $this->state->getValue( BootstrapState::IS_PROTECTED_COMMAND, false ) ) {
 			return false;
 		}
 

--- a/php/WP_CLI/Bootstrap/LoadRequiredCommand.php
+++ b/php/WP_CLI/Bootstrap/LoadRequiredCommand.php
@@ -22,7 +22,7 @@ final class LoadRequiredCommand implements BootstrapStep {
 	 * @return BootstrapState Modified state to pass to the next step.
 	 */
 	public function process( BootstrapState $state ) {
-		if ( $state->get_value( BootstrapState::IS_PROTECTED_COMMAND, false ) ) {
+		if ( $state->getValue( BootstrapState::IS_PROTECTED_COMMAND, false ) ) {
 			return $state;
 		}
 


### PR DESCRIPTION
Reverts wp-cli/wp-cli#5173

Changing the method names breaks autoload interactions between Phar & framework/commands you use outside of Phar (like when running the Phar WP inside of a command folder).