### PR TITLE
Run test only on PHP 7.0+

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -143,7 +143,7 @@ Feature: Get help about WP-CLI commands
       GLOBAL PARAMETERS
       """
 
-  @require-php-5.6
+  @require-php-7.0
   Scenario: Help when WordPress is downloaded but not installed
     Given an empty directory
 


### PR DESCRIPTION
Tests involving the WP release can now only run on PHP 7.0+ due to the new minimum requirement.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
