### PR TITLE
Include classmap in order to fix composer 2.0 deprecation notices.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,12 @@
     },
     "autoload": {
         "psr-0": {
-            "WP_CLI": "php"
-        }
+            "WP_CLI//": "php/"
+        },
+        "classmap": [
+            "php/class-wp-cli.php",
+            "php/class-wp-cli-command.php"
+        ]
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Fixes #5365.

Tested with https://github.com/wp-cli/wp-cli-dev and seems to work, all tests seem to pass.