### PR TITLE
Require PHP 7.0 for tests installing WP via Composer

### DIFF
--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -317,7 +317,7 @@ Feature: Bootstrap WP-CLI
       1
       """
 
-  @requires-php-7.0
+  @require-php-7.0
   Scenario: Composer stack with both WordPress and wp-cli as dependencies (command line)
     Given a WP installation with Composer
     And a dependency on current wp-cli
@@ -330,14 +330,14 @@ Feature: Bootstrap WP-CLI
       WP CLI Site with both WordPress and wp-cli as Composer dependencies
       """
 
-  @broken @requires-php-7.0
+  @broken @require-php-7.0
   Scenario: Composer stack with both WordPress and wp-cli as dependencies (web)
     Given a WP installation with Composer
     And a dependency on current wp-cli
     And a PHP built-in web server to serve 'WordPress'
     Then the HTTP status code should be 200
 
-  @requires-php-7.0
+  @require-php-7.0
   Scenario: Composer stack with both WordPress and wp-cli as dependencies and a custom vendor directory
     Given a WP installation with Composer and a custom vendor directory 'vendor-custom'
     And a dependency on current wp-cli

--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -317,6 +317,7 @@ Feature: Bootstrap WP-CLI
       1
       """
 
+  @requires-php-7.0
   Scenario: Composer stack with both WordPress and wp-cli as dependencies (command line)
     Given a WP installation with Composer
     And a dependency on current wp-cli
@@ -329,13 +330,14 @@ Feature: Bootstrap WP-CLI
       WP CLI Site with both WordPress and wp-cli as Composer dependencies
       """
 
-  @broken
+  @broken @requires-php-7.0
   Scenario: Composer stack with both WordPress and wp-cli as dependencies (web)
     Given a WP installation with Composer
     And a dependency on current wp-cli
     And a PHP built-in web server to serve 'WordPress'
     Then the HTTP status code should be 200
 
+  @requires-php-7.0
   Scenario: Composer stack with both WordPress and wp-cli as dependencies and a custom vendor directory
     Given a WP installation with Composer and a custom vendor directory 'vendor-custom'
     And a dependency on current wp-cli


### PR DESCRIPTION
They install the latest WP version, which now requires PHP 7.0

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
