### PR TITLE
Implement CS checking based on the `WP_CLI_CS` ruleset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ PHAR_BUILD_VERSION
 /packages
 /vendor
 /*.phar
-/phpunit.xml.dist
-/codesniffer
-/PHP_Codesniffer-VariableAnalysis
 .*.swp
 *.log
+phpunit.xml
+phpcs.xml
+.phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "wp-cli/entity-command": "^1.2 || ^2",
         "wp-cli/extension-command": "^1.1 || ^2",
         "wp-cli/package-command": "^1 || ^2",
-        "wp-cli/wp-cli-tests": "^2.0.8"
+        "wp-cli/wp-cli-tests": "^2.1"
     },
     "suggest": {
         "ext-readline": "Include for a better --prompt implementation",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "724ebd3482de16592cdeb06eaacb6d75",
+    "content-hash": "bf1b59d9c71a789bdc41dcf21cc222e0",
     "packages": [
         {
             "name": "mustache/mustache",
@@ -997,16 +997,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "8.2.0",
+            "version": "9.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
+                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
+                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
                 "shasum": ""
             },
             "require": {
@@ -1024,75 +1024,34 @@
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
-            "autoload": {
-                "psr-4": {
-                    "PHPCompatibility\\": "PHPCompatibility/"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                },
+                {
                     "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
                     "role": "lead"
                 }
             ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
             "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
             "keywords": [
                 "compatibility",
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-07-17T13:42:26+00:00"
-        },
-        {
-            "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "b26c84df3ec1d4850d0f22264a4a16482a171996"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b26c84df3ec1d4850d0f22264a4a16482a171996",
-                "reference": "b26c84df3ec1d4850d0f22264a4a16482a171996",
-                "shasum": ""
-            },
-            "require": {
-                "phpcompatibility/php-compatibility": "^8.1"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
-                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-            },
-            "type": "phpcodesniffer-standard",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Wim Godden",
-                    "role": "lead"
-                },
-                {
-                    "name": "Juliette Reinders Folmer",
-                    "role": "lead"
-                }
-            ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility for WordPress projects.",
-            "homepage": "http://phpcompatibility.com/",
-            "keywords": [
-                "compatibility",
-                "phpcs",
-                "standards",
-                "wordpress"
-            ],
-            "time": "2018-07-16T22:10:02+00:00"
+            "time": "2018-12-30T23:16:27+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -1636,12 +1595,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "9c6c45a2bf8825209fc18861ff666a90f4d878cf"
+                "reference": "1b329f4f2d9a0a3981fd79dbfe37754bedd383e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/9c6c45a2bf8825209fc18861ff666a90f4d878cf",
-                "reference": "9c6c45a2bf8825209fc18861ff666a90f4d878cf",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/1b329f4f2d9a0a3981fd79dbfe37754bedd383e2",
+                "reference": "1b329f4f2d9a0a3981fd79dbfe37754bedd383e2",
                 "shasum": ""
             },
             "conflict": {
@@ -1655,7 +1614,7 @@
                 "aws/aws-sdk-php": ">=3,<3.2.1",
                 "brightlocal/phpwhois": "<=4.2.5",
                 "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
-                "cakephp/cakephp": ">=1.3,<1.3.18|>=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=2.7,<2.7.6|>=3,<3.0.15|>=3.1,<3.1.4|>=3.4,<3.4.14|>=3.5,<3.5.17|>=3.6,<3.6.4",
+                "cakephp/cakephp": ">=1.3,<1.3.18|>=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=2.7,<2.7.6|>=3,<3.5.18|>=3.6,<3.6.15|>=3.7,<3.7.7",
                 "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
                 "cartalyst/sentry": "<=2.1.6",
                 "codeigniter/framework": "<=3.0.6",
@@ -1740,7 +1699,7 @@
                 "silverstripe/userforms": "<3",
                 "simple-updates/phpwhois": "<=1",
                 "simplesamlphp/saml2": "<1.10.6|>=2,<2.3.8|>=3,<3.1.4",
-                "simplesamlphp/simplesamlphp": "<1.16.3",
+                "simplesamlphp/simplesamlphp": "<1.15.2|>=1.16,<1.16.3",
                 "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
                 "slim/slim": "<2.6",
                 "smarty/smarty": "<3.1.33",
@@ -1751,23 +1710,26 @@
                 "swiftmailer/swiftmailer": ">=4,<5.4.5",
                 "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
                 "sylius/sylius": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
-                "symfony/dependency-injection": ">=2,<2.0.17",
+                "symfony/cache": ">=3.2,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/dependency-injection": ">=2,<2.0.17|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
                 "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
-                "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2",
-                "symfony/http-foundation": ">=2,<2.7.49|>=2.8,<2.8.44|>=3,<3.3.18|>=3.4,<3.4.14|>=4,<4.0.14|>=4.1,<4.1.3",
+                "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/http-foundation": ">=2,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
                 "symfony/http-kernel": ">=2,<2.3.29|>=2.4,<2.5.12|>=2.6,<2.6.8",
                 "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
+                "symfony/phpunit-bridge": ">=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
                 "symfony/polyfill": ">=1,<1.10",
                 "symfony/polyfill-php55": ">=1,<1.10",
+                "symfony/proxy-manager-bridge": ">=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
                 "symfony/routing": ">=2,<2.0.19",
-                "symfony/security": ">=2,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.19|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
+                "symfony/security": ">=2,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
                 "symfony/security-bundle": ">=2,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
                 "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<2.8.37|>=3,<3.3.17|>=3.4,<3.4.7|>=4,<4.0.7",
                 "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
                 "symfony/security-guard": ">=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
-                "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
+                "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
                 "symfony/serializer": ">=2,<2.0.11",
-                "symfony/symfony": ">=2,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
+                "symfony/symfony": ">=2,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
                 "symfony/translation": ">=2,<2.0.17",
                 "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
                 "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
@@ -1833,7 +1795,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2019-04-18T06:59:35+00:00"
+            "time": "2019-04-24T06:22:37+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -2981,16 +2943,16 @@
         },
         {
             "name": "wp-cli/config-command",
-            "version": "v2.0.2",
+            "version": "v2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/config-command.git",
-                "reference": "21daa36c3960676ef58ab4e4db35106134ddcb79"
+                "reference": "79f9ae8a95405fc55f3ae239b4d3dfcdbd814217"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/config-command/zipball/21daa36c3960676ef58ab4e4db35106134ddcb79",
-                "reference": "21daa36c3960676ef58ab4e4db35106134ddcb79",
+                "url": "https://api.github.com/repos/wp-cli/config-command/zipball/79f9ae8a95405fc55f3ae239b4d3dfcdbd814217",
+                "reference": "79f9ae8a95405fc55f3ae239b4d3dfcdbd814217",
                 "shasum": ""
             },
             "require": {
@@ -2999,7 +2961,7 @@
             },
             "require-dev": {
                 "wp-cli/db-command": "^1.3 || ^2",
-                "wp-cli/wp-cli-tests": "^2.0.7"
+                "wp-cli/wp-cli-tests": "^2.1"
             },
             "type": "wp-cli-package",
             "extra": {
@@ -3046,7 +3008,7 @@
             ],
             "description": "Generates and reads the wp-config.php file.",
             "homepage": "https://github.com/wp-cli/config-command",
-            "time": "2018-12-12T13:09:35+00:00"
+            "time": "2019-04-22T13:20:03+00:00"
         },
         {
             "name": "wp-cli/core-command",
@@ -3393,23 +3355,23 @@
         },
         {
             "name": "wp-cli/eval-command",
-            "version": "v2.0.3",
+            "version": "v2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/eval-command.git",
-                "reference": "fc440912f9e89e1075082020594c5b301df025e5"
+                "reference": "47a4f1a910b6d88f090d776a80d893cf19ca2047"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/eval-command/zipball/fc440912f9e89e1075082020594c5b301df025e5",
-                "reference": "fc440912f9e89e1075082020594c5b301df025e5",
+                "url": "https://api.github.com/repos/wp-cli/eval-command/zipball/47a4f1a910b6d88f090d776a80d893cf19ca2047",
+                "reference": "47a4f1a910b6d88f090d776a80d893cf19ca2047",
                 "shasum": ""
             },
             "require": {
                 "wp-cli/wp-cli": "^2"
             },
             "require-dev": {
-                "wp-cli/wp-cli-tests": "^2.0.7"
+                "wp-cli/wp-cli-tests": "^2.1"
             },
             "type": "wp-cli-package",
             "extra": {
@@ -3443,7 +3405,7 @@
             ],
             "description": "Executes arbitrary PHP code or files.",
             "homepage": "https://github.com/wp-cli/eval-command",
-            "time": "2019-04-10T12:14:19+00:00"
+            "time": "2019-04-20T18:22:05+00:00"
         },
         {
             "name": "wp-cli/extension-command",
@@ -3595,16 +3557,16 @@
         },
         {
             "name": "wp-cli/wp-cli-tests",
-            "version": "v2.0.13",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli-tests.git",
-                "reference": "53232fac382df0655180d2adafacd764fe3f30f8"
+                "reference": "83b636fc7cb69ff257e025d1c855c190143a45db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli-tests/zipball/53232fac382df0655180d2adafacd764fe3f30f8",
-                "reference": "53232fac382df0655180d2adafacd764fe3f30f8",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli-tests/zipball/83b636fc7cb69ff257e025d1c855c190143a45db",
+                "reference": "83b636fc7cb69ff257e025d1c855c190143a45db",
                 "shasum": ""
             },
             "require": {
@@ -3613,17 +3575,17 @@
                 "jakub-onderka/php-console-highlighter": "^0.3.2",
                 "jakub-onderka/php-parallel-lint": "^1.0",
                 "php": ">=5.4",
-                "phpcompatibility/phpcompatibility-wp": "^1",
+                "phpcompatibility/php-compatibility": "^9",
                 "phpunit/phpunit": ">=4.8 <7",
                 "roave/security-advisories": "dev-master",
                 "wp-cli/config-command": "^1 || ^2",
                 "wp-cli/core-command": "^1 || ^2",
                 "wp-cli/eval-command": "^1 || ^2",
-                "wp-coding-standards/wpcs": "^1"
+                "wp-cli/wp-cli": "^2",
+                "wp-coding-standards/wpcs": "^2.1"
             },
             "require-dev": {
-                "wp-cli/regenerate-readme": "^2",
-                "wp-cli/wp-cli": "^2"
+                "wp-cli/regenerate-readme": "^2"
             },
             "bin": [
                 "bin/install-package-tests",
@@ -3633,7 +3595,7 @@
                 "bin/run-php-unit-tests",
                 "bin/run-phpcs-tests"
             ],
-            "type": "library",
+            "type": "phpcodesniffer-standard",
             "extra": {
                 "readme": {
                     "sections": [
@@ -3657,7 +3619,7 @@
                 "cli",
                 "wordpress"
             ],
-            "time": "2018-12-04T16:06:40+00:00"
+            "time": "2019-04-20T16:55:30+00:00"
         },
         {
             "name": "wp-cli/wp-config-transformer",
@@ -3702,27 +3664,29 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "1.2.1",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c"
+                "reference": "8c7a2e7682de9ef5955251874b639deda51ef470"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
-                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/8c7a2e7682de9ef5955251874b639deda51ef470",
+                "reference": "8c7a2e7682de9ef5955251874b639deda51ef470",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
             },
             "require-dev": {
-                "phpcompatibility/php-compatibility": "^9.0"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -3741,7 +3705,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-12-18T09:43:51+00:00"
+            "time": "2019-04-08T10:53:57+00:00"
         }
     ],
     "aliases": [],

--- a/php/WP_CLI/Bootstrap/BootstrapState.php
+++ b/php/WP_CLI/Bootstrap/BootstrapState.php
@@ -8,6 +8,10 @@ namespace WP_CLI\Bootstrap;
  * Represents the state that is passed from one bootstrap step to the next.
  *
  * @package WP_CLI\Bootstrap
+ *
+ * Maintain BC: Changing the method names in this class breaks autoload interactions between Phar
+ * & framework/commands you use outside of Phar (like when running the Phar WP inside of a command folder).
+ * @phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
  */
 class BootstrapState {
 
@@ -34,7 +38,6 @@ class BootstrapState {
 	 *
 	 * @return mixed
 	 */
-	// @codingStandardsIgnoreLine
 	public function getValue( $key, $fallback = null ) {
 		return array_key_exists( $key, $this->state )
 			? $this->state[ $key ]
@@ -49,7 +52,6 @@ class BootstrapState {
 	 *
 	 * @return void
 	 */
-	// @codingStandardsIgnoreLine
 	public function setValue( $key, $value ) {
 		$this->state[ $key ] = $value;
 	}

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -331,12 +331,14 @@ class Subcommand extends CompositeCommand {
 				if ( isset( $spec_args['options'] ) ) {
 					if ( ! empty( $spec['repeating'] ) ) {
 						do {
+							// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict -- This is a loose comparison by design.
 							if ( isset( $args[ $i ] ) && ! in_array( $args[ $i ], $spec_args['options'] ) ) {
 								\WP_CLI::error( 'Invalid value specified for positional arg.' );
 							}
 							$i++;
 						} while ( isset( $args[ $i ] ) );
 					} else {
+						// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict -- This is a loose comparison by design.
 						if ( isset( $args[ $i ] ) && ! in_array( $args[ $i ], $spec_args['options'] ) ) {
 							\WP_CLI::error( 'Invalid value specified for positional arg.' );
 						}
@@ -351,6 +353,7 @@ class Subcommand extends CompositeCommand {
 					}
 				}
 				if ( isset( $assoc_args[ $spec['name'] ] ) && isset( $spec_args['options'] ) ) {
+					// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict -- This is a loose comparison by design.
 					if ( ! in_array( $assoc_args[ $spec['name'] ], $spec_args['options'] ) ) {
 						$errors['fatal'][ $spec['name'] ] = "Invalid value specified for '{$spec['name']}'";
 					}

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -320,7 +320,7 @@ class FileCache {
 				return false;
 			}
 
-			if ( ! @mkdir( $dir, 0777, true ) ) { // @codingStandardsIgnoreLine
+			if ( ! @mkdir( $dir, 0777, true ) ) {
 				$error = error_get_last();
 				\WP_CLI::warning( sprintf( "Failed to create directory '%s': %s.", $dir, $error['message'] ) );
 				return false;

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -157,7 +157,7 @@ class Formatter {
 
 				if ( 'json' === $this->args['format'] ) {
 					if ( defined( 'JSON_PARTIAL_OUTPUT_ON_ERROR' ) ) {
-						// @codingStandardsIgnoreLine
+						// phpcs:ignore PHPCompatibility.Constants.NewConstants.json_partial_output_on_errorFound
 						echo json_encode( $out, JSON_PARTIAL_OUTPUT_ON_ERROR );
 					} else {
 						echo json_encode( $out );

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -239,6 +239,7 @@ class Runner {
 	 */
 	private static function set_wp_root( $path ) {
 		if ( ! defined( 'ABSPATH' ) ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Declaring a WP native constant.
 			define( 'ABSPATH', Utils\normalize_path( Utils\trailingslashit( $path ) ) );
 		} elseif ( ! is_null( $path ) ) {
 			WP_CLI::error_multi_line(
@@ -1075,6 +1076,8 @@ class Runner {
 			);
 		}
 
+		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Declaring WP native constants.
+
 		if ( $this->cmd_starts_with( array( 'core', 'is-installed' ) )
 			|| $this->cmd_starts_with( array( 'core', 'update-db' ) ) ) {
 			define( 'WP_INSTALLING', true );
@@ -1112,6 +1115,7 @@ class Runner {
 		if ( $this->cmd_starts_with( array( 'cron', 'event', 'run' ) ) ) {
 			define( 'DOING_CRON', true );
 		}
+		// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 
 		$this->load_wordpress();
 
@@ -1161,6 +1165,7 @@ class Runner {
 
 			// phpcs:ignore PHPCompatibility.Variables.ForbiddenGlobalVariableVariable.NonBareVariableFound
 			global ${$key};
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 			${$key} = $var;
 		}
 
@@ -1197,6 +1202,7 @@ class Runner {
 		}
 
 		// Fix memory limit. See http://core.trac.wordpress.org/ticket/14889
+		// phpcs:ignore WordPress.PHP.IniSet.memory_limit_Blacklisted -- This is perfectly fine for CLI usage.
 		ini_set( 'memory_limit', -1 );
 
 		// Load all the admin APIs, for convenience
@@ -1227,6 +1233,7 @@ class Runner {
 			$url_parts['path'] = '/';
 		}
 
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intentional override.
 		$current_site = (object) array(
 			'id'            => 1,
 			'blog_id'       => 1,
@@ -1236,6 +1243,10 @@ class Runner {
 			'site_name'     => 'Fake Site',
 		);
 
+		// Bug in WPCS {@link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/1693}
+		// which will be fixed in WPCS 2.1.1/2.2.0. Once the bug fix is in, this comment can be removed.
+		// However, it then need to be replaced with the GlobalVariableOverride ignore as used above.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 		$current_blog = (object) array(
 			'blog_id'  => 1,
 			'site_id'  => 1,
@@ -1747,6 +1758,6 @@ class Runner {
 			// Don't enable E_DEPRECATED as old versions of WP use PHP 4 style constructors and the mysql extension.
 			error_reporting( E_ALL & ~E_DEPRECATED );
 		}
-		ini_set( 'display_errors', 'stderr' );
+		ini_set( 'display_errors', 'stderr' ); // phpcs:ignore WordPress.PHP.IniSet.display_errors_Blacklisted
 	}
 }

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1160,7 +1160,8 @@ class Runner {
 			if ( array_key_exists( $key, $wp_cli_original_defined_vars ) || 'wp_cli_original_defined_vars' === $key ) {
 				continue;
 			}
-			// @codingStandardsIgnoreLine
+
+			// phpcs:ignore PHPCompatibility.Variables.ForbiddenGlobalVariableVariable.NonBareVariableFound
 			global ${$key};
 			${$key} = $var;
 		}

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -181,7 +181,7 @@ class Runner {
 		$wp_path_src = $matches[1] . $matches[2];
 		$wp_path_src = Utils\replace_path_consts( $wp_path_src, $index_path );
 
-		$wp_path = eval( "return $wp_path_src;" ); // phpcs:ignore Squiz.PHP.Eval.Discouraged -- @codingStandardsIgnoreLine
+		$wp_path = eval( "return $wp_path_src;" ); // phpcs:ignore Squiz.PHP.Eval.Discouraged
 
 		if ( ! Utils\is_path_absolute( $wp_path ) ) {
 			$wp_path = dirname( $index_path ) . "/$wp_path";
@@ -851,7 +851,6 @@ class Runner {
 
 		$minimum_version = '3.7';
 
-		// @codingStandardsIgnoreStart
 		if ( version_compare( $wp_version, $minimum_version, '<' ) ) {
 			WP_CLI::error(
 				"WP-CLI needs WordPress $minimum_version or later to work properly. " .
@@ -859,7 +858,6 @@ class Runner {
 				'Try running `wp core download --force`.'
 			);
 		}
-		// @codingStandardsIgnoreEnd
 	}
 
 	public function init_config() {
@@ -1154,7 +1152,7 @@ class Runner {
 		// Load wp-config.php code, in the global scope
 		$wp_cli_original_defined_vars = get_defined_vars();
 
-		eval( $this->get_wp_config_code() ); // phpcs:ignore Squiz.PHP.Eval.Discouraged -- @codingStandardsIgnoreLine
+		eval( $this->get_wp_config_code() ); // phpcs:ignore Squiz.PHP.Eval.Discouraged
 
 		foreach ( get_defined_vars() as $key => $var ) {
 			if ( array_key_exists( $key, $wp_cli_original_defined_vars ) || 'wp_cli_original_defined_vars' === $key ) {

--- a/php/WP_CLI/UpgraderSkin.php
+++ b/php/WP_CLI/UpgraderSkin.php
@@ -44,6 +44,8 @@ class UpgraderSkin extends WP_Upgrader_Skin {
 		}
 
 		if ( strpos( $string, '%' ) !== false ) {
+			// Only looking at the arguments from the second one onwards, so this is "safe".
+			// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.Changed
 			$args = func_get_args();
 			$args = array_splice( $args, 1 );
 			if ( ! empty( $args ) ) {

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1358,7 +1358,7 @@ class WP_CLI {
 	}
 
 	// back-compat
-	// @codingStandardsIgnoreLine
+	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Deprecated method.
 	public static function addCommand( $name, $class ) {
 		trigger_error(
 			sprintf(

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -327,7 +327,9 @@ class WP_CLI {
 		if ( function_exists( 'add_filter' ) ) {
 			add_filter( $tag, $function_to_add, $priority, $accepted_args );
 		} else {
-			$idx                                    = self::wp_hook_build_unique_id( $tag, $function_to_add, $priority );
+			$idx = self::wp_hook_build_unique_id( $tag, $function_to_add, $priority );
+
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- This is intentional & the purpose of this function.
 			$wp_filter[ $tag ][ $priority ][ $idx ] = array(
 				'function'      => $function_to_add,
 				'accepted_args' => $accepted_args,

--- a/php/commands/src/Help_Command.php
+++ b/php/commands/src/Help_Command.php
@@ -124,6 +124,7 @@ class Help_Command extends WP_CLI_Command {
 		if ( 'more' === $pager && defined( 'PHP_WINDOWS_VERSION_MAJOR' ) && PHP_WINDOWS_VERSION_MAJOR < 10 && function_exists( 'sapi_windows_cp_set' ) ) {
 			// Note will also apply to Windows 8 (see http://msdn.microsoft.com/en-us/library/windows/desktop/ms724832.aspx) but probably harmless anyway.
 			$cp = getenv( 'WP_CLI_WINDOWS_CODE_PAGE' ) ?: 1252; // Code page 1252 is the most used so probably the most compat.
+			// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions -- Wrapped in function_exists() call.
 			sapi_windows_cp_set( $cp ); // `sapi_windows_cp_set()` introduced PHP 7.1.
 		}
 

--- a/php/compat.php
+++ b/php/compat.php
@@ -8,8 +8,9 @@
  *
  * @copyright Copyright (c) Ben Ramsey (http://benramsey.com)
  * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @phpcs:disable -- Code from external source. Left as-is for easier compare.
  */
-// @codingStandardsIgnoreStart
 if (!function_exists('array_column')) {
     /**
      * Returns the values from a single column of the input array, identified by
@@ -114,4 +115,4 @@ if (!function_exists('array_column')) {
     }
 
 }
-// @codingStandardsIgnoreEnd
+// phpcs:enable

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -338,7 +338,9 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 		if ( empty( $tables_sql ) ) {
 			$tables_sql = 'SHOW TABLES';
 		}
-		$tables = $wpdb->get_col( $tables_sql, 0 ); // WPCS: unprepared SQL OK.
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is safe, see above.
+		$tables = $wpdb->get_col( $tables_sql, 0 );
 
 	} elseif ( get_flag_value( $assoc_args, 'all-tables-with-prefix' ) ) {
 		if ( empty( $tables_sql ) ) {
@@ -346,7 +348,9 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 		} else {
 			$tables_sql .= sprintf( " AND %s LIKE '%s'", esc_sql_ident( 'Tables_in_' . $wpdb->dbname ), esc_like( $wpdb->get_blog_prefix() ) . '%' );
 		}
-		$tables = $wpdb->get_col( $tables_sql, 0 ); // WPCS: unprepared SQL OK.
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared, see above.
+		$tables = $wpdb->get_col( $tables_sql, 0 );
 
 	} else {
 		$scope = get_flag_value( $assoc_args, 'scope', 'all' );
@@ -377,7 +381,8 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 
 		if ( get_flag_value( $assoc_args, 'base-tables-only' ) || get_flag_value( $assoc_args, 'views-only' ) ) {
 			// Apply Views restriction args if needed.
-			$views_query_tables = $wpdb->get_col( $tables_sql, 0 ); // WPCS: unprepared SQL OK.
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared, see above.
+			$views_query_tables = $wpdb->get_col( $tables_sql, 0 );
 			$tables             = array_intersect( $tables, $views_query_tables );
 		}
 	}

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -34,6 +34,7 @@ function wp_not_installed() {
 	}
 }
 
+// phpcs:disable WordPress.PHP.IniSet -- Intentional & correct usage.
 function wp_debug_mode() {
 	if ( \WP_CLI::get_config( 'debug' ) ) {
 		if ( ! defined( 'WP_DEBUG' ) ) {
@@ -67,6 +68,7 @@ function wp_debug_mode() {
 	// XDebug already sends errors to STDERR.
 	ini_set( 'display_errors', function_exists( 'xdebug_debug_zval' ) ? false : 'STDERR' );
 }
+// phpcs:enable
 
 function replace_wp_die_handler() {
 	\remove_filter( 'wp_die_handler', '_default_wp_die_handler' );

--- a/php/utils.php
+++ b/php/utils.php
@@ -458,9 +458,8 @@ function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
 	}
 
 	if ( isset( $assoc_args['host'] ) ) {
-		//@codingStandardsIgnoreStart
+		// phpcs:ignore WordPress.DB.RestrictedFunctions.mysql_mysql_host_to_cli_args -- Misidentified as PHP native MySQL function.
 		$assoc_args = array_merge( $assoc_args, mysql_host_to_cli_args( $assoc_args['host'] ) );
-		//@codingStandardsIgnoreEnd
 	}
 
 	$pass = $assoc_args['pass'];
@@ -1032,8 +1031,7 @@ function basename( $path, $suffix = '' ) {
  *
  * @return bool
  */
-// @codingStandardsIgnoreLine
-function isPiped() {
+function isPiped() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid -- Renaming would break BC.
 	$shell_pipe = getenv( 'SHELL_PIPE' );
 
 	if ( false !== $shell_pipe ) {

--- a/php/utils.php
+++ b/php/utils.php
@@ -1384,16 +1384,13 @@ function get_php_binary() {
 
 	// Available since PHP 5.4.
 	if ( defined( 'PHP_BINARY' ) ) {
-		// @codingStandardsIgnoreLine
 		return PHP_BINARY;
 	}
 
-	// @codingStandardsIgnoreLine
 	if ( @is_executable( PHP_BINDIR . '/php' ) ) {
 		return PHP_BINDIR . '/php';
 	}
 
-	// @codingStandardsIgnoreLine
 	if ( is_windows() && @is_executable( PHP_BINDIR . '/php.exe' ) ) {
 		return PHP_BINDIR . '/php.exe';
 	}

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -1,6 +1,11 @@
 <?php
 /**
  * A modified version of wp-settings.php, tailored for CLI use.
+ *
+ * @phpcs:disable WordPress.WP.GlobalVariablesOverride -- Setting the globals is the point of this file.
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- These are WP native constants which are needed.
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- All hook calls in this file are to WP native hooks.
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Ensuring native WP variables are available.
  */
 
 use WP_CLI\Utils;
@@ -41,10 +46,13 @@ wp_initial_constants();
 wp_check_php_mysql_versions();
 
 // Disable magic quotes at runtime. Magic quotes are added using wpdb later in wp-settings.php.
+// phpcs:disable PHPCompatibility.IniDirectives.RemovedIniDirectives,WordPress.PHP.IniSet.Risky
 ini_set( 'magic_quotes_runtime', 0 );
 ini_set( 'magic_quotes_sybase', 0 );
+// phpc:enable PHPCompatibility.IniDirectives.RemovedIniDirectives,WordPress.PHP.IniSet
 
 // WordPress calculates offsets from UTC.
+// phpcs:ignore WordPress.WP.TimezoneChange.timezone_change_date_default_timezone_set
 date_default_timezone_set( 'UTC' );
 
 // Turn register_globals off.
@@ -401,6 +409,7 @@ require_once ABSPATH . WPINC . '/locale.php';
 $GLOBALS['wp_locale'] = new WP_Locale();
 
 // Load the functions for the active theme, for both parent and child theme if applicable.
+// phpcs:disable WordPress.WP.DiscouragedConstants.STYLESHEETPATHUsageFound,WordPress.WP.DiscouragedConstants.TEMPLATEPATHUsageFound
 global $pagenow;
 if ( ! defined( 'WP_INSTALLING' ) || 'wp-activate.php' === $pagenow ) {
 	if ( TEMPLATEPATH !== STYLESHEETPATH && file_exists( STYLESHEETPATH . '/functions.php' ) ) {
@@ -410,6 +419,7 @@ if ( ! defined( 'WP_INSTALLING' ) || 'wp-activate.php' === $pagenow ) {
 		include TEMPLATEPATH . '/functions.php';
 	}
 }
+// phpcs:enable WordPress.WP.DiscouragedConstants
 
 do_action( 'after_setup_theme' );
 

--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -130,9 +130,7 @@ if ( ! empty( $wpdb->error ) ) {
 }
 
 // Set the database table prefix and the format specifiers for database table columns.
-// @codingStandardsIgnoreStart
 $GLOBALS['table_prefix'] = $table_prefix;
-// @codingStandardsIgnoreEnd
 wp_set_wpdb_vars();
 
 // Start the WordPress object cache, or an external object cache if the drop-in is present.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,60 +2,114 @@
 <ruleset name="WP-CLI">
 	<description>Custom ruleset for WP-CLI</description>
 
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	#############################################################################
+	-->
 
-	<!-- What to scan -->
+	<!-- What to scan. -->
 	<file>.</file>
-	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
-	<exclude-pattern>*/.git/*</exclude-pattern>
-	<exclude-pattern>*/ci/*</exclude-pattern>
-	<exclude-pattern>*/features/*</exclude-pattern>
-	<exclude-pattern>*/packages/*</exclude-pattern>
-	<exclude-pattern>*/tests/*</exclude-pattern>
-	<exclude-pattern>*/utils/*</exclude-pattern>
-	<exclude-pattern>*/vendor/*</exclude-pattern>
 
-	<!-- How to scan -->
-	<arg value="sp"/> <!-- Show sniff and progress -->
-	<arg name="colors"/> <!-- Show results with colors -->
-	<arg name="extensions" value="php"/> <!-- Limit to PHP files -->
+	<!-- Ignoring select files/folders.
+		 https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+	<exclude-pattern>*/tests/data/*</exclude-pattern>
 
-	<!-- Rules: Check PHP version compatibility - see
-		https://github.com/PHPCompatibility/PHPCompatibilityWP -->
-	<rule ref="PHPCompatibilityWP">
-		<!-- Polyfill package is used so array_column() is available for PHP 5.4- -->
-		<exclude name="PHPCompatibility.PHP.NewFunctions.array_columnFound"/>
-		<!-- Both magic quotes directives set in wp-settings-cli.php to provide consistent starting point. -->
-		<exclude name="PHPCompatibility.PHP.DeprecatedIniDirectives.magic_quotes_runtimeDeprecatedRemoved"/>
-		<exclude name="PHPCompatibility.PHP.DeprecatedIniDirectives.magic_quotes_sybaseDeprecatedRemoved"/>
+	<!-- Show progress. -->
+	<arg value="p"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+	<!--
+	#############################################################################
+	USE THE WP_CLI_CS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="WP_CLI_CS">
+		<!-- The `while` control structure is the only one where assignments in conditions are mostly valid. -->
+		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
+
+		<!-- This is a bug in PHPCS. A fix for which has been pulled already and is expected to be
+			 merged in PHPCS 3.5.0. Once this repos upgrades to that version, this exclusion
+			 should be removed. -->
+		<exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter"/>
 	</rule>
 
-	<!-- For help in understanding this testVersion:
-		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<!--
+	#############################################################################
+	PROJECT SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+	<!-- For help understanding the `testVersion` configuration setting:
+		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
 	<config name="testVersion" value="5.4-"/>
 
-	<!-- Ignore php_uname mode issue, we're conditionally providing a callback -->
-	<rule ref="PHPCompatibility.PHP.NewFunctionParameters.php_uname_modeFound">
-		<exclude-pattern>*/php/commands/src/CLI_Command.php</exclude-pattern>
-	</rule>
-
-	<!-- Rules: WordPress Coding Standards - see
-		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
-	<rule ref="WordPress-Core">
-		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found" />
-		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar" />
-		<exclude name="WordPress.NamingConventions.ValidVariableName.MemberNotSnakeCase" />
-		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" />
-	</rule>
-
-	<!-- For help in understanding these custom sniff properties:
-		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<rule ref="WordPress.Files.FileName">
+	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 The default prefixes `WP_CLI` (for namespaces and classes) and `wpcli` (for variables) are inherited
+		 from the ruleset. This adds one additional allowed prefix specifically for hooks (though
+		 not automatically limited to them).
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
-			<property name="strict_class_file_names" value="false"/>
+			<property name="prefixes" type="array" extend="true">
+				<element value="cli_"/><!-- Hooks. -->
+			</property>
 		</properties>
-		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 	</rule>
+
+	<!-- Whitelist the Utils\mysql_host_to_cli_args() method.
+		 See: https://github.com/phpcompatibility/phpcompatibility#phpcompatibility-specific-options -->
+	<rule ref="PHPCompatibility.Extensions.RemovedExtensions">
+		<properties>
+			<property name="functionWhitelist" type="array">
+				<element value="mysql_host_to_cli_args"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Allow for back-compat conversion comments to be explained in logical shorthand.
+		 See: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties#squizphpcommentedoutcode -->
+	<rule ref="Squiz.PHP.CommentedOutCode">
+		<properties>
+			<property name="maxPercentage" value="45"/>
+		</properties>
+	</rule>
+
+	<!--
+	#############################################################################
+	SELECTIVE EXCLUSIONS
+	#############################################################################
+	-->
+
+	<!-- Exclude existing classes from the prefix rule as it would break BC to prefix them now. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
+		<exclude-pattern>*/php/commands/src/CLI_(Cache_)?Command\.php$</exclude-pattern>
+		<exclude-pattern>*/php/commands/src/Help_Command\.php$</exclude-pattern>
+		<exclude-pattern>*/utils/contrib-list\.php$</exclude-pattern>
+	</rule>
+
+	<!-- These are all to do with file-system related tests. Just ignore them. -->
+	<rule ref="WordPress.WP.CapitalPDangit">
+		<exclude-pattern>*/tests/test-(extractor|utils)\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Allow for select data providers for tests to use single-line associative arrays. -->
+	<rule ref="WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound">
+		<exclude-pattern>*/tests/test-(process|utils)\.php$</exclude-pattern>
+	</rule>
+
+	<!-- This is a procedural stand-alone file that is never loaded in a WordPress context,
+		 so this file does not have to comply with WP naming conventions. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<exclude-pattern>*/utils/get-package-require-from-composer\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/tests/phpunit6-compat.php
+++ b/tests/phpunit6-compat.php
@@ -1,5 +1,6 @@
 <?php
 // From core "tests/phpunit/includes/phpunit6-compat.php" without `getTickets()` (see https://core.trac.wordpress.org/ticket/39822).
+// phpcs:disable Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma
 
 if ( class_exists( 'PHPUnit\Runner\Version' ) && version_compare( PHPUnit\Runner\Version::id(), '6.0', '>=' ) ) {
 

--- a/tests/test-bundled-commands.php
+++ b/tests/test-bundled-commands.php
@@ -1,9 +1,12 @@
 <?php
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Ignoring test doubles.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Ignoring test doubles.
 
 use WP_CLI\Utils;
 use WP_CLI\Dispatcher\CompositeCommand;
 
 // Mock class to test whether `CLI_Command` will be found.
+// phpcs:ignore Generic.Classes.DuplicateClassName -- Intentional for test purposes.
 class CLI_Command extends CompositeCommand {
 
 	public function __construct() { }

--- a/tests/test-logging.php
+++ b/tests/test-logging.php
@@ -1,4 +1,6 @@
 <?php
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Ignoring test doubles.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Ignoring test doubles.
 
 class MockRegularLogger extends WP_CLI\Loggers\Regular {
 


### PR DESCRIPTION
This basically updates the PHPCS ruleset to use the new `WP_CLI_CS` standard and adds a number of whitelist comments and exclusions.

As annotated in issue #5166, there is currently only one issue still remaining to be fixed:
```
FILE: php\utils-wp.php
------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------
 111 | WARNING | strip_tags() is discouraged. Use the more comprehensive
     |         | wp_strip_all_tags() instead.
     |         | (WordPress.WP.AlternativeFunctions.strip_tags_strip_tags)
------------------------------------------------------------------------------------------
```

Please see the individual commits for more detail.

N.B.: In contrast to some of my other PRs, the commits in this PR should probably not be squashed.

Fixes #5166 

Relates to https://github.com/wp-cli/wp-cli/issues/5179

## Commit summary

### Composer: use wp-cli-tests ^2.1

... as that version contains the new WPCliCS PHPCS standard.

Includes updating the `composer.lock` file with `composer update wp-cli/wp-cli-tests --with-all-dependencies` which resulted in the following updates:
```
  - Removing phpcompatibility/phpcompatibility-wp (1.0.0)
  - Updating wp-coding-standards/wpcs (1.2.1 => 2.1.0)
  - Updating wp-cli/eval-command (v2.0.3 => v2.0.4)
  - Updating wp-cli/config-command (v2.0.2 => v2.0.3)
  - Updating phpcompatibility/php-compatibility (8.2.0 => 9.1.1)
  - Removing wp-cli/wp-cli-tests (v2.0.13)
  - Installing wp-cli/wp-cli-tests (v2.1.1)
  - Updating roave/security-advisories (dev-master 9c6c45a => dev-master 1b329f4)
```

### .gitignore: ignore correct phpcs/phpunit config files

* Remove refs which shouldn't be in this file.
    - The `phpunit.xml.dist` file shouldn't be ignored.
    - The two directory entries look like personal ones which shouldn't have gotten into the `.gitignore` file in the first place, but should have been put into someone's personal `.git/info/exclude` file.
* Add files which allow devs to overwrite config files for PHPUnit and PHPCS
    - The `.dist` files should be committed. However, for their personal use, devs can overrule those files with versions without `.dist`.
        Those personal versions should never be committed.

As a side-note: for PHPCS, having a personal version while still using the original `.dist` file is made very easy, as you can just import the `.dist` file as a starting point, like so:
```xml
<?xml version="1.0"?>
<ruleset name="WP-CLI">
    <rule ref="./phpcs.xml.dist"/>
</ruleset>
```

### PHPCS: update the ruleset/defer to WPCliCS

The file is completely documented in-line.

### PHPCS: replace some old-style whitelist comments with new-style

### PHPCS: replace some WPCS whitelist comments with PHPCS whitelist comments

The WPCS native whitelist comments have been deprecated in WPCS 2.0 and will be removed in 3.0, in favour of the PHPCS native selective ignore comments which were introduced in PHPCS 3.2.

### PHPCS: remove some redundant old-style ignore comments

### PHPCS: whitelist some code for select sniffs 

Depends on #5199