### PR TITLE
Extract cacert from Phar for cURL

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -762,6 +762,12 @@ function http_request( $method, $url, $data = null, $headers = [], $options = []
 		$options['verify'] = ! empty( ini_get( 'curl.cainfo' ) ) ? ini_get( 'curl.cainfo' ) : true;
 	}
 
+	// The certificate location provided by default by the Requests library could point to a file inside a Phar archive.
+	// This is not supported by cURL, so we need to extract the file to a temporary location.
+	if ( 0 === strpos( $options['verify'], PHAR_STREAM_PREFIX ) ) {
+		$options['verify'] = extract_from_phar( $options['verify'] );
+	}
+
 	try {
 		try {
 			return Requests::request( $url, $headers, $data, $method, $options );


### PR DESCRIPTION
The Requests library already points to its own bundled certificates file in some instances. In case the library is also compiled into a Phar file, cURL will not be able to use the certificate, as it cannot read the file from within the Phar archive. We'll need to extract the file into a temporary location first for this to work properly.

This fixes the following issue observed during deployment runs:
![Image 2023-05-02 at 1 44 49 PM](https://user-images.githubusercontent.com/83631/235862674-740a1b68-42fc-4fb3-afec-7606c5fe3391.jpeg)
