### PR TITLE
Fix 5463 `Utils\http_request` verify option

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -763,28 +763,7 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 				throw $ex;
 			}
 
-			// Fallback to the embedded CA file.
-			$cert_path = '/rmccue/requests/library/Requests/Transport/cacert.pem';
-			if ( inside_phar() ) {
-				// cURL can't read Phar archives.
-				$options['verify'] = extract_from_phar(
-					WP_CLI_VENDOR_DIR . $cert_path
-				);
-			} else {
-				foreach ( get_vendor_paths() as $vendor_path ) {
-					if ( file_exists( $vendor_path . $cert_path ) ) {
-						$options['verify'] = $vendor_path . $cert_path;
-						break;
-					}
-				}
-				if ( empty( $options['verify'] ) ) {
-					$error_msg = 'Cannot find SSL certificate.';
-					if ( $halt_on_error ) {
-						WP_CLI::error( $error_msg );
-					}
-					throw new RuntimeException( $error_msg );
-				}
-			}
+			$options['verify'] = get_default_cacert( $halt_on_error );
 
 			return Requests::request( $url, $headers, $data, $method, $options );
 		}

--- a/php/utils.php
+++ b/php/utils.php
@@ -736,7 +736,14 @@ function replace_path_consts( $source, $path ) {
  * @param string $method  HTTP method (GET, POST, DELETE, etc.).
  * @param string $url     URL to make the HTTP request to.
  * @param array  $headers Add specific headers to the request.
- * @param array $options
+ * @param array  $options {
+ *     Optional. An associative array of additional request options.
+ *
+ *     @type bool $halt_on_error Whether or not command execution should be halted on error. Default: true
+ *     @type bool|string $verify A boolean to use enable/disable SSL verification
+ *                               or string absolute path to CA cert to use.
+ *                               Defaults to detected CA cert bundled with the Requests library.
+ * }
  * @return object
  * @throws RuntimeException If the request failed.
  * @throws WP_CLI\ExitException If the request failed and $halt_on_error is true.

--- a/php/utils.php
+++ b/php/utils.php
@@ -813,6 +813,36 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 }
 
 /**
+ * Gets the full path to the default CA cert.
+ *
+ * @param bool $halt_on_error Whether or not command execution should be halted on error. Default: false
+ * @return string Absolute path to the default CA cert.
+ * @throws RuntimeException If unable to locate the cert.
+ * @throws WP_CLI\ExitException If unable to locate the cert and $halt_on_error is true.
+ */
+function get_default_cacert( $halt_on_error = false ) {
+	$cert_path = '/rmccue/requests/library/Requests/Transport/cacert.pem';
+	$error_msg = 'Cannot find SSL certificate.';
+
+	if ( inside_phar() ) {
+		// cURL can't read Phar archives
+		return extract_from_phar( WP_CLI_VENDOR_DIR . $cert_path );
+	}
+
+	foreach ( get_vendor_paths() as $vendor_path ) {
+		if ( file_exists( $vendor_path . $cert_path ) ) {
+			return $vendor_path . $cert_path;
+		}
+	}
+
+	if ( $halt_on_error ) {
+		WP_CLI::error( $error_msg );
+	}
+
+	throw new RuntimeException( $error_msg );
+}
+
+/**
  * Increments a version string using the "x.y.z-pre" format.
  *
  * Can increment the major, minor or patch number by one.

--- a/tests/mock-requests-transport.php
+++ b/tests/mock-requests-transport.php
@@ -1,0 +1,21 @@
+<?php
+
+class Mock_Requests_Transport implements Requests_Transport {
+	public $requests = array();
+
+	public function request( $url, $headers = array(), $data = array(), $options = array() ) {
+		$this->requests[] = compact( 'url', 'headers', 'data', 'options' );
+
+		return 'HTTP/1.1 418' . "\r\n"
+			. 'Content-Type: water/leaf-infused' . "\r\n"
+			. "\r\n\r\n"; // This last line is actually important or the request will error.
+	}
+
+	public function request_multiple( $requests, $options ) {
+		throw new Exception( 'Method not implemented: ' . __METHOD__ );
+	}
+
+	public static function test() {
+		return true;
+	}
+}

--- a/tests/mock-requests-transport.php
+++ b/tests/mock-requests-transport.php
@@ -1,5 +1,6 @@
 <?php
 
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
 class Mock_Requests_Transport implements Requests_Transport {
 	public $requests = array();
 

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -511,7 +511,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 	 * @dataProvider dataHttpRequestVerify
 	 */
 	public function testHttpRequestVerify( $expected, $options ) {
-		$transport_spy = new Mock_Requests_Transport();
+		$transport_spy        = new Mock_Requests_Transport();
 		$options['transport'] = $transport_spy;
 
 		Utils\http_request( 'GET', 'https://wordpress.org', null /*data*/, array() /*headers*/, $options );
@@ -522,22 +522,22 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 
 	public function dataHttpRequestVerify() {
 		return array(
-			'not passed' => array(
+			'not passed'    => array(
 				Utils\get_default_cacert(),
 				array(),
 			),
-			'true' => array(
+			'true'          => array(
 				Utils\get_default_cacert(),
 				array( 'verify' => true ),
 			),
-			'false' => array(
+			'false'         => array(
 				false,
 				array( 'verify' => false ),
 			),
 			'custom cacert' => array(
 				__FILE__,
 				array( 'verify' => __FILE__ ),
-			)
+			),
 		);
 	}
 

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -523,11 +523,11 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 	public function dataHttpRequestVerify() {
 		return array(
 			'not passed'    => array(
-				Utils\get_default_cacert(),
+				true,
 				array(),
 			),
 			'true'          => array(
-				Utils\get_default_cacert(),
+				true,
 				array( 'verify' => true ),
 			),
 			'false'         => array(


### PR DESCRIPTION
This PR fixes #5463 in that it respects the given value of `$options['verify']` rather than overwriting it with the path to the default CA cert.

It does this partly by extracting the default CA cert detection/lookup into a new utility: `get_default_cacert`.

The tests added also include a very simple `Mock_Requests_Transport` class to make testing the `http_request` call much cleaner and simpler, but is only used in the added test. Regarding the way this class is loaded, normally I would expect it to be autoloaded but there didn't seem to be any existing configuration for this yet so I left that out for now for simplicity.