### PR TITLE
Fix `--skip-themes` for WordPress 6.4

### DIFF
--- a/features/requests.feature
+++ b/features/requests.feature
@@ -25,6 +25,7 @@ Feature: Requests integration with both v1 and v2
 
     Given a WP installation
     And I run `vendor/bin/wp core update --version=5.8 --force`
+    And I run `rm -r wp-content/themes/*`
 
     When I run `vendor/bin/wp core version`
     Then STDOUT should contain:
@@ -46,6 +47,7 @@ Feature: Requests integration with both v1 and v2
   Scenario: Current version with WordPress-bundled Requests v1
     Given a WP installation
     And I run `wp core update --version=5.8 --force`
+    And I run `rm -r wp-content/themes/*`
 
     When I run `wp core version`
     Then STDOUT should contain:

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1794,8 +1794,10 @@ class Runner {
 		}
 
 		// Noop memoization added in WP 6.4.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- WordPress core global.
 		$GLOBALS['wp_stylesheet_path'] = null;
-		$GLOBALS['wp_template_path']   = null;
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- WordPress core global.
+		$GLOBALS['wp_template_path'] = null;
 
 		// Remove theme-related actions not directly tied into the theme lifecycle.
 		if ( WP_CLI::get_runner()->config['skip-themes'] ) {
@@ -1817,8 +1819,10 @@ class Runner {
 					remove_filter( $hook, $wp_cli_filter_active_theme, 999 );
 				}
 				// Noop memoization added in WP 6.4 again.
+				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- WordPress core global.
 				$GLOBALS['wp_stylesheet_path'] = null;
-				$GLOBALS['wp_template_path']   = null;
+				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- WordPress core global.
+				$GLOBALS['wp_template_path'] = null;
 			},
 			0
 		);

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1793,6 +1793,10 @@ class Runner {
 			add_filter( $hook, $wp_cli_filter_active_theme, 999 );
 		}
 
+		// Noop memoization added in WP 6.4.
+		$GLOBALS['wp_stylesheet_path'] = null;
+		$GLOBALS['wp_template_path']   = null;
+
 		// Remove theme-related actions not directly tied into the theme lifecycle.
 		if ( WP_CLI::get_runner()->config['skip-themes'] ) {
 			$theme_related_actions = [
@@ -1812,6 +1816,9 @@ class Runner {
 				foreach ( $hooks as $hook ) {
 					remove_filter( $hook, $wp_cli_filter_active_theme, 999 );
 				}
+				// Noop memoization added in WP 6.4 again.
+				$GLOBALS['wp_stylesheet_path'] = null;
+				$GLOBALS['wp_template_path']   = null;
 			},
 			0
 		);


### PR DESCRIPTION
WordPress 6.4 added some memoization that impacts `get_template_directory()` and `get_stylesheet_directory()`. Fortunately, we only need to noop the global to fix `--skip-themes`.

Fixes https://github.com/wp-cli/wp-cli/issues/5839