### PR TITLE
Throw exception when misusing `error_to_string()`

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1010,6 +1010,13 @@ class WP_CLI {
 		if ( interface_exists( 'Throwable' ) && ( $errors instanceof \Throwable ) || ( $errors instanceof \Exception ) ) {
 			return get_class( $errors ) . ': ' . $errors->getMessage();
 		}
+
+		throw new InvalidArgumentException(
+			sprintf(
+				"Unsupported argument type passed to WP_CLI::error_to_string(): '%s'",
+				gettype( $errors )
+			)
+		);
 	}
 
 	/**

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -979,6 +979,8 @@ class WP_CLI {
 	 * Convert a WP_Error or Exception into a string
 	 *
 	 * @param mixed $errors
+	 * @throws \InvalidArgumentException
+	 *
 	 * @return string
 	 */
 	public static function error_to_string( $errors ) {
@@ -1011,7 +1013,7 @@ class WP_CLI {
 			return get_class( $errors ) . ': ' . $errors->getMessage();
 		}
 
-		throw new InvalidArgumentException(
+		throw new \InvalidArgumentException(
 			sprintf(
 				"Unsupported argument type passed to WP_CLI::error_to_string(): '%s'",
 				gettype( $errors )

--- a/tests/test-wp-cli.php
+++ b/tests/test-wp-cli.php
@@ -8,6 +8,6 @@ class WP_CLI_Test extends PHPUnit_Framework_TestCase {
 
 	public function testErrorToString() {
 		$this->setExpectedException( 'InvalidArgumentException', "Unsupported argument type passed to WP_CLI::error_to_string(): 'boolean'" );
-		WP_CLI::error_to_string( (bool) true );
+		WP_CLI::error_to_string( true );
 	}
 }

--- a/tests/test-wp-cli.php
+++ b/tests/test-wp-cli.php
@@ -5,4 +5,9 @@ class WP_CLI_Test extends PHPUnit_Framework_TestCase {
 	public function testGetPHPBinary() {
 		$this->assertSame( WP_CLI\Utils\get_php_binary(), WP_CLI::get_php_binary() );
 	}
+
+	public function testErrorToString() {
+		$this->setExpectedException( 'InvalidArgumentException', "Unsupported argument type passed to WP_CLI::error_to_string(): 'boolean'" );
+		WP_CLI::error_to_string( (bool) true );
+	}
 }


### PR DESCRIPTION
Fixes #5356