### PR TITLE
Upgrade WP-CLI to Requests v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "^5.6 || ^7.0 || ^8.0",
         "ext-curl": "*",
         "mustache/mustache": "^2.14.1",
-        "rmccue/requests": "^1.8",
+        "rmccue/requests": "^2",
         "symfony/finder": ">2.7",
         "wp-cli/mustangostang-spyc": "^0.6.3",
         "wp-cli/php-cli-tools": "~0.11.2"

--- a/features/requests.feature
+++ b/features/requests.feature
@@ -1,0 +1,134 @@
+Feature: Requests integration with both v1 and v2
+
+  Scenario: Composer stack with Requests v1
+    Given an empty directory
+    And a composer.json file:
+      """
+      {
+          "name": "wp-cli/composer-test",
+          "type": "project",
+          "require": {
+              "wp-cli/wp-cli": "2.7.0",
+              "wp-cli/core-command": "^2",
+              "wp-cli/eval-command": "^2"
+          }
+      }
+      """
+    # Note: Composer outputs messages to stderr.
+    And I run `composer install --no-interaction 2>&1`
+
+    When I run `vendor/bin/wp cli version`
+    Then STDOUT should contain:
+      """
+      WP-CLI 2.7.0
+      """
+
+    Given a WP installation
+    And I run `vendor/bin/wp core update --version=5.8 --force`
+
+    When I run `vendor/bin/wp core version`
+    Then STDOUT should contain:
+      """
+      5.8
+      """
+
+    When I run `vendor/bin/wp eval 'var_dump( \WP_CLI\Utils\http_request( "GET", "https://example.com/" ) );'`
+    Then STDOUT should contain:
+      """
+      object(Requests_Response)
+      """
+    And STDOUT should contain:
+      """
+      HTTP/1.1 200 OK
+      """
+    And STDERR should be empty
+
+  Scenario: Current version with WordPress-bundled Requests v1
+    Given a WP installation
+    And I run `wp core update --version=5.8 --force`
+
+    When I run `wp core version`
+    Then STDOUT should contain:
+      """
+      5.8
+      """
+
+    When I run `wp eval 'var_dump( \WP_CLI\Utils\http_request( "GET", "https://example.com/" ) );'`
+    Then STDOUT should contain:
+      """
+      object(WpOrg\Requests\Response)
+      """
+    And STDOUT should contain:
+      """
+      HTTP/1.1 200 OK
+      """
+    And STDERR should be empty
+
+    When I run `wp eval 'var_dump( \WpOrg\Requests\Requests::get( "https://example.com/" ) );'`
+    Then STDOUT should contain:
+      """
+      object(WpOrg\Requests\Response)
+      """
+    And STDOUT should contain:
+      """
+      HTTP/1.1 200 OK
+      """
+    And STDERR should be empty
+
+    When I run `wp eval 'var_dump( \Requests::get( "https://example.com/" ) );'`
+    Then STDOUT should contain:
+      """
+      object(WpOrg\Requests\Response)
+      """
+    And STDOUT should contain:
+      """
+      HTTP/1.1 200 OK
+      """
+    And STDERR should be empty
+
+  Scenario: Current version with WordPress-bundled Requests v2
+    Given a WP installation
+    And I run `wp core update --version=6.2 --force`
+
+    When I run `wp core version`
+    Then STDOUT should contain:
+      """
+      6.2
+      """
+
+    When I run `wp eval 'var_dump( \WP_CLI\Utils\http_request( "GET", "https://example.com/" ) );'`
+    Then STDOUT should contain:
+      """
+      object(WpOrg\Requests\Response)
+      """
+    And STDOUT should contain:
+      """
+      HTTP/1.1 200 OK
+      """
+    And STDERR should be empty
+
+    When I run `wp eval 'var_dump( \WpOrg\Requests\Requests::get( "https://example.com/" ) );'`
+    Then STDOUT should contain:
+      """
+      object(WpOrg\Requests\Response)
+      """
+    And STDOUT should contain:
+      """
+      HTTP/1.1 200 OK
+      """
+    And STDERR should be empty
+
+    # Expect a deprecation warning here.
+    When I try `wp eval 'var_dump( \Requests::get( "https://example.com/" ) );'`
+    Then STDOUT should contain:
+      """
+      object(WpOrg\Requests\Response)
+      """
+    And STDOUT should contain:
+      """
+      HTTP/1.1 200 OK
+      """
+    And STDERR should contain:
+      """
+      The PSR-0 `Requests_...` class names in the Requests library are deprecated.
+      """

