### PR TITLE
Allowed tilde in alias pathnames and inherit directive.

### DIFF
--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -249,6 +249,8 @@ class Configurator {
 	 * @param string $path Path to YAML file.
 	 */
 	public function merge_yml( $path, $current_alias = null ) {
+		// Make path absolute, if necessary, before loading file.
+		$this->absolutize ($path,dirname($path));
 		$yaml = self::load_yml( $path );
 		if ( ! empty( $yaml['_']['inherit'] ) ) {
 			$this->merge_yml( $yaml['_']['inherit'], $current_alias );
@@ -388,7 +390,14 @@ class Configurator {
 	 */
 	private static function absolutize( &$path, $base ) {
 		if ( ! empty( $path ) && ! Utils\is_path_absolute( $path ) ) {
-			$path = $base . DIRECTORY_SEPARATOR . $path;
+			// Limit this to Unix operating systems?
+			$home_dir = getenv( 'HOME' ) ;
+			if ( substr( $path, 0, 2 ) === '~/' && isset( $home_dir ) ) {
+				$path = $home_dir . DIRECTORY_SEPARATOR . substr( $path, 2 );
+			}
+			else {
+				$path = $base . DIRECTORY_SEPARATOR . $path;
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi there,

This commit fixes two distinct issues:

+ Using path names with tildes as values for the "path" attribute in an alias definition (raised in #5339). Currently, this does not work:

```
@cap-local:
     path: ~/www/cap.local
```

The path would expand to `/Users/saul/.wp-cli/~/www/cap.local`. With this commit, the path is properly expanded to `/Users/saul/www/cap.local`. Note that  “~/“ notation works, but “~username” does not.

+ Using a path name with a tilde as a value for the `inherit` directive in a WP CLI configuration file. Currently, the following does not work:

```
inherit: ~/.local-wp-cli-config.yml
```

The filename simply appears to be ignored. With this commit, the file will be properly read. Note that  “~/“ notation works, but “~username” does not.
