### PR TITLE
Allow root from environment

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -959,7 +959,7 @@ class Runner {
 	}
 
 	private function check_root() {
-		if ( $this->config['allow-root'] ) {
+		if ( $this->config['allow-root'] || getenv( 'WP_CLI_ALLOW_ROOT' ) ) {
 			return; # they're aware of the risks!
 		}
 		if ( count( $this->arguments ) >= 2 && 'cli' === $this->arguments[0] && in_array( $this->arguments[1], array( 'update', 'info' ), true ) ) {


### PR DESCRIPTION
As already stated in the code __they're aware of the risks!__
Also good point had @iandunn in https://github.com/wp-cli/wp-cli/issues/1838#issuecomment-505592503
Composer (which is used here for running unit and behat test scripts) allows superuser through environment