### PR TITLE
Add exception for invalid argument in error-to-string method

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -982,6 +982,10 @@ class WP_CLI {
 	 * @return string
 	 */
 	public static function error_to_string( $errors ) {
+		if ( ! is_string( $errors ) && ! $errors instanceof \WP_Error ) {
+			throw new InvalidArgumentException( sprintf( 'Unsupported argument type passed to WP_CLI::error_to_string(): %s', gettype( $errors ) ) );
+		}
+
 		if ( is_string( $errors ) ) {
 			return $errors;
 		}


### PR DESCRIPTION
Fix: #5356 

Add `InvalidArgumentException` for `WP_CLI::error_to_string()`