### PR TITLE
Permit phpdbg usage

### DIFF
--- a/php/boot-fs.php
+++ b/php/boot-fs.php
@@ -2,7 +2,7 @@
 
 // This file needs to parse without error in PHP < 5.3
 
-if ( 'cli' !== PHP_SAPI ) {
+if ( 'cli' !== PHP_SAPI && 'phpdbg' !== PHP_SAPI ) {
 	echo "Only CLI access.\n";
 	die( -1 );
 }


### PR DESCRIPTION
Allow invocation of WP-CLI using `phpdbg` because sometimes you want better eyes on a problem. This would allow usage such as `phpdbg php/boot-fs.php --debug theme update Avada --version=7.1`.
