### PR TITLE
Fix registering a command with a class and method name pair on PHP 8.

### DIFF
--- a/php/WP_CLI/Dispatcher/CommandFactory.php
+++ b/php/WP_CLI/Dispatcher/CommandFactory.php
@@ -5,6 +5,7 @@ namespace WP_CLI\Dispatcher;
 use ReflectionClass;
 use ReflectionFunction;
 use ReflectionMethod;
+use function WP_CLI\Utils\is_valid_class_and_method_pair;
 
 /**
  * Creates CompositeCommand or Subcommand instances.
@@ -29,7 +30,7 @@ class CommandFactory {
 			|| ( is_string( $callable ) && function_exists( $callable ) ) ) {
 			$reflection = new ReflectionFunction( $callable );
 			$command    = self::create_subcommand( $parent, $name, $callable, $reflection );
-		} elseif ( is_array( $callable ) && is_callable( $callable ) ) {
+		} elseif ( is_array( $callable ) && ( is_callable( $callable ) || is_valid_class_and_method_pair( $callable ) ) ) {
 			$reflection = new ReflectionClass( $callable[0] );
 			$command    = self::create_subcommand(
 				$parent,

--- a/php/WP_CLI/Dispatcher/CommandFactory.php
+++ b/php/WP_CLI/Dispatcher/CommandFactory.php
@@ -5,7 +5,7 @@ namespace WP_CLI\Dispatcher;
 use ReflectionClass;
 use ReflectionFunction;
 use ReflectionMethod;
-use function WP_CLI\Utils\is_valid_class_and_method_pair;
+use WP_CLI\Utils;
 
 /**
  * Creates CompositeCommand or Subcommand instances.
@@ -30,7 +30,7 @@ class CommandFactory {
 			|| ( is_string( $callable ) && function_exists( $callable ) ) ) {
 			$reflection = new ReflectionFunction( $callable );
 			$command    = self::create_subcommand( $parent, $name, $callable, $reflection );
-		} elseif ( is_array( $callable ) && ( is_callable( $callable ) || is_valid_class_and_method_pair( $callable ) ) ) {
+		} elseif ( is_array( $callable ) && ( is_callable( $callable ) || Utils\is_valid_class_and_method_pair( $callable ) ) ) {
 			$reflection = new ReflectionClass( $callable[0] );
 			$command    = self::create_subcommand(
 				$parent,

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -451,6 +451,8 @@ class WP_CLI {
 			$valid = true;
 		} elseif ( is_object( $callable ) ) {
 			$valid = true;
+		} elseif ( Utils\is_valid_class_and_method_pair( $callable ) ) {
+			$valid = true;
 		}
 		if ( ! $valid ) {
 			if ( is_array( $callable ) ) {

--- a/php/utils.php
+++ b/php/utils.php
@@ -1619,6 +1619,35 @@ function describe_callable( $callable ) {
 }
 
 /**
+ * Checks if the given class and method pair is a valid callable.
+ *
+ * This accommodates changes to `is_callable()` in PHP 8 that mean an array of a
+ * classname and instance method is no longer callable.
+ *
+ * @param array $pair The class and method pair to check.
+ * @return bool
+ */
+function is_valid_class_and_method_pair( $pair ) {
+	if ( ! is_array( $pair ) || 2 !== count( $pair ) ) {
+		return false;
+	}
+
+	if ( ! is_string( $pair[0] ) || ! is_string( $pair[1] ) ) {
+		return false;
+	}
+
+	if ( ! class_exists( $pair[0] ) ) {
+		return false;
+	}
+
+	if ( ! method_exists( $pair[0], $pair[1] ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
  * Pluralizes a noun in a grammatically correct way.
  *
  * @param string   $noun  Noun to be pluralized. Needs to be in singular form.

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -813,7 +813,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 
 	/** @dataProvider dataValidClassAndMethodPair */
 	public function testValidClassAndMethodPair( $pair, $is_valid ) {
-		$this->assertEquals( $pair, Utils\is_valid_class_and_method_pair( $is_valid ) );
+		$this->assertEquals( $is_valid, Utils\is_valid_class_and_method_pair( $pair ) );
 	}
 
 	public function dataValidClassAndMethodPair() {

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -810,4 +810,22 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$actual   = Utils\replace_path_consts( $source, "C:\Users\\test's\site" );
 		$this->assertSame( $expected, $actual );
 	}
+
+	/** @dataProvider dataValidClassAndMethodPair */
+	public function testValidClassAndMethodPair( $pair, $is_valid ) {
+		$this->assertEquals( $pair, Utils\is_valid_class_and_method_pair( $is_valid ) );
+	}
+
+	public function dataValidClassAndMethodPair() {
+		return [
+			[ 'string', false ],
+			[ [], false ],
+			[ [ 'WP_CLI' ], false ],
+			[ [ true, false ], false ],
+			[ [ 'WP_CLI', 'invalid_method' ], false ],
+			[ [ 'Invalid_Class', 'invalid_method' ], false ],
+			[ [ 'WP_CLI', 'add_command' ], true ],
+			[ [ 'Exception', 'getMessage' ], true ],
+		];
+	}
 }


### PR DESCRIPTION
On PHP 8, an array of a class name and instance method name is no longer
considered a callable. This commit adds an additional check to see if
the command is a pair of a class name and method name that exists on that
class before rejecting the command registration.

Fixes #5472.