### PR TITLE
Use -R instead of -r for fallback pager command

### DIFF
--- a/php/commands/src/Help_Command.php
+++ b/php/commands/src/Help_Command.php
@@ -118,7 +118,7 @@ class Help_Command extends WP_CLI_Command {
 
 		$pager = getenv( 'PAGER' );
 		if ( false === $pager ) {
-			$pager = Utils\is_windows() ? 'more' : 'less -r';
+			$pager = Utils\is_windows() ? 'more' : 'less -R';
 		}
 
 		// For Windows 7 need to set code page to something other than Unicode (65001) to get around "Not enough memory." error with `more.com` on PHP 7.1+.


### PR DESCRIPTION
Not all versions of less offer `-r` as seen in #5758

Also, modern versions of LESS have the following warning when viewing man pages:

From `man less`

```
USE OF THE -r OPTION IS NOT RECOMMENDED.

-R or --RAW-CONTROL-CHARS is defined as:

 Like -r, but only ANSI "color" escape sequences and OSC 8 hyperlink sequences are output in "raw" form.

```

Reference: https://man7.org/linux/man-pages/man1/less.1.html

Fixes #5758