### PR TITLE
Fix cli cache prune command

### DIFF
--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -292,9 +292,13 @@ class FileCache {
 			$pieces                   = explode( '-', $file->getBasename( $file->getExtension() ) );
 			$version                  = end( $pieces );
 			$basename_without_version = str_replace( '-' . $version, '', $file->getBasename() );
+			$extension                = $file->getExtension();
 
+			// Cache should only contain .zip files
+			if ( 'zip' !== $extension ) {
+				unlink( $file->getRealPath() );
 			// There's a file with an older version, delete it.
-			if ( isset( $files_maxversion[ $basename_without_version ] ) ) {
+			} elseif ( isset( $files_maxversion[ $basename_without_version ] ) ) {
 				$vcomp = version_compare( $basename_without_version, $files_maxversion[ $basename_without_version ] );
 				if ( -1 === $vcomp ) {
 					//this version is older, so delete this one
@@ -305,6 +309,7 @@ class FileCache {
 					$files_maxversionpath[ $basename_without_version ] = $file->getRealPath();
 					$files_maxversion[ $basename_without_version ]     = $version;
 				}
+			// First version of this, so save it
 			} else {
 					$files_maxversionpath[ $basename_without_version ] = $file->getRealPath();
 					$files_maxversion[ $basename_without_version ]     = $version;

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -285,30 +285,35 @@ class FileCache {
 		/** @var Finder $finder */
 		$finder = $this->get_finder()->sortByName();
 
-		$files_to_delete = [];
+		$files_maxversion = [];
+		$files_maxversionpath = [];
 
 		foreach ( $finder as $file ) {
 			$pieces    = explode( '-', $file->getBasename( $file->getExtension() ) );
-			$timestamp = end( $pieces );
-
-			// No way to compare versions, do nothing.
-			if ( ! is_numeric( $timestamp ) ) {
-				continue;
+			$version = end( $pieces );
+			$basename_without_version = str_replace( '-' . $version, '', $file->getBasename() );
+			
+			// There's a file with an older version, delete it.
+			if ( isset( $files_maxversion[ $basename_without_version ] ) ) {
+				$vcomp=version_compare($basename_without_version,$files_maxversion[ $basename_without_version ]);
+				if ($vcomp == -1) {
+					//this version is older, so delete this one
+					unlink($file->getRealPath());
+				} else {
+					//the other version is older, delete it and save this version
+					unlink( $files_maxversionpath[ $basename_without_version ] );
+					$files_maxversionpath[ $basename_without_version ] = $file->getRealPath();
+					$files_maxversion[ $basename_without_version ] = $version;
+				}
+			} else {
+					$files_maxversionpath[ $basename_without_version ] = $file->getRealPath();
+					$files_maxversion[ $basename_without_version ] = $version;
 			}
-
-			$basename_without_timestamp = str_replace( '-' . $timestamp, '', $file->getBasename() );
-
-			// There's a file with an older timestamp, delete it.
-			if ( isset( $files_to_delete[ $basename_without_timestamp ] ) ) {
-				unlink( $files_to_delete[ $basename_without_timestamp ] );
-			}
-
-			$files_to_delete[ $basename_without_timestamp ] = $file->getRealPath();
 		}
 
 		return true;
 	}
-
+	
 	/**
 	 * Ensure directory exists
 	 *

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -296,7 +296,7 @@ class FileCache {
 			// There's a file with an older version, delete it.
 			if ( isset( $files_maxversion[ $basename_without_version ] ) ) {
 				$vcomp = version_compare( $basename_without_version, $files_maxversion[ $basename_without_version ] );
-				if ( $vcomp === -1 ) {
+				if ( -1 === $vcomp ) {
 					//this version is older, so delete this one
 					unlink( $file->getRealPath() );
 				} else {

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -294,25 +294,25 @@ class FileCache {
 			$basename_without_version = str_replace( '-' . $version, '', $file->getBasename() );
 			$extension                = $file->getExtension();
 
-			// Cache should only contain .zip files
-			if ( 'zip' !== $extension ) {
-				unlink( $file->getRealPath() );
-			// There's a file with an older version, delete it.
-			} elseif ( isset( $files_maxversion[ $basename_without_version ] ) ) {
-				$vcomp = version_compare( $basename_without_version, $files_maxversion[ $basename_without_version ] );
-				if ( -1 === $vcomp ) {
-					//this version is older, so delete this one
-					unlink( $file->getRealPath() );
+			// pruning Doesn't apply to tmp files
+			if ( 'tmp' !== $extension ) {
+				// There's a file with an older version, delete it.
+				if ( isset( $files_maxversion[ $basename_without_version ] ) ) {
+					$vcomp = version_compare( $basename_without_version, $files_maxversion[ $basename_without_version ] );
+					if ( -1 === $vcomp ) {
+						//this version is older, so delete this one
+						unlink( $file->getRealPath() );
+					} else {
+						//the other version is older, delete it and save this version
+						unlink( $files_maxversionpath[ $basename_without_version ] );
+						$files_maxversionpath[ $basename_without_version ] = $file->getRealPath();
+						$files_maxversion[ $basename_without_version ]     = $version;
+					}
+				// First version of this, so save it
 				} else {
-					//the other version is older, delete it and save this version
-					unlink( $files_maxversionpath[ $basename_without_version ] );
-					$files_maxversionpath[ $basename_without_version ] = $file->getRealPath();
-					$files_maxversion[ $basename_without_version ]     = $version;
+						$files_maxversionpath[ $basename_without_version ] = $file->getRealPath();
+						$files_maxversion[ $basename_without_version ]     = $version;
 				}
-			// First version of this, so save it
-			} else {
-					$files_maxversionpath[ $basename_without_version ] = $file->getRealPath();
-					$files_maxversion[ $basename_without_version ]     = $version;
 			}
 		}
 

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -308,8 +308,8 @@ class FileCache {
 						$files_maxversionpath[ $basename_without_version ] = $file->getRealPath();
 						$files_maxversion[ $basename_without_version ]     = $version;
 					}
-				// First version of this, so save it
 				} else {
+						// First version of this, so save it
 						$files_maxversionpath[ $basename_without_version ] = $file->getRealPath();
 						$files_maxversion[ $basename_without_version ]     = $version;
 				}

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -283,7 +283,7 @@ class FileCache {
 		}
 
 		/** @var Finder $finder */
-		$finder = $this->get_finder()->sortByName();
+		$finder               = $this->get_finder()->sortByName();
 
 		$files_maxversion     = [];
 		$files_maxversionpath = [];
@@ -296,7 +296,7 @@ class FileCache {
 			// There's a file with an older version, delete it.
 			if ( isset( $files_maxversion[ $basename_without_version ] ) ) {
 				$vcomp = version_compare( $basename_without_version, $files_maxversion[ $basename_without_version ] );
-				if ( $vcomp == -1 ) {
+				if ( $vcomp === -1 ) {
 					//this version is older, so delete this one
 					unlink( $file->getRealPath() );
 				} else {

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -283,7 +283,7 @@ class FileCache {
 		}
 
 		/** @var Finder $finder */
-		$finder               = $this->get_finder()->sortByName();
+		$finder = $this->get_finder()->sortByName();
 
 		$files_maxversion     = [];
 		$files_maxversionpath = [];


### PR DESCRIPTION
Use version number instead of timestamp to keep the latest version of each cached package.

Prior: prune command did nothing because it was looking for a timestamp suffix for each package which was replaced at some point by a version number.

After: prune command uses highest version number to keep latest package version for each page, removing the rest.

See issue https://github.com/wp-cli/wp-cli/issues/5467