### PR TITLE
Fix `SERVER_PORT` JSON encoding failure

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -1,5 +1,20 @@
 Feature: Global flags
 
+  @require-wp-5.5
+  Scenario: Setting the URL
+    Given a WP installation
+
+    When I run `wp --url=localhost:8001 eval 'echo json_encode( $_SERVER );'`
+    Then STDOUT should be JSON containing:
+      """
+      {
+        "HTTP_HOST": "localhost:8001",
+        "SERVER_NAME": "localhost",
+        "SERVER_PORT": 8001
+      }
+      """
+
+  @less-than-wp-5.5
   Scenario: Setting the URL
     Given a WP installation
 


### PR DESCRIPTION
A Travis failure was introduced somewhere in the WordPress Core 5.5 development cycle where the `$_SERVER` superglobal treats the server port as an actual number, not a string.

This broke one of our Travis tests: https://travis-ci.org/github/wp-cli/automated-tests/jobs/705037602#L1019-L1026

This PR differentiates between WP versions to support both interpretations.