### PR TITLE
Display a custom error message when `themes/functions.php` fatals

### DIFF
--- a/features/skip-themes.feature
+++ b/features/skip-themes.feature
@@ -198,5 +198,5 @@ Feature: Skipping themes
     When I try `wp --skip-themes plugin list`
     Then STDERR should contain:
       """
-      Error: There was an internal server error that may have been caused by an unexpected functions.php file in the themes directory.
+      Error: An unexpected functions.php file in the themes directory may have caused this internal server error.
       """

--- a/features/skip-themes.feature
+++ b/features/skip-themes.feature
@@ -185,3 +185,17 @@ Feature: Skipping themes
       """
       bool(false)
       """
+
+  Scenario: Display a custom error message when themes/functions.php causes the fatal
+    Given a WP installation
+    And a wp-content/themes/functions.php file:
+      """
+      <?php
+      wp_cli_function_doesnt_exist_5240();
+      """
+
+    When I try `wp --skip-themes plugin list`
+    Then STDERR should contain:
+      """
+      Error: There was an internal server error that may have been caused by an unexpected functions.php file in the themes directory.
+      """

--- a/features/skip-themes.feature
+++ b/features/skip-themes.feature
@@ -186,6 +186,7 @@ Feature: Skipping themes
       bool(false)
       """
 
+  @require-wp-5.2
   Scenario: Display a custom error message when themes/functions.php causes the fatal
     Given a WP installation
     And a wp-content/themes/functions.php file:

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -100,7 +100,7 @@ function wp_die_handler( $message ) {
 		$error_data   = $message->get_error_data( 'internal_server_error' );
 		if ( ! empty( $error_data['error']['file'] )
 			&& false !== stripos( $error_data['error']['file'], 'themes/functions.php' ) ) {
-			$text_message = 'There was an internal server error that may have been caused by an unexpected functions.php file in the themes directory.';
+			$text_message = 'An unexpected functions.php file in the themes directory may have caused this internal server error.';
 		}
 	} else {
 		$text_message = $message;

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -97,7 +97,7 @@ function wp_die_handler( $message ) {
 
 	if ( $message instanceof \WP_Error ) {
 		$text_message = $message->get_error_message();
-		$error_data = $message->get_error_data( 'internal_server_error' );
+		$error_data   = $message->get_error_data( 'internal_server_error' );
 		if ( ! empty( $error_data['error']['file'] )
 			&& false !== stripos( $error_data['error']['file'], 'themes/functions.php' ) ) {
 			$text_message = 'There was an internal server error that may have been caused by an unexpected functions.php file in the themes directory.';

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -94,13 +94,21 @@ function replace_wp_die_handler() {
 }
 
 function wp_die_handler( $message ) {
+
 	if ( $message instanceof \WP_Error ) {
-		$message = $message->get_error_message();
+		$text_message = $message->get_error_message();
+		$error_data = $message->get_error_data( 'internal_server_error' );
+		if ( ! empty( $error_data['error']['file'] )
+			&& false !== stripos( $error_data['error']['file'], 'themes/functions.php' ) ) {
+			$text_message = 'There was an internal server error that may have been caused by an unexpected functions.php file in the themes directory.';
+		}
+	} else {
+		$text_message = $message;
 	}
 
-	$message = wp_clean_error_message( $message );
+	$text_message = wp_clean_error_message( $text_message );
 
-	WP_CLI::error( $message );
+	WP_CLI::error( $text_message );
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/5240

Trying to fix this upstream is too much of a rabbit hole. Instead, let's give the user a more helpful pointer:

```
$ wp --skip-themes option get home
Fatal error: Uncaught Error: Call to undefined function genesis_register_sidebar() in /Users/danielbachhuber/projects/vanilla/wp-content/themes/functions.php:3
Stack trace:
#0 /Users/danielbachhuber/projects/vanilla/wp-settings.php(599): include()
#1 /Users/danielbachhuber/projects/wp-cli-dev/wp-cli/php/WP_CLI/Runner.php(1349): require('/Users/danielba...')
#2 /Users/danielbachhuber/projects/wp-cli-dev/wp-cli/php/WP_CLI/Runner.php(1267): WP_CLI\Runner->load_wordpress()
#3 /Users/danielbachhuber/projects/wp-cli-dev/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(28): WP_CLI\Runner->start()
#4 /Users/danielbachhuber/projects/wp-cli-dev/wp-cli/php/bootstrap.php(83): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#5 /Users/danielbachhuber/projects/wp-cli-dev/wp-cli/php/wp-cli.php(32): WP_CLI\bootstrap()
#6 /Users/danielbachhuber/projects/wp-cli-dev/wp-cli/php/boot-fs.php(17): require_once('/Users/danielba...')
#7 {main}
  thrown in /Users/danielbachhuber/projects/vanilla/wp-content/themes/functions.php on line 3
Error: An unexpected functions.php file in the themes directory may have caused this internal server error.
```