### PR TITLE
Fix `--skip-themes` for themes with block patterns

### DIFF
--- a/features/skip-themes.feature
+++ b/features/skip-themes.feature
@@ -150,3 +150,38 @@ Feature: Skipping themes
       false
       """
     And STDERR should be empty
+
+  @require-wp-6.1
+  Scenario: Skip a theme using block patterns
+    Given a WP installation
+    And I run `wp theme install blockline --activate`
+
+    When I run `wp eval 'var_dump( function_exists( "blockline_support" ) );'`
+    Then STDOUT should be:
+      """
+      bool(true)
+      """
+
+    When I run `wp --skip-themes=blockline eval 'var_dump( function_exists( "blockline_support" ) );'`
+    Then STDOUT should be:
+      """
+      bool(false)
+      """
+
+  @require-wp-6.1
+  Scenario: Skip a theme using block patterns with Gutenberg active
+    Given a WP installation
+    And I run `wp plugin install gutenberg --activate`
+    And I run `wp theme install blockline --activate`
+
+    When I run `wp eval 'var_dump( function_exists( "blockline_support" ) );'`
+    Then STDOUT should be:
+      """
+      bool(true)
+      """
+
+    When I run `wp --skip-themes=blockline eval 'var_dump( function_exists( "blockline_support" ) );'`
+    Then STDOUT should be:
+      """
+      bool(false)
+      """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1778,6 +1778,10 @@ class Runner {
 		foreach ( $hooks as $hook ) {
 			add_filter( $hook, $wp_cli_filter_active_theme, 999 );
 		}
+		// Remove block pattern loading
+		remove_action( 'init', '_register_theme_block_patterns' );
+		remove_action( 'init', 'gutenberg_register_theme_block_patterns' );
+
 		// Clean up after the TEMPLATEPATH and STYLESHEETPATH constants are defined
 		WP_CLI::add_wp_hook(
 			'after_setup_theme',


### PR DESCRIPTION
Core and the Gutenberg plugin hook a `register_theme_block_patterns()` function onto `init`. When a theme with block patterns isn't loaded, the function can cause some errors.

Because `--skip-themes` isn't formally supported by core, let's incorporate another hack for block pattern theme compatibility. Hopefully it doesn't come up again for another 10 years.

Fixes https://github.com/wp-cli/wp-cli/issues/5736