### PR TITLE
Update type hint of $callable parameter in add_command() method

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -463,7 +463,7 @@ class WP_CLI {
 	 * @category Registration
 	 *
 	 * @param string   $name Name for the command (e.g. "post list" or "site empty").
-	 * @param callable $callable Command implementation as a class, function or closure.
+	 * @param callable|object|string $callable Command implementation as a class, function or closure.
 	 * @param array    $args {
 	 *    Optional. An associative array with additional registration parameters.
 	 *


### PR DESCRIPTION
The `$callable` can be a class name or an object as well, so allow `object` and `string` types in the type hint.

I've noticed this issue while analyzing a plugin of mine with PHPStan on level 7.
