### PR TITLE
Fix OOM issues when exporting to STDOUT

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2223,12 +2223,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "fc5e5d772af47d035df8178172391259b6e30566"
+                "reference": "736d41298189b79074e555d056bfe040b4970f47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/fc5e5d772af47d035df8178172391259b6e30566",
-                "reference": "fc5e5d772af47d035df8178172391259b6e30566",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/736d41298189b79074e555d056bfe040b4970f47",
+                "reference": "736d41298189b79074e555d056bfe040b4970f47",
                 "shasum": ""
             },
             "conflict": {
@@ -2317,6 +2317,7 @@
                 "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
                 "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
                 "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
+                "froala/wysiwyg-editor": "<3.2.7",
                 "fuel/core": "<1.8.1",
                 "getgrav/grav": "<=1.7.10",
                 "getkirby/cms": "<=3.5.6",
@@ -2591,7 +2592,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-13T18:03:10+00:00"
+            "time": "2021-07-19T22:02:46+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -4843,16 +4844,16 @@
         },
         {
             "name": "wp-cli/wp-cli-tests",
-            "version": "v3.0.14",
+            "version": "v3.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli-tests.git",
-                "reference": "03fdabdae9e9a081ef57b0ce7e6d66dc45212c09"
+                "reference": "17ff779d7678e4dc3fbd85017fb921e44b8639d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli-tests/zipball/03fdabdae9e9a081ef57b0ce7e6d66dc45212c09",
-                "reference": "03fdabdae9e9a081ef57b0ce7e6d66dc45212c09",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli-tests/zipball/17ff779d7678e4dc3fbd85017fb921e44b8639d4",
+                "reference": "17ff779d7678e4dc3fbd85017fb921e44b8639d4",
                 "shasum": ""
             },
             "require": {
@@ -4867,7 +4868,7 @@
                 "wp-cli/eval-command": "^1 || ^2",
                 "wp-cli/wp-cli": "^2",
                 "wp-coding-standards/wpcs": "^2.3",
-                "yoast/phpunit-polyfills": "^0.2"
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "require-dev": {
                 "roave/security-advisories": "dev-master"
@@ -4917,7 +4918,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli-tests/issues",
                 "source": "https://github.com/wp-cli/wp-cli-tests"
             },
-            "time": "2021-05-12T07:43:00+00:00"
+            "time": "2021-07-20T07:00:50+00:00"
         },
         {
             "name": "wp-cli/wp-config-transformer",
@@ -5017,25 +5018,25 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "0.2.0",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab"
+                "reference": "5d257d5a6977137016f3df440ce640ce72ffd61a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/c48e4cf0c44b2d892540846aff19fb0468627bab",
-                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5d257d5a6977137016f3df440ce640ce72ffd61a",
+                "reference": "5d257d5a6977137016f3df440ce640ce72ffd61a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": ">=5.4",
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.0",
                 "yoast/yoastcs": "^2.1.0"
             },
             "type": "library",
@@ -5076,7 +5077,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2020-11-25T02:59:57+00:00"
+            "time": "2021-06-21T03:13:22+00:00"
         }
     ],
     "aliases": [],

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -103,6 +103,7 @@ Feature: Utilities that do NOT depend on WordPress code
 
   Scenario: Ensure that Utils\run_mysql_command() passes through without reading full DB into memory
     Given a WP install
+
     And I run `printf '%*s' 1048576 | tr ' ' "."`
     And STDOUT should not be empty
     And save STDOUT as {ONE_MB_OF_DATA}
