### PR TITLE
Converted alias, cli, cache, and help commands help summaries to use third-person singular verbs.

### DIFF
--- a/php/commands/src/CLI_Alias_Command.php
+++ b/php/commands/src/CLI_Alias_Command.php
@@ -46,7 +46,7 @@ use Mustangostang\Spyc;
 class CLI_Alias_Command extends WP_CLI_Command {
 
 	/**
-	 * List available WP-CLI aliases.
+	 * Lists available WP-CLI aliases.
 	 *
 	 * ## OPTIONS
 	 *

--- a/php/commands/src/CLI_Cache_Command.php
+++ b/php/commands/src/CLI_Cache_Command.php
@@ -18,7 +18,7 @@
 class CLI_Cache_Command extends WP_CLI_Command {
 
 	/**
-	 * Clear the internal cache.
+	 * Clears the internal cache.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -40,7 +40,7 @@ class CLI_Cache_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Prune the internal cache.
+	 * Prunes the internal cache.
 	 *
 	 * Removes all cached files except for the newest version of each one.
 	 *

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -4,7 +4,7 @@ use Composer\Semver\Comparator;
 use WP_CLI\Utils;
 
 /**
- * Review current WP-CLI info, check for updates, or see defined aliases.
+ * Reviews current WP-CLI info, checks for updates, or views defined aliases.
  *
  * ## EXAMPLES
  *
@@ -50,7 +50,7 @@ class CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Print WP-CLI version.
+	 * Prints WP-CLI version.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -63,7 +63,7 @@ class CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Print various details about the WP-CLI environment.
+	 * Prints various details about the WP-CLI environment.
 	 *
 	 * Helpful for diagnostic purposes, this command shares:
 	 *
@@ -162,7 +162,7 @@ class CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Check to see if there is a newer version of WP-CLI available.
+	 * Checks to see if there is a newer version of WP-CLI available.
 	 *
 	 * Queries the Github releases API. Returns available versions if there are
 	 * updates available, or success message if using the latest release.
@@ -228,7 +228,7 @@ class CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Update WP-CLI to the latest release.
+	 * Updates WP-CLI to the latest release.
 	 *
 	 * Default behavior is to check the releases API for the newest stable
 	 * version, and prompt if one is available.
@@ -460,7 +460,7 @@ class CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Dump the list of global parameters, as JSON or in var_export format.
+	 * Dumps the list of global parameters, as JSON or in var_export format.
 	 *
 	 * ## OPTIONS
 	 *
@@ -518,7 +518,7 @@ class CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Dump the list of installed commands, as JSON.
+	 * Dumps the list of installed commands, as JSON.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -533,7 +533,7 @@ class CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Generate tab completion strings.
+	 * Generates tab completion strings.
 	 *
 	 * ## OPTIONS
 	 *

--- a/php/commands/src/Help_Command.php
+++ b/php/commands/src/Help_Command.php
@@ -6,7 +6,7 @@ use WP_CLI\Dispatcher;
 class Help_Command extends WP_CLI_Command {
 
 	/**
-	 * Get help on WP-CLI, or on a specific command.
+	 * Gets help on WP-CLI, or on a specific command.
 	 *
 	 * ## OPTIONS
 	 *


### PR DESCRIPTION
This pull request converts the help docs for the alias, cli, cache, and help commands to use third-person singular verbs.

This is in response to issue #4542 
