### PR TITLE
PHP 8.2: explicitly declare CompositeCommand::$longdesc to fix deprecation warning

### DIFF
--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -16,6 +16,7 @@ class CompositeCommand {
 
 	protected $name;
 	protected $shortdesc;
+	protected $longdesc;
 	protected $synopsis;
 	protected $docparser;
 


### PR DESCRIPTION
This PR fixes the following deprecation warnings when running `wp --info` with PHP 8.2 RC6:

```
Deprecated: Creation of dynamic property WP_CLI\Dispatcher\CompositeCommand::$longdesc is deprecated in phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CompositeCommand.php on line 38
Deprecated: Creation of dynamic property WP_CLI\Dispatcher\Subcommand::$longdesc is deprecated in phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CompositeCommand.php on line 38
Deprecated: Creation of dynamic property WP_CLI\Dispatcher\CommandNamespace::$longdesc is deprecated in phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CompositeCommand.php on line 38
```

Dynamic properties are deprecated in PHP 8.2. The solution was to simply declare CompositeCommand::$longdesc before it is used.