### PR TITLE
Add name context to before_invoke and after_invoke

### DIFF
--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -464,10 +464,10 @@ class Subcommand extends CompositeCommand {
 		$parent = implode( ' ', array_slice( $path, 1 ) );
 		$cmd    = $this->name;
 		if ( $parent ) {
-			WP_CLI::do_hook( "before_invoke:{$parent}" );
+			WP_CLI::do_hook( "before_invoke:{$parent}", $parent );
 			$cmd = $parent . ' ' . $cmd;
 		}
-		WP_CLI::do_hook( "before_invoke:{$cmd}" );
+		WP_CLI::do_hook( "before_invoke:{$cmd}", $cmd );
 
 		// Check if `--prompt` arg passed or not.
 		if ( $prompted_once ) {
@@ -491,9 +491,9 @@ class Subcommand extends CompositeCommand {
 		call_user_func( $this->when_invoked, $args, array_merge( $extra_args, $assoc_args ) );
 
 		if ( $parent ) {
-			WP_CLI::do_hook( "after_invoke:{$parent}" );
+			WP_CLI::do_hook( "after_invoke:{$parent}", $parent );
 		}
-		WP_CLI::do_hook( "after_invoke:{$cmd}" );
+		WP_CLI::do_hook( "after_invoke:{$cmd}", $cmd );
 	}
 
 	/**

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -227,8 +227,8 @@ class WP_CLI {
 	 *
 	 * * `before_add_command:<command>` - Before the command is added.
 	 * * `after_add_command:<command>` - After the command was added.
-	 * * `before_invoke:<command>` - Just before a command is invoked.
-	 * * `after_invoke:<command>` - Just after a command is invoked.
+	 * * `before_invoke:<command>` (1) - Just before a command is invoked.
+	 * * `after_invoke:<command>` (1) - Just after a command is invoked.
 	 * * `find_command_to_run_pre` - Just before WP-CLI finds the command to run.
 	 * * `before_registering_contexts` (1) - Before the contexts are registered.
 	 * * `before_wp_load` - Just before the WP load process begins.
@@ -249,7 +249,7 @@ class WP_CLI {
 	 * ```
 	 * # `wp network meta` confirms command is executing in multisite context.
 	 * WP_CLI::add_command( 'network meta', 'Network_Meta_Command', array(
-	 *    'before_invoke' => function () {
+	 *    'before_invoke' => function ( $name ) {
 	 *        if ( !is_multisite() ) {
 	 *            WP_CLI::error( 'This is not a multisite installation.' );
 	 *        }


### PR DESCRIPTION
Hello!
**Why**: For `__invoke` commands, the `before_invoke` and `after_invoke` hooks run twice, creating potential unexpected behavior.
**Solution**: I propose an easy fix: pass the command name to the callback, so that it can choose when to run.
If you think it is a viable solution, I'll add tests :-)
Cheers,
Cocco