### PR TITLE
Add PHP-version-specific traits to extend the upgrader skin feedback method

### DIFF
--- a/php/WP_CLI/Compat/FeedbackMethodTrait.php
+++ b/php/WP_CLI/Compat/FeedbackMethodTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WP_CLI\Compat;
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound,Generic.Classes.DuplicateClassName.Found
+
+if ( PHP_VERSION_ID >= 50600 ) {
+	require_once __DIR__ . '/Min_PHP_5_6/FeedbackMethodTrait.php';
+
+	trait FeedbackMethodTrait {
+
+		use Min_PHP_5_6\FeedbackMethodTrait;
+	}
+
+	return;
+}
+
+require_once __DIR__ . '/Min_PHP_5_4/FeedbackMethodTrait.php';
+
+trait FeedbackMethodTrait {
+
+	use Min_PHP_5_4\FeedbackMethodTrait;
+}

--- a/php/WP_CLI/Compat/Min_PHP_5_4/FeedbackMethodTrait.php
+++ b/php/WP_CLI/Compat/Min_PHP_5_4/FeedbackMethodTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace WP_CLI\Compat\Min_PHP_5_4;
+
+trait FeedbackMethodTrait {
+
+	/**
+	 * @param string $string
+	 */
+	public function feedback( $string ) {
+		$args = func_get_args();
+		$args = array_splice( $args, 1 );
+
+		$this->process_feedback( $string, $args );
+	}
+}

--- a/php/WP_CLI/Compat/Min_PHP_5_6/FeedbackMethodTrait.php
+++ b/php/WP_CLI/Compat/Min_PHP_5_6/FeedbackMethodTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace WP_CLI\Compat\Min_PHP_5_6;
+
+trait FeedbackMethodTrait {
+
+	/**
+	 * @param string $string
+	 * @param mixed  ...$args Optional text replacements.
+	 *
+	 */
+	public function feedback( $string, ...$args ) { // phpcs:ignore PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ellipsisFound
+		$args_array = [];
+		foreach ( $args as $arg ) {
+			$args_array[] = $args;
+		}
+
+		$this->process_feedback( $string, $args );
+	}
+}

--- a/php/WP_CLI/UpgraderSkin.php
+++ b/php/WP_CLI/UpgraderSkin.php
@@ -13,6 +13,8 @@ use WP_Upgrader_Skin;
  */
 class UpgraderSkin extends WP_Upgrader_Skin {
 
+	use WP_CLI\Compat\FeedbackMethodTrait;
+
 	public $api;
 
 	public function header() {}
@@ -33,7 +35,13 @@ class UpgraderSkin extends WP_Upgrader_Skin {
 		WP_CLI::warning( $error );
 	}
 
-	public function feedback( $string ) {
+	/**
+	 * Process the feedback collected through the compat indirection.
+	 *
+	 * @param string $string String to use as feedback message.
+	 * @param array $args Array of additional arguments to process.
+	 */
+	public function process_feedback( $string, $args ) {
 
 		if ( 'parent_theme_prepare_install' === $string ) {
 			WP_CLI::get_http_cache_manager()->whitelist_package( $this->api->download_link, 'theme', $this->api->slug, $this->api->version );
@@ -43,14 +51,8 @@ class UpgraderSkin extends WP_Upgrader_Skin {
 			$string = $this->upgrader->strings[ $string ];
 		}
 
-		if ( strpos( $string, '%' ) !== false ) {
-			// Only looking at the arguments from the second one onwards, so this is "safe".
-			// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.Changed
-			$args = func_get_args();
-			$args = array_splice( $args, 1 );
-			if ( ! empty( $args ) ) {
-				$string = vsprintf( $string, $args );
-			}
+		if ( ! empty( $args ) && strpos( $string, '%' ) !== false ) {
+			$string = vsprintf( $string, $args );
 		}
 
 		if ( empty( $string ) ) {


### PR DESCRIPTION
WordPress trunk is doing refactorings to use more PHP 5.6+ features since the minimum PHP version was raised.

As long as we stick to PHP 5.4, we need to provide compatibility mechanisms to deal with this.

This PR adds a `Compat` namespace to systematically provide compatibility code that can be easily retraced and removed later again.

This should solve the build failure found at https://travis-ci.org/wp-cli/wp-cli/jobs/586215547#L736

Related #5282