### PR TITLE
Speed up vagrant scheme calls by caching vagrant ssh-config

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -279,14 +279,14 @@ Feature: Global flags
     When I try `WP_CLI_STRICT_ARGS_MODE=1 wp --debug --ssh=/ --version`
     Then STDERR should contain:
       """
-      Running SSH command: ssh -q '' -T 'WP_CLI_STRICT_ARGS_MODE=1 wp
+      Running SSH command: ssh -q -T '' 'WP_CLI_STRICT_ARGS_MODE=1 wp
       """
 
   Scenario: SSH flag should support changing directories
     When I try `wp --debug --ssh=wordpress:/my/path --version`
     Then STDERR should contain:
       """
-      Running SSH command: ssh -q 'wordpress' -T 'cd '\''/my/path'\''; wp
+      Running SSH command: ssh -q -T 'wordpress' 'cd '\''/my/path'\''; wp
       """
 
   Scenario: SSH flag should support Docker

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -566,8 +566,8 @@ class Runner {
 
 			$command_args = [
 				$bits['port'] ? '-p ' . (int) $bits['port'] . ' ' : '',
-				$is_tty ? '-t' : '-T',
 				$bits['key'] ? sprintf( '-i %s', $bits['key'] ) : '',
+				$is_tty ? '-t' : '-T',
 			];
 
 			$escaped_command = sprintf(

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -566,14 +566,14 @@ class Runner {
 
 			$command_args = [
 				$bits['port'] ? '-p ' . (int) $bits['port'] . ' ' : '',
-				$bits['key'] ? sprintf( '-i "%s"', $bits['key'] ) : '',
+				$bits['key'] ? sprintf( '-i %s', $bits['key'] ) : '',
+				$is_tty ? '-t' : '-T',
 			];
 
 			$escaped_command = sprintf(
 				$command,
 				implode( ' ', array_filter( $command_args ) ),
 				escapeshellarg( $bits['host'] ),
-				$is_tty ? '-t' : '-T',
 				escapeshellarg( $wp_command )
 			);
 		}

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -487,7 +487,7 @@ class Runner {
 		$escaped_command = '';
 
 		// Set default values.
-		foreach ( array( 'scheme', 'user', 'host', 'port', 'path' ) as $bit ) {
+		foreach ( array( 'scheme', 'user', 'host', 'port', 'path', 'key' ) as $bit ) {
 			if ( ! isset( $bits[ $bit ] ) ) {
 				$bits[ $bit ] = null;
 			}
@@ -523,28 +523,57 @@ class Runner {
 
 		// Vagrant ssh-config.
 		if ( 'vagrant' === $bits['scheme'] ) {
-			$command = 'vagrant ssh -c %s %s';
+			$cache     = WP_CLI::get_cache();
+			$cache_key = 'vagrant:' . $this->project_config_path;
+			if ( $cache->has( $cache_key ) ) {
+				$cached = $cache->read( $cache_key );
+				$values = json_decode( $cached, true );
+			} else {
+				$ssh_config = shell_exec( 'vagrant ssh-config 2>/dev/null' );
+				if ( preg_match_all( '#\s*(?<NAME>[a-zA-Z]+)\s(?<VALUE>.+)\s*#', $ssh_config, $matches ) ) {
+					$values = array_combine( $matches['NAME'], $matches['VALUE'] );
+					$cache->write( $cache_key, json_encode( $values ) );
+				}
+			}
 
-			$escaped_command = sprintf(
-				$command,
-				escapeshellarg( $wp_command ),
-				escapeshellarg( $bits['host'] )
-			);
+			if ( empty( $bits['host'] ) || $bits['host'] === $values['Host'] ) {
+				$bits['scheme'] = 'ssh';
+				$bits['host']   = $values['HostName'];
+				$bits['port']   = $values['Port'];
+				$bits['user']   = $values['User'];
+				$bits['key']    = $values['IdentityFile'];
+			}
+
+			// If we could not resolve the bits still, fallback to just `vagrant ssh`
+			if ( 'vagrant' === $bits['scheme'] ) {
+				$command = 'vagrant ssh -c %s %s';
+
+				$escaped_command = sprintf(
+					$command,
+					escapeshellarg( $wp_command ),
+					escapeshellarg( $bits['host'] )
+				);
+			}
 		}
 
 		// Default scheme is SSH.
 		if ( 'ssh' === $bits['scheme'] || null === $bits['scheme'] ) {
-			$command = 'ssh -q %s%s %s %s';
+			$command = 'ssh -q %s %s %s';
 
 			if ( $bits['user'] ) {
 				$bits['host'] = $bits['user'] . '@' . $bits['host'];
 			}
 
+			$command_args = [
+				$bits['port'] ? '-p ' . (int) $bits['port'] . ' ' : '',
+				$is_tty ? '-t' : '-T',
+				$bits['key'] ? sprintf( '-i %s', $bits['key'] ) : '',
+			];
+
 			$escaped_command = sprintf(
 				$command,
-				$bits['port'] ? '-p ' . (int) $bits['port'] . ' ' : '',
+				implode( ' ', array_filter( $command_args ) ),
 				escapeshellarg( $bits['host'] ),
-				$is_tty ? '-t' : '-T',
 				escapeshellarg( $wp_command )
 			);
 		}

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -566,14 +566,14 @@ class Runner {
 
 			$command_args = [
 				$bits['port'] ? '-p ' . (int) $bits['port'] . ' ' : '',
-				$bits['key'] ? sprintf( '-i %s', $bits['key'] ) : '',
-				$is_tty ? '-t' : '-T',
+				$bits['key'] ? sprintf( '-i "%s"', $bits['key'] ) : '',
 			];
 
 			$escaped_command = sprintf(
 				$command,
 				implode( ' ', array_filter( $command_args ) ),
 				escapeshellarg( $bits['host'] ),
+				$is_tty ? '-t' : '-T',
 				escapeshellarg( $wp_command )
 			);
 		}

--- a/php/utils.php
+++ b/php/utils.php
@@ -915,11 +915,8 @@ function parse_ssh_url( $url, $component = -1 ) {
 	// Find the hostname from `vagrant ssh-config` automatically.
 	if ( preg_match( '/^vagrant:?/', $url ) ) {
 		if ( 'vagrant' === $bits['host'] && empty( $bits['scheme'] ) ) {
-			$ssh_config = shell_exec( 'vagrant ssh-config 2>/dev/null' );
-			if ( preg_match( '/Host\s(.+)/', $ssh_config, $matches ) ) {
-				$bits['scheme'] = 'vagrant';
-				$bits['host']   = $matches[1];
-			}
+			$bits['scheme'] = 'vagrant';
+			$bits['host']   = '';
 		}
 	}
 

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -219,13 +219,14 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		// vagrant scheme
 		$testcase = 'vagrant:/var/www/html';
 		$expected = array(
-			'host' => 'vagrant',
-			'path' => '/var/www/html',
+			'scheme' => 'vagrant',
+			'host'   => '',
+			'path'   => '/var/www/html',
 		);
 		$this->assertEquals( $expected, Utils\parse_ssh_url( $testcase ) );
-		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
+		$this->assertEquals( 'vagrant', Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_USER ) );
-		$this->assertEquals( 'vagrant', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
+		$this->assertEquals( '', Utils\parse_ssh_url( $testcase, PHP_URL_HOST ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( '/var/www/html', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 


### PR DESCRIPTION
Hello!

This improves handling for `vagrant` scheme by caching the output of `vagrant ssh-config`, and using values within to convert the call to use the standard `ssh` scheme.

This helps speed up sample requests up to 3 seconds ( ie: sometimes **700%** ) in all calls.

Before:
```
time wp --ssh=vagrant:default cli version                                                                                  WP-CLI 2.1.0
Connection to 127.0.0.1 closed.
        3.23 real         2.26 user         0.43 sys

time wp --ssh=vagrant:default option get siteurl                                                                          
https:///wordpress
Connection to 127.0.0.1 closed.
        4.14 real         2.27 user         0.44 sys

```

After:
```
time wp --ssh=vagrant:default cli version                                                                                  WP-CLI 2.1.0
        0.54 real         0.28 user         0.04 sys

time wp --ssh=vagrant:default option get siteurl                                                                          
https:///wordpress
        1.34 real         0.27 user         0.03 sys
```

Also fixed handling of `vagrant` connection URL so it behaves more consistently with the rest of connection types.

_Fun irrelevant realization I couldn't resist to share: Shaving a minute a day off a developer's time, multiplied by 22 days a month, equals 22 minutes, multiplied by 30 developers a company, equals 11 hours a month, which is more than a billable day for agencies! And that doesn't even include the cost of interruptions!_