### PR TITLE
Let `Utils\run_mysql_command()` return data

### DIFF
--- a/features/utils.feature
+++ b/features/utils.feature
@@ -48,7 +48,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
 
   Scenario: Check that `Utils\run_mysql_command()` can return data and errors if requested
-    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;", false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
+    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr, $exit_code ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;", false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
     Then STDOUT should not contain:
       """
       Database
@@ -67,7 +67,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDERR should be empty
 
-    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query", null, false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
+    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr, $exit_code ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query", null, false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
     Then STDOUT should be empty
     And STDERR should not contain:
       """

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -44,14 +44,22 @@ Feature: Utilities that do NOT depend on WordPress code
     Then STDOUT should be empty
     And STDERR should contain:
       """
-      YOU HAVE AN ERROR IN YOUR SQL SYNTAX
+      You have an error in your SQL syntax
       """
 
   Scenario: Check that `Utils\run_mysql_command()` can return data and errors if requested
-    When I run `wp --skip-wordpress eval '$stdout = ""; WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;", $stdout ); echo str_to_upper( $stdout );'`
-    Then STDOUT should contain:
+    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;", false ); fwrite( STDOUT, str_to_upper( $stdout ) ); fwrite( STDERR, str_to_upper( $stderr ) );'`
+    Then STDOUT should not contain:
+      """
+      Database
+      """
+    And STDOUT should contain:
       """
       DATABASE
+      """
+    And STDOUT should not contain:
+      """
+      wp_cli_test
       """
     And STDOUT should contain:
       """
@@ -59,8 +67,12 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDERR should be empty
 
-    When I run `wp --skip-wordpress eval '$stderr = ""; WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query", null, $stderr ); echo str_to_upper( $stderr );'`
+    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query", null, false ); fwrite( STDOUT, str_to_upper( $stdout ) ); fwrite( STDERR, str_to_upper( $stderr ) );'`
     Then STDOUT should be empty
+    And STDERR should not contain:
+      """
+      You have an error in your SQL syntax
+      """
     And STDERR should contain:
       """
       YOU HAVE AN ERROR IN YOUR SQL SYNTAX

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -29,7 +29,7 @@ Feature: Utilities that do NOT depend on WordPress code
       | proc_close |
 
   Scenario: Check that `Utils\run_mysql_command()` uses STDOUT and STDERR by default
-    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/local/bin/mysql --no-defaults", [], "SHOW DATABASES;" );'`
+    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;" );'`
     Then STDOUT should contain:
       """
       Database
@@ -40,7 +40,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDERR should be empty
 
-    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/local/bin/mysql --no-defaults", [], "broken query");'`
+    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query");'`
     Then STDOUT should be empty
     And STDERR should contain:
       """
@@ -48,7 +48,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
 
   Scenario: Check that `Utils\run_mysql_command()` can return data and errors if requested
-    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr ) = WP_CLI\Utils\run_mysql_command( "/usr/local/bin/mysql --no-defaults", [], "SHOW DATABASES;", false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
+    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;", false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
     Then STDOUT should not contain:
       """
       Database
@@ -67,7 +67,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDERR should be empty
 
-    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr ) = WP_CLI\Utils\run_mysql_command( "/usr/local/bin/mysql --no-defaults", [], "broken query", null, false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
+    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query", null, false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
     Then STDOUT should be empty
     And STDERR should not contain:
       """

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -29,7 +29,7 @@ Feature: Utilities that do NOT depend on WordPress code
       | proc_close |
 
   Scenario: Check that `Utils\run_mysql_command()` uses STDOUT and STDERR by default
-    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;" );'`
+    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [ "user" => "wp_cli_test", "pass" => "password1", "host" => "127.0.0.1", "execute" => "SHOW DATABASES;" ] );'`
     Then STDOUT should contain:
       """
       Database
@@ -40,7 +40,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDERR should be empty
 
-    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query");'`
+    When I try `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [ "user" => "wp_cli_test", "pass" => "password1", "host" => "127.0.0.1", "execute" => "broken query" ]);'`
     Then STDOUT should be empty
     And STDERR should contain:
       """
@@ -48,7 +48,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
 
   Scenario: Check that `Utils\run_mysql_command()` can return data and errors if requested
