### PR TITLE
Fixed wrong variable used in parsing args.

### DIFF
--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -148,8 +148,8 @@ class Configurator {
 		$local_assoc     = [];
 
 		foreach ( $arguments as $arg ) {
-			$positional_arg = null;
-			$assoc_arg      = null;
+			$positional = null;
+			$assoc_arg  = null;
 
 			if ( preg_match( '|^--no-([^=]+)$|', $arg, $matches ) ) {
 				$assoc_arg = [ $matches[1], false ];


### PR DESCRIPTION
As per issue #5558 Fixed unused variable `$positional_arg` in foreach loop and replaced to `$positional` variable.