### PR TITLE
Update phpcs.xml to match new WPCS rules

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -35,12 +35,7 @@
 
 	<rule ref="WP_CLI_CS">
 		<!-- The `while` control structure is the only one where assignments in conditions are mostly valid. -->
-		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
-
-		<!-- This is a bug in PHPCS. A fix for which has been pulled already and is expected to be
-			 merged in PHPCS 3.5.0. Once this repos upgrades to that version, this exclusion
-			 should be removed. -->
-		<exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter"/>
+		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
 	</rule>
 
 	<!--


### PR DESCRIPTION
It looks like `WordPress.CodeAnalysis.AssignmentInCondition.Found` has been renamed upstream and is now `Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition`

I don't believe this repo actually does an assignment inside of a while condition at the moment -- which is why there weren't any test failures when updating to WPCS 3.0.

I had one of these in a local wp-cli project and when searching for the origin of that exclude I realized that it had been copied from the phpcs.xml file in this repo which I used as a starting point.

While I was here I also removed the PSR2 rule below it based on the comment suggesting it should be removed once PHPCS is above 3.5.0 (it is).