### PR TITLE
Use `wp_cache_flush_runtime` if supported.

### DIFF
--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -330,6 +330,13 @@ function wp_clear_object_cache() {
 
 	$wpdb->queries = [];
 
+	if ( function_exists( 'wp_cache_flush_runtime' ) && function_exists( 'wp_cache_supports' ) ) {
+		if ( wp_cache_supports( 'flush_runtime' ) ) {
+			wp_cache_flush_runtime();
+			return;
+		}
+	}
+
 	if ( ! is_object( $wp_object_cache ) ) {
 		return;
 	}


### PR DESCRIPTION
Call the function  `wp_cache_flush_runtime` in `wp_clear_object_cache `. This function has been in core since 6.0.0 ( https://github.com/WordPress/wordpress-develop/commit/c98f4c04db13a1c3db14345db4cff116dd01bf51) and is designed to perform the what currently `wp_clear_object_cache` does. 

Checks to see if `wp_cache_flush_runtime` and `wp_cache_supports` exists before b/c
 
Fixes #5769