### PR TITLE
Allow user to suppress global parameters info from help display

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -82,7 +82,7 @@ Feature: Get help about WP-CLI commands
       """
       --path
       """
-    And STDOUT should not  contain:
+    And STDOUT should not contain:
       """
       Path to the WordPress files.
       """

--- a/features/help.feature
+++ b/features/help.feature
@@ -53,6 +53,40 @@ Feature: Get help about WP-CLI commands
       """
     And STDERR should be empty
 
+  Scenario: Hide Global parameters when requested
+    Given an empty directory
+
+    When I run `wp help`
+    Then STDOUT should contain:
+      """
+      GLOBAL PARAMETERS
+      """
+
+    And STDOUT should contain:
+      """
+      --path
+      """
+
+    And STDOUT should contain:
+      """
+      Path to the WordPress files.
+      """
+
+    When I run `WP_CLI_SUPPRESS_GLOBAL_PARAMS=true wp help`
+    Then STDOUT should not contain:
+      """
+      GLOBAL PARAMETERS
+      """
+
+    And STDOUT should not contain:
+      """
+      --path
+      """
+    And STDOUT should not  contain:
+      """
+      Path to the WordPress files.
+      """
+
   # Prior to WP 4.3 widgets & others used PHP 4 style constructors and prior to WP 3.9 wpdb used the mysql extension which can all lead (depending on PHP version) to PHP Deprecated notices.
   @require-wp-4.3
   Scenario: Help for internal commands with WP

--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -296,10 +296,14 @@ class CompositeCommand {
 				$synopsis = "--$key" . $details['runtime'];
 			}
 
-			$binding['parameters'][] = array(
-				'synopsis' => $synopsis,
-				'desc'     => $details['desc'],
-			);
+			// Check if global parameters synopsis should be displayed or not.
+			if ( true !== (bool) getenv( 'WP_CLI_SUPPRESS_GLOBAL_PARAMS' ) ) {
+				$binding['parameters'][]   = array(
+					'synopsis' => $synopsis,
+					'desc'     => $details['desc'],
+				);
+				$binding['has_parameters'] = true;
+			}
 		}
 
 		if ( $this->get_subcommands() ) {

--- a/templates/man-params.mustache
+++ b/templates/man-params.mustache
@@ -6,6 +6,7 @@
 
 
 {{/has_subcommands}}
+{{#has_parameters}}
 ## GLOBAL PARAMETERS
 
 {{#parameters}}
@@ -13,6 +14,7 @@
       {{desc}}
 
 {{/parameters}}
+{{/has_parameters}}
 {{#root_command}}
   Run 'wp help <command>' to get more information on a specific command.
 


### PR DESCRIPTION
Fixes https://github.com/wp-cli/ideas/issues/104
