### PR TITLE
Use custom certificate if provided

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -766,7 +766,7 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 			// Fallback to the embedded CA file.
 			$cert_path = '/rmccue/requests/library/Requests/Transport/cacert.pem';
 			if ( inside_phar() ) {
-				// cURL can't read Phar archives
+				// cURL can't read Phar archives.
 				$options['verify'] = extract_from_phar(
 					WP_CLI_VENDOR_DIR . $cert_path
 				);

--- a/php/utils.php
+++ b/php/utils.php
@@ -747,10 +747,10 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 		// Autoloader for the Requests library has not been registered yet.
 		Requests::register_autoloader();
 	}
-	
+
 	$halt_on_error = ! isset( $options['halt_on_error'] ) || (bool) $options['halt_on_error'];
 
-	if ( ! isset($options['verify'] ) ) {
+	if ( ! isset( $options['verify'] ) ) {
 		// 'curl.cainfo' enforces the CA file to use, otherwise fallback to system-wide defaults then use the embedded CA file.
 		$options['verify'] = ini_get( 'curl.cainfo' ) ? ini_get( 'curl.cainfo' ) : true;
 	}

--- a/php/utils.php
+++ b/php/utils.php
@@ -747,6 +747,8 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 		// Autoloader for the Requests library has not been registered yet.
 		Requests::register_autoloader();
 	}
