### PR TITLE
Updated default branch for roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "wp-cli/php-cli-tools": "~0.11.2"
     },
     "require-dev": {
-        "roave/security-advisories": "dev-master",
+        "roave/security-advisories": "dev-latest",
         "wp-cli/db-command": "^1.3 || ^2",
         "wp-cli/entity-command": "^1.2 || ^2",
         "wp-cli/extension-command": "^1.1 || ^2",


### PR DESCRIPTION
See details here -> https://github.com/Roave/SecurityAdvisories#stability

It's causing issues with compatibilities with other projects 