### PR TITLE
Add missing required arguments when using `--prompt`

### DIFF
--- a/features/prompt.feature
+++ b/features/prompt.feature
@@ -204,3 +204,25 @@ Feature: Prompt user for input
       """
       "Hello world!",hello-world,publish
       """
+
+  Scenario: Prompt should show positional arguments
+    Given a WP installation
+    And a value-file file:
+      """
+      category
+      General
+      general
+
+
+
+      """
+
+    When I run `wp term create --prompt < value-file`
+    Then STDOUT should contain:
+      """
+      wp term create 'category' 'General' --slug='general'
+      """
+    And STDOUT should contain:
+      """
+      Created category
+      """

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -480,7 +480,16 @@ class Subcommand extends CompositeCommand {
 				sprintf(
 					'wp %s %s',
 					$cmd,
-					ltrim( Utils\assoc_args_to_str( $actual_args ), ' ' )
+					ltrim(
+						implode(
+							' ',
+							[
+								ltrim( Utils\args_to_str( $args ), ' ' ),
+								ltrim( Utils\assoc_args_to_str( $actual_args ), ' ' ),
+							]
+						),
+						' '
+					)
 				)
 			);
 		}


### PR DESCRIPTION
When using the `--prompt` argument on a command, the executed command gets logged, showing the command and arguments the prompt had collected.

This logged command, however, lacks all required `$args` and only lists the `$assoc_args` (that are not empty).

This patch will add the required arguments as well.

Fixes #5768 

Related: https://github.com/wp-cli/wp-cli/issues/5859