### PR TITLE
[PHP 8] Add properties argument to __set_state magic method

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -475,7 +475,7 @@ Feature: Get help about WP-CLI commands
         function __sleep() {}
         function __wakeup() {}
         function __toString() {}
-        function __set_state() {}
+        function __set_state( $properties ) {}
         function __clone() {}
         function __debugInfo() {}
       }


### PR DESCRIPTION
On PHP 8 a fatal error is issued if a magic method doesn't match the [expected signature](https://www.php.net/manual/en/language.oop5.magic.php#object.set-state).

```
PHP Fatal error:  Method Test_Magic_Methods::__set_state() must take exactly 1 argument
```