### PR TITLE
Fix deprecation notice triggered in WpOrgApi class in PHP 8.1

### DIFF
--- a/php/WP_CLI/WpOrgApi.php
+++ b/php/WP_CLI/WpOrgApi.php
@@ -105,7 +105,7 @@ final class WpOrgApi {
 		$url = sprintf(
 			'%s?%s',
 			self::CORE_CHECKSUMS_ENDPOINT,
-			http_build_query( compact( 'version', 'locale' ), null, '&' )
+			http_build_query( compact( 'version', 'locale' ), '', '&' )
 		);
 
 		$response = $this->json_get_request( $url );
@@ -132,7 +132,7 @@ final class WpOrgApi {
 		$url = sprintf(
 			'%s?%s',
 			self::VERSION_CHECK_ENDPOINT,
-			http_build_query( compact( 'locale' ), null, '&' )
+			http_build_query( compact( 'locale' ), '', '&' )
 		);
 
 		$response = $this->json_get_request( $url );
@@ -218,7 +218,7 @@ final class WpOrgApi {
 		$url = sprintf(
 			'%s?%s',
 			self::PLUGIN_INFO_ENDPOINT,
-			http_build_query( compact( 'action', 'request' ), null, '&' )
+			http_build_query( compact( 'action', 'request' ), '', '&' )
 		);
 
 		$response = $this->json_get_request( $url );
@@ -248,7 +248,7 @@ final class WpOrgApi {
 		$url = sprintf(
 			'%s?%s',
 			self::THEME_INFO_ENDPOINT,
-			http_build_query( compact( 'action', 'request' ), null, '&' )
+			http_build_query( compact( 'action', 'request' ), '', '&' )
 		);
 
 		$response = $this->json_get_request( $url );


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

Currently, the `wp core download` command returns a deprecated notice triggered by WpOrgApi class:

```
$ bin/wp core download --force
PHP Deprecated:  http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated in /Volumes/Sites/wp-cli/php/WP_CLI/WpOrgApi.php on line 135

Deprecated: http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated in /Volumes/Sites/wp-cli/php/WP_CLI/WpOrgApi.php on line 135
```

In this PR, I propose to fix the notice.