### PR TITLE
Add cache dir path to info output FIX #5580

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -95,8 +95,7 @@ class WP_CLI {
 		static $cache;
 
 		if ( ! $cache ) {
-			$home     = Utils\get_home_dir();
-			$dir      = getenv( 'WP_CLI_CACHE_DIR' ) ? : "$home/.wp-cli/cache";
+			$dir      = Utils\get_cache_dir();
 			$ttl      = getenv( 'WP_CLI_CACHE_EXPIRY' ) ? : 15552000;
 			$max_size = getenv( 'WP_CLI_CACHE_MAX_SIZE' ) ? : 314572800;
 			// 6 months, 300mb

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -136,6 +136,8 @@ class CLI_Command extends WP_CLI_Command {
 			$packages_dir = null;
 		}
 
+		$home_dir = Utils\get_home_dir();
+
 		if ( Utils\get_flag_value( $assoc_args, 'format' ) === 'json' ) {
 			$info = [
 				'system_os'                => $system_os,
@@ -150,6 +152,7 @@ class CLI_Command extends WP_CLI_Command {
 				'wp_cli_vendor_path'       => WP_CLI_VENDOR_DIR,
 				'wp_cli_phar_path'         => defined( 'WP_CLI_PHAR_PATH' ) ? WP_CLI_PHAR_PATH : '',
 				'wp_cli_packages_dir_path' => $packages_dir,
+				'wp_cli_cache_dir_path'    => getenv( 'WP_CLI_CACHE_DIR' ) ? : "$home_dir/.wp-cli/cache",
 				'global_config_path'       => $runner->global_config_path,
 				'project_config_path'      => $runner->project_config_path,
 				'wp_cli_version'           => WP_CLI_VERSION,
@@ -169,6 +172,7 @@ class CLI_Command extends WP_CLI_Command {
 			WP_CLI::line( "WP-CLI vendor dir:\t" . WP_CLI_VENDOR_DIR );
 			WP_CLI::line( "WP_CLI phar path:\t" . ( defined( 'WP_CLI_PHAR_PATH' ) ? WP_CLI_PHAR_PATH : '' ) );
 			WP_CLI::line( "WP-CLI packages dir:\t" . $packages_dir );
+			WP_CLI::line( "WP-CLI cache dir:\t" . ( getenv( 'WP_CLI_CACHE_DIR' ) ? : "$home_dir/.wp-cli/cache" ) );
 			WP_CLI::line( "WP-CLI global config:\t" . $runner->global_config_path );
 			WP_CLI::line( "WP-CLI project config:\t" . $runner->project_config_path );
 			WP_CLI::line( "WP-CLI version:\t" . WP_CLI_VERSION );

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -136,8 +136,6 @@ class CLI_Command extends WP_CLI_Command {
 			$packages_dir = null;
 		}
 
-		$home_dir = Utils\get_home_dir();
-
 		if ( Utils\get_flag_value( $assoc_args, 'format' ) === 'json' ) {
 			$info = [
 				'system_os'                => $system_os,
@@ -152,7 +150,7 @@ class CLI_Command extends WP_CLI_Command {
 				'wp_cli_vendor_path'       => WP_CLI_VENDOR_DIR,
 				'wp_cli_phar_path'         => defined( 'WP_CLI_PHAR_PATH' ) ? WP_CLI_PHAR_PATH : '',
 				'wp_cli_packages_dir_path' => $packages_dir,
-				'wp_cli_cache_dir_path'    => getenv( 'WP_CLI_CACHE_DIR' ) ? : "$home_dir/.wp-cli/cache",
+				'wp_cli_cache_dir_path'    => Utils\get_cache_dir(),
 				'global_config_path'       => $runner->global_config_path,
 				'project_config_path'      => $runner->project_config_path,
 				'wp_cli_version'           => WP_CLI_VERSION,
@@ -172,7 +170,7 @@ class CLI_Command extends WP_CLI_Command {
 			WP_CLI::line( "WP-CLI vendor dir:\t" . WP_CLI_VENDOR_DIR );
 			WP_CLI::line( "WP_CLI phar path:\t" . ( defined( 'WP_CLI_PHAR_PATH' ) ? WP_CLI_PHAR_PATH : '' ) );
 			WP_CLI::line( "WP-CLI packages dir:\t" . $packages_dir );
-			WP_CLI::line( "WP-CLI cache dir:\t" . ( getenv( 'WP_CLI_CACHE_DIR' ) ? : "$home_dir/.wp-cli/cache" ) );
+			WP_CLI::line( "WP-CLI cache dir:\t" . Utils\get_cache_dir() );
 			WP_CLI::line( "WP-CLI global config:\t" . $runner->global_config_path );
 			WP_CLI::line( "WP-CLI project config:\t" . $runner->project_config_path );
 			WP_CLI::line( "WP-CLI version:\t" . WP_CLI_VERSION );

--- a/php/utils.php
+++ b/php/utils.php
@@ -1785,3 +1785,13 @@ function get_sql_modes() {
 
 	return $sql_modes;
 }
+
+/**
+ * Get the WP-CLI cache directory.
+ *
+ * @return string
+ */
+function get_cache_dir() {
+	$home = get_home_dir();
+	return getenv( 'WP_CLI_CACHE_DIR' ) ? : "$home/.wp-cli/cache";
+}


### PR DESCRIPTION
Adds the cache directory path to the `wp --info` output.

Fixes: #5580 

<img width="1081" alt="wp-cli-info-cache" src="https://user-images.githubusercontent.com/9557392/194117057-8e2b4379-a7a2-43d2-b45d-1e8273b9652b.png">


