### PR TITLE
Allow defining a custom config spec with WP_CLI_CONFIG_SPEC_PATH constant

### DIFF
--- a/features/configurator.feature
+++ b/features/configurator.feature
@@ -1,0 +1,49 @@
+Feature: Define global parameters
+
+  Scenario: Throws exception for an invalid config spec
+    Given an empty directory
+    And a wp-invalid-config-spec.php file:
+      """
+      <?php
+      // A hacky way to inject our constant into the runtime.
+      define( 'WP_CLI_CONFIG_SPEC_PATH', 'invalid-path' );
+      
+      $wp_cli_info = json_decode( trim( shell_exec( 'wp cli info --format=json' ) ), true );
+      require $wp_cli_info['wp_cli_dir_path'] . '/php/boot-fs.php';
+      """
+
+    When I try `php wp-invalid-config-spec.php option get home`
+    Then STDOUT should contain:
+      """
+      Uncaught Exception: Unable to load config spec:
+      """
+
+  Scenario: Errors when a global parameter doesn't exist
+    Given a WP installation in 'foo'
+    And a empty-config-spec.php file:
+      """
+      <?php
+      return [];
+      """
+    And a wp-empty-config-spec.php file:
+      """
+      <?php
+      // A hacky way to inject our constant into the runtime.
+      define( 'WP_CLI_CONFIG_SPEC_PATH', __DIR__ . '/empty-config-spec.php' );
+      
+      $wp_cli_info = json_decode( trim( shell_exec( 'wp cli info --format=json' ) ), true );
+      require $wp_cli_info['wp_cli_dir_path'] . '/php/boot-fs.php';
+      """
+
+    When I run `wp --path=foo option get home`
+    Then STDOUT should be:
+      """
+      https://example.com
+      """
+
+    When I try `php wp-empty-config-spec.php --path=foo option get home`
+    Then STDERR should be:
+      """
+      Error: Parameter errors:
+        unknown --path parameter
+      """

--- a/php/WP_CLI/Bootstrap/IncludePackageAutoloader.php
+++ b/php/WP_CLI/Bootstrap/IncludePackageAutoloader.php
@@ -25,7 +25,7 @@ final class IncludePackageAutoloader extends AutoloaderStep {
 		}
 
 		$runner        = new RunnerInstance();
-		$skip_packages = $runner()->config['skip-packages'];
+		$skip_packages = ! empty( $runner()->config['skip-packages'] );
 		if ( true === $skip_packages ) {
 			WP_CLI::debug( 'Skipped loading packages.', 'bootstrap' );
 

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -2,6 +2,7 @@
 
 namespace WP_CLI;
 
+use Exception;
 use Mustangostang\Spyc;
 
 /**
@@ -63,6 +64,9 @@ class Configurator {
 	 * @param string $path Path to config spec file.
 	 */
 	public function __construct( $path ) {
+		if ( ! file_exists( $path ) ) {
+			throw new Exception( sprintf( 'Unable to load config spec: %s', $path ) );
+		}
 		$this->spec = include $path;
 
 		$defaults = [

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -174,7 +174,7 @@ class Subcommand extends CompositeCommand {
 
 		$spec = array_values( $spec );
 
-		$prompt_args = WP_CLI::get_config( 'prompt' );
+		$prompt_args = ! empty( WP_CLI::get_runner()->config['prompt'] ) ? WP_CLI::get_runner()->config['prompt'] : false;
 		if ( true !== $prompt_args ) {
 			$prompt_args = explode( ',', $prompt_args );
 		}

--- a/php/WP_CLI/Loggers/Base.php
+++ b/php/WP_CLI/Loggers/Base.php
@@ -41,7 +41,7 @@ abstract class Base {
 		if ( null === $start_time ) {
 			$start_time = microtime( true );
 		}
-		$debug = $this->get_runner()->config['debug'];
+		$debug = isset( $this->get_runner()->config['debug'] ) && $this->get_runner()->config['debug'];
 		if ( ! $debug ) {
 			return;
 		}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -62,7 +62,12 @@ class WP_CLI {
 		static $configurator;
 
 		if ( ! $configurator ) {
-			$configurator = new Configurator( WP_CLI_ROOT . '/php/config-spec.php' );
+			if ( defined( 'WP_CLI_CONFIG_SPEC_PATH' ) ) {
+				$config_spec = WP_CLI_CONFIG_SPEC_PATH;
+			} else {
+				$config_spec = WP_CLI_ROOT . '/php/config-spec.php';
+			}
+			$configurator = new Configurator( $config_spec );
 		}
 
 		return $configurator;

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -41,7 +41,7 @@ function wp_not_installed() {
 
 // phpcs:disable WordPress.PHP.IniSet -- Intentional & correct usage.
 function wp_debug_mode() {
-	if ( WP_CLI::get_config( 'debug' ) ) {
+	if ( ! empty( WP_CLI::get_runner()->config['debug'] ) ) {
 		if ( ! defined( 'WP_DEBUG' ) ) {
 			define( 'WP_DEBUG', true );
 		}


### PR DESCRIPTION
Fixes #5649

## Proposed changes

Allows use of a custom `config-spec.php` file (for registering global parameters or disabling existing) by defining a `WP_CLI_CONFIG_SPEC_PATH` constant.

The use of a constant (instead of an environment variable) enables the platform operator to register a platform-specific `config-spec.php`, and prevent later changes to it.

## Testing instructions

To come...