### PR TITLE
Require PHP 7+ for installing Gutenberg

### DIFF
--- a/features/skip-themes.feature
+++ b/features/skip-themes.feature
@@ -168,7 +168,7 @@ Feature: Skipping themes
       bool(false)
       """
 
-  @require-wp-6.1
+  @require-wp-6.1 @require-php-7.0
   Scenario: Skip a theme using block patterns with Gutenberg active
     Given a WP installation
     And I run `wp plugin install gutenberg --activate`


### PR DESCRIPTION
The latest Gutenberg release now requires PHP 7.0 too. This fixes a test failure on PHP 5.6