### PR TITLE
Use proper `WP_User_Query` for fetching users

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -195,7 +195,7 @@ Feature: Get help about WP-CLI commands
     Then the return code should be 1
     And STDERR should contain:
       """
-      We were able to connect to the database server (which means your username and password is okay) but not able to select the `wp_cli_test` database.
+      Error establishing a database connection.
       """
     And STDERR should contain:
       """

--- a/php/WP_CLI/Fetchers/User.php
+++ b/php/WP_CLI/Fetchers/User.php
@@ -23,22 +23,37 @@ class User extends Base {
 	 * @return WP_User|false The item if found; false otherwise.
 	 */
 	public function get( $arg ) {
-
 		if ( is_numeric( $arg ) ) {
-			$users = get_users( [ 'include' => [ (int) $arg ] ] );
+			$users = get_users(
+				[
+					'include' => [ (int) $arg ],
+					'number'  => 1,
+				]
+			);
 		} elseif ( is_email( $arg ) ) {
 			$users = get_users(
 				[
 					'search'         => $arg,
 					'search_columns' => [ 'user_email' ],
+					'number'         => 1,
 				]
 			);
 			// Logins can be emails.
 			if ( ! $users ) {
-				$users = get_users( [ 'login' => $arg ] );
+				$users = get_users(
+					[
+						'login'  => $arg,
+						'number' => 1,
+					]
+				);
 			}
 		} else {
-			$users = get_users( [ 'login' => $arg ] );
+			$users = get_users(
+				[
+					'login'  => $arg,
+					'number' => 1,
+				]
+			);
 		}
 
 		return is_array( $users ) ? $users[0] : false;

--- a/php/WP_CLI/Fetchers/User.php
+++ b/php/WP_CLI/Fetchers/User.php
@@ -25,18 +25,23 @@ class User extends Base {
 	public function get( $arg ) {
 
 		if ( is_numeric( $arg ) ) {
-			$user = get_user_by( 'id', $arg );
+			$users = get_users( [ 'include' => [ (int) $arg ] ] );
 		} elseif ( is_email( $arg ) ) {
-			$user = get_user_by( 'email', $arg );
+			$users = get_users(
+				[
+					'search'         => $arg,
+					'search_columns' => 'user_email',
+				]
+			);
 			// Logins can be emails.
 			if ( ! $user ) {
-				$user = get_user_by( 'login', $arg );
+				$users = get_users( [ 'login' => $arg ] );
 			}
 		} else {
-			$user = get_user_by( 'login', $arg );
+			$users = get_users( [ 'login' => $arg ] );
 		}
 
-		return $user;
+		return is_array( $users ) ? $users[0] : false;
 	}
 }
 

--- a/php/WP_CLI/Fetchers/User.php
+++ b/php/WP_CLI/Fetchers/User.php
@@ -34,7 +34,7 @@ class User extends Base {
 				]
 			);
 			// Logins can be emails.
-			if ( ! $user ) {
+			if ( ! $users ) {
 				$users = get_users( [ 'login' => $arg ] );
 			}
 		} else {

--- a/php/WP_CLI/Fetchers/User.php
+++ b/php/WP_CLI/Fetchers/User.php
@@ -56,7 +56,7 @@ class User extends Base {
 			);
 		}
 
-		return is_array( $users ) ? $users[0] : false;
+		return ( is_array( $users ) && count( $users ) > 0 ) ? $users[0] : false;
 	}
 }
 

--- a/php/WP_CLI/Fetchers/User.php
+++ b/php/WP_CLI/Fetchers/User.php
@@ -30,7 +30,7 @@ class User extends Base {
 			$users = get_users(
 				[
 					'search'         => $arg,
-					'search_columns' => 'user_email',
+					'search_columns' => [ 'user_email' ],
 				]
 			);
 			// Logins can be emails.

--- a/php/WP_CLI/Fetchers/User.php
+++ b/php/WP_CLI/Fetchers/User.php
@@ -42,16 +42,18 @@ class User extends Base {
 			if ( ! $users ) {
 				$users = get_users(
 					[
-						'login'  => $arg,
-						'number' => 1,
+						'search'         => $arg,
+						'search_columns' => [ 'user_login' ],
+						'number'         => 1,
 					]
 				);
 			}
 		} else {
 			$users = get_users(
 				[
-					'login'  => $arg,
-					'number' => 1,
+					'search'         => $arg,
+					'search_columns' => [ 'user_login' ],
+					'number'         => 1,
 				]
 			);
 		}


### PR DESCRIPTION
There seems to be a fundamental difference between `get_user_by()` and `get_users()`. Where the former creates a new `WP_User` object and initiates it via an array of data, the latter puts the actual database result into the `WP_User`'s ` $data` property via its constructor.

The end result is that the set of available properties is different. As an example, when a user is fetched via `get_users()`, it knows about its `nickname`. If it is fetched by `get_user_by()`, the `nickname` property does not exist.

This PR changes the `UserFetcher` to rely on `get_users()` (instead of `get_user_by()`), to make all properties available.