### PR TITLE
Improve "Adding deferred command..." debug output (Closes: #4893)

### DIFF
--- a/php/WP_CLI/Bootstrap/RegisterDeferredCommands.php
+++ b/php/WP_CLI/Bootstrap/RegisterDeferredCommands.php
@@ -42,11 +42,29 @@ final class RegisterDeferredCommands implements BootstrapStep {
 		$deferred_additions = \WP_CLI::get_deferred_additions();
 
 		foreach ( $deferred_additions as $name => $addition ) {
+			$addition_data = array();
+			foreach ( $addition as $addition_key => $addition_value ) {
+				// Describe the callable as a string instead of directly printing it
+				// for better debug info
+				if ( 'callable' === $addition_key ) {
+					$addition_value = \WP_CLI\Utils\describe_callable( $addition_value );
+
+				} elseif ( is_array( $addition_value ) ) {
+					$addition_value = json_encode( $addition_value );
+				}
+
+				$addition_data[] = sprintf(
+					'%s: %s',
+					$addition_key,
+					$addition_value
+				);
+			}
+
 			\WP_CLI::debug(
 				sprintf(
-					'Adding deferred command: %s => %s',
+					'Adding deferred command: %s (%s)',
 					$name,
-					json_encode( $addition )
+					implode( ', ', $addition_data )
 				),
 				'bootstrap'
 			);


### PR DESCRIPTION
This PR addresses https://github.com/wp-cli/wp-cli/issues/4893 to print the output of deferred additions in a prettier format.

Before:
```
Debug (bootstrap): Adding deferred command: premise-authnet cancel-subscription => {"parent":"premise-authnet","callable":[{},"cancel_subscription"],"args":{"is_deferred":true}} (0.828s)
```

After:
```
Debug (bootstrap): Adding deferred command:  premise-authnet cancel-subscription (parent: premise-authnet, callable: Array::cancel_subscription(), args: {"is_deferred":true}) (0.828s)
```