### PR TITLE
Remove bug-provoking test for a bug in WPDB that was fixed

### DIFF
--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -272,6 +272,7 @@ Feature: Bootstrap WP-CLI
     And a PHP built-in web server to serve 'WordPress'
     Then the HTTP status code should be 200
 
+  @require-php-5.6
   Scenario: Composer stack with both WordPress and wp-cli as dependencies and a custom vendor directory
     Given a WP installation with Composer and a custom vendor directory 'vendor-custom'
     And a dependency on current wp-cli

--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -253,6 +253,7 @@ Feature: Bootstrap WP-CLI
       Success: WP-Override-Eval
       """
 
+  @require-php-5.6
   Scenario: Composer stack with both WordPress and wp-cli as dependencies (command line)
     Given a WP installation with Composer
     And a dependency on current wp-cli
@@ -264,7 +265,7 @@ Feature: Bootstrap WP-CLI
       WP CLI Site with both WordPress and wp-cli as Composer dependencies
       """
 
-  @require-php-5.4
+  @require-php-5.6
   Scenario: Composer stack with both WordPress and wp-cli as dependencies (web)
     Given a WP installation with Composer
     And a dependency on current wp-cli

--- a/features/help.feature
+++ b/features/help.feature
@@ -94,6 +94,7 @@ Feature: Get help about WP-CLI commands
       """
     And STDERR should be empty
 
+  @require-php-5.6
   Scenario: Help when WordPress is downloaded but not installed
     Given an empty directory
 

--- a/features/help.feature
+++ b/features/help.feature
@@ -153,20 +153,6 @@ Feature: Get help about WP-CLI commands
       """
     And STDOUT should be empty
 
-    # Bug: if `WP_DEBUG` (or `WP_DEBUG_DISPLAY') is defined falsey than a db error won't be trapped.
-    Given a define-wp-debug-false.php file:
-      """
-      <?php define( 'WP_DEBUG', false );
-      """
-
-    When I try `wp help core --require=define-wp-debug-false.php`
-    Then the return code should be 1
-    And STDERR should be:
-      """
-      Error: Can’t select database. We were able to connect to the database server (which means your username and password is okay) but not able to select the `wp_cli_test` database.
-      """
-    And STDOUT should be empty
-
   Scenario: Help for nonexistent commands
     Given a WP installation
 


### PR DESCRIPTION
If I read the code and the test correctly, this is just testing for a bug that was now fixed with release 5.2 of WP Core.


<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->