### PR TITLE
Address some PHP 8.1 deprecation notices

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -277,6 +277,8 @@ class Runner {
 			}
 			$dir = $parent_dir;
 		}
+
+		return getcwd();
 	}
 
 	/**

--- a/php/utils.php
+++ b/php/utils.php
@@ -978,6 +978,10 @@ function get_home_dir() {
  * @return string String with trailing slash added.
  */
 function trailingslashit( $string ) {
+	if ( ! is_string( $string ) ) {
+		return '/';
+	}
+
 	return rtrim( $string, '/\\' ) . '/';
 }
 


### PR DESCRIPTION
**Ensure `Runner::find_wp_root()` always returns a directory**

According to the docblock, the method is supposed to default to the current working dir, but in reality it could return `null` if nothing was found.

This breaks other methods like `::set_wp_root()` which expect a string.

Prevents PHP deprecation notices because `null` was passed to `realpath()`.

**Handle null values in `trailingslashit` util** 

Prevents PHP deprecation notices when inadvertently passing `null` to the function and thus `rtrim`.

