### PR TITLE
Fix proc_open_compat util on Windows

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -1529,8 +1529,7 @@ function get_php_binary() {
  */
 function proc_open_compat( $cmd, $descriptorspec, &$pipes, $cwd = null, $env = null, $other_options = null ) {
 	if ( is_windows() ) {
-		// Need to encompass the whole command in double quotes - PHP bug https://bugs.php.net/bug.php?id=49139
-		$cmd = '"' . _proc_open_compat_win_env( $cmd, $env ) . '"';
+		$cmd = _proc_open_compat_win_env( $cmd, $env );
 	}
 	return proc_open( $cmd, $descriptorspec, $pipes, $cwd, $env, $other_options );
 }


### PR DESCRIPTION
Wrapping the commands in double quotes conflicts with various flags also using double quotes. 

For example when running `db export` you get.

`Warning: Failed to get current character set of the posts table. Reason: '"mysql --no-defaults --no-auto-rehash --batch --skip-column-names --host="localhost" --user="mat" --default-ch
aracter-set="utf8" --execute="SELECT' is not recognized as an internal or external command,
operable program or batch file.`

Removing the quotes resolves the issue.