### PR TITLE
Use `WP_CLI_FORCE_USER_LOGIN=1` to force `--user=<login>`

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -92,18 +92,21 @@ Feature: Global flags
       """
       false
       """
+    And STDERR should be empty
 
     When I run `wp --user=admin eval 'echo wp_get_current_user()->user_login;'`
     Then STDOUT should be:
       """
       admin
       """
+    And STDERR should be empty
 
     When I run `wp --user=admin@example.com eval 'echo wp_get_current_user()->user_login;'`
     Then STDOUT should be:
       """
       admin
       """
+    And STDERR should be empty
 
     When I try `wp --user=non-existing-user eval 'echo wp_get_current_user()->user_login;'`
     Then the return code should be 1
@@ -111,6 +114,39 @@ Feature: Global flags
       """
       Error: Invalid user ID, email or login: 'non-existing-user'
       """
+
+  Scenario: Warn when provided user is ambigious
+    Given a WP installation
+
+    When I run `wp --user=1 eval 'echo wp_get_current_user()->user_email;'`
+    Then STDOUT should be:
+      """
+      admin@example.com
+      """
+    And STDERR should be empty
+
+    When I run `wp user create 1 user1@example.com`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I try `wp --user=1 eval 'echo wp_get_current_user()->user_email;'`
+    Then STDOUT should be:
+      """
+      admin@example.com
+      """
+    And STDERR should be:
+      """
+      Warning: Ambigious user match (ID=1 and user_login=1). Defaulting to ID. Force user_login with WP_CLI_FORCE_USER_LOGIN=1.
+      """
+
+    When I run `WP_CLI_FORCE_USER_LOGIN=1 wp --user=1 eval 'echo wp_get_current_user()->user_email;'`
+    Then STDOUT should be:
+      """
+      user1@example.com
+      """
+    And STDERR should be empty
 
   Scenario: Using a custom logger
     Given an empty directory

--- a/features/flags.feature
+++ b/features/flags.feature
@@ -148,6 +148,19 @@ Feature: Global flags
       """
     And STDERR should be empty
 
+    When I run `wp --user=user1@example.com eval 'echo wp_get_current_user()->user_email;'`
+    Then STDOUT should be:
+      """
+      user1@example.com
+      """
+    And STDERR should be empty
+
+    When I try `WP_CLI_FORCE_USER_LOGIN=1 wp --user=user1@example.com eval 'echo wp_get_current_user()->user_email;'`
+    Then STDERR should be:
+      """
+      Error: Invalid user login: 'user1@example.com'
+      """
+
   Scenario: Using a custom logger
     Given an empty directory
     And a custom-logger.php file:

--- a/features/flags.feature
+++ b/features/flags.feature
@@ -138,7 +138,7 @@ Feature: Global flags
       """
     And STDERR should be:
       """
-      Warning: Ambiguous user match (ID=1 and user_login=1). Defaulting to ID. Force user_login with WP_CLI_FORCE_USER_LOGIN=1.
+      Warning: Ambiguous user match detected (both ID and user_login exist for identifier '1'). WP-CLI will default to the ID, but you can force user_login instead with WP_CLI_FORCE_USER_LOGIN=1.
       """
 
     When I run `WP_CLI_FORCE_USER_LOGIN=1 wp --user=1 eval 'echo wp_get_current_user()->user_email;'`

--- a/features/flags.feature
+++ b/features/flags.feature
@@ -115,7 +115,7 @@ Feature: Global flags
       Error: Invalid user ID, email or login: 'non-existing-user'
       """
 
-  Scenario: Warn when provided user is ambigious
+  Scenario: Warn when provided user is ambiguous
     Given a WP installation
 
     When I run `wp --user=1 eval 'echo wp_get_current_user()->user_email;'`
@@ -138,7 +138,7 @@ Feature: Global flags
       """
     And STDERR should be:
       """
-      Warning: Ambigious user match (ID=1 and user_login=1). Defaulting to ID. Force user_login with WP_CLI_FORCE_USER_LOGIN=1.
+      Warning: Ambiguous user match (ID=1 and user_login=1). Defaulting to ID. Force user_login with WP_CLI_FORCE_USER_LOGIN=1.
       """
 
     When I run `WP_CLI_FORCE_USER_LOGIN=1 wp --user=1 eval 'echo wp_get_current_user()->user_email;'`

