### PR TITLE
Fix some PHP 8.2 depreciation notices in behat tests

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -141,7 +141,7 @@ Feature: WP-CLI Commands
       """
       <?php
       class Foo_Class extends WP_CLI_Command {
-
+        private $prefix;
         public function __construct( $prefix ) {
           $this->prefix = $prefix;
         }
@@ -236,7 +236,7 @@ Feature: WP-CLI Commands
       """
       <?php
       class Foo_Class {
-
+        private $message;
         public function __construct( $message ) {
           $this->message = $message;
         }
@@ -948,7 +948,7 @@ Feature: WP-CLI Commands
       """
       <?php
       class Foo_Class {
-
+        private $message;
         public function __construct( $message ) {
           $this->message = $message;
         }


### PR DESCRIPTION
Fixes `Creation of dynamic property Foo_Class::$message is deprecated type errors`