### PR TITLE
Update allow-list

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -125,7 +125,7 @@ jobs:
           php-version: '${{ matrix.php }}'
           extensions: gd, imagick, mysql, zip
           coverage: none
-          tools: composer
+          tools: composer:2.2
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ phpunit.xml
 phpcs.xml
 .phpcs.xml
 composer.lock
+wordpress/

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,8 @@
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "ext-curl": "*",
+        "johnpbloch/wordpress-core": "^6.0",
+        "johnpbloch/wordpress-core-installer": "^2.0",
         "mustache/mustache": "^2.14.1",
         "rmccue/requests": "^1.8",
         "symfony/finder": ">2.7",
@@ -30,7 +32,9 @@
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "johnpbloch/wordpress-core-installer": true,
+            "johnpbloch/wordpress-core": true
         },
         "process-timeout": 7200,
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,20 @@
     ],
     "homepage": "https://wp-cli.org",
     "license": "MIT",
+    "repositories": [
+        {
+          "type": "package",
+          "package": {
+            "name": "wp-cli/wp-cli-tests",
+            "version": "3.1.5",
+            "source": {
+              "url": "https://github.com/Lewiscowles1986/wp-cli-tests.git",
+              "type": "git",
+              "reference": "6fbfd2a50fe9a2d859654edeac627dce6cfb7d90"
+            }
+          }
+        }
+      ],
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "ext-curl": "*",
@@ -22,7 +36,7 @@
         "wp-cli/entity-command": "^1.2 || ^2",
         "wp-cli/extension-command": "^1.1 || ^2",
         "wp-cli/package-command": "^1 || ^2",
-        "wp-cli/wp-cli-tests": "^3.1.3"
+        "wp-cli/wp-cli-tests": "^3.1.5"
     },
     "suggest": {
         "ext-readline": "Include for a better --prompt implementation",

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,6 @@
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "ext-curl": "*",
-        "johnpbloch/wordpress-core": "^6.0",
-        "johnpbloch/wordpress-core-installer": "^2.0",
         "mustache/mustache": "^2.14.1",
         "rmccue/requests": "^1.8",
         "symfony/finder": ">2.7",
@@ -32,9 +30,7 @@
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "johnpbloch/wordpress-core-installer": true,
-            "johnpbloch/wordpress-core": true
+            "dealerdirect/phpcodesniffer-composer-installer": true
         },
         "process-timeout": 7200,
         "sort-packages": true


### PR DESCRIPTION
https://github.com/Lewiscowles1986/wp-cli/pull/1 shows feature tests failing due to a composer plugin allow-list problem.

This adds the mentioned plugin to allow list