--- a/php/WP_CLI/Bootstrap/IncludeFrameworkAutoloader.php
+++ b/php/WP_CLI/Bootstrap/IncludeFrameworkAutoloader.php
@@ -34,7 +34,7 @@ final class IncludeFrameworkAutoloader implements BootstrapStep {
 		$mappings = [
 			'WP_CLI'                   => WP_CLI_ROOT . '/php/WP_CLI',
 			'cli'                      => WP_CLI_VENDOR_DIR . '/wp-cli/php-cli-tools/lib/cli',
-			'Requests'                 => WP_CLI_VENDOR_DIR . '/rmccue/requests/library/Requests',
+			'WpOrg\Requests'           => WP_CLI_VENDOR_DIR . '/rmccue/requests/src',
 			'Symfony\Component\Finder' => WP_CLI_VENDOR_DIR . '/symfony/finder/',
 		];
 
@@ -45,7 +45,6 @@ final class IncludeFrameworkAutoloader implements BootstrapStep {
 			);
 		}
 
-		include_once WP_CLI_VENDOR_DIR . '/rmccue/requests/library/Requests.php';
 		include_once WP_CLI_VENDOR_DIR . '/wp-cli/mustangostang-spyc/Spyc.php';
 
 		$autoloader->register();

--- a/php/utils.php
+++ b/php/utils.php
@@ -821,7 +821,7 @@ function http_request( $method, $url, $data = null, $headers = [], $options = []
  * @throws ExitException If unable to locate the cert and $halt_on_error is true.
  */
 function get_default_cacert( $halt_on_error = false ) {
-	$cert_path = '/rmccue/requests/library/Requests/Transport/cacert.pem';
+	$cert_path = '/rmccue/requests/certificates/cacert.pem';
 	$error_msg = 'Cannot find SSL certificate.';
 
 	if ( inside_phar() ) {

--- a/tests/mock-requests-transport.php
+++ b/tests/mock-requests-transport.php
@@ -28,7 +28,7 @@ class Mock_Requests_Transport implements Transport {
 		throw new Exception( 'Method not implemented: ' . __METHOD__ );
 	}
 
-	public static function test($capabilities = []) {
+	public static function test( $capabilities = [] ) {
 		return true;
 	}
 }

--- a/tests/mock-requests-transport.php
+++ b/tests/mock-requests-transport.php
@@ -1,7 +1,9 @@
 <?php
 
+use WpOrg\Requests\Transport;
+
 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
-class Mock_Requests_Transport implements Requests_Transport {
+class Mock_Requests_Transport implements Transport {
 	public $requests = [];
 
 	public function request( $url, $headers = [], $data = [], $options = [] ) {
@@ -26,7 +28,7 @@ class Mock_Requests_Transport implements Requests_Transport {
 		throw new Exception( 'Method not implemented: ' . __METHOD__ );
 	}
 
-	public static function test() {
+	public static function test($capabilities = []) {
 		return true;
 	}
 }

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -563,7 +563,7 @@ class UtilsTest extends TestCase {
 	public function testGetDefaultCaCert() {
 		$default_cert = Utils\get_default_cacert();
 		$this->assertStringEndsWith(
-			'/rmccue/requests/library/Requests/Transport/cacert.pem',
+			'/rmccue/requests/certificates/cacert.pem',
 			$default_cert
 		);
 		$this->assertFileExists( $default_cert );


### PR DESCRIPTION
Fixes #5623

This PR upgrades the included dependency on the Requests library to v2.

It includes namespace changes to the integration points with the Requests library as well as a few tests to ensure it works across both old and new integrations of Requests into WordPress core.