### PR TITLE
Use rtrim on phar-safe path to avoid double slash

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -1421,7 +1421,7 @@ function phar_safe_path( $path ) {
 	}
 
 	return str_replace(
-		PHAR_STREAM_PREFIX . WP_CLI_PHAR_PATH . '/',
+		PHAR_STREAM_PREFIX . rtrim( WP_CLI_PHAR_PATH, '/' ) . '/',
 		PHAR_STREAM_PREFIX,
 		$path
 	);


### PR DESCRIPTION
While trying to debug the following issue, I noticed that we have a triple slash in the Phar prefix:
![Image 2023-05-02 at 1 44 49 PM](https://user-images.githubusercontent.com/83631/235657256-77853ddb-cb55-428f-9fd6-caf034d79a52.jpeg)

I suspect this comes from an empty `WP_CLI_PHAR_PATH` that would already end up being `/`.