+	
+	$halt_on_error = ! isset( $options['halt_on_error'] ) || (bool) $options['halt_on_error'];
 
 	if ( ! isset($options['verify'])) {
 		// 'curl.cainfo' enforces the CA file to use, otherwise fallback to system-wide defaults then use the embedded CA file.
@@ -763,7 +765,6 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 
 			// Fallback to the embedded CA file.
 			$cert_path     = '/rmccue/requests/library/Requests/Transport/cacert.pem';
-			$halt_on_error = ! isset( $options['halt_on_error'] ) || (bool) $options['halt_on_error'];
 			if ( inside_phar() ) {
 				// cURL can't read Phar archives
 				$options['verify'] = extract_from_phar(

--- a/php/utils.php
+++ b/php/utils.php
@@ -743,36 +743,50 @@ function replace_path_consts( $source, $path ) {
  */
 function http_request( $method, $url, $data = null, $headers = array(), $options = array() ) {
 
-	$cert_path     = '/rmccue/requests/library/Requests/Transport/cacert.pem';
-	$halt_on_error = ! isset( $options['halt_on_error'] ) || (bool) $options['halt_on_error'];
-	if ( inside_phar() ) {
-		// cURL can't read Phar archives
-		$options['verify'] = extract_from_phar(
-			WP_CLI_VENDOR_DIR . $cert_path
-		);
-	} else {
-		foreach ( get_vendor_paths() as $vendor_path ) {
-			if ( file_exists( $vendor_path . $cert_path ) ) {
-				$options['verify'] = $vendor_path . $cert_path;
-				break;
-			}
-		}
-		if ( empty( $options['verify'] ) ) {
-			$error_msg = 'Cannot find SSL certificate.';
-			if ( $halt_on_error ) {
-				WP_CLI::error( $error_msg );
-			}
-			throw new RuntimeException( $error_msg );
-		}
-	}
-
 	if ( ! class_exists( 'Requests_Hooks' ) ) {
 		// Autoloader for the Requests library has not been registered yet.
 		Requests::register_autoloader();
 	}
 
+	if ( ! isset($options['verify'])) {
+		// 'curl.cainfo' enforces the CA file to use, otherwise fallback to system-wide defaults then use the embedded CA file.
+		$options['verify'] = ini_get('curl.cainfo') ? ini_get('curl.cainfo') : True;
+	}
+
 	try {
-		return Requests::request( $url, $headers, $data, $method, $options );
+		try {
+			return Requests::request( $url, $headers, $data, $method, $options );
+		} catch ( Requests_Exception $ex ) {
+			if ( True !== $options['verify'] || 'curlerror' !== $ex->getType() || curl_errno( $ex->getData() ) !== CURLE_SSL_CACERT ) {
+				throw $ex;
+			}
+
+			// Fallback to the embedded CA file.
+			$cert_path     = '/rmccue/requests/library/Requests/Transport/cacert.pem';
+			$halt_on_error = ! isset( $options['halt_on_error'] ) || (bool) $options['halt_on_error'];
+			if ( inside_phar() ) {
+				// cURL can't read Phar archives
+				$options['verify'] = extract_from_phar(
+					WP_CLI_VENDOR_DIR . $cert_path
+				);
+			} else {
+				foreach ( get_vendor_paths() as $vendor_path ) {
+					if ( file_exists( $vendor_path . $cert_path ) ) {
+						$options['verify'] = $vendor_path . $cert_path;
+						break;
+					}
+				}
+				if ( empty( $options['verify'] ) ) {
+					$error_msg = 'Cannot find SSL certificate.';
+					if ( $halt_on_error ) {
+						WP_CLI::error( $error_msg );
+					}
+					throw new RuntimeException( $error_msg );
+				}
+			}
+		
+			return Requests::request( $url, $headers, $data, $method, $options );
+		}
 	} catch ( Requests_Exception $ex ) {
 		// CURLE_SSL_CACERT_BADFILE only defined for PHP >= 7.
 		if ( 'curlerror' !== $ex->getType() || ! in_array( curl_errno( $ex->getData() ), array( CURLE_SSL_CONNECT_ERROR, CURLE_SSL_CERTPROBLEM, 77 /*CURLE_SSL_CACERT_BADFILE*/ ), true ) ) {

--- a/php/utils.php
+++ b/php/utils.php
@@ -750,21 +750,21 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 	
 	$halt_on_error = ! isset( $options['halt_on_error'] ) || (bool) $options['halt_on_error'];
 
-	if ( ! isset($options['verify'])) {
+	if ( ! isset($options['verify'] ) ) {
 		// 'curl.cainfo' enforces the CA file to use, otherwise fallback to system-wide defaults then use the embedded CA file.
-		$options['verify'] = ini_get('curl.cainfo') ? ini_get('curl.cainfo') : True;
+		$options['verify'] = ini_get( 'curl.cainfo' ) ? ini_get( 'curl.cainfo' ) : true;
 	}
 
 	try {
 		try {
 			return Requests::request( $url, $headers, $data, $method, $options );
 		} catch ( Requests_Exception $ex ) {
-			if ( True !== $options['verify'] || 'curlerror' !== $ex->getType() || curl_errno( $ex->getData() ) !== CURLE_SSL_CACERT ) {
+			if ( true !== $options['verify'] || 'curlerror' !== $ex->getType() || curl_errno( $ex->getData() ) !== CURLE_SSL_CACERT ) {
 				throw $ex;
 			}
 
 			// Fallback to the embedded CA file.
-			$cert_path     = '/rmccue/requests/library/Requests/Transport/cacert.pem';
+			$cert_path = '/rmccue/requests/library/Requests/Transport/cacert.pem';
 			if ( inside_phar() ) {
 				// cURL can't read Phar archives
 				$options['verify'] = extract_from_phar(
@@ -785,7 +785,7 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 					throw new RuntimeException( $error_msg );
 				}
 			}
-		
+
 			return Requests::request( $url, $headers, $data, $method, $options );
 		}
 	} catch ( Requests_Exception $ex ) {

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -490,7 +490,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$logger = new \WP_CLI\Loggers\Execution();
 		WP_CLI::set_logger( $logger );
 
-		Utils\http_request( 'GET', 'https://example.com' );
+		Utils\http_request( 'GET', 'https://example.com', null, array(), array( 'verify' => $bad_cacert_path ) );
 
 		// Undo bad CAcert hack before asserting.
 		unlink( $bad_cacert_path );


### PR DESCRIPTION
- PHP setting 'curl.cainfo' enforces the CA file to use,
- Otherwise fallback to system-wide defaults, then use the embedded CA file.

Fixes #5111 