### PR TITLE
Fix PHP 8.1 deprecation: ReturnTypeWillChange

### DIFF
--- a/php/WP_CLI/Iterators/Query.php
+++ b/php/WP_CLI/Iterators/Query.php
@@ -88,19 +88,23 @@ class Query implements Iterator {
 		return true;
 	}
 
+	#[\ReturnTypeWillChange]
 	public function current() {
 		return $this->results[ $this->index_in_results ];
 	}
 
+	#[\ReturnTypeWillChange]
 	public function key() {
 		return $this->global_index;
 	}
 
+	#[\ReturnTypeWillChange]
 	public function next() {
 		$this->index_in_results++;
 		$this->global_index++;
 	}
 
+	#[\ReturnTypeWillChange]
 	public function rewind() {
 		$this->results          = [];
 		$this->global_index     = 0;
@@ -109,6 +113,7 @@ class Query implements Iterator {
 		$this->depleted         = false;
 	}
 
+	#[\ReturnTypeWillChange]
 	public function valid() {
 		if ( $this->depleted ) {
 			return false;


### PR DESCRIPTION
Fixes PHP 8.1 deprecation by adding `#[\ReturnTypeWillChange]` to Iterator methods.

Fixes #5806