### PR TITLE
Fix undefined function error

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -587,7 +587,7 @@ class WP_CLI {
 			throw new Exception(
 				sprintf(
 					"'%s' can't have subcommands.",
-					implode( ' ', get_path( $command ) )
+					implode( ' ', Dispatcher\get_path( $command ) )
 				)
 			);
 		}


### PR DESCRIPTION
Previously if you were to do the following, you would get an undefined function error instead of the expected exception for `wp one` not being able to have subcommands:

```php
WP_CLI::add_command('one', function() {});
WP_CLI::add_command('one two', function() {});
```