### PR TITLE
Escape path before `wp-config.php` string replacement

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -613,9 +613,12 @@ function is_windows() {
  * @return string Adapted PHP code.
  */
 function replace_path_consts( $source, $path ) {
+	// Solve issue with Windows allowing single quotes in account names.
+	$file = addslashes( $path );
+
 	$replacements = array(
-		'__FILE__' => "'$path'",
-		'__DIR__'  => "'" . dirname( $path ) . "'",
+		'__FILE__' => "'$file'",
+		'__DIR__'  => "'" . dirname( $file ) . "'",
 	);
 
 	$old = array_keys( $replacements );

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -803,4 +803,11 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			[ 'http://example.com', PHP_URL_HOST, true, 'example.com' ],
 		];
 	}
+
+	public function testReplacePathConstsAddSlashes() {
+		$expected = "define( 'ABSPATH', dirname( 'C:\\\\Users\\\\test\'s\\\\site' ) . '/' );";
+		$source   = "define( 'ABSPATH', dirname( __FILE__ ) . '/' );";
+		$actual   = Utils\replace_path_consts( $source, "C:\Users\\test's\site" );
+		$this->assertSame( $expected, $actual );
+	}
 }


### PR DESCRIPTION
Due to the way wp-cli modifies the wp-config.php when loading, and the fact that Windows allows single quotes in account names, a user with a single quote in their account name will get fatal errors when the wp-config.php const replacement ends up like this: 

```PHP
/* That's all, stop editing! Happy publishing. */
/** Absolute path to the WordPress directory. */
if ( ! defined( 'ABSPATH' ) ) {
        define( 'ABSPATH', 'C:\Users\local's\Local Sites\dickens-llc\app\public' . '/' );
}
```

Notice the single quote in the username breaking the quoted path. 

More details on this issue can be found here: https://github.com/wp-cli/wp-cli/issues/1631

This patch resolved the problem for us, and we're currently using it in a forked build. Would love to see it included in core! 