### PR TITLE
Update test to reflect warning when `--url=<url>` is provided

### DIFF
--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -401,10 +401,10 @@ Feature: Bootstrap WP-CLI
       """
     And the return code should be 1
 
-    When I run `wp cache flush --url=invalid.com`
+    When I try `wp cache flush --url=invalid.com`
     Then STDOUT should contain:
       """
-      Success:
+      Success: The cache was flushed.
       """
     And the return code should be 0
 


### PR DESCRIPTION
The warning was added in https://github.com/wp-cli/cache-command/pull/86