### PR TITLE
Remove checks for `wp_blog_versions` table in Behat tests

### DIFF
--- a/features/utils-wp.feature
+++ b/features/utils-wp.feature
@@ -373,10 +373,7 @@ Feature: Utilities that depend on WordPress code
 
     # With no subsite.
     When I run `wp --require=table_names.php get_table_names`
-    Then STDOUT should contain:
-      """
-      wp_blog_versions
-      """
+    # Leave out wp_blog_versions as it was never used and is removed with WP 5.3+.
     # Leave out wp_blogmeta for old WP compat.
     Then STDOUT should contain:
       """
@@ -428,10 +425,7 @@ Feature: Utilities that depend on WordPress code
       """
 
     When I run `wp --require=table_names.php get_table_names --scope=global`
-    Then STDOUT should contain:
-      """
-      wp_blog_versions
-      """
+    # Leave out wp_blog_versions as it was never used and is removed with WP 5.3+.
     # Leave out wp_blogmeta for old WP compat.
     Then STDOUT should contain:
       """
@@ -446,10 +440,7 @@ Feature: Utilities that depend on WordPress code
     And save STDOUT as {GLOBAL_STDOUT}
 
     When I run `wp --require=table_names.php get_table_names --scope=ms_global`
-    Then STDOUT should contain:
-      """
-      wp_blog_versions
-      """
+    # Leave out wp_blog_versions as it was never used and is removed with WP 5.3+.
     # Leave out wp_blogmeta for old WP compat.
     Then STDOUT should contain:
       """
@@ -538,8 +529,8 @@ Feature: Utilities that depend on WordPress code
       """
       wp_2_terms
       wp_2_xx_posts
-      wp_blog_versions
       """
+    # Leave out wp_blog_versions as it was never used and is removed with WP 5.3+.
     # Leave out wp_blogmeta for old WP compat.
     Then STDOUT should contain:
       """
@@ -759,16 +750,13 @@ Feature: Utilities that depend on WordPress code
 
     Given an enable_sitecategories.php file:
       """
-      <?php 
+      <?php
       WP_CLI::add_hook( 'after_wp_load', function () {
         add_filter( 'global_terms_enabled', '__return_true' );
       } );
       """
     When I run `wp --require=table_names.php --require=enable_sitecategories.php get_table_names`
-    Then STDOUT should contain:
-      """
-      wp_blog_versions
-      """
+    # Leave out wp_blog_versions as it was never used and is removed with WP 5.3+.
     # Leave out wp_blogmeta for old WP compat.
     Then STDOUT should contain:
       """


### PR DESCRIPTION
The table `wp_blog_versions` was never used and will be removed in WordPress 5.3.

This PR removes all checks for that table from the Behat tests so they don't break with the next Core version.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->