### PR TITLE
Fix return type of make_progress_bar

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -613,7 +613,7 @@ function mustache_render( $template_name, $data = [] ) {
  * @param string  $message  Text to display before the progress bar.
  * @param integer $count    Total number of ticks to be performed.
  * @param int     $interval Optional. The interval in milliseconds between updates. Default 100.
- * @return cli\progress\Bar|NoOp
+ * @return \cli\progress\Bar|\WP_CLI\NoOp
  */
 function make_progress_bar( $message, $count, $interval = 100 ) {
 	if ( Shell::isPiped() ) {


### PR DESCRIPTION
Docblocks are absolute (FQCN).