### PR TITLE
Load template functions in Runner

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1247,6 +1247,9 @@ class Runner {
 		// Load all the admin APIs, for convenience
 		require ABSPATH . 'wp-admin/includes/admin.php';
 
+		// Load template functions, as they might be needed by starter content.
+		require ABSPATH . 'wp-includes/link-template.php';
+
 		add_filter(
 			'filesystem_method',
 			function() {

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1247,8 +1247,11 @@ class Runner {
 		// Load all the admin APIs, for convenience
 		require ABSPATH . 'wp-admin/includes/admin.php';
 
-		// Load template functions, as they might be needed by starter content.
-		require ABSPATH . 'wp-includes/link-template.php';
+		// Maybe load template functions, as they might be needed by starter
+		// content.
+		if ( ! function_exists( 'get_theme_file_uri' ) ) {
+			require_once ABSPATH . 'wp-includes/link-template.php';
+		}
 
 		add_filter(
 			'filesystem_method',


### PR DESCRIPTION
The template functions might be needed in the starter content functionality for some themes.

This hopefully fixes the broken tests with TwentyTwenty starter content: https://travis-ci.org/wp-cli/automated-tests/jobs/605262104#L1103-L1109