@@ -143,6 +144,13 @@ Feature: Utilities that do NOT depend on WordPress code
       --host
       """
     And save STDOUT as {DB_HOST_STRING}
+
+    # Added for debugging purposes.
+    When I try `mysql --max_allowed_packet=256M --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} -e "SHOW VARIABLES LIKE 'max_allowed_packet';"`
+    Then STDOUT should contain:
+      """
+      peeking into GHA from here
+      """
 
     # This throws a warning because of the password.
     When I try `mysql --max_allowed_packet=256M --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -112,7 +112,7 @@ Feature: Utilities that do NOT depend on WordPress code
       echo "CREATE TABLE \`custom_table\` (\`key\` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT, \`text\` LONGTEXT, PRIMARY KEY (\`key\`) );" > test_db.sql
       echo "INSERT INTO \`custom_table\` (\`text\`) VALUES" >> test_db.sql
       index=1
-      while [[ $index -le 20 ]];
+      while [[ $index -le 60 ]];
       do
         echo "('{ONE_MB_OF_DATA}')," >> test_db.sql
         index=`expr $index + 1`
@@ -146,7 +146,7 @@ Feature: Utilities that do NOT depend on WordPress code
     And I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
 
     # This throws a warning because of the password.
-    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} eval "\\WP_CLI\\Utils\\run_mysql_command('/usr/bin/env mysqldump {DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING}', [], null, true);"`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=50M -ddisable_functions=ini_set} eval "\\WP_CLI\\Utils\\run_mysql_command('/usr/bin/env mysqldump {DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING}', [], null, true);"`
     Then the return code should be 0
     And STDOUT should not be empty
     And STDOUT should contain:

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -145,7 +145,7 @@ Feature: Utilities that do NOT depend on WordPress code
     And save STDOUT as {DB_HOST_STRING}
 
     # This throws a warning because of the password.
-    When I try `mysql --max_allowed_packet=64M --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
+    When I try `mysql --max_allowed_packet=256M --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
     Then the return code should be 0
 
     # This throws a warning because of the password.

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -146,7 +146,7 @@ Feature: Utilities that do NOT depend on WordPress code
     And I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
 
     # This throws a warning because of the password.
-    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=50M -ddisable_functions=ini_set} eval '\WP_CLI\Utils\run_mysql_command("/usr/bin/env mysqldump {DB_NAME}", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}" ], null, true);'`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=50M -ddisable_functions=ini_set} eval '\WP_CLI\Utils\run_mysql_command("/usr/bin/env mysqldump --skip-column-statistics --no-tablespaces {DB_NAME}", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}" ], null, true);'`
     Then the return code should be 0
     And STDOUT should not be empty
     And STDOUT should contain:

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -145,9 +145,9 @@ Feature: Utilities that do NOT depend on WordPress code
     # This throws a warning because of the password.
     And I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
 
-    When I run `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} eval "\\WP_CLI\\Utils\\run_mysql_command('/usr/bin/env mysqldump {DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING}', []);"`
+    # This throws a warning because of the password.
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} eval "\\WP_CLI\\Utils\\run_mysql_command('/usr/bin/env mysqldump {DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING}', []);"`
     Then the return code should be 0
-    And STDERR should be empty
     And STDOUT should not be empty
     And STDOUT should contain:
       """

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -120,6 +120,7 @@ Feature: Utilities that do NOT depend on WordPress code
         echo "('{ONE_MB_OF_DATA}');" >> test_db.sql
       """
     And I run `bash create_sql_file.sh`
+    And I run `test $(wc -c < test_db.sql) -gt 52428800`
     And a calculate_host_string.sh file:
       """
       #!/bin/bash
@@ -142,8 +143,10 @@ Feature: Utilities that do NOT depend on WordPress code
       --host
       """
     And save STDOUT as {DB_HOST_STRING}
+
     # This throws a warning because of the password.
-    And I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
+    When I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
+    Then the return code should be 0
 
     # This throws a warning because of the password.
     When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=50M -ddisable_functions=ini_set} eval '\WP_CLI\Utils\run_mysql_command("/usr/bin/env mysqldump --skip-column-statistics --no-tablespaces {DB_NAME}", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}" ], null, true);'`

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -145,7 +145,7 @@ Feature: Utilities that do NOT depend on WordPress code
     And save STDOUT as {DB_HOST_STRING}
 
     # This throws a warning because of the password.
-    When I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
+    When I try `mysql --max_allowed_packet=64M --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
     Then the return code should be 0
 
     # This throws a warning because of the password.

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -145,9 +145,15 @@ Feature: Utilities that do NOT depend on WordPress code
     # This throws a warning because of the password.
     And I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
 
-    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} eval "\\WP_CLI\\Utils\\run_mysql_command('/usr/bin/env mysqldump {DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING}', []);"`
-    Then the return code should not be 0
-    And STDERR should not contain:
+    When I run `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} eval "\\WP_CLI\\Utils\\run_mysql_command('/usr/bin/env mysqldump {DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING}', []);"`
+    Then the return code should be 0
+    And STDERR should be empty
+    And STDOUT should not be empty
+    And STDOUT should contain:
       """
