### PR TITLE
Make logger accessible and add colorization control to `Quiet` logger

### DIFF
--- a/php/WP_CLI/Loggers/Quiet.php
+++ b/php/WP_CLI/Loggers/Quiet.php
@@ -10,6 +10,13 @@ use WP_CLI;
 class Quiet extends Base {
 
 	/**
+	 * @param bool $in_color Whether or not to Colorize strings.
+	 */
+	public function __construct( $in_color = false ) {
+		$this->in_color = $in_color;
+	}
+
+	/**
 	 * Informational messages aren't logged.
 	 *
 	 * @param string $message Message to write.
@@ -42,7 +49,7 @@ class Quiet extends Base {
 	 * @param string $message Message to write.
 	 */
 	public function error( $message ) {
-		$this->write( STDERR, WP_CLI::colorize( "%RError:%n $message\n" ) );
+		$this->_line( $message, 'Error', '%R', STDERR );
 	}
 
 	/**
@@ -53,7 +60,7 @@ class Quiet extends Base {
 	public function error_multi_line( $message_lines ) {
 		$message = implode( "\n", $message_lines );
 
-		$this->write( STDERR, WP_CLI::colorize( "%RError:%n\n$message\n" ) );
-		$this->write( STDERR, WP_CLI::colorize( "%R---------%n\n\n" ) );
+		$this->_line( $message, 'Error', '%R', STDERR );
+		$this->_line( '', '---------', '%R', STDERR );
 	}
 }

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -862,7 +862,7 @@ class Runner {
 
 	public function init_logger() {
 		if ( $this->config['quiet'] ) {
-			$logger = new Loggers\Quiet();
+			$logger = new Loggers\Quiet( $this->in_color() );
 		} else {
 			$logger = new Loggers\Regular( $this->in_color() );
 		}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -38,10 +38,19 @@ class WP_CLI {
 	/**
 	 * Set the logger instance.
 	 *
-	 * @param object $logger
+	 * @param object $logger Logger instance to set.
 	 */
 	public static function set_logger( $logger ) {
 		self::$logger = $logger;
+	}
+
+	/**
+	 * Get the logger instance.
+	 *
+	 * @return object $logger Logger instance.
+	 */
+	public static function get_logger() {
+		return self::$logger;
 	}
 
 	/**

--- a/tests/test-extractor.php
+++ b/tests/test-extractor.php
@@ -1,6 +1,7 @@
 <?php
 
 use WP_CLI\Extractor;
+use WP_CLI\Loggers;
 use WP_CLI\Utils;
 
 class Extractor_Test extends PHPUnit_Framework_TestCase {
@@ -27,12 +28,9 @@ class Extractor_Test extends PHPUnit_Framework_TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		// Save and set logger.
-		$class_wp_cli_logger = new \ReflectionProperty( 'WP_CLI', 'logger' );
-		$class_wp_cli_logger->setAccessible( true );
-		self::$prev_logger = $class_wp_cli_logger->getValue();
+		self::$prev_logger = WP_CLI::get_logger();
 
-		self::$logger = new \WP_CLI\Loggers\Execution();
+		self::$logger = new Loggers\Execution();
 		WP_CLI::set_logger( self::$logger );
 
 		// Remove any failed tests detritus.

--- a/tests/test-file-cache.php
+++ b/tests/test-file-cache.php
@@ -1,6 +1,7 @@
 <?php
 
 use WP_CLI\FileCache;
+use WP_CLI\Loggers;
 use WP_CLI\Utils;
 
 require_once dirname( __DIR__ ) . '/php/class-wp-cli.php';
@@ -32,11 +33,9 @@ class FileCacheTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function test_ensure_dir_exists() {
-		$class_wp_cli_logger = new ReflectionProperty( 'WP_CLI', 'logger' );
-		$class_wp_cli_logger->setAccessible( true );
-		$prev_logger = $class_wp_cli_logger->getValue();
+		$prev_logger = WP_CLI::get_logger();
 
-		$logger = new WP_CLI\Loggers\Execution();
+		$logger = new Loggers\Execution();
 		WP_CLI::set_logger( $logger );
 
 		$max_size  = 32;
@@ -79,7 +78,7 @@ class FileCacheTest extends PHPUnit_Framework_TestCase {
 		rmdir( $cache_dir . '/test1' );
 		unlink( $cache_dir . '/test2' );
 		rmdir( $cache_dir );
-		$class_wp_cli_logger->setValue( $prev_logger );
+		WP_CLI::set_logger( $prev_logger );
 	}
 
 	public function test_export() {

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -418,13 +418,11 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 
 	public function testHttpRequestBadAddress() {
 		// Save WP_CLI state.
-		$class_wp_cli_logger = new \ReflectionProperty( 'WP_CLI', 'logger' );
-		$class_wp_cli_logger->setAccessible( true );
 		$class_wp_cli_capture_exit = new \ReflectionProperty( 'WP_CLI', 'capture_exit' );
 		$class_wp_cli_capture_exit->setAccessible( true );
-
-		$prev_logger       = $class_wp_cli_logger->getValue();
 		$prev_capture_exit = $class_wp_cli_capture_exit->getValue();
+
+		$prev_logger = WP_CLI::get_logger();
 
 		// Enable exit exception.
 		$class_wp_cli_capture_exit->setValue( true );
@@ -445,8 +443,8 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue( 0 === strpos( $logger->stderr, 'Error: Failed to get url' ) );
 
 		// Restore.
-		$class_wp_cli_logger->setValue( $prev_logger );
 		$class_wp_cli_capture_exit->setValue( $prev_capture_exit );
+		WP_CLI::set_logger( $prev_logger );
 	}
 
 	public function dataHttpRequestBadCAcert() {
@@ -498,10 +496,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 			$this->expectExceptionMessage( $exception_message );
 		} else {
 			// Save WP_CLI state.
-			$class_wp_cli_logger = new \ReflectionProperty( 'WP_CLI', 'logger' );
-			$class_wp_cli_logger->setAccessible( true );
-
-			$prev_logger = $class_wp_cli_logger->getValue();
+			$prev_logger = WP_CLI::get_logger();
 			$logger      = new Loggers\Execution();
 			WP_CLI::set_logger( $logger );
 		}
@@ -509,7 +504,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		Utils\http_request( 'GET', 'https://example.com', null, [], $options );
 
 		// Restore.
-		$class_wp_cli_logger->setValue( $prev_logger );
+		WP_CLI::set_logger( $prev_logger );
 
 		$this->assertTrue( empty( $logger->stdout ) );
 		$this->assertNotFalse( strpos( $logger->stderr, $exception_message ) );
@@ -644,13 +639,11 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testReportBatchOperationResults( $stdout, $stderr, $noun, $verb, $total, $successes, $failures, $skips ) {
 		// Save WP_CLI state.
-		$class_wp_cli_logger = new \ReflectionProperty( 'WP_CLI', 'logger' );
-		$class_wp_cli_logger->setAccessible( true );
 		$class_wp_cli_capture_exit = new \ReflectionProperty( 'WP_CLI', 'capture_exit' );
 		$class_wp_cli_capture_exit->setAccessible( true );
-
-		$prev_logger       = $class_wp_cli_logger->getValue();
 		$prev_capture_exit = $class_wp_cli_capture_exit->getValue();
+
+		$prev_logger = WP_CLI::get_logger();
 
 		// Enable exit exception.
 		$class_wp_cli_capture_exit->setValue( true );
@@ -669,8 +662,8 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame( $stderr, $logger->stderr );
 
 		// Restore.
-		$class_wp_cli_logger->setValue( $prev_logger );
 		$class_wp_cli_capture_exit->setValue( $prev_capture_exit );
+		WP_CLI::set_logger( $prev_logger );
 	}
 
 	public function dataReportBatchOperationResults() {


### PR DESCRIPTION
This PR:
- makes the current logger instance accessible outside of `WP_CLI`, so it is easier to roll back any logger changes that are being done;
- adds colorization control to the `Quiet` logger, so that it doesn't create colorization success and error messages.