### PR TITLE
Use Mustache work-around for PHP 8.1 compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,16 +7,10 @@
     ],
     "homepage": "https://wp-cli.org",
     "license": "MIT",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/schlessera/mustache.php"
-        }
-    ],
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "ext-curl": "*",
-        "mustache/mustache": "dev-fix/trim-php-8.1 as 2.13.1",
+        "mustache/mustache": "^2.13",
         "rmccue/requests": "^1.8",
         "symfony/finder": ">2.7",
         "wp-cli/mustangostang-spyc": "^0.6.3",

--- a/php/WP_CLI/Compat/MustacheTokenizer.php
+++ b/php/WP_CLI/Compat/MustacheTokenizer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WP_CLI\Compat;
+
+use Mustache_Exception_InvalidArgumentException;
+use Mustache_Exception_SyntaxException;
+use Mustache_Tokenizer;
+
+/**
+ * Work-around extension for Mustache Tokenizer.
+ */
+class MustacheTokenizer extends Mustache_Tokenizer {
+
+	/**
+	 * Scan and tokenize template source.
+	 *
+	 * @param string $text       Mustache template source to tokenize.
+	 * @param string $delimiters Optional. Pass initial opening and closing delimiters (default: null).
+	 *
+	 * @return array Set of Mustache tokens
+	 * @throws Mustache_Exception_InvalidArgumentException When $delimiters string is invalid.
+	 *
+	 * @throws Mustache_Exception_SyntaxException When mismatched section tags are encountered.
+	 */
+	public function scan( $text, $delimiters = null ) {
+		// Work-around while waiting for PHP 8.1 compat fix to be released.
+		// See https://github.com/bobthecow/mustache.php/pull/380
+		if ( ! is_string( $delimiters ) ) {
+			$delimiters = '';
+		}
+
+		return parent::scan( $text, $delimiters );
+	}
+}

--- a/php/utils.php
+++ b/php/utils.php
@@ -576,14 +576,16 @@ function mustache_render( $template_name, $data = [] ) {
 
 	$template = file_get_contents( $template_name );
 
-	$m = new Mustache_Engine(
+	$mustache = new Mustache_Engine(
 		[
 			'escape' => function ( $val ) {
 				return $val; },
 		]
 	);
 
-	return $m->render( $template, $data );
+	$mustache->setTokenizer( new WP_CLI\Compat\MustacheTokenizer() );
+
+	return $mustache->render( $template, $data );
 }
 
 /**


### PR DESCRIPTION
Instead of pulling in a fork to get the temporary fix for PHP 8.1 in the PR https://github.com/bobthecow/mustache.php/pull/380, this PR uses a class extension instead that overrides the default tokenizer.

This leads to less downstream issues with Composer dependency resolution.