### PR TITLE
Autocomplete `--url`

### DIFF
--- a/features/cli-bash-completion.feature
+++ b/features/cli-bash-completion.feature
@@ -325,3 +325,35 @@ Feature: `wp cli completions` tasks
       """
       --no-color
       """
+
+ Scenario: Bash Completion for global --url parameter
+    Given a WP multisite installation
+    And I run `wp site create --slug=foo.example.org`
+    And I run `wp site create --slug=foot.example.org`
+    And I run `wp site create --slug=football.example.org`
+    And I run `wp site create --slug=bar.example.org/quix`
+    And I run `wp site create --slug=bar.example.org/quiz`
+    And I run `wp site create --slug=waldo.example.org`
+
+    # show all matches
+    When I run `wp cli completions --line="wp plugin list --url=foo"
+    Then STDOUT should contain:
+      """
+      foo.example.org       foot.example.org      football.example.org
+      """
+
+    # autocomplete up to where the matches diverge
+    # todo probably needs to check in a different way than the others?
+    # todo not necessary if cant autocomplete when multiple
+    When I run `wp cli completions --line="wp plugin list --url=bar"
+        Then STDOUT should contain:
+          """
+          bar.example.org/qui
+          """
+
+    # autocomplete entirely when only 1 match
+    When I run `wp cli completions --line="wp plugin list --url=wal"
+            Then STDOUT should contain:
+              """
+              waldo.example.org
+              """

--- a/php/WP_CLI/Completions.php
+++ b/php/WP_CLI/Completions.php
@@ -7,6 +7,7 @@ use WP_CLI;
 class Completions {
 
 	private $words;
+	private $cur_word;
 	private $opts = [];
 
 	/**
@@ -25,6 +26,23 @@ class Completions {
 		$this->cur_word = end( $this->words );
 		if ( '' !== $this->cur_word && ! preg_match( '/^\-/', $this->cur_word ) ) {
 			array_pop( $this->words );
+		}
+
+		// Last word is an incomplete `--url` parameter
+		// todo maybe need php56 compat w/out wp polyfills?
+		if ( str_starts_with( $this->cur_word, '--url' ) ) {
+			$parameter      = explode( '=', $this->cur_word );
+				// todo maybe strip out the --
+			$this->cur_word = $parameter[1];
+			$urls           = $this->get_network_urls( 'foo' );
+
+			foreach ( $urls as $url ) {
+				$this->add( $url );
+				// todo parse out just the domain/path, no scheme
+				// or maybe accept 'http://foo', 'https://foo', and 'foo', and adjust output accordingly?
+			}
+
+			return;
 		}
 
 		$is_alias = false;
@@ -166,6 +184,45 @@ class Completions {
 		}
 
 		return $params;
+	}
+
+	/**
+	 * Get URLs in the Multisite network matching the input.
+	 *
+	 * @param string $prefix Beginning of a domain. e.g., `foo` for `football.example.org`
+	 *
+	 * @return string[] All of the URLs that start with $prefix
+	 */
+	private function get_network_urls( $prefix ) {
+		$cache            = WP_CLI::get_cache();
+		$main_site_domain = 'example.org';
+			// todo get via WP_CLI::launch_self( 'wp option get homeurl' ) ?
+			// todo parse out just the domain/path, not scheme/etc
+			// maybe run through php/wp filter to sanitize filename
+		$cache_key        = sprintf( 'network-urls:%s', $main_site_domain );
+		$cached_urls      = json_decode( $cache->read( $cache_key ) ); //specify ttl?
+
+		if ( $cached_urls ) {
+			return $cached_urls;
+		}
+
+		// todo get via wp site list --format...
+		$urls = array(
+			'foo.example.org',
+			'foot.example.org',
+			'football.example.org',
+		);
+
+		// todo how to get it to autocomplete when there's only 1 match found?
+
+		// todo how to get it to fill up to the point where the matches differ? e.g., 'foo' should autocomplete to 'foo.example.org/' if the urls are
+		// 'foo.example.org/bar' and 'foo.example.org/quix'
+
+		// In mutli-network installs, it should probably just search all networks, since everything is stored in wp_blogs anyway.
+
+		// $cache->write( $cache_key, json_encode( $urls ) );
+
+		return $urls;
 	}
 
 	/**


### PR DESCRIPTION
_This is a continuation of #5675, which was closed by the history purge. There's discussion there about where it left off._

---
Fixes #5256 

This adds tab completion for the global `--url` parameter, to make it more convenient to type long URLs in Multisite environments.

```sh
> wp cron event list --url=foo
foo.example.org       foot.example.org      football.example.org
```

This is just a rough sketch at the moment. There are some unanswered questions, and I haven't even tried running the tests. I'd just like to get feedback on the general approach etc before putting too much time into it.

Are there any fundamental things that should change? Or does it basically look good and just needs to be finished?