### PR TITLE
Disable automatic retry by default on certificate validation error

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -701,6 +701,10 @@ class WP_CLI {
 	 * @param string $message Message to write to STDOUT.
 	 */
 	public static function log( $message ) {
+		if ( null === self::$logger ) {
+			return;
+		}
+
 		self::$logger->info( $message );
 	}
 
@@ -728,6 +732,10 @@ class WP_CLI {
 	 * @return null
 	 */
 	public static function success( $message ) {
+		if ( null === self::$logger ) {
+			return;
+		}
+
 		self::$logger->success( $message );
 	}
 
@@ -805,6 +813,10 @@ class WP_CLI {
 	 * @return null
 	 */
 	public static function warning( $message ) {
+		if ( null === self::$logger ) {
+			return;
+		}
+
 		self::$logger->warning( self::error_to_string( $message ) );
 	}
 
@@ -832,7 +844,7 @@ class WP_CLI {
 	 * @return null
 	 */
 	public static function error( $message, $exit = true ) {
-		if ( ! isset( self::get_runner()->assoc_args['completions'] ) ) {
+		if ( null !== self::$logger && ! isset( self::get_runner()->assoc_args['completions'] ) ) {
 			self::$logger->error( self::error_to_string( $message ) );
 		}
 
@@ -879,6 +891,10 @@ class WP_CLI {
 	 * @param array $message Multi-line error message to be displayed.
 	 */
 	public static function error_multi_line( $message_lines ) {
+		if ( null === self::$logger ) {
+			return;
+		}
+
 		if ( ! isset( self::get_runner()->assoc_args['completions'] ) && is_array( $message_lines ) ) {
 			self::$logger->error_multi_line( array_map( array( __CLASS__, 'error_to_string' ), $message_lines ) );
 		}

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -4,6 +4,9 @@
 
 namespace WP_CLI\Utils;
 
+use WP_CLI;
+use WP_CLI\UpgraderSkin;
+
 function wp_not_installed() {
 	global $wpdb, $table_prefix;
 	if ( ! is_blog_installed() && ! defined( 'WP_INSTALLING' ) ) {
@@ -20,13 +23,13 @@ function wp_not_installed() {
 		if ( count( $found_prefixes ) ) {
 			$prefix_list   = implode( ', ', $found_prefixes );
 			$install_label = count( $found_prefixes ) > 1 ? 'installations' : 'installation';
-			\WP_CLI::error(
+			WP_CLI::error(
 				"The site you have requested is not installed.\n" .
 				"Your table prefix is '{$table_prefix}'. Found {$install_label} with table prefix: {$prefix_list}.\n" .
 				'Or, run `wp core install` to create database tables.'
 			);
 		} else {
-			\WP_CLI::error(
+			WP_CLI::error(
 				"The site you have requested is not installed.\n" .
 				'Run `wp core install` to create database tables.'
 			);
@@ -36,7 +39,7 @@ function wp_not_installed() {
 
 // phpcs:disable WordPress.PHP.IniSet -- Intentional & correct usage.
 function wp_debug_mode() {
-	if ( \WP_CLI::get_config( 'debug' ) ) {
+	if ( WP_CLI::get_config( 'debug' ) ) {
 		if ( ! defined( 'WP_DEBUG' ) ) {
 			define( 'WP_DEBUG', true );
 		}
@@ -87,7 +90,7 @@ function wp_die_handler( $message ) {
 
 	$message = wp_clean_error_message( $message );
 
-	\WP_CLI::error( $message );
+	WP_CLI::error( $message );
 }
 
 /**
@@ -115,7 +118,7 @@ function wp_clean_error_message( $message ) {
 }
 
 function wp_redirect_handler( $url ) {
-	\WP_CLI::warning( 'Some code is trying to do a URL redirect. Backtrace:' );
+	WP_CLI::warning( 'Some code is trying to do a URL redirect. Backtrace:' );
 
 	ob_start();
 	debug_print_backtrace();
@@ -130,12 +133,12 @@ function maybe_require( $since, $path ) {
 	}
 }
 
-function get_upgrader( $class ) {
+function get_upgrader( $class, $insecure = false ) {
 	if ( ! class_exists( '\WP_Upgrader' ) ) {
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 	}
 
-	return new $class( new \WP_CLI\UpgraderSkin() );
+	return new $class( new UpgraderSkin(), $insecure );
 }
 
 /**
@@ -154,7 +157,7 @@ function get_plugin_name( $basename ) {
 function is_plugin_skipped( $file ) {
 	$name = get_plugin_name( str_replace( WP_PLUGIN_DIR . '/', '', $file ) );
 
-	$skipped_plugins = \WP_CLI::get_runner()->config['skip-plugins'];
+	$skipped_plugins = WP_CLI::get_runner()->config['skip-plugins'];
 	if ( true === $skipped_plugins ) {
 		return true;
 	}
@@ -173,7 +176,7 @@ function get_theme_name( $path ) {
 function is_theme_skipped( $path ) {
 	$name = get_theme_name( $path );
 
-	$skipped_themes = \WP_CLI::get_runner()->config['skip-themes'];
+	$skipped_themes = WP_CLI::get_runner()->config['skip-themes'];
 	if ( true === $skipped_themes ) {
 		return true;
 	}
@@ -328,7 +331,7 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 
 	// Abort if incompatible args supplied.
 	if ( get_flag_value( $assoc_args, 'base-tables-only' ) && get_flag_value( $assoc_args, 'views-only' ) ) {
-		\WP_CLI::error( 'You cannot supply --base-tables-only and --views-only at the same time.' );
+		WP_CLI::error( 'You cannot supply --base-tables-only and --views-only at the same time.' );
 	}
 
 	// Pre-load tables SQL query with Views restriction if needed.
@@ -414,7 +417,7 @@ function wp_get_table_names( $args, $assoc_args = array() ) {
 		$args_tables = array_values( array_unique( $args_tables ) );
 		$tables      = array_values( array_intersect( $tables, $args_tables ) );
 		if ( empty( $tables ) ) {
-			\WP_CLI::error( sprintf( "Couldn't find any tables matching: %s", implode( ' ', $args ) ) );
+			WP_CLI::error( sprintf( "Couldn't find any tables matching: %s", implode( ' ', $args ) ) );
 		}
 	}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -757,6 +757,7 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 		Requests::register_autoloader();
 	}
 
+	$insecure      = isset( $options['insecure'] ) && (bool) $options['insecure'];
 	$halt_on_error = ! isset( $options['halt_on_error'] ) || (bool) $options['halt_on_error'];
 
 	if ( ! isset( $options['verify'] ) ) {
@@ -785,7 +786,7 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 			}
 			throw new RuntimeException( $error_msg, null, $ex );
 		}
-		if ( array_key_exists( 'insecure', $options ) && true === $options['insecure'] ) {
+		if ( $insecure ) {
 			WP_CLI::warning( sprintf( "Re-trying without verify after failing to get verified url '%s' %s.", $url, $ex->getMessage() ) );
 			$options['verify'] = false;
 			try {

--- a/php/utils.php
+++ b/php/utils.php
@@ -759,7 +759,7 @@ function http_request( $method, $url, $data = null, $headers = array(), $options
 
 	$insecure      = isset( $options['insecure'] ) && (bool) $options['insecure'];
 	$halt_on_error = ! isset( $options['halt_on_error'] ) || (bool) $options['halt_on_error'];
-	unset( $options['insecure'], $options['halt_on_error'] );
+	unset( $options['halt_on_error'] );
 
 	if ( ! isset( $options['verify'] ) ) {
 		// 'curl.cainfo' enforces the CA file to use, otherwise fallback to system-wide defaults then use the embedded CA file.


### PR DESCRIPTION
This PR disables the automatic retrying of `Utils/http_request()` that was skipping certificate validation.

The new default is to produce a hard error on certificate errors.

This PR also adds a new `--insecure` flag to the `cli update` command that turns this retrying back on when explicitly requested, which allows manually going back to the previous behavior.

Subsequent PRs on the command repositories will add a similar `--insecure` flag to the appropriate commands on the following repositories:

- [x] [`wp-cli/config-command`](https://github.com/wp-cli/config-command) => https://github.com/wp-cli/config-command/pull/128
- [x] [`wp-cli/core-command`](https://github.com/wp-cli/core-command) => https://github.com/wp-cli/core-command/pull/186
- [x] [`wp-cli/extension-command`](https://github.com/wp-cli/extension-command) => https://github.com/wp-cli/extension-command/pull/287
- [x] [`wp-cli/checksum-command`](https://github.com/wp-cli/checksum-command) => https://github.com/wp-cli/checksum-command/pull/86
- [x] [`wp-cli/package-command`](https://github.com/wp-cli/package-command) => https://github.com/wp-cli/package-command/pull/138
