### PR TITLE
Check that `proc_open()` is available in `Process::run()`

### DIFF
--- a/php/WP_CLI/Process.php
+++ b/php/WP_CLI/Process.php
@@ -67,6 +67,8 @@ class Process {
 	 * @return ProcessRun
 	 */
 	public function run() {
+		Utils\check_proc_available( 'Process::run' );
+
 		$start_time = microtime( true );
 
 		$pipes = [];


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/5710