### PR TITLE
Detect and ignore BOMs

### DIFF
--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -320,7 +320,7 @@ Feature: Bootstrap WP-CLI
   Scenario: Composer stack with both WordPress and wp-cli as dependencies (command line)
     Given a WP installation with Composer
     And a dependency on current wp-cli
-    And I try `composer require wp-cli/entity-command --no-interaction`
+    And I run `composer require wp-cli/entity-command --no-interaction`
 
     When I run `vendor/bin/wp option get blogname`
     Then STDOUT should contain:
@@ -338,7 +338,7 @@ Feature: Bootstrap WP-CLI
   Scenario: Composer stack with both WordPress and wp-cli as dependencies and a custom vendor directory
     Given a WP installation with Composer and a custom vendor directory 'vendor-custom'
     And a dependency on current wp-cli
-    And I try `composer require wp-cli/entity-command --no-interaction`
+    And I run `composer require wp-cli/entity-command --no-interaction`
 
     When I run `vendor-custom/bin/wp option get blogname`
     Then STDOUT should contain:

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -656,7 +656,7 @@ class Runner {
 		// Detect and strip byte-order marks (BOMs).
 		// This code assumes they can only be found on the first line.
 		foreach ( self::BYTE_ORDER_MARKS as $bom_name => $bom_sequence ) {
-			WP_CLI::debug( "Looking for {$bom_name} BOM", 'bom' );
+			WP_CLI::debug( "Looking for {$bom_name} BOM", 'bootstrap' );
 
 			$length = strlen( $bom_sequence );
 


### PR DESCRIPTION
This PR adds byte-order marks (BOM) detection to the logic that parses the `wp-config.php` file for loading WP within the WP-CLI context.

If a BOM is detected, WP-CLI issues a warning and then strips that BOM for further parsing.

![_ 2022-01-05 at 11 52 24 AM li-dev_wp-cli](https://user-images.githubusercontent.com/83631/148265594-2fcf2d30-b9f3-4a21-bd2f-84f59f426a6f.jpeg)

Fixes #5577 
Fixes #5578 