### PR TITLE
Always return PHP_BINARY when using a PHAR bundle

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -1495,6 +1495,11 @@ function past_tense_verb( $verb ) {
  * @return string
  */
 function get_php_binary() {
+	// PHAR installs always use PHP_BINARY.
+	if ( inside_phar() ) {
+		return PHP_BINARY;
+	}
+
 	$wp_cli_php_used = getenv( 'WP_CLI_PHP_USED' );
 	if ( false !== $wp_cli_php_used ) {
 		return $wp_cli_php_used;


### PR DESCRIPTION
This PR adds a check to the `get_php_binary()` utility method so that when running `wp-cli` as a PHAR bundle the `wp --info` command will *always* output the shell's current PHP version.

Fixes https://github.com/wp-cli/wp-cli/issues/5615


I believe this is a _safe_ method of determining whether or not the `wp-cli` binary is a PHAR or not but if there's a preferred or better method I'll switch this to that.

Existing tests pass and I didn't add any new ones due to the usage of the constant.