### PR TITLE
Documents return type for WP_CLI::halt() as never

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -932,6 +932,7 @@ class WP_CLI {
 	 * @category Output
 	 *
 	 * @param integer $return_code
+	 * @return never
 	 */
 	public static function halt( $return_code ) {
 		if ( self::$capture_exit ) {


### PR DESCRIPTION
Just a small change - Not sure if there is interest in this sort of thing, but it is nice to have for the sake of static analysis tools.

As it is currently, both psalm and phpstan raise an issue for a function with `never` return type that exits via a call to `WP_CLI::halt()`.