### PR TITLE
Skip using removed `Operation::getReason()` for Composer v2 compat

### DIFF
--- a/php/WP_CLI/PackageManagerEventSubscriber.php
+++ b/php/WP_CLI/PackageManagerEventSubscriber.php
@@ -29,7 +29,13 @@ class PackageManagerEventSubscriber implements EventSubscriberInterface {
 	public static function post_install( PackageEvent $event ) {
 
 		$operation = $event->getOperation();
-		$reason    = $operation->getReason();
+
+		// getReason() was removed in Composer v2 without replacement.
+		if ( ! method_exists( $operation, 'getReason' ) ) {
+			return;
+		}
+
+		$reason = $operation->getReason();
 		if ( $reason instanceof Rule ) {
 
 			switch ( $reason->getReason() ) {


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
