### PR TITLE
Testing `wp cli update` command

### DIFF
--- a/features/cli-update.feature
+++ b/features/cli-update.feature
@@ -1,0 +1,11 @@
+Feature: CLI Update
+
+  Scenario: Errors when not using a Phar
+
+    When I try `wp cli update`
+
+    Then STDOUT should be empty
+    Then STDERR should contain:
+      """
+      Error: You can only self-update Phar files.
+      """

--- a/features/cli-update.feature
+++ b/features/cli-update.feature
@@ -9,3 +9,46 @@ Feature: CLI Update
       """
       Error: You can only self-update Phar files.
       """
+
+  @github-api
+  Scenario: Do WP-CLI Update
+    Given an empty directory
+    And a new Phar with version "0.0.0"
+
+    When I run `{PHAR_PATH} --info`
+    Then STDOUT should contain:
+      """
+      WP-CLI version
+      """
+    And STDOUT should contain:
+      """
+      0.0.0
+      """
+
+    When I run `{PHAR_PATH} cli update --yes`
+    Then STDOUT should contain:
+      """
+      md5 hash verified:
+      """
+    And STDOUT should contain:
+    """
+    Success:
+    """
+    And STDERR should be empty
+    And the return code should be 0
+
+    When I run `{PHAR_PATH} --info`
+    Then STDOUT should contain:
+      """
+      WP-CLI version
+      """
+    And STDOUT should not contain:
+      """
+      0.0.0
+      """
+
+    When I run `{PHAR_PATH} cli update`
+    Then STDOUT should be:
+      """
+      Success: WP-CLI is at the latest version.
+      """


### PR DESCRIPTION
## Summary

Within #5815 , one of the potential fixes was merged (#5818 ) and later reverted ([Issue Comment](https://github.com/wp-cli/wp-cli/issues/5815#issuecomment-1663059289) Reverted commit: #5822 )

In the original issue, it was recommended to [start testing this part of the code](https://github.com/wp-cli/wp-cli/issues/5815#issuecomment-1789831048) so here's a start!

## PR Status

This is still a bit of a wip PR as I become more familiar with the project at large. Right now, the first scenario passes locally just fine, but the second scenario which tries to mimic the [failed scenario](https://github.com/wp-cli/wp-cli/issues/5815#issuecomment-1789394971) is failing for me locally. I curious to see what the GH actions say, but I'm starting to think I might need to add some Behat glue (idk the terms 😂) so that we can correctly make a Phar.

