### PR TITLE
Add support for the proxyjump key

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -186,7 +186,7 @@ Feature: Create shortcuts to specific WordPress installs
     When I try `wp @foo --debug --version`
     Then STDERR should contain:
       """
-      Running SSH command: ssh -q -J proxyhost 
+      Running SSH command: ssh -q -J 'proxyhost' 
       """
 
   Scenario: Adds key to ssh command
@@ -201,7 +201,7 @@ Feature: Create shortcuts to specific WordPress installs
     When I try `wp @foo --debug --version`
     Then STDERR should contain:
       """
-      Running SSH command: ssh -q -i identityfile.key 
+      Running SSH command: ssh -q -i 'identityfile.key' 
       """
 
   Scenario: Add an alias

--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -174,6 +174,36 @@ Feature: Create shortcuts to specific WordPress installs
       Error: No alias found with key '@someotherfoo'.
       """
 
+  Scenario: Adds proxyjump to ssh command
+    Given a WP installation in 'foo'
+    And a wp-cli.yml file:
+      """
+      @foo:
+        ssh: user@host:/path/to/wordpress
+        proxyjump: proxyhost
+      """
+
+    When I try `wp @foo --debug --version`
+    Then STDERR should contain:
+      """
+      Running SSH command: ssh -q -J proxyhost 
+      """
+
+  Scenario: Adds key to ssh command
+    Given a WP installation in 'foo'
+    And a wp-cli.yml file:
+      """
+      @foo:
+        ssh: user@host:/path/to/wordpress
+        key: identityfile.key
+      """
+
+    When I try `wp @foo --debug --version`
+    Then STDERR should contain:
+      """
+      Running SSH command: ssh -q -i identityfile.key 
+      """
+
   Scenario: Add an alias
     Given a WP installation in 'foo'
     And a wp-cli.yml file:

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -57,6 +57,8 @@ class Configurator {
 		'path',
 		'ssh',
 		'http',
+		'proxyjump',
+		'key',
 	];
 
 	/**

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -650,9 +650,9 @@ class Runner {
 			}
 
 			$command_args = [
-				$bits['proxyjump'] ? sprintf( '-J %s ', $bits['proxyjump'] ) : '',
+				$bits['proxyjump'] ? sprintf( '-J %s ', escapeshellarg( $bits['proxyjump'] ) ) : '',
 				$bits['port'] ? '-p ' . (int) $bits['port'] . ' ' : '',
-				$bits['key'] ? sprintf( '-i %s', $bits['key'] ) : '',
+				$bits['key'] ? sprintf( '-i %s', escapeshellarg( $bits['key'] ) ) : '',
 				$is_tty ? '-t' : '-T',
 			];
 

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -551,7 +551,7 @@ class Runner {
 		$escaped_command = '';
 
 		// Set default values.
-		foreach ( [ 'scheme', 'user', 'host', 'port', 'path', 'key' ] as $bit ) {
+		foreach ( [ 'scheme', 'user', 'host', 'port', 'path', 'key', 'proxyjump' ] as $bit ) {
 			if ( ! isset( $bits[ $bit ] ) ) {
 				$bits[ $bit ] = null;
 			}
@@ -640,7 +640,17 @@ class Runner {
 				$bits['host'] = $bits['user'] . '@' . $bits['host'];
 			}
 
+			if ( ! empty( $this->alias ) ) {
+				$alias_config = isset( $this->aliases[ $this->alias ] ) ? $this->aliases[ $this->alias ] : false;
+
+				if ( is_array( $alias_config ) ) {
+					$bits['proxyjump'] = isset( $alias_config['proxyjump'] ) ? $alias_config['proxyjump'] : '';
+					$bits['key']       = isset( $alias_config['key'] ) ? $alias_config['key'] : '';
+				}
+			}
+
 			$command_args = [
+				$bits['proxyjump'] ? sprintf( '-J %s ', $bits['proxyjump'] ) : '',
 				$bits['port'] ? '-p ' . (int) $bits['port'] . ' ' : '',
 				$bits['key'] ? sprintf( '-i %s', $bits['key'] ) : '',
 				$is_tty ? '-t' : '-T',


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
SSH has the capability to route traffic through a proxy. This is done using the [`-J xxx`](https://www.redhat.com/sysadmin/ssh-proxy-bastion-proxyjump) argument. The ProxyJump can be used for security purposes by limiting access to remote servers to specific IP addresses.

Previously it had to use wp-cli with a proxy in between. The only somewhat practical way was adding it to your personal `~/.ssh/config`:

```
Host production
  HostName xxx.xxx.xxx.xxx
  ProxyCommand ssh -q -W %h:22 vagrant
```

But this is technical and has to be done on every single machine in a team of multiple contributors.

This PR adds an option `proxyjump` to the alias specification so the `wp-cli.yml` config file can specify a comon proxy for all traffic to go through.

The change also includes a fix for the `key` attribute. It was part of the options for vagrant but did not seem possible for regular SSH commands, even though is can be usefull.