### PR TITLE
Use different action for admin context logic

### DIFF
--- a/features/context.feature
+++ b/features/context.feature
@@ -31,24 +31,24 @@ Feature: Context handling via --context global flag
       true
       """
 
+    When I run `wp eval 'add_action( "admin_init", static function () { WP_CLI::warning( "admin_init was triggered." ); } );'`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      admin_init was triggered.
+      """
+
+    When I run `wp --context=cli eval 'add_action( "admin_init", static function () { WP_CLI::warning( "admin_init was triggered." ); } );'`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      admin_init was triggered.
+      """
+
   Scenario: Admin context can be selected
     Given a WP install
 
-    When I run `wp eval 'var_export( is_admin() );'`
-    Then the return code should be 0
-    And STDOUT should be:
-      """
-      false
-      """
-
     When I run `wp --context=admin eval 'var_export( is_admin() );'`
-    Then the return code should be 0
-    And STDOUT should be:
-      """
-      true
-      """
-
-    When I run `wp eval 'var_export( function_exists( "media_handle_upload" ) );'`
     Then the return code should be 0
     And STDOUT should be:
       """
@@ -62,15 +62,15 @@ Feature: Context handling via --context global flag
       true
       """
 
+    When I run `wp eval --context=admin 'add_action( "admin_init", static function () { WP_CLI::warning( "admin_init was triggered." ); } );'`
+    Then the return code should be 0
+    And STDERR should not contain:
+      """
+      admin_init was triggered.
+      """
+
   Scenario: Frontend context can be selected (and does nothing yet...)
     Given a WP install
-
-    When I run `wp eval 'var_export( is_admin() );'`
-    Then the return code should be 0
-    And STDOUT should be:
-      """
-      false
-      """
 
     When I run `wp --context=frontend eval 'var_export( is_admin() );'`
     Then the return code should be 0
@@ -79,18 +79,18 @@ Feature: Context handling via --context global flag
       false
       """
 
-    When I run `wp eval 'var_export( function_exists( "media_handle_upload" ) );'`
+    When I run `wp --context=frontend eval 'var_export( function_exists( "media_handle_upload" ) );'`
     Then the return code should be 0
     And STDOUT should be:
       """
       true
       """
 
-    When I run `wp --context=frontend eval 'var_export( function_exists( "media_handle_upload" ) );'`
+    When I run `wp --context=frontend eval 'add_action( "admin_init", static function () { WP_CLI::warning( "admin_init was triggered." ); } );'`
     Then the return code should be 0
-    And STDOUT should be:
+    And STDERR should not contain:
       """
-      true
+      admin_init was triggered.
       """
 
   Scenario: Auto context can be selected and changes environment based on command

--- a/php/WP_CLI/Context/Admin.php
+++ b/php/WP_CLI/Context/Admin.php
@@ -57,7 +57,7 @@ final class Admin implements Context {
 
 				require_once ABSPATH . 'wp-admin/admin.php';
 			},
-			PHP_INT_MIN,
+			defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : -2147483648
 			0
 		);
 	}

--- a/php/WP_CLI/Context/Admin.php
+++ b/php/WP_CLI/Context/Admin.php
@@ -57,7 +57,7 @@ final class Admin implements Context {
 
 				require_once ABSPATH . 'wp-admin/admin.php';
 			},
-			defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : -2147483648
+			defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : -2147483648, // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
 			0
 		);
 	}

--- a/php/WP_CLI/Context/Admin.php
+++ b/php/WP_CLI/Context/Admin.php
@@ -39,7 +39,7 @@ final class Admin implements Context {
 
 		// Bootstrap the WordPress administration area.
 		WP_CLI::add_wp_hook(
-			'admin_init',
+			'plugins_loaded',
 			function () {
 				global $wp_db_version, $_wp_submenu_nopriv;
 
@@ -57,6 +57,7 @@ final class Admin implements Context {
 
 				require_once ABSPATH . 'wp-admin/admin.php';
 			},
+			PHP_INT_MIN,
 			0
 		);
 	}

--- a/php/WP_CLI/Context/Admin.php
+++ b/php/WP_CLI/Context/Admin.php
@@ -65,21 +65,17 @@ final class Admin implements Context {
 		wp_set_current_user( $admin_user_id );
 
 		$expiration = time() + DAY_IN_SECONDS;
-		$manager    = WP_Session_Tokens::get_instance( $admin_user_id );
-		$token      = $manager->create( $expiration );
 
 		$_COOKIE[ AUTH_COOKIE ] = wp_generate_auth_cookie(
 			$admin_user_id,
 			$expiration,
-			'auth',
-			$token
+			'auth'
 		);
 
 		$_COOKIE[ SECURE_AUTH_COOKIE ] = wp_generate_auth_cookie(
 			$admin_user_id,
 			$expiration,
-			'secure_auth',
-			$token
+			'secure_auth'
 		);
 	}
 
@@ -95,7 +91,11 @@ final class Admin implements Context {
 	 * @return void
 	 */
 	private function load_admin_environment() {
-		global $wp_db_version, $_wp_submenu_nopriv;
+		global $hook_suffix, $pagenow, $wp_db_version, $_wp_submenu_nopriv;
+
+		if ( ! isset( $hook_suffix ) ) {
+			$hook_suffix = 'index'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
 
 		// Make sure we don't trigger a DB upgrade as that tries to redirect
 		// the page.
@@ -114,7 +114,7 @@ final class Admin implements Context {
 		$admin_php_file = preg_replace( '/\s+\?>$/', '', $admin_php_file );
 
 		// Then we remove the loading of either wp-config.php or wp-load.php.
-		$admin_php_file = preg_replace( '/^\s*(?:include|require).*[\'"]\/?wp-(?:load|config)\.php[\'"];$/m', '', $admin_php_file );
+		$admin_php_file = preg_replace( '/^\s*(?:include|require).*[\'"]\/?wp-(?:load|config)\.php[\'"]\s*\)?;$/m', '', $admin_php_file );
 
 		// We also remove the authentication redirect.
 		$admin_php_file = preg_replace( '/^\s*auth_redirect\(\);$/m', '', $admin_php_file );

--- a/php/WP_CLI/Context/Admin.php
+++ b/php/WP_CLI/Context/Admin.php
@@ -39,7 +39,7 @@ final class Admin implements Context {
 
 		// Bootstrap the WordPress administration area.
 		WP_CLI::add_wp_hook(
-			'plugins_loaded',
+			'init',
 			function () {
 				$this->log_in_as_admin_user();
 				$this->load_admin_environment();


### PR DESCRIPTION
The `-context=admin` logic was hooking some of its logic to the `admin_init` action. However, as the loading was adapted, the requirement for triggering the `admin_init` action ended up within the action's closures, causing the entire construct to not be executed at all.

This PR changes the `--context=admin` logic to use `plugins_loaded` with the lowest possible priority instead of `admin_init`.