### PR TITLE
Allow for array of strings in ComposerIO

### DIFF
--- a/php/WP_CLI/ComposerIO.php
+++ b/php/WP_CLI/ComposerIO.php
@@ -31,10 +31,12 @@ class ComposerIO extends NullIO {
 		self::output_clean_message( $messages );
 	}
 
-	private static function output_clean_message( $message ) {
-		$message = preg_replace( '#<(https?)([^>]+)>#', '$1$2', $message );
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
-		WP_CLI::log( strip_tags( trim( $message ) ) );
+	private static function output_clean_message( $messages ) {
+		$messages = (array) preg_replace( '#<(https?)([^>]+)>#', '$1$2', $messages );
+		foreach ( $messages as $message ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
+			WP_CLI::log( strip_tags( trim( $message ) ) );
+		}
 	}
 
 }


### PR DESCRIPTION
Composer seems to sometimes output arrays of strings through the ComposerIO interface, and this breaks our trim logic that only expects single strings.

This PR turns the logic into a loop over an array of strings instead to avoid throwing a notice.

See https://travis-ci.org/github/wp-cli/automated-tests/jobs/666134609#L2615