### PR TITLE
Load `config-spec.php` in a "filterable" way

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -574,3 +574,27 @@ Feature: Have a config file
       """
       Warning: UTF-8 byte-order mark (BOM) detected in wp-config.php file, stripping it for parsing.
       """
+
+  Scenario: Customize config-spec with WP_CLI_CONFIG_SPEC_FILTER_CALLBACK
+    Given a WP installation
+    And a wp-cli-early-require.php file:
+      """
+      <?php
+      function wp_cli_remove_user_arg( $spec ) {
+        unset( $spec['user'] );
+        return $spec;
+      }
+      define( 'WP_CLI_CONFIG_SPEC_FILTER_CALLBACK', 'wp_cli_remove_user_arg' );
+      """
+
+    When I run `WP_CLI_EARLY_REQUIRE=wp-cli-early-require.php wp help`
+    Then STDOUT should not contain:
+      """
+      --user=<id|login|email>
+      """
+
+    When I run `wp help`
+    Then STDOUT should contain:
+      """
+      --user=<id|login|email>
+      """

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -63,7 +63,7 @@ class Configurator {
 	 * @param string $path Path to config spec file.
 	 */
 	public function __construct( $path ) {
-		self::load_config_spec( $path );
+		$this->load_config_spec( $path );
 
 		$defaults = [
 			'runtime'  => false,

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -89,9 +89,9 @@ class Configurator {
 		$config_spec = include $path;
 		// A way for platforms to modify $config_spec.
 		// Use with caution!
-		if ( getenv( 'WP_CLI_INCLUDE_AFTER_CONFIG_SPEC_LOAD' )
-			&& is_readable( getenv( 'WP_CLI_INCLUDE_AFTER_CONFIG_SPEC_LOAD' ) ) ) {
-			include getenv( 'WP_CLI_INCLUDE_AFTER_CONFIG_SPEC_LOAD' );
+		$config_spec_filter_callback = getenv( 'WP_CLI_CONFIG_SPEC_FILTER_CALLBACK' );
+		if ( callable( $config_spec_filter_callback ) ) {
+			$config_spec = $config_spec_filter_callback( $config_spec );
 		}
 		$this->spec = $config_spec;
 	}

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -63,7 +63,7 @@ class Configurator {
 	 * @param string $path Path to config spec file.
 	 */
 	public function __construct( $path ) {
-		$this->spec = include $path;
+		self::load_config_spec( $path );
 
 		$defaults = [
 			'runtime'  => false,
@@ -78,6 +78,22 @@ class Configurator {
 
 			$this->config[ $key ] = $details['default'];
 		}
+	}
+
+	/**
+	 * Loads the config spec file.
+	 *
+	 * @param string $path Path to the config spec file.
+	 */
+	private function load_config_spec( $path ) {
+		$config_spec = include $path;
+		// A way for platforms to modify $config_spec.
+		// Use with caution!
+		if ( getenv( 'WP_CLI_INCLUDE_AFTER_CONFIG_SPEC_LOAD' )
+			&& is_readable( getenv( 'WP_CLI_INCLUDE_AFTER_CONFIG_SPEC_LOAD' ) ) ) {
+			include getenv( 'WP_CLI_INCLUDE_AFTER_CONFIG_SPEC_LOAD' );
+		}
+		$this->spec = $config_spec;
 	}
 
 	/**

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -90,7 +90,7 @@ class Configurator {
 		// A way for platforms to modify $config_spec.
 		// Use with caution!
 		$config_spec_filter_callback = getenv( 'WP_CLI_CONFIG_SPEC_FILTER_CALLBACK' );
-		if ( callable( $config_spec_filter_callback ) ) {
+		if ( is_callable( $config_spec_filter_callback ) ) {
 			$config_spec = $config_spec_filter_callback( $config_spec );
 		}
 		$this->spec = $config_spec;

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -89,8 +89,8 @@ class Configurator {
 		$config_spec = include $path;
 		// A way for platforms to modify $config_spec.
 		// Use with caution!
-		$config_spec_filter_callback = getenv( 'WP_CLI_CONFIG_SPEC_FILTER_CALLBACK' );
-		if ( is_callable( $config_spec_filter_callback ) ) {
+		$config_spec_filter_callback = defined( 'WP_CLI_CONFIG_SPEC_FILTER_CALLBACK' ) ? constant( 'WP_CLI_CONFIG_SPEC_FILTER_CALLBACK' ) : false;
+		if ( $config_spec_filter_callback && is_callable( $config_spec_filter_callback ) ) {
 			$config_spec = $config_spec_filter_callback( $config_spec );
 		}
 		$this->spec = $config_spec;

--- a/php/wp-cli.php
+++ b/php/wp-cli.php
@@ -24,4 +24,9 @@ $_SERVER['REQUEST_METHOD']  = 'GET';
 $_SERVER['REMOTE_ADDR']     = '127.0.0.1';
 
 require_once WP_CLI_ROOT . '/php/bootstrap.php';
+
+if ( getenv( 'WP_CLI_EARLY_REQUIRE' ) ) {
+	require_once getenv( 'WP_CLI_EARLY_REQUIRE' );
+}
+
 WP_CLI\bootstrap();


### PR DESCRIPTION
* Moves `config-spec.php` loading to a standalone method.
* Calls `WP_CLI_CONFIG_SPEC_FILTER_CALLBACK` against `$config_spec` if callback is defined.
* Introduces `WP_CLI_EARLY_REQUIRE` environment variable for early loading of a PHP file.

Fixes #5649