### PR TITLE
PHP 7.4 Compatibility: Update `implode()` calls.

### DIFF
--- a/php/WP_CLI/DocParser.php
+++ b/php/WP_CLI/DocParser.php
@@ -72,7 +72,7 @@ class DocParser {
 
 			$lines[] = $line;
 		}
-		$longdesc = trim( implode( $lines, "\n" ) );
+		$longdesc = trim( implode( "\n", $lines ) );
 
 		return $longdesc;
 	}

--- a/php/commands/src/Help_Command.php
+++ b/php/commands/src/Help_Command.php
@@ -104,7 +104,7 @@ class Help_Command extends WP_CLI_Command {
 		foreach ( $lines as &$line ) {
 			$line = $whitespace . $line;
 		}
-		return implode( $lines, "\n" );
+		return implode( "\n", $lines );
 	}
 
 	private static function pass_through_pager( $out ) {


### PR DESCRIPTION
PHP 7.4 deprecates the `implode( array $pieces, string $glue )` function
signature.

Switch to `implode( string $glue, array $pieces )`.

https://wiki.php.net/rfc/deprecations_php_7_4#implode_parameter_order_mix

This resolves some deprecation notices under PHP 7.4. E.g.:

> Deprecated: implode(): Passing glue string after array is deprecated. Swap the parameters in …wp-cli/php/WP_CLI/DocParser.php on line 75