### PR TITLE
Change "Fake Site" site name to "WordPress" wp core multisite-install subcommand

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1312,7 +1312,7 @@ class Runner {
 			'domain'        => $url_parts['host'],
 			'path'          => $url_parts['path'],
 			'cookie_domain' => $url_parts['host'],
-			'site_name'     => 'Fake Site',
+			'site_name'     => 'WordPress',
 		];
 
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intentional override.


### PR DESCRIPTION
Currently, the `wp core multisite-install` command creates sites called "Fake Site".

```
Just another Fake Site site
 Welcome to Fake Site
```

This is hardcoded in Runner.php. This PR changes the terminology to replace `Fake Site` with `WordPress`, which is more expected and user friendly.

There's likely room for improvement here to use the WP default rather than hardcoding a new value, but this at least removes the unexpected `Fake Site` string.

Fixes #5515


