### PR TITLE
Update tests to accommodate for SQLite

### DIFF
--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -367,7 +367,7 @@ Feature: Bootstrap WP-CLI
           define( 'WP_CLI_TEST_CONSTANT', getenv( 'WP_CLI_TEST_ENV_VAR' ) );
       """
 
-    When I run `wp config create {CORE_CONFIG_SETTINGS}`
+    When I run `wp config create --skip-check {CORE_CONFIG_SETTINGS}`
     Then STDOUT should contain:
       """
       Success:
@@ -410,7 +410,9 @@ Feature: Bootstrap WP-CLI
       """
     And the return code should be 0
 
-  @require-wp-4.0
+  # `wp search-replace` does not yet support SQLite
+  # See https://github.com/wp-cli/search-replace-command/issues/190
+  @require-wp-4.0 @require-mysql
   Scenario: Run search-replace on ms_site_not_found
     Given a WP multisite installation
     And a wp-cli.yml file:

--- a/features/framework.feature
+++ b/features/framework.feature
@@ -84,6 +84,9 @@ Feature: Load WP-CLI
       Error: This does not seem to be a WordPress installation.
       """
 
+  # `wp db create` does not yet work on SQLite,
+  # See https://github.com/wp-cli/db-command/issues/234
+  @require-mysql
   Scenario: Globalize global variables in wp-config.php
     Given an empty directory
     And WP files
@@ -92,7 +95,7 @@ Feature: Load WP-CLI
       $redis_server = 'foo';
       """
 
-    When I run `wp core config {CORE_CONFIG_SETTINGS} --extra-php < wp-config-extra.php`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --extra-php < wp-config-extra.php`
     Then the wp-config.php file should contain:
       """
       $redis_server = 'foo';
@@ -265,6 +268,9 @@ Feature: Load WP-CLI
       https://example.com/
       """
 
+  # `wp db reset` does not yet work on SQLite,
+  # See https://github.com/wp-cli/db-command/issues/234
+  @require-mysql
   Scenario: Show error message when site isn't found and there aren't additional prefixes.
     Given a WP installation
     And I run `wp db reset --yes`
@@ -309,7 +315,9 @@ Feature: Load WP-CLI
       """
     And STDOUT should be empty
 
-  @require-wp-3.9
+  # `wp db query` does not yet work on SQLite,
+  # See https://github.com/wp-cli/db-command/issues/234
+  @require-wp-3.9 @require-mysql
   Scenario: Display a more helpful error message when site can't be found
     Given a WP multisite installation
     And "define( 'DOMAIN_CURRENT_SITE', 'example.com' );" replaced with "define( 'DOMAIN_CURRENT_SITE', 'example.org' );" in the wp-config.php file

--- a/features/framework.feature
+++ b/features/framework.feature
@@ -182,6 +182,7 @@ Feature: Load WP-CLI
       https://example.com
       """
 
+  @require-mysql
   Scenario: Handle error when WordPress cannot connect to the database host
     Given a WP installation
     And a invalid-host.php file:

--- a/features/help.feature
+++ b/features/help.feature
@@ -155,7 +155,7 @@ Feature: Get help about WP-CLI commands
       """
     And STDERR should be empty
 
