### PR TITLE
Escape shell command in `wp-cli update`

### DIFF
--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -357,7 +357,7 @@ class CLI_Command extends WP_CLI_Command {
 
 		$allow_root = WP_CLI::get_runner()->config['allow-root'] ? '--allow-root' : '';
 		$php_binary = Utils\get_php_binary();
-		$process    = Process::create( "{$php_binary} $temp --info {$allow_root}" );
+		$process    = Process::create( Utils\esc_cmd( '%s %s --info %s', $php_binary, $temp, $allow_root ) );
 		$result     = $process->run();
 		if ( 0 !== $result->return_code || false === stripos( $result->stdout, 'WP-CLI version' ) ) {
 			$multi_line = explode( PHP_EOL, $result->stderr );


### PR DESCRIPTION
[Link to original issue.](https://github.com/wp-cli/wp-cli/issues/5815)

[Link to comment about existing tests.](https://github.com/wp-cli/wp-cli/issues/5815#issuecomment-1645834087)

This fix escapes a command that was causing `wp cli update` to fail when the `$php_binary` path contained a space.