### PR TITLE
Fix default `mysqli` error reporting mode for PHP 8.1+

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1155,6 +1155,15 @@ class Runner {
 			);
 		}
 
+		/*
+		 * Set the MySQLi error reporting off because WordPress handles its own.
+		 * This is due to the default value change from `MYSQLI_REPORT_OFF`
+		 * to `MYSQLI_REPORT_ERROR|MYSQLI_REPORT_STRICT` in PHP 8.1.
+		 */
+		if ( function_exists( 'mysqli_report' ) ) {
+			mysqli_report( 0 ); // phpcs:ignore WordPress.DB.RestrictedFunctions.mysql_mysqli_report
+		}
+
 		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Declaring WP native constants.
 
 		if ( $this->cmd_starts_with( [ 'core', 'is-installed' ] )


### PR DESCRIPTION
Starting with PHP 8.1, `mysqli` has a new default error reporting mode that throws exceptions.

As WordPress handles error conditions on its own, this is not needed.

The default error mode is already adapted with WP Core 5.9+, but on older versions the above changes means that you cannot even update WordPress sites on PHP 8.1, as they fatal with an uncaught exception.

Therefore, WP-CLI also sets the default error reporting mode now to avoid these fatals.