-    When I run `wp config create {CORE_CONFIG_SETTINGS}`
+    When I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check`
     And I run `wp help core install`
     Then STDOUT should contain:
       """

--- a/features/hook.feature
+++ b/features/hook.feature
@@ -24,6 +24,9 @@ Feature: Tests `WP_CLI::add_hook()`
       """
     And the return code should be 0
 
+  # `wp db check` does not yet work on SQLite,
+  # See https://github.com/wp-cli/db-command/issues/234
+  @require-mysql
   Scenario: Add callback to the `before_invoke:db check`
     Given a WP installation
     And a before-invoke.php file:

--- a/features/requests.feature
+++ b/features/requests.feature
@@ -1,5 +1,7 @@
 Feature: Requests integration with both v1 and v2
 
+  # This test downgrades to WordPress 5.8, but the SQLite plugin requires 6.0+
+  @require-mysql
   Scenario: Composer stack with Requests v1
     Given an empty directory
     And a composer.json file:
@@ -44,6 +46,8 @@ Feature: Requests integration with both v1 and v2
       """
     And STDERR should be empty
 
+  # This test downgrades to WordPress 5.8, but the SQLite plugin requires 6.0+
+  @require-mysql
   Scenario: Current version with WordPress-bundled Requests v1
     Given a WP installation
     And I run `wp core update --version=5.8 --force`
@@ -99,6 +103,8 @@ Feature: Requests integration with both v1 and v2
       Success: Installed 1 of 1 plugins.
       """
 
+  # This test downgrades to WordPress 5.8, but the SQLite plugin requires 6.0+
+  @require-mysql
   Scenario: Current version with WordPress-bundled Request v1 and an alias
     Given a WP installation in 'foo'
     And I run `wp --path=foo core download --version=5.8 --force`

--- a/features/utils-wp.feature
+++ b/features/utils-wp.feature
@@ -333,6 +333,9 @@ Feature: Utilities that depend on WordPress code
       wp_posts
       """
 
+  # `wp db query` does not yet work on SQLite,
+  # See https://github.com/wp-cli/db-command/issues/234
+  @require-mysql
   Scenario: Get WP table names for multisite install
     Given a WP multisite install
     And I run `wp db query "CREATE TABLE xx_wp_posts ( id int );"`

--- a/features/utils-wp.feature
+++ b/features/utils-wp.feature
@@ -21,6 +21,9 @@ Feature: Utilities that depend on WordPress code
       1,,,
       """
 
+  # `wp db query` does not yet work on SQLite,
+  # See https://github.com/wp-cli/db-command/issues/234
+  @require-mysql
   Scenario: Get WP table names for single site install
     Given a WP installation
     And I run `wp db query "CREATE TABLE xx_wp_posts ( id int );"`

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -1,5 +1,6 @@
 Feature: Utilities that do NOT depend on WordPress code
 
+  @require-mysql
   Scenario Outline: Check that `proc_open()` and `proc_close()` aren't disabled for `Utils\run_mysql_command()`
     When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--ddisable_functions=<func>} --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( null, array() );'`
     Then STDERR should contain:
@@ -28,6 +29,7 @@ Feature: Utilities that do NOT depend on WordPress code
       | proc_open  |
       | proc_close |
 
+  @require-mysql
   Scenario: Check that `Utils\run_mysql_command()` uses STDOUT and STDERR by default
     When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}", "execute" => "SHOW DATABASES;" ] );'`
     Then STDOUT should contain:
@@ -47,6 +49,7 @@ Feature: Utilities that do NOT depend on WordPress code
       You have an error in your SQL syntax
       """
 
+  @require-mysql
   Scenario: Check that `Utils\run_mysql_command()` can return data and errors if requested
     When I run `wp --skip-wordpress eval 'list( $stdout, $stderr, $exit_code ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}", "execute" => "SHOW DATABASES;" ], null, false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
     Then STDOUT should not contain:
@@ -101,6 +104,7 @@ Feature: Utilities that do NOT depend on WordPress code
     When I run `{INVOKE_WP_CLI_WITH_PHP_ARGS--dsys_temp_dir=} --skip-wordpress eval 'echo WP_CLI\Utils\get_temp_dir();'`
     Then STDOUT should match /\/$/
 
+  @require-mysql
   Scenario: Ensure that Utils\run_mysql_command() passes through without reading full DB into memory
     Given a WP install
 

--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -23,6 +23,7 @@ function wp_not_installed() {
 			}
 		}
 		if ( count( $found_prefixes ) ) {
+			sort( $found_prefixes );
 			$prefix_list   = implode( ', ', $found_prefixes );
 			$install_label = count( $found_prefixes ) > 1 ? 'installations' : 'installation';
 			WP_CLI::error(


### PR DESCRIPTION
One functionality change:

In `wp_not_installed()` the list of found table prefixes is now explicitly sorted in ascending order. Without that, order would differ between MySQL and SQLite.