### PR TITLE
Avoid double registration of commands

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -519,10 +519,6 @@ class WP_CLI {
 
 		$leaf_command = Dispatcher\CommandFactory::create( $leaf_name, $callable, $command );
 
-		if ( $leaf_command instanceof Dispatcher\CommandNamespace && array_key_exists( $leaf_name, $command->get_subcommands() ) ) {
-			return false;
-		}
-
 		// Reattach commands attached to namespace to real command.
 		$subcommand_name  = (array) $leaf_name;
 		$existing_command = $command->find_subcommand( $subcommand_name );
@@ -535,6 +531,9 @@ class WP_CLI {
 					$leaf_command->add_subcommand( $subname, $subcommand );
 				}
 			}
+		} elseif ( false !== $existing_command ) {
+			// Command already registered, so abort to avoid double registration.
+			return false;
 		}
 
 		/** @var $leaf_command Dispatcher\Subcommand|Dispatcher\CompositeCommand|Dispatcher\CommandNamespace */


### PR DESCRIPTION
When a given subcommand is already found:
- if it is a command namespace, we replace it with the new command, and attach all children of the namespace to the new command.
- if it is a regular command, we skip registration, to avoid double registration. This means only the first registration counts (making overrides through packages and requires precede bundled commands).

Fixes #5186