-      Fatal error:  Allowed memory size
+      CREATE TABLE
+      """
+    And STDOUT should contain:
+      """
+      {ONE_MB_OF_DATA}
       """

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -147,7 +147,7 @@ Feature: Utilities that do NOT depend on WordPress code
 
     When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} eval "\\WP_CLI\\Utils\\run_mysql_command('/usr/bin/env mysqldump {DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING}', []);"`
     Then the return code should not be 0
-    And STDERR should contain:
+    And STDERR should not contain:
       """
-      Out of memory
+      Fatal error:  Allowed memory size
       """

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -148,13 +148,6 @@ Feature: Utilities that do NOT depend on WordPress code
     When I try `mysql --database={DB_NAME} --user={DB_ROOT_USER} --password={DB_ROOT_PASSWORD} {DB_HOST_STRING} -e "SET GLOBAL max_allowed_packet=64*1024*1024;"`
     Then the return code should be 0
 
-    # Added for debugging purposes.
-    When I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} -e "SHOW VARIABLES LIKE 'max_allowed_packet';"`
-    Then STDOUT should contain:
-      """
-      peeking into GHA from here
-      """
-
     # This throws a warning because of the password.
     When I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
     Then the return code should be 0

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -146,7 +146,7 @@ Feature: Utilities that do NOT depend on WordPress code
     And I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
 
     # This throws a warning because of the password.
-    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} eval "\\WP_CLI\\Utils\\run_mysql_command('/usr/bin/env mysqldump {DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING}', []);"`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} eval "\\WP_CLI\\Utils\\run_mysql_command('/usr/bin/env mysqldump {DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING}', [], null, true);"`
     Then the return code should be 0
     And STDOUT should not be empty
     And STDOUT should contain:

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -145,7 +145,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And save STDOUT as {DB_HOST_STRING}
 
-    When I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} -e "SET GLOBAL max_allowed_packet=64*1024*1024;"`
+    When I try `mysql --database={DB_NAME} --user={DB_ROOT_USER} --password={DB_ROOT_PASSWORD} {DB_HOST_STRING} -e "SET GLOBAL max_allowed_packet=64*1024*1024;"`
     Then the return code should be 0
 
     # Added for debugging purposes.

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -145,15 +145,18 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And save STDOUT as {DB_HOST_STRING}
 
+    When I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} -e "SET GLOBAL max_allowed_packet=64*1024*1024;"`
+    Then the return code should be 0
+
     # Added for debugging purposes.
-    When I try `mysql --max_allowed_packet=256M --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} -e "SHOW VARIABLES LIKE 'max_allowed_packet';"`
+    When I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} -e "SHOW VARIABLES LIKE 'max_allowed_packet';"`
     Then STDOUT should contain:
       """
       peeking into GHA from here
       """
 
     # This throws a warning because of the password.
-    When I try `mysql --max_allowed_packet=256M --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
+    When I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
     Then the return code should be 0
 
     # This throws a warning because of the password.

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -146,7 +146,7 @@ Feature: Utilities that do NOT depend on WordPress code
     And I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
 
     # This throws a warning because of the password.
-    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=50M -ddisable_functions=ini_set} eval "\\WP_CLI\\Utils\\run_mysql_command('/usr/bin/env mysqldump {DB_NAME} --user={DB_USER} --password={DB_PASSWORD} --no-tablespaces {DB_HOST_STRING}', [], null, true);"`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=50M -ddisable_functions=ini_set} eval '\WP_CLI\Utils\run_mysql_command("/usr/bin/env mysqldump {DB_NAME}", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}" ], null, true);'`
     Then the return code should be 0
     And STDOUT should not be empty
     And STDOUT should contain:

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -146,7 +146,7 @@ Feature: Utilities that do NOT depend on WordPress code
     And I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
 
     # This throws a warning because of the password.
-    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=50M -ddisable_functions=ini_set} eval "\\WP_CLI\\Utils\\run_mysql_command('/usr/bin/env mysqldump {DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING}', [], null, true);"`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=50M -ddisable_functions=ini_set} eval "\\WP_CLI\\Utils\\run_mysql_command('/usr/bin/env mysqldump {DB_NAME} --user={DB_USER} --password={DB_PASSWORD} --no-tablespaces {DB_HOST_STRING}', [], null, true);"`
     Then the return code should be 0
     And STDOUT should not be empty
     And STDOUT should contain:

--- a/php/utils.php
+++ b/php/utils.php
@@ -502,7 +502,7 @@ function mysql_host_to_cli_args( $raw_host ) {
 function run_mysql_command( $cmd, $assoc_args, $_ = null, $send_to_shell = true, $interactive = false ) {
 	check_proc_available( 'run_mysql_command' );
 
-	$descriptors = $interactive ?
+	$descriptors = ( $interactive || $send_to_shell ) ?
 		[
 			0 => STDIN,
 			1 => STDOUT,
@@ -543,14 +543,9 @@ function run_mysql_command( $cmd, $assoc_args, $_ = null, $send_to_shell = true,
 		exit( 1 );
 	}
 
-	if ( is_resource( $process ) ) {
-		if ( $send_to_shell ) {
-			fpassthru( $pipes[1] );
-			fwrite( STDERR, stream_get_contents( $pipes[2] ) );
-		} elseif ( ! $interactive ) {
-			$stdout = stream_get_contents( $pipes[1] );
-			$stderr = stream_get_contents( $pipes[2] );
-		}
+	if ( is_resource( $process ) && ! $send_to_shell && ! $interactive ) {
+		$stdout = stream_get_contents( $pipes[1] );
+		$stderr = stream_get_contents( $pipes[2] );
 
 		fclose( $pipes[1] );
 		fclose( $pipes[2] );

--- a/php/utils.php
+++ b/php/utils.php
@@ -539,6 +539,7 @@ function run_mysql_command( $cmd, $assoc_args, $_ = null, $send_to_shell = true,
 	}
 
 	if ( ! $process ) {
+		WP_CLI::debug( 'Failed to create a valid process using proc_open_compat()', 'db' );
 		exit( 1 );
 	}
 
@@ -557,7 +558,7 @@ function run_mysql_command( $cmd, $assoc_args, $_ = null, $send_to_shell = true,
 
 	$exit_code = proc_close( $process );
 
-	if ( $exit_code ) {
+	if ( $exit_code && ( $send_to_shell || $interactive ) ) {
 		exit( $exit_code );
 	}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -545,11 +545,14 @@ function run_mysql_command( $cmd, $assoc_args, $_ = null, $send_to_shell = true,
 	if ( is_resource( $process ) ) {
 		if ( $send_to_shell ) {
 			fpassthru( $pipes[1] );
-			fpassthru( $pipes[2] );
+			fwrite( STDERR, stream_get_contents( $pipes[2] ) );
 		} elseif ( ! $interactive ) {
 			$stdout = stream_get_contents( $pipes[1] );
 			$stderr = stream_get_contents( $pipes[2] );
 		}
+
+		fclose( $pipes[1] );
+		fclose( $pipes[2] );
 	}
 
 	$exit_code = proc_close( $process );

--- a/php/utils.php
+++ b/php/utils.php
@@ -542,27 +542,20 @@ function run_mysql_command( $cmd, $assoc_args, $_ = null, $send_to_shell = true,
 		exit( 1 );
 	}
 
-	if ( ! $interactive && is_resource( $process ) ) {
-		$stdout = stream_get_contents( $pipes[1] );
-		$stderr = stream_get_contents( $pipes[2] );
-
-		fclose( $pipes[1] );
-		fclose( $pipes[2] );
+	if ( is_resource( $process ) ) {
+		if ( $send_to_shell ) {
+			fpassthru( $pipes[1] );
+			fpassthru( $pipes[2] );
+		} elseif ( ! $interactive ) {
+			$stdout = stream_get_contents( $pipes[1] );
+			$stderr = stream_get_contents( $pipes[2] );
+		}
 	}
 
 	$exit_code = proc_close( $process );
 
-	if ( $interactive && $exit_code ) {
+	if ( $exit_code ) {
 		exit( $exit_code );
-	}
-
-	if ( $send_to_shell ) {
-		fwrite( STDOUT, $stdout );
-		fwrite( STDERR, $stderr );
-
-		if ( $exit_code ) {
-			exit( $exit_code );
-		}
 	}
 
 	return [


### PR DESCRIPTION
This fixes the out-of-memory errors on `db export` to `STDOUT` by using `fpassthru()` when `$send_to_shell` is `true`, instead of using `stream_get_contents()`.

This is technically not a full fix, as the stream is still fully read when `$send_to_shell` is `false`, however there's no current use case I can think of where that would matter.

Fixes https://github.com/wp-cli/db-command/issues/195