### PR TITLE
Use AWK instead of sed to create BOM in feature test

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -563,7 +563,7 @@ Feature: Have a config file
       /** Sets up WordPress vars and included files. */
       require_once(ABSPATH . 'wp-settings.php');
       """
-    And I run `sed -i '1s/^\(\xef\xbb\xbf\)\?/\xef\xbb\xbf/' wp-config.php`
+    And I run `awk 'BEGIN {print "\xef\xbb\xbf"} {print}' wp-config.php > wp-config.php`
 
     When I try `wp core is-installed`
     Then STDERR should not contain:


### PR DESCRIPTION
The current test fails on MacOS because of:

  `sed: -I or -i may not be used with stdin`

After fixing that,  I found sed on MacOS works in text mode vs binary mode and it is difficult have it make a binary change like this. Use AWK instead since it works the same everywhere in this case.

Fixes #5723
