### PR TITLE
Harden loading of upgrader

### DIFF
--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -145,16 +145,14 @@ function maybe_require( $since, $path ) {
 
 function get_upgrader( $class, $insecure = false ) {
 	if ( ! class_exists( '\WP_Upgrader' ) ) {
-		if ( ! file_exists( ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php' ) ) {
-			WP_CLI::error( 'The WP_Upgrader class from WordPress Core is not available.' );
+		if ( file_exists( ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php' ) ) {
+			include ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 		}
-
-		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 	}
 
 	if ( ! class_exists( '\WP_Upgrader_Skin' ) ) {
 		if ( file_exists( ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php';
+			include ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php';
 		}
 	}
 

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -145,7 +145,7 @@ function maybe_require( $since, $path ) {
 
 function get_upgrader( $class, $insecure = false ) {
 	if ( ! class_exists( '\WP_Upgrader' ) ) {
-		if ( file_exists( ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php' ) ) {
+		if ( file_exists( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' ) ) {
 			include ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 		}
 	}

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -153,11 +153,9 @@ function get_upgrader( $class, $insecure = false ) {
 	}
 
 	if ( ! class_exists( '\WP_Upgrader_Skin' ) ) {
-		if ( ! file_exists( ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php' ) ) {
-			WP_CLI::error( 'The WP_Upgrader_Skin class from WordPress Core is not available.' );
+		if ( file_exists( ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php';
 		}
-
-		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php';
 	}
 
 	$uses_insecure_flag = false;

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -145,7 +145,19 @@ function maybe_require( $since, $path ) {
 
 function get_upgrader( $class, $insecure = false ) {
 	if ( ! class_exists( '\WP_Upgrader' ) ) {
+		if ( ! file_exists( ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php' ) ) {
+			WP_CLI::error( 'The WP_Upgrader class from WordPress Core is not available.' );
+		}
+
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+	}
+
+	if ( ! class_exists( '\WP_Upgrader_Skin' ) ) {
+		if ( ! file_exists( ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php' ) ) {
+			WP_CLI::error( 'The WP_Upgrader_Skin class from WordPress Core is not available.' );
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php';
 	}
 
 	$uses_insecure_flag = false;


### PR DESCRIPTION
Reports from Cloudways indicate that there is an intermittent issue with the `WP_Upgrader_Skin` class.

```
PHP Fatal error:  Uncaught Error: Class 'WP_Upgrader_Skin' not found in phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/UpgraderSkin.php:13
```

I have yet not been able to replicate the issue, but this PR already adds hardening around that code section which potentially avoids fatal errors.