### PR TITLE
Respect alias `--path=` in `IncludeRequestsAutoloader`

### DIFF
--- a/features/requests.feature
+++ b/features/requests.feature
@@ -107,11 +107,11 @@ Feature: Requests integration with both v1 and v2
       """
 
     When I run `WP_CLI_RUNTIME_ALIAS='{"@foo":{"path":"foo"}}' wp @foo option get home --debug`
-    Then STDOUT should contain:
+    Then STDERR should contain:
       """
       Setting RequestsLibrary::$version to v1
       """
-    And STDOUT should contain:
+    And STDERR should contain:
       """
       Setting RequestsLibrary::$source to wp-core
       """

--- a/features/requests.feature
+++ b/features/requests.feature
@@ -96,3 +96,22 @@ Feature: Requests integration with both v1 and v2
       """
       Success: Installed 1 of 1 plugins.
       """
+
+  Scenario: Current version with WordPress-bundled Request v1 and an alias
+    Given a WP installation in 'foo'
+    And I run `wp --path=foo core download --version=5.8 --force`
+    And a wp-cli.yml file:
+      """
+      @foo:
+        path: foo
+      """
+
+    When I run `WP_CLI_RUNTIME_ALIAS='{"@foo":{"path":"foo"}}' wp @foo option get home --debug`
+    Then STDOUT should contain:
+      """
+      Setting RequestsLibrary::$version to v1
+      """
+    And STDOUT should contain:
+      """
+      Setting RequestsLibrary::$source to wp-core
+      """

--- a/features/requests.feature
+++ b/features/requests.feature
@@ -106,7 +106,7 @@ Feature: Requests integration with both v1 and v2
         path: foo
       """
 
-    When I run `WP_CLI_RUNTIME_ALIAS='{"@foo":{"path":"foo"}}' wp @foo option get home --debug`
+    When I try `WP_CLI_RUNTIME_ALIAS='{"@foo":{"path":"foo"}}' wp @foo option get home --debug`
     Then STDERR should contain:
       """
       Setting RequestsLibrary::$version to v1

--- a/php/WP_CLI/Bootstrap/IncludeRequestsAutoloader.php
+++ b/php/WP_CLI/Bootstrap/IncludeRequestsAutoloader.php
@@ -48,15 +48,29 @@ final class IncludeRequestsAutoloader implements BootstrapStep {
 
 		$runner = new RunnerInstance();
 
-		// Make sure we don't deal with an invalid `--path` value.
-		$config = $runner()->config;
-		if ( isset( $config['path'] ) &&
-			( is_bool( $config['path'] ) || empty( $config['path'] ) )
-		) {
-			return $state;
+		// Use `--path` from the alias if one is matching.
+		$alias_path = null;
+		if ( $runner()->alias
+			&& isset( $runner()->aliases[ $runner()->alias ]['path'] ) ) {
+			$alias_path = $runner()->aliases[ $runner()->alias ]['path'];
+			// Make sure it isn't an invalid value.
+			if ( is_bool( $alias_path ) || empty( $alias_path ) ) {
+				return $state;
+			}
+			if ( ! \WP_CLI\Utils\is_path_absolute( $alias_path ) ) {
+				$alias_path = getcwd() . '/' . $alias_path;
+			}
+			$wp_root = rtrim( $alias_path, '/' );
+		} else {
+			// Make sure we don't deal with an invalid `--path` value.
+			$config = $runner()->config;
+			if ( isset( $config['path'] ) &&
+				( is_bool( $config['path'] ) || empty( $config['path'] ) )
+			) {
+				return $state;
+			}
+			$wp_root = rtrim( $runner()->find_wp_root(), '/' );
 		}
-
-		$wp_root = rtrim( $runner()->find_wp_root(), '/' );
 
 		// First try to detect a newer Requests version bundled with WordPress.
 		if ( file_exists( $wp_root . '/wp-includes/Requests/src/Autoload.php' ) ) {

--- a/php/WP_CLI/Bootstrap/IncludeRequestsAutoloader.php
+++ b/php/WP_CLI/Bootstrap/IncludeRequestsAutoloader.php
@@ -4,6 +4,7 @@ namespace WP_CLI\Bootstrap;
 
 use WP_CLI\Autoloader;
 use WP_CLI\RequestsLibrary;
+use WP_CLI\Utils;
 
 /**
  * Class IncludeRequestsAutoloader.
@@ -57,7 +58,7 @@ final class IncludeRequestsAutoloader implements BootstrapStep {
 			if ( is_bool( $alias_path ) || empty( $alias_path ) ) {
 				return $state;
 			}
-			if ( ! \WP_CLI\Utils\is_path_absolute( $alias_path ) ) {
+			if ( ! Utils\is_path_absolute( $alias_path ) ) {
 				$alias_path = getcwd() . '/' . $alias_path;
 			}
 			$wp_root = rtrim( $alias_path, '/' );


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/5816

Ensures WP-CLI works with older versions of WordPress with `--path=` is defined via an alias.