### PR TITLE
Add ComposerIO implementation with types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,12 @@
     ],
     "homepage": "https://wp-cli.org",
     "license": "MIT",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/wp-cli/package-command.git"
+        }
+    ],
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "ext-curl": "*",
@@ -20,7 +26,7 @@
         "wp-cli/db-command": "^1.3 || ^2",
         "wp-cli/entity-command": "^1.2 || ^2",
         "wp-cli/extension-command": "^1.1 || ^2",
-        "wp-cli/package-command": "^1 || ^2",
+        "wp-cli/package-command": "^1 || dev-dependabot/composer/composer/composer-tw-2.5.5",
         "wp-cli/wp-cli-tests": "^4.0.1"
     },
     "suggest": {

--- a/php/WP_CLI/ComposerIO.php
+++ b/php/WP_CLI/ComposerIO.php
@@ -1,41 +1,15 @@
 <?php
-
-namespace WP_CLI;
-
-use Composer\IO\NullIO;
-use WP_CLI;
-
 /**
- * A Composer IO class so we can provide some level of interactivity from WP-CLI
+ * Due to PHP 5.6 compatibility, we have two different implementations of this class.
+ *
+ * See https://github.com/wp-cli/package-command/issues/172.
  */
-class ComposerIO extends NullIO {
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public function isVerbose() {
-		return true;
-	}
+use Composer\Semver\VersionParser;
+use Composer\InstalledVersions;
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public function write( $messages, $newline = true, $verbosity = self::NORMAL ) {
-		self::output_clean_message( $messages );
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function writeError( $messages, $newline = true, $verbosity = self::NORMAL ) {
-		self::output_clean_message( $messages );
-	}
-
-	private static function output_clean_message( $messages ) {
-		$messages = (array) preg_replace( '#<(https?)([^>]+)>#', '$1$2', $messages );
-		foreach ( $messages as $message ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
-			WP_CLI::log( strip_tags( trim( $message ) ) );
-		}
-	}
+if ( InstalledVersions::satisfies( new VersionParser(), 'composer/composer', '^2.3' ) ) {
+	require 'ComposerIOWithTypes.php';
+} else {
+	require 'ComposerIOWithoutTypes.php';
 }

--- a/php/WP_CLI/ComposerIOWithTypes.php
+++ b/php/WP_CLI/ComposerIOWithTypes.php
@@ -1,0 +1,43 @@
+<?php // phpcs:disable PHPCompatibility.FunctionDeclarations
+
+namespace WP_CLI;
+
+use Composer\IO\NullIO;
+use WP_CLI;
+
+/**
+ * A Composer IO class so we can provide some level of interactivity from WP-CLI
+ */
+class ComposerIO extends NullIO {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isVerbose(): bool {
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function write( $messages, bool $newline = true, int $verbosity = self::NORMAL ): void {
+		self::output_clean_message( $messages );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function writeError( $messages, bool $newline = true, int $verbosity = self::NORMAL ): void {
+		self::output_clean_message( $messages );
+	}
+
+	private static function output_clean_message( $messages ) {
+		$messages = (array) preg_replace( '#<(https?)([^>]+)>#', '$1$2', $messages );
+		foreach ( $messages as $message ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
+			WP_CLI::log( strip_tags( trim( $message ) ) );
+		}
+	}
+}
+
+// phpcs:enable

--- a/php/WP_CLI/ComposerIOWithoutTypes.php
+++ b/php/WP_CLI/ComposerIOWithoutTypes.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace WP_CLI;
+
+use Composer\IO\NullIO;
+use WP_CLI;
+
+/**
+ * A Composer IO class so we can provide some level of interactivity from WP-CLI
+ */
+class ComposerIO extends NullIO {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isVerbose() {
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function write( $messages, $newline = true, $verbosity = self::NORMAL ) {
+		self::output_clean_message( $messages );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function writeError( $messages, $newline = true, $verbosity = self::NORMAL ) {
+		self::output_clean_message( $messages );
+	}
+
+	private static function output_clean_message( $messages ) {
+		$messages = (array) preg_replace( '#<(https?)([^>]+)>#', '$1$2', $messages );
+		foreach ( $messages as $message ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
+			WP_CLI::log( strip_tags( trim( $message ) ) );
+		}
+	}
+}


### PR DESCRIPTION
The latest version of `composer/composer` uses type declarations, which is not backwards compatible with PHP 5.6.

See https://github.com/wp-cli/package-command/issues/172
