### PR TITLE
Pass in args to before_run_command hook

### DIFF
--- a/features/hook.feature
+++ b/features/hook.feature
@@ -77,7 +77,7 @@ Feature: Tests `WP_CLI::add_hook()`
     And a before-run-command.php file:
       """
       <?php
-      $callback = function( $args, $assoc_args, $options ) {
+      $callback = function ( $args, $assoc_args, $options ) {
         WP_CLI::log( '`add_hook()` to the `before_run_command` is working.' );
         if ( 'version' !== $args[1] ) {
           WP_CLI::error( 'Arg context not being passed in to callback properly' );

--- a/features/hook.feature
+++ b/features/hook.feature
@@ -78,12 +78,12 @@ Feature: Tests `WP_CLI::add_hook()`
       """
       <?php
       $callback = function( $args, $assoc_args, $options ) {
-        WP_CLI::log( '`add_hook()` to the `before_run_command` is working.');
+        WP_CLI::log( '`add_hook()` to the `before_run_command` is working.' );
         if ( 'version' !== $args[0] ) {
           WP_CLI::error( 'Arg context not being passed in to callback properly' );
         }
 
-        if ( ! array_key_exists( 'extra', $assoc_args ) {
+        if ( ! array_key_exists( 'extra', $assoc_args ) ) {
           WP_CLI::error( 'Assoc arg context not being passed in to callback properly' );
         }
       };

--- a/features/hook.feature
+++ b/features/hook.feature
@@ -79,7 +79,7 @@ Feature: Tests `WP_CLI::add_hook()`
       <?php
       $callback = function( $args, $assoc_args, $options ) {
         WP_CLI::log( '`add_hook()` to the `before_run_command` is working.' );
-        if ( 'version' !== $args[0] ) {
+        if ( 'version' !== $args[1] ) {
           WP_CLI::error( 'Arg context not being passed in to callback properly' );
         }
 

--- a/features/hook.feature
+++ b/features/hook.feature
@@ -71,3 +71,34 @@ Feature: Tests `WP_CLI::add_hook()`
       `add_hook()` to the `before_invoke` is working.
       """
     And the return code should be 0
+
+  Scenario: Add callback to the `before_run_command` with args
+    Given a WP installation
+    And a before-run-command.php file:
+      """
+      <?php
+      $callback = function( $args, $assoc_args, $options ) {
+        WP_CLI::log( '`add_hook()` to the `before_run_command` is working.');
+        if ( 'version' !== $args[0] ) {
+          WP_CLI::error( 'Arg context not being passed in to callback properly' );
+        }
+
+        if ( ! array_key_exists( 'extra', $assoc_args ) {
+          WP_CLI::error( 'Assoc arg context not being passed in to callback properly' );
+        }
+      };
+
+      WP_CLI::add_hook( 'before_run_command', $callback );
+      """
+    And a wp-cli.yml file:
+      """
+      require:
+        - before-run-command.php
+      """
+
+    When I run `wp core version --extra`
+    Then STDOUT should contain:
+      """
+      `add_hook()` to the `before_run_command` is working.
+      """
+    And the return code should be 0

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -374,7 +374,7 @@ class Runner {
 	 * @param array $options     Configuration options for the function.
 	 */
 	public function run_command( $args, $assoc_args = [], $options = [] ) {
-		WP_CLI::do_hook( 'before_run_command' );
+		WP_CLI::do_hook( 'before_run_command', $args, $assoc_args, $options );
 
 		if ( ! empty( $options['back_compat_conversions'] ) ) {
 			list( $args, $assoc_args ) = self::back_compat_conversions( $args, $assoc_args );


### PR DESCRIPTION
This PR passes in some args to the `before_run_command` hook so callbacks have some more context to base their logic off of.

The reason for proposing this change is because of a particular use case I have where I'm implementing some logging to track CLI commands that are being run in our codebase. I currently have an implementation that looks something like:

```php
WP_CLI::add_hook( 'before_run_command', function() {
	$runner  = WP_CLI::get_runner();
	$command = $runner->find_command_to_run( $runner->arguments )[0];
	log( $command->get_name() );
} );
```

This works for commands invoked from the command line but doesn't work for commands invoked via `WP_CLI::run_command` with `launch => false` set. This is because `run_command` will call the `Runner->run_command()` method directly so the `Runner` instance doesn't get bootstrapped again with the proper context.

To get around this, I'm proposing we pass the params from the `run_command` method into the `before_run_command` hook.