### PR TITLE
fix for root user competition

### DIFF
--- a/utils/wp-completion.bash
+++ b/utils/wp-completion.bash
@@ -5,7 +5,7 @@ _wp_complete() {
 	local cur=${COMP_WORDS[COMP_CWORD]}
 
 	IFS=$'\n';  # want to preserve spaces at the end
-	local opts="$(wp cli completions --line="$COMP_LINE" --point="$COMP_POINT")"
+	local opts="$(wp cli completions --line="$COMP_LINE" --point="$COMP_POINT" --allow-root)"
 
 	if [[ "$opts" =~ \<file\>\s* ]]
 	then


### PR DESCRIPTION
Completion not working for system root user, warning shows. This fix added `--allow-root` parameter for getting completions list for root user.

Default behavior:
![image](https://user-images.githubusercontent.com/12094229/164748115-f6721ee3-bea0-45c1-88dd-bf5e3a3ba672.png)

After fix:
![image](https://user-images.githubusercontent.com/12094229/164749164-eb84b4fd-bccf-446a-9e0d-9ef91794cc52.png)
