### PR TITLE
Update `Formatter\show_table` to use `Runner->in_color` rather than `shouldColorize`

### DIFF
--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -302,7 +302,7 @@ class Formatter {
 	private static function show_table( $items, $fields, $ascii_pre_colorized = false ) {
 		$table = new Table();
 
-		$enabled = Colors::shouldColorize();
+		$enabled = WP_CLI::get_runner()->in_color();
 		if ( $enabled ) {
 			Colors::disable( true );
 		}


### PR DESCRIPTION
Fixes #5744.

## Problem

When a WP-CLI command outputs a table, the table formatter:
1. Checks whether colorization is enabled. If so, disables it.
2. Outputs the table.
3. If colorization was previously enabled, re-enables it.

The problem is that we're using `Colors::shouldColorize()` to determine whether colorization is enabled. `Colors::shouldColorize()` returns `true` if (a) the _terminal_ is capable of colors, AND (b) no output has yet been produced by the colorizer.

This means that if WP-CLI outputs a table _before_ it outputs any colorized messages, it will _always_ switch to color mode after the table has bveen printed.

You can demonstrate this for yourself by adding the line `WP_CLI::success( 'nothing here!' );` to the top of `function show_table`. This makes the problem go away (but prints out "Success: nothing here!" at the top of every table, which is undesirable).

## Solution

This PR switches the table formatter to use `WP_CLI::get_runner()->in_color()` to determine whether or not colorization is enabled. This returns `false` if `--no-color` was passed, `true` otherwise, and so the test below works properly.

## Testing

1. Check out this branch
2. Set up a copy of WordPress with an outdated plugin, e.g. `bin/wp plugin install classic-editor --version=1.6.2 --path=/your/wp`
3. Request that the plugin is updated, e.g. `bin/wp plugin update --all --path=/your/wp`, and see the usual output
4. Set up a copy of WordPress with an outdated plugin, e.g. `bin/wp plugin install classic-editor --version=1.6.2 --path=/your/wp`
5. Request that the plugin is updated **without colorized output**, e.g. `bin/wp plugin update --all --no-color --path=/your/wp`
6. Please test around to ensure that , e.g. quiet mode (`--quiet`) or using a terminal that isn't capable of color output