### PR TITLE
Add magic properties to docblock

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -10,6 +10,21 @@ use WP_CLI\Dispatcher\CompositeCommand;
 /**
  * Performs the execution of a command.
  *
+ * @property-read string $global_config_path
+ * @property-read string $project_config_path
+ * @property-read array  $config
+ * @property-read array  $extra_config
+ * @property-read string $alias
+ * @property-read array  $aliases
+ * @property-read array  $arguments
+ * @property-read array  $assoc_args
+ * @property-read array  $runtime_config
+ * @property-read bool   $colorize
+ * @property-read array  $early_invoke
+ * @property-read string $global_config_path_debug
+ * @property-read string $project_config_path_debug
+ * @property-read array  $required_files
+ *
  * @package WP_CLI
  */
 class Runner {


### PR DESCRIPTION
The `Runner` has a magic `__get()` method that lets consumers retrieve the private properties in a read-only form.

This PR adds a docblock documenting these read-only properties so as to improve static analysis.