### PR TITLE
WIP: Add logic to differentiate between namespace and command via reflection

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -1521,3 +1521,28 @@ Feature: WP-CLI Commands
     """
     wp custom
     """
+
+  Scenario: Differentiate between namespace and command whenn registering a new command
+    Given an empty directory
+    And a custom-cmd.php file:
+      """
+      <?php
+
+      use WP_CLI\Dispatcher\CommandNamespace;
+
+      class Command_Class1 {}
+      class Command_Class2 extends CommandNamespace {}
+
+      WP_CLI::add_command( 'command example 1', 'Command_Class1' );
+      WP_CLI::add_command( 'command example 2', 'Command_Class2' );
+      """
+
+    When I try `wp --require=custom-cmd.php --debug`
+    Then STDOUT should contain:
+      """
+      Adding command:
+      """
+    Then STDOUT should contain:
+      """
+      Adding namespace:
+      """

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -444,11 +444,14 @@ class WP_CLI {
 			return false;
 		}
 
-		$valid = false;
+		$valid        = false;
+		$is_namespace = false;
+
 		if ( is_callable( $callable ) ) {
 			$valid = true;
 		} elseif ( is_string( $callable ) && class_exists( (string) $callable ) ) {
-			$valid = true;
+			$valid        = true;
+			$is_namespace = ( new ReflectionClass( $callable ) )->isSubclassOf( Dispatcher\CommandNamespace::class );
 		} elseif ( is_object( $callable ) ) {
 			$valid = true;
 		}
@@ -604,7 +607,8 @@ class WP_CLI {
 			$sub_command = trim( str_replace( $parent, '', $name ) );
 			self::debug( "Adding command: {$sub_command} in {$parent} Namespace", 'commands' );
 		} else {
-			self::debug( "Adding command: {$name}", 'commands' );
+			$adding_kind = $is_namespace ? 'namespace' : 'command';
+			self::debug( "Adding {$adding_kind}: {$name}", 'commands' );
 		}
 
 		$command->add_subcommand( $leaf_name, $leaf_command );


### PR DESCRIPTION
Fixes #4937 

This PR adds more informative CLI output in debug mode when registering a namespace.

I added a test, but I'm not sure how to run it or if it passes. Not very familiar with Behat so support here would be welcome.

Thanks!