--- a/php/WP_CLI/Fetchers/User.php
+++ b/php/WP_CLI/Fetchers/User.php
@@ -2,6 +2,7 @@
 
 namespace WP_CLI\Fetchers;
 
+use WP_CLI;
 use WP_User;
 
 /**
@@ -24,8 +25,19 @@ class User extends Base {
 	 */
 	public function get( $arg ) {
 
-		if ( is_numeric( $arg ) ) {
-			$user = get_user_by( 'id', $arg );
+		if ( is_numeric( $arg ) && ! getenv( 'WP_CLI_FORCE_USER_LOGIN' ) ) {
+			$check = get_user_by( 'login', $arg );
+			$user  = get_user_by( 'id', $arg );
+			if ( $check && $user ) {
+				WP_CLI::warning(
+					sprintf(
+						'Ambigious user match (ID=%d and user_login=%d). Defaulting to ID. Force user_login with WP_CLI_FORCE_USER_LOGIN=1.',
+						$arg,
+						$arg,
+						$arg
+					)
+				);
+			}
 		} elseif ( is_email( $arg ) ) {
 			$user = get_user_by( 'email', $arg );
 			// Logins can be emails.

--- a/php/WP_CLI/Fetchers/User.php
+++ b/php/WP_CLI/Fetchers/User.php
@@ -36,7 +36,7 @@ class User extends Base {
 			if ( $check && $user ) {
 				WP_CLI::warning(
 					sprintf(
-						'Ambigious user match (ID=%d and user_login=%d). Defaulting to ID. Force user_login with WP_CLI_FORCE_USER_LOGIN=1.',
+						'Ambiguous user match (ID=%d and user_login=%d). Defaulting to ID. Force user_login with WP_CLI_FORCE_USER_LOGIN=1.',
 						$arg,
 						$arg,
 						$arg

--- a/php/WP_CLI/Fetchers/User.php
+++ b/php/WP_CLI/Fetchers/User.php
@@ -25,7 +25,12 @@ class User extends Base {
 	 */
 	public function get( $arg ) {
 
-		if ( is_numeric( $arg ) && ! getenv( 'WP_CLI_FORCE_USER_LOGIN' ) ) {
+		if ( getenv( 'WP_CLI_FORCE_USER_LOGIN' ) ) {
+			$this->msg = "Invalid user login: '%s'";
+			return get_user_by( 'login', $arg );
+		}
+
+		if ( is_numeric( $arg ) ) {
 			$check = get_user_by( 'login', $arg );
 			$user  = get_user_by( 'id', $arg );
 			if ( $check && $user ) {

--- a/php/WP_CLI/Fetchers/User.php
+++ b/php/WP_CLI/Fetchers/User.php
@@ -36,9 +36,7 @@ class User extends Base {
 			if ( $check && $user ) {
 				WP_CLI::warning(
 					sprintf(
-						'Ambiguous user match (ID=%d and user_login=%d). Defaulting to ID. Force user_login with WP_CLI_FORCE_USER_LOGIN=1.',
-						$arg,
-						$arg,
+						'Ambiguous user match detected (both ID and user_login exist for identifier \'%d\'). WP-CLI will default to the ID, but you can force user_login instead with WP_CLI_FORCE_USER_LOGIN=1.',
 						$arg
 					)
 				);


### PR DESCRIPTION
Also squelches with a warning when there's an ambiguous match.

To be documented with https://github.com/wp-cli/wp-cli/issues/5739

Fixes #5706