### PR TITLE
fix PHP Deprecation for 8.1

### DIFF
--- a/php/WP_CLI/Iterators/Transform.php
+++ b/php/WP_CLI/Iterators/Transform.php
@@ -16,7 +16,7 @@ class Transform extends IteratorIterator {
 		$this->transformers[] = $fn;
 	}
 
-	#[ReturnTypeWillChange]
+	#[\ReturnTypeWillChange]
 	public function current() {
 		$value = parent::current();
 

--- a/php/WP_CLI/Iterators/Transform.php
+++ b/php/WP_CLI/Iterators/Transform.php
@@ -3,6 +3,7 @@
 namespace WP_CLI\Iterators;
 
 use IteratorIterator;
+use ReturnTypeWillChange;
 
 /**
  * Applies one or more callbacks to an item before returning it.
@@ -15,6 +16,7 @@ class Transform extends IteratorIterator {
 		$this->transformers[] = $fn;
 	}
 
+	#[ReturnTypeWillChange]
 	public function current() {
 		$value = parent::current();
 
@@ -25,4 +27,3 @@ class Transform extends IteratorIterator {
 		return $value;
 	}
 }
-

--- a/php/WP_CLI/Iterators/Transform.php
+++ b/php/WP_CLI/Iterators/Transform.php
@@ -3,7 +3,6 @@
 namespace WP_CLI\Iterators;
 
 use IteratorIterator;
-use ReturnTypeWillChange;
 
 /**
  * Applies one or more callbacks to an item before returning it.


### PR DESCRIPTION
PHP 8.1 shows a PHP Deprecated warning for an improper return type for `WP_CLI/Iterators/Transform::transform()`.

Fixes https://github.com/wp-cli/wp-cli/issues/5742