### PR TITLE
Require `v3.1.6` of `wp-cli/wp-cli-tests`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "wp-cli/entity-command": "^1.2 || ^2",
         "wp-cli/extension-command": "^1.1 || ^2",
         "wp-cli/package-command": "^1 || ^2",
-        "wp-cli/wp-cli-tests": "^3.1.3"
+        "wp-cli/wp-cli-tests": "^3.1.5"
     },
     "suggest": {
         "ext-readline": "Include for a better --prompt implementation",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "wp-cli/entity-command": "^1.2 || ^2",
         "wp-cli/extension-command": "^1.1 || ^2",
         "wp-cli/package-command": "^1 || ^2",
-        "wp-cli/wp-cli-tests": "^3.1.5"
+        "wp-cli/wp-cli-tests": "^3.1.6"
     },
     "suggest": {
         "ext-readline": "Include for a better --prompt implementation",


### PR DESCRIPTION
This fixes test failures in the test scenarios that build a custom Composer file.