### PR TITLE
Move fetcher implementations back into framework

### DIFF
--- a/php/WP_CLI/Fetchers/Base.php
+++ b/php/WP_CLI/Fetchers/Base.php
@@ -2,43 +2,52 @@
 
 namespace WP_CLI\Fetchers;
 
+use WP_CLI;
+use WP_CLI\ExitException;
+
 /**
  * Fetch a WordPress entity for use in a subcommand.
  */
 abstract class Base {
 
 	/**
-	 * @var string $msg The message to display when an item is not found
+	 * The message to display when an item is not found.
+	 *
+	 * @var string
 	 */
 	protected $msg;
 
 	/**
-	 * @param string $arg The raw CLI argument
-	 * @return mixed|false The item if found; false otherwise
+	 * @param string $arg The raw CLI argument.
+	 * @return mixed|false The item if found; false otherwise.
 	 */
 	abstract public function get( $arg );
 
 	/**
 	 * Like get(), but calls WP_CLI::error() instead of returning false.
 	 *
-	 * @param string $arg The raw CLI argument
+	 * @param string $arg The raw CLI argument.
+	 * @return mixed The item if found.
+	 * @throws ExitException If the item is not found.
 	 */
 	public function get_check( $arg ) {
 		$item = $this->get( $arg );
 
 		if ( ! $item ) {
-			\WP_CLI::error( sprintf( $this->msg, $arg ) );
+			WP_CLI::error( sprintf( $this->msg, $arg ) );
 		}
 
 		return $item;
 	}
 
 	/**
-	 * @param array The raw CLI arguments
-	 * @return array The list of found items
+	 * Get multiple items.
+	 *
+	 * @param array The raw CLI arguments.
+	 * @return array The list of found items.
 	 */
 	public function get_many( $args ) {
-		$items = array();
+		$items = [];
 
 		foreach ( $args as $arg ) {
 			$item = $this->get( $arg );
@@ -46,7 +55,7 @@ abstract class Base {
 			if ( $item ) {
 				$items[] = $item;
 			} else {
-				\WP_CLI::warning( sprintf( $this->msg, $arg ) );
+				WP_CLI::warning( sprintf( $this->msg, $arg ) );
 			}
 		}
 

--- a/php/WP_CLI/Fetchers/Comment.php
+++ b/php/WP_CLI/Fetchers/Comment.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WP_CLI\Fetchers;
+
+use WP_Comment;
+
+/**
+ * Fetch a WordPress comment based on one of its attributes.
+ */
+class Comment extends Base {
+
+	/**
+	 * The message to display when an item is not found.
+	 *
+	 * @var string
+	 */
+	protected $msg = 'Could not find the comment with ID %d.';
+
+	/**
+	 * Get a comment object by ID
+	 *
+	 * @param string $arg The raw CLI argument.
+	 * @return WP_Comment|array|false The item if found; false otherwise.
+	 */
+	public function get( $arg ) {
+		$comment_id = (int) $arg;
+		$comment    = get_comment( $comment_id );
+
+		if ( null === $comment ) {
+			return false;
+		}
+
+		return $comment;
+	}
+}
+

--- a/php/WP_CLI/Fetchers/Post.php
+++ b/php/WP_CLI/Fetchers/Post.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WP_CLI\Fetchers;
+
+use WP_Post;
+
+/**
+ * Fetch a WordPress post based on one of its attributes.
+ */
+class Post extends Base {
+
+	/**
+	 * The message to display when an item is not found.
+	 *
+	 * @var string
+	 */
+	protected $msg = 'Could not find the post with ID %d.';
+
+	/**
+	 * Get a post object by ID
+	 *
+	 * @param string $arg The raw CLI argument.
+	 * @return WP_Post|array|false The item if found; false otherwise.
+	 */
+	public function get( $arg ) {
+		$post = get_post( $arg );
+
+		if ( null === $post ) {
+			return false;
+		}
+
+		return $post;
+	}
+}
+

--- a/php/WP_CLI/Fetchers/Site.php
+++ b/php/WP_CLI/Fetchers/Site.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace WP_CLI\Fetchers;
+
+/**
+ * Fetch a WordPress site based on one of its attributes.
+ */
+class Site extends Base {
+
+	/**
+	 * The message to display when an item is not found.
+	 *
+	 * @var string
+	 */
+	protected $msg = 'Could not find the site with ID %d.';
+
+	/**
+	 * Get a site object by ID
+	 *
+	 * @param int $site_id
+	 * @return object|false
+	 */
+	public function get( $site_id ) {
+		return $this->get_site( $site_id );
+	}
+
+	/**
+	 * Get site (blog) data for a given id.
+	 *
+	 * @param string $arg The raw CLI argument.
+	 * @return array|false The item if found; false otherwise.
+	 */
+	private function get_site( $arg ) {
+		global $wpdb;
+
+		// Load site data
+		$site = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM {$wpdb->blogs} WHERE blog_id = %d",
+				$arg
+			)
+		);
+
+		if ( ! empty( $site ) ) {
+			// Only care about domain and path which are set here
+			return $site;
+		}
+
+		return false;
+	}
+}

--- a/php/WP_CLI/Fetchers/User.php
+++ b/php/WP_CLI/Fetchers/User.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace WP_CLI\Fetchers;
+
+use WP_User;
+
+/**
+ * Fetch a WordPress user based on one of its attributes.
+ */
+class User extends Base {
+
+	/**
+	 * The message to display when an item is not found.
+	 *
+	 * @var string
+	 */
+	protected $msg = "Invalid user ID, email or login: '%s'";
+
+	/**
+	 * Get a user object by one of its identifying attributes.
+	 *
+	 * @param string $arg The raw CLI argument.
+	 * @return WP_User|false The item if found; false otherwise.
+	 */
+	public function get( $arg ) {
+
+		if ( is_numeric( $arg ) ) {
+			$user = get_user_by( 'id', $arg );
+		} elseif ( is_email( $arg ) ) {
+			$user = get_user_by( 'email', $arg );
+			// Logins can be emails.
+			if ( ! $user ) {
+				$user = get_user_by( 'login', $arg );
+			}
+		} else {
+			$user = get_user_by( 'login', $arg );
+		}
+
+		return $user;
+	}
+}
+

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -3,9 +3,12 @@
 namespace WP_CLI;
 
 use WP_CLI;
+use WP_CLI\Fetchers;
 use WP_CLI\Utils;
 use WP_CLI\Dispatcher;
 use WP_CLI\Dispatcher\CompositeCommand;
+use WP_CLI\Loggers;
+use WP_Error;
 
 /**
  * Performs the execution of a command.
@@ -314,7 +317,7 @@ class Runner {
 	 * @return array|string Command, args, and path on success; error message on failure
 	 */
 	public function find_command_to_run( $args ) {
-		$command = \WP_CLI::get_root_command();
+		$command = WP_CLI::get_root_command();
 
 		WP_CLI::do_hook( 'find_command_to_run_pre' );
 
@@ -612,7 +615,7 @@ class Runner {
 	 * @return bool
 	 */
 	public function is_command_disabled( $command ) {
-		$path = implode( ' ', array_slice( \WP_CLI\Dispatcher\get_path( $command ), 1 ) );
+		$path = implode( ' ', array_slice( Dispatcher\get_path( $command ), 1 ) );
 		return in_array( $path, $this->config['disabled_commands'], true );
 	}
 
@@ -850,7 +853,7 @@ class Runner {
 
 	public function init_colorization() {
 		if ( 'auto' === $this->config['color'] ) {
-			$this->colorize = ( ! \WP_CLI\Utils\isPiped() && ! \WP_CLI\Utils\is_windows() );
+			$this->colorize = ( ! Utils\isPiped() && ! Utils\is_windows() );
 		} else {
 			$this->colorize = $this->config['color'];
 		}
@@ -858,9 +861,9 @@ class Runner {
 
 	public function init_logger() {
 		if ( $this->config['quiet'] ) {
-			$logger = new \WP_CLI\Loggers\Quiet();
+			$logger = new Loggers\Quiet();
 		} else {
-			$logger = new \WP_CLI\Loggers\Regular( $this->in_color() );
+			$logger = new Loggers\Regular( $this->in_color() );
 		}
 
 		WP_CLI::set_logger( $logger );
@@ -929,7 +932,7 @@ class Runner {
 	}
 
 	public function init_config() {
-		$configurator = \WP_CLI::get_configurator();
+		$configurator = WP_CLI::get_configurator();
 
 		$argv = array_slice( $GLOBALS['argv'], 1 );
 
@@ -1125,7 +1128,7 @@ class Runner {
 		// Handle --url parameter
 		$url = self::guess_url( $this->config );
 		if ( $url ) {
-			\WP_CLI::set_url( $url );
+			WP_CLI::set_url( $url );
 		}
 
 		$this->do_early_invoke( 'before_wp_load' );
@@ -1160,7 +1163,7 @@ class Runner {
 			// We really need a URL here
 			if ( ! isset( $_SERVER['HTTP_HOST'] ) ) {
 				$url = 'http://example.com';
-				\WP_CLI::set_url( $url );
+				WP_CLI::set_url( $url );
 			}
 
 			if ( 'multisite-install' === $this->arguments[1] ) {
@@ -1338,7 +1341,7 @@ class Runner {
 			if ( defined( 'PATH_CURRENT_SITE' ) ) {
 				$url .= PATH_CURRENT_SITE;
 			}
-			\WP_CLI::set_url( $url );
+			WP_CLI::set_url( $url );
 		}
 	}
 
@@ -1542,7 +1545,7 @@ class Runner {
 				'init',
 				static function () use ( $config ) {
 					if ( isset( $config['user'] ) ) {
-						$fetcher = new \WP_CLI\Fetchers\User();
+						$fetcher = new Fetchers\User();
 						$user    = $fetcher->get_check( $config['user'] );
 						wp_set_current_user( $user->ID );
 					} else {
@@ -1714,10 +1717,10 @@ class Runner {
 	 */
 	public function help_wp_die_handler( $message ) {
 		$help_exit_warning = 'Error during WordPress load.';
-		if ( $message instanceof \WP_Error ) {
-			$help_exit_warning = WP_CLI\Utils\wp_clean_error_message( $message->get_error_message() );
+		if ( $message instanceof WP_Error ) {
+			$help_exit_warning = Utils\wp_clean_error_message( $message->get_error_message() );
 		} elseif ( is_string( $message ) ) {
-			$help_exit_warning = WP_CLI\Utils\wp_clean_error_message( $message );
+			$help_exit_warning = Utils\wp_clean_error_message( $message );
 		}
 		$this->run_command_and_exit( $help_exit_warning );
 	}
@@ -1803,7 +1806,7 @@ class Runner {
 	 */
 	private function get_subcommand_suggestion( $entry, CompositeCommand $root_command = null ) {
 		$commands = array();
-		$this->enumerate_commands( $root_command ?: \WP_CLI::get_root_command(), $commands );
+		$this->enumerate_commands( $root_command ?: WP_CLI::get_root_command(), $commands );
 
 		return Utils\get_suggestion( $entry, $commands, $threshold = 2 );
 	}


### PR DESCRIPTION
Moving the fetcher implementations out of the framework and into the `wp-cli/entity-command` broke the `--user` flag when the `wp-cli/entity-command` package was not loaded.

This PR moves the fetcher implementations back into the framework.

Fixes https://github.com/wp-cli/wp-cli/issues/5328