### PR TITLE
Add runtime_args to options array for runcommand

### DIFF
--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -302,7 +302,7 @@ Feature: Run a WP-CLI command
       | proc_open  |
       | proc_close |
 
-  Scenario: Check that runtime_args provided to runcommand are used in command
+  Scenario: Check that command_args provided to runcommand are used in command
     Given a WP installation
     And a custom-cmd.php file:
       """
@@ -310,16 +310,16 @@ Feature: Run a WP-CLI command
       class Custom_Command extends WP_CLI_Command {
 
         /**
-         * Custom command to test passing runtime_args via runcommand options
+         * Custom command to test passing command_args via runcommand options
          *
          * @when after_wp_load
          */
         public function echo_test( $args ) {
-          $cli_opts = array( 'runtime_args' => array( '--exec="echo \'test\' . PHP_EOL;"' ) );
+          $cli_opts = array( 'command_args' => array( '--exec="echo \'test\' . PHP_EOL;"' ) );
           WP_CLI::runcommand( 'option get home', $cli_opts);
         }
         public function bad_path( $args ) {
-          $cli_opts = array( 'runtime_args' => array('--path=/bad/path' ) );
+          $cli_opts = array( 'command_args' => array('--path=/bad/path' ) );
           WP_CLI::runcommand( 'option get home', $cli_opts);
         }
       }

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -301,3 +301,40 @@ Feature: Run a WP-CLI command
       | func       |
       | proc_open  |
       | proc_close |
+
+  Scenario: Check that runtime_args provided to runcommand are used in command
+    Given a WP installation
+    And a custom-cmd.php file:
+      """
+      <?php
+      class Custom_Command extends WP_CLI_Command {
+
+        /**
+         * Custom command to test passing runtime_args via runcommand options
+         *
+         * @when after_wp_load
+         */
+        public function echo_test( $args ) {
+          $cli_opts = array( 'runtime_args' => array( '--exec="echo \'test\' . PHP_EOL;"' ) );
+          WP_CLI::runcommand( 'option get home', $cli_opts);
+        }
+        public function bad_path( $args ) {
+          $cli_opts = array( 'runtime_args' => array('--path=/bad/path' ) );
+          WP_CLI::runcommand( 'option get home', $cli_opts);
+        }
+      }
+      WP_CLI::add_command( 'custom-command', 'Custom_Command' );
+      """
+
+    When I run `wp --require=custom-cmd.php custom-command echo_test`
+    Then STDOUT should be:
+      """
+      test
+      https://example.com
+      """
+
+    When I try `wp --require=custom-cmd.php custom-command bad_path`
+    Then STDERR should contain:
+      """
+      The used path is: /bad/path/
+      """

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1277,7 +1277,7 @@ class WP_CLI {
 	 *   'parse'      => 'json', // Parse captured STDOUT to JSON array.
 	 *   'launch'     => false,  // Reuse the current process.
 	 *   'exit_error' => true,   // Halt script execution on error.
-	 *   'runtime_args' => array('--skip-themes'), // Additional runtime arguments to be used with $command
+	 *   'command_args' => array('--skip-themes'), // Additional command arguments to be used with $command
 	 * );
 	 * $plugins = WP_CLI::runcommand( 'plugin list --format=json', $options );
 	 * ```
@@ -1295,17 +1295,17 @@ class WP_CLI {
 			'exit_error'   => true, // Exit on error by default.
 			'return'       => false, // Capture and return output, or render in realtime.
 			'parse'        => false, // Parse returned output as a particular format.
-			'runtime_args' => array(), //Include optional runtime arguments
+			'command_args' => array(), //Include optional command arguments
 		];
 		$options      = array_merge( $defaults, $options );
 		$launch       = $options['launch'];
 		$exit_error   = $options['exit_error'];
 		$return       = $options['return'];
 		$parse        = $options['parse'];
-		$runtime_args = $options['runtime_args'];
+		$command_args = $options['command_args'];
 
-		if ( ! empty( $runtime_args ) ) {
-			$command .= ' ' . implode( ' ', $runtime_args );
+		if ( ! empty( $command_args ) ) {
+			$command .= ' ' . implode( ' ', $command_args );
 		}
 
 		$retval = null;

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1305,7 +1305,7 @@ class WP_CLI {
 		$runtime_args = $options['runtime_args'];
 
 		if ( ! empty( $runtime_args ) ) {
-			$command = $command . ' ' . implode( ' ', $runtime_args );
+			$command .= ' ' . implode( ' ', $runtime_args );
 		}
 
 		$retval = null;

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1269,15 +1269,15 @@ class WP_CLI {
 	 * * Prevent halting script execution on error.
 	 * * Capture and return STDOUT, or full details about command execution.
 	 * * Parse JSON output if the command rendered it.
-	 * * Include additional runtime arguments to be used with command.
+	 * * Include additional arguments that are passed to the command.
 	 *
 	 * ```
 	 * $options = array(
-	 *   'return'     => true,   // Return 'STDOUT'; use 'all' for full object.
-	 *   'parse'      => 'json', // Parse captured STDOUT to JSON array.
-	 *   'launch'     => false,  // Reuse the current process.
-	 *   'exit_error' => true,   // Halt script execution on error.
-	 *   'command_args' => array('--skip-themes'), // Additional command arguments to be used with $command
+	 *   'return'       => true,                // Return 'STDOUT'; use 'all' for full object.
+	 *   'parse'        => 'json',              // Parse captured STDOUT to JSON array.
+	 *   'launch'       => false,               // Reuse the current process.
+	 *   'exit_error'   => true,                // Halt script execution on error.
+	 *   'command_args' => [ '--skip-themes' ], // Additional arguments to be passed to the $command.
 	 * );
 	 * $plugins = WP_CLI::runcommand( 'plugin list --format=json', $options );
 	 * ```
@@ -1291,11 +1291,11 @@ class WP_CLI {
 	 */
 	public static function runcommand( $command, $options = [] ) {
 		$defaults     = [
-			'launch'       => true, // Launch a new process, or reuse the existing.
-			'exit_error'   => true, // Exit on error by default.
+			'launch'       => true,  // Launch a new process, or reuse the existing.
+			'exit_error'   => true,  // Exit on error by default.
 			'return'       => false, // Capture and return output, or render in realtime.
 			'parse'        => false, // Parse returned output as a particular format.
-			'command_args' => array(), //Include optional command arguments
+			'command_args' => [],    // Include optional command arguments.
 		];
 		$options      = array_merge( $defaults, $options );
 		$launch       = $options['launch'];

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1269,6 +1269,7 @@ class WP_CLI {
 	 * * Prevent halting script execution on error.
 	 * * Capture and return STDOUT, or full details about command execution.
 	 * * Parse JSON output if the command rendered it.
+	 * * Include additional runtime arguments to be used with command.
 	 *
 	 * ```
 	 * $options = array(
@@ -1276,6 +1277,7 @@ class WP_CLI {
 	 *   'parse'      => 'json', // Parse captured STDOUT to JSON array.
 	 *   'launch'     => false,  // Reuse the current process.
 	 *   'exit_error' => true,   // Halt script execution on error.
+	 *   'runtime_args' => array('--skip-themes'), // Additional runtime arguments to be used with $command
 	 * );
 	 * $plugins = WP_CLI::runcommand( 'plugin list --format=json', $options );
 	 * ```
@@ -1288,18 +1290,25 @@ class WP_CLI {
 	 * @return mixed
 	 */
 	public static function runcommand( $command, $options = [] ) {
-		$defaults   = [
-			'launch'     => true, // Launch a new process, or reuse the existing.
-			'exit_error' => true, // Exit on error by default.
-			'return'     => false, // Capture and return output, or render in realtime.
-			'parse'      => false, // Parse returned output as a particular format.
+		$defaults     = [
+			'launch'       => true, // Launch a new process, or reuse the existing.
+			'exit_error'   => true, // Exit on error by default.
+			'return'       => false, // Capture and return output, or render in realtime.
+			'parse'        => false, // Parse returned output as a particular format.
+			'runtime_args' => array(), //Include optional runtime arguments
 		];
-		$options    = array_merge( $defaults, $options );
-		$launch     = $options['launch'];
-		$exit_error = $options['exit_error'];
-		$return     = $options['return'];
-		$parse      = $options['parse'];
-		$retval     = null;
+		$options      = array_merge( $defaults, $options );
+		$launch       = $options['launch'];
+		$exit_error   = $options['exit_error'];
+		$return       = $options['return'];
+		$parse        = $options['parse'];
+		$runtime_args = $options['runtime_args'];
+
+		if ( ! empty( $runtime_args ) ) {
+			$command = $command . ' ' . implode( ' ', $runtime_args );
+		}
+
+		$retval = null;
 		if ( $launch ) {
 			Utils\check_proc_available( 'launch option' );
 


### PR DESCRIPTION
Per https://wordpress.slack.com/archives/C02RP4T41/p1673268015148999?thread_ts=1672934225.683679&cid=C02RP4T41

I have a command that calls `WP_CLI::runcommand` a lot and I want to set some default global options for most of these (particularly `--skip-themes --skip-plugins`). I also have default global options for `WP_CLI::runcommand` itself.

Currently, this ends up looking something like:

```
private $default_cli_opts = array(
	'return'       => 'all',
	'exit_error'   => false,
);

private $default_command_opts = '--skip-themes --skip-plugins';

WP_CLI::runcommand( "config has set WPCACHEHOME --path=$path " . $this->default_command_opts, $this->default_cli_opts );
etc...
```

It would be nice to be able to keep these options in a single place like:

```
private $default_cli_opts = array(
	'return'       => 'all', // returns an OBJECT
	'exit_error'   => false,
	'runtime_args' => array( '--skip-themes', '--skip-plugins' ),
);

WP_CLI::runcommand( "config has set WPCACHEHOME --path=$path", $this->default_cli_opts );
```
This PR just appends the options to the command as if the caller included them in the command directly.

I didn't see any place that runcommand was tested as if being called from a script so I wasn't sure where/how to add a test for this as it isn't accessible when using wp-cli directly. Happy to add one though