### PR TITLE
Polyfill `is_customize_preview()`

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1252,6 +1252,14 @@ class Runner {
 			require_once ABSPATH . 'wp-includes/link-template.php';
 		}
 
+		// Polyfill is_customize_preview(), as it is needed by TwentyTwenty to
+		// check for starter content.
+		if ( ! function_exists( 'is_customize_preview' ) ) {
+			function is_customize_preview() {
+				return false;
+			}
+		}
+
 		add_filter(
 			'filesystem_method',
 			function() {


### PR DESCRIPTION
This is needed to keep the TwentyTwenty theme (and maybe others) to fatal when downgrading Core, as it is the recommended way of checking whether to initialize starter content, an action that can only be done directly in `functions.php`.