-    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr, $exit_code ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;", false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
+    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr, $exit_code ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [ "user" => "wp_cli_test", "pass" => "password1", "host" => "127.0.0.1", "execute" => "SHOW DATABASES;" ], null, false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
     Then STDOUT should not contain:
       """
       Database
@@ -67,7 +67,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDERR should be empty
 
-    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr, $exit_code ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query", null, false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
+    When I try `wp --skip-wordpress eval 'list( $stdout, $stderr, $exit_code ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [ "user" => "wp_cli_test", "pass" => "password1", "host" => "127.0.0.1", "execute" => "broken query" ], null, false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
     Then STDOUT should be empty
     And STDERR should not contain:
       """

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -29,7 +29,7 @@ Feature: Utilities that do NOT depend on WordPress code
       | proc_close |
 
   Scenario: Check that `Utils\run_mysql_command()` uses STDOUT and STDERR by default
-    When I run `wp eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;" );'`
+    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;" );'`
     Then STDOUT should contain:
       """
       Database
@@ -40,7 +40,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDERR should be empty
 
-    When I run `wp eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query");'`
+    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query");'`
     Then STDOUT should be empty
     And STDERR should contain:
       """
@@ -48,7 +48,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
 
   Scenario: Check that `Utils\run_mysql_command()` can return data and errors if requested
-    When I run `wp eval '$stdout = ""; WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;", $stdout ); echo str_to_upper( $stdout );'`
+    When I run `wp --skip-wordpress eval '$stdout = ""; WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;", $stdout ); echo str_to_upper( $stdout );'`
     Then STDOUT should contain:
       """
       DATABASE
@@ -59,7 +59,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDERR should be empty
 
-    When I run `wp eval '$stderr = ""; WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query", null, $stderr ); echo str_to_upper( $stderr );'`
+    When I run `wp --skip-wordpress eval '$stderr = ""; WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query", null, $stderr ); echo str_to_upper( $stderr );'`
     Then STDOUT should be empty
     And STDERR should contain:
       """

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -36,7 +36,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDOUT should contain:
       """
-      wp_cli_test
+      information_schema
       """
     And STDERR should be empty
 
@@ -59,11 +59,11 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDOUT should not contain:
       """
-      wp_cli_test
+      information_schema
       """
     And STDOUT should contain:
       """
-      WP_CLI_TEST
+      INFORMATION_SCHEMA
       """
     And STDERR should be empty
 

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -29,25 +29,6 @@ Feature: Utilities that do NOT depend on WordPress code
       | proc_close |
 
   Scenario: Check that `Utils\run_mysql_command()` uses STDOUT and STDERR by default
-    When I run `wp db query 'SELECT "column_data" as column_name;'`
-    Then STDOUT should contain:
-      """
-      column_name
-      """
-    And STDOUT should contain:
-      """
-      column_data
-      """
-    And STDERR should be empty
-
-    When I run `wp db query 'broken query'`
-    Then STDOUT should be empty
-    And STDERR should contain:
-      """
-      You have an error in your SQL syntax
-      """
-
-  Scenario: Check that `Utils\run_mysql_command()` can return data and errors if requested
     When I run `wp eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;" );'`
     Then STDOUT should contain:
       """
@@ -59,7 +40,15 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDERR should be empty
 
-    When I run `wp eval '$stdout = ""; WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;", $stdout ); echo str_to_upper( $stdout )'`
+    When I run `wp eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query");'`
+    Then STDOUT should be empty
+    And STDERR should contain:
+      """
+      YOU HAVE AN ERROR IN YOUR SQL SYNTAX
+      """
+
+  Scenario: Check that `Utils\run_mysql_command()` can return data and errors if requested
+    When I run `wp eval '$stdout = ""; WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;", $stdout ); echo str_to_upper( $stdout );'`
     Then STDOUT should contain:
       """
       DATABASE
@@ -70,7 +59,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDERR should be empty
 
-    When I run `wp eval '$stderr = ""; WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query", null, $stderr ); echo str_to_upper( $stderr )'`
+    When I run `wp eval '$stderr = ""; WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query", null, $stderr ); echo str_to_upper( $stderr );'`
     Then STDOUT should be empty
     And STDERR should contain:
       """

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -29,7 +29,7 @@ Feature: Utilities that do NOT depend on WordPress code
       | proc_close |
 
   Scenario: Check that `Utils\run_mysql_command()` uses STDOUT and STDERR by default
-    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;" );'`
+    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/local/bin/mysql --no-defaults", [], "SHOW DATABASES;" );'`
     Then STDOUT should contain:
       """
       Database
@@ -40,7 +40,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDERR should be empty
 
-    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query");'`
+    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/local/bin/mysql --no-defaults", [], "broken query");'`
     Then STDOUT should be empty
     And STDERR should contain:
       """
@@ -48,7 +48,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
 
   Scenario: Check that `Utils\run_mysql_command()` can return data and errors if requested
-    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "SHOW DATABASES;", false ); fwrite( STDOUT, str_to_upper( $stdout ) ); fwrite( STDERR, str_to_upper( $stderr ) );'`
+    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr ) = WP_CLI\Utils\run_mysql_command( "/usr/local/bin/mysql --no-defaults", [], "SHOW DATABASES;", false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
     Then STDOUT should not contain:
       """
       Database
@@ -67,7 +67,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDERR should be empty
 
-    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [], "broken query", null, false ); fwrite( STDOUT, str_to_upper( $stdout ) ); fwrite( STDERR, str_to_upper( $stderr ) );'`
+    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr ) = WP_CLI\Utils\run_mysql_command( "/usr/local/bin/mysql --no-defaults", [], "broken query", null, false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
     Then STDOUT should be empty
     And STDERR should not contain:
       """

--- a/php/utils.php
+++ b/php/utils.php
@@ -474,8 +474,9 @@ function mysql_host_to_cli_args( $raw_host ) {
  * @return array {
  *     Associative array containing STDOUT and STDERR output.
  *
- *     @type string $stdout Output that was sent to STDOUT.
- *     @type string $stderr Output that was sent to STDERR.
+ *     @type string $stdout    Output that was sent to STDOUT.
+ *     @type string $stderr    Output that was sent to STDERR.
+ *     @type int    $exit_code Exit code of the process.
  * }
  */
 function run_mysql_command( $cmd, $assoc_args, $_ = null, $send_to_shell = true ) {
@@ -520,13 +521,13 @@ function run_mysql_command( $cmd, $assoc_args, $_ = null, $send_to_shell = true 
 	if ( $send_to_shell ) {
 		fwrite( STDOUT, $stdout );
 		fwrite( STDERR, $stderr );
+
+		if ( $exit_code ) {
+			exit( $exit_code );
+		}
 	}
 
-	if ( $exit_code ) {
-		exit( $exit_code );
-	}
-
-	return compact( 'stdout', 'stderr' );
+	return compact( 'stdout', 'stderr', 'exit_code' );
 }
 
 /**

--- a/php/utils.php
+++ b/php/utils.php
@@ -482,9 +482,9 @@ function run_mysql_command( $cmd, $assoc_args, $_ = null, $send_to_shell = true 
 	check_proc_available( 'run_mysql_command' );
 
 	$descriptors = [
-		STDIN,
-		[ 'pipe', 'w' ],
-		[ 'pipe', 'w' ],
+		0 => STDIN,
+		1 => [ 'pipe', 'w' ],
+		2 => [ 'pipe', 'w' ],
 	];
 
 	$stdout = '';

--- a/php/utils.php
+++ b/php/utils.php
@@ -495,11 +495,13 @@ function run_mysql_command( $cmd, $assoc_args, $_ = null, $send_to_shell = true 
 		$assoc_args = array_merge( $assoc_args, mysql_host_to_cli_args( $assoc_args['host'] ) );
 	}
 
-	$pass = $assoc_args['pass'];
-	unset( $assoc_args['pass'] );
+	$env = $_ENV;
 
-	$env              = $_ENV;
-	$env['MYSQL_PWD'] = $pass;
+	if ( isset( $assoc_args['pass'] ) ) {
+		$password = $assoc_args['pass'];
+		unset( $assoc_args['pass'] );
+		$env['MYSQL_PWD'] = $password;
+	}
 
 	$final_cmd = force_env_on_nix_systems( $cmd ) . assoc_args_to_str( $assoc_args );
 


### PR DESCRIPTION
Change the `Utils\run_mysql_command()` so that it can also return data & errors when running a query via the `mysql` binary.

Fixes #5383 