### PR TITLE
Add verbosity level and quiet flag in ssh command based on debug flag

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -184,9 +184,9 @@ Feature: Create shortcuts to specific WordPress installs
       """
 
     When I try `wp @foo --debug --version`
-    Then STDERR should contain:
+    And STDERR should contain:
       """
-      Running SSH command: ssh -q -J 'proxyhost' 
+      Running SSH command: ssh -J 'proxyhost' -T -vvv
       """
 
   Scenario: Adds key to ssh command
@@ -201,7 +201,7 @@ Feature: Create shortcuts to specific WordPress installs
     When I try `wp @foo --debug --version`
     Then STDERR should contain:
       """
-      Running SSH command: ssh -q -i 'identityfile.key' 
+      Running SSH command: ssh -i 'identityfile.key' -T -vvv
       """
 
   Scenario: Add an alias

--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -184,7 +184,7 @@ Feature: Create shortcuts to specific WordPress installs
       """
 
     When I try `wp @foo --debug --version`
-    And STDERR should contain:
+    Then STDERR should contain:
       """
       Running SSH command: ssh -J 'proxyhost' -T -vvv
       """

--- a/features/flags.feature
+++ b/features/flags.feature
@@ -344,14 +344,14 @@ Feature: Global flags
     When I try `WP_CLI_STRICT_ARGS_MODE=1 wp --debug --ssh=/ --version`
     Then STDERR should contain:
       """
-      Running SSH command: ssh -q -T '' 'WP_CLI_STRICT_ARGS_MODE=1 wp
+      Running SSH command: ssh -T -vvv '' 'WP_CLI_STRICT_ARGS_MODE=1 wp
       """
 
   Scenario: SSH flag should support changing directories
     When I try `wp --debug --ssh=wordpress:/my/path --version`
     Then STDERR should contain:
       """
-      Running SSH command: ssh -q -T 'wordpress' 'cd '\''/my/path'\''; wp
+      Running SSH command: ssh -T -vvv 'wordpress' 'cd '\''/my/path'\''; wp
       """
 
   Scenario: SSH flag should support Docker

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -639,7 +639,7 @@ class Runner {
 
 		// Default scheme is SSH.
 		if ( 'ssh' === $bits['scheme'] || null === $bits['scheme'] ) {
-			$command = 'ssh -q %s %s %s';
+			$command = 'ssh %s %s %s';
 
 			if ( $bits['user'] ) {
 				$bits['host'] = $bits['user'] . '@' . $bits['host'];
@@ -659,6 +659,7 @@ class Runner {
 				$bits['port'] ? '-p ' . (int) $bits['port'] . ' ' : '',
 				$bits['key'] ? sprintf( '-i %s', escapeshellarg( $bits['key'] ) ) : '',
 				$is_tty ? '-t' : '-T',
+				WP_CLI::get_config( 'debug' ) ? '-vvv' : '-q',
 			];
 
 			$escaped_command = sprintf(

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -655,8 +655,8 @@ class Runner {
 			}
 
 			$command_args = [
-				$bits['proxyjump'] ? sprintf( '-J %s ', escapeshellarg( $bits['proxyjump'] ) ) : '',
-				$bits['port'] ? '-p ' . (int) $bits['port'] . ' ' : '',
+				$bits['proxyjump'] ? sprintf( '-J %s', escapeshellarg( $bits['proxyjump'] ) ) : '',
+				$bits['port'] ? sprintf( '-p %d', (int) $bits['port'] ) : '',
 				$bits['key'] ? sprintf( '-i %s', escapeshellarg( $bits['key'] ) ) : '',
 				$is_tty ? '-t' : '-T',
 				WP_CLI::get_config( 'debug' ) ? '-vvv' : '-q',


### PR DESCRIPTION
Fixes: #5378 
Related #5859 

As reported in the above ticket, in case the SSH command fails it doesn't output the exact reason why it's failing because it uses the `-q` flag in it which suppresses SSH command logs as per its [man page](https://man7.org/linux/man-pages/man1/ssh.1.html#:~:text=%2Dq%20%20%20%20%20%20Quiet%20mode.%20%20Causes%20most%20warning%20and%20diagnostic%20messages%20to%0A%20%20%20%20%20%20%20%20%20%20%20%20%20be%20suppressed.).

Suppressing the SSH logs makes sense to keep the WP CLI output cleaner, but it can be hard to debug due to the lack of proper logs. This PR proposes to replace the `-q` flag with `-vvv` flag while using the `--debug` flag with the `wp` command.

#### Examples
<details><summary> <code>wp --ssh=wordpress:/my/path --version</code> </summary>

<br/>

```sh

> wp '--ssh=wordpress:/my/path' '--version'
Error: Cannot connect over SSH using provided configuration.
Script wp handling the wp event returned with error code 255
```

</details> 

<details><summary> <code>wp --debug --ssh=wordpress:/my/path --version</code> </summary>

<br/>

```sh
> wp '--debug' '--ssh=wordpress:/my/path' '--version'
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\DeclareAbstractBaseCommand (0.004s)
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\IncludeFrameworkAutoloader (0.004s)
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\ConfigureRunner (0.004s)
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\IncludeRequestsAutoloader (0.004s)
Debug (bootstrap): Setting RequestsLibrary::$version to v2 (0.004s)
Debug (bootstrap): Setting RequestsLibrary::$source to wp-core (0.004s)
Debug (bootstrap): Setting RequestsLibrary::$class_name to \WpOrg\Requests\Requests (0.004s)
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\InitializeColorization (0.004s)
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\InitializeLogger (0.004s)
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\DefineProtectedCommands (0.004s)
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\LoadExecCommand (0.005s)
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\LoadRequiredCommand (0.005s)
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\IncludePackageAutoloader (0.005s)
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\IncludeFallbackAutoloader (0.005s)
Debug (bootstrap): Fallback autoloader paths: /home/thelovekesh/Desktop/work/travelopia/moorings/vendor/wp-cli/wp-cli/vendor/autoload.php (0.005s)
Debug (bootstrap): Loading detected autoloader: /home/thelovekesh/Desktop/work/travelopia/moorings/vendor/wp-cli/wp-cli/vendor/autoload.php (0.005s)
Debug (bootstrap): Attaching command 'config edit' to hook before_wp_load (0.008s)
Debug (bootstrap): Attaching command 'config path' to hook before_wp_load (0.008s)
Debug (bootstrap): Attaching command 'config list' to hook before_wp_load (0.008s)
Debug (bootstrap): Attaching command 'config get' to hook before_wp_load (0.008s)
Debug (bootstrap): Attaching command 'config is-true' to hook before_wp_load (0.009s)
Debug (bootstrap): Attaching command 'config set' to hook before_wp_load (0.009s)
Debug (bootstrap): Attaching command 'config delete' to hook before_wp_load (0.009s)
Debug (bootstrap): Attaching command 'config has' to hook before_wp_load (0.009s)
Debug (bootstrap): Attaching command 'config shuffle-salts' to hook before_wp_load (0.009s)
Debug (commands): Adding command: config (0.009s)
Debug (bootstrap): Attaching command 'core download' to hook before_wp_load (0.009s)
Debug (bootstrap): Attaching command 'core version' to hook before_wp_load (0.01s)
Debug (commands): Adding command: core (0.01s)
Debug (bootstrap): Attaching command 'eval' to hook before_wp_load (0.01s)
Debug (commands): Adding command: eval (0.01s)
Debug (bootstrap): Attaching command 'eval-file' to hook before_wp_load (0.01s)
Debug (commands): Adding command: eval-file (0.01s)
Debug (bootstrap): Attaching command 'db' to hook after_wp_config_load (0.011s)
Debug (bootstrap): Attaching command 'db clean' to hook after_wp_load (0.011s)
Debug (bootstrap): Attaching command 'db tables' to hook after_wp_load (0.011s)
Debug (bootstrap): Attaching command 'db size' to hook after_wp_load (0.011s)
Debug (bootstrap): Attaching command 'db prefix' to hook after_wp_load (0.011s)
Debug (bootstrap): Attaching command 'db search' to hook after_wp_load (0.011s)
Debug (bootstrap): Attaching command 'db columns' to hook after_wp_load (0.011s)
Debug (commands): Adding command: db (0.011s)
Debug (commands): Adding command: comment (0.011s)
Debug (commands): Adding command: meta in comment Namespace (0.012s)
Debug (commands): Adding command: menu (0.012s)
Debug (commands): Adding command: item in menu Namespace (0.012s)
Debug (commands): Adding command: location in menu Namespace (0.012s)
Debug (commands): Deferring command: network meta (0.012s)
Debug (commands): Adding command: option (0.013s)
Debug (commands): Adding command: post (0.013s)
Debug (commands): Adding command: meta in post Namespace (0.013s)
Debug (commands): Adding command: term in post Namespace (0.013s)
Debug (commands): Adding command: post-type (0.014s)
Debug (commands): Adding command: site (0.014s)
Debug (commands): Adding command: meta in site Namespace (0.014s)
Debug (commands): Adding command: option in site Namespace (0.014s)
Debug (commands): Adding command: taxonomy (0.015s)
Debug (commands): Adding command: term (0.015s)
Debug (commands): Adding command: meta in term Namespace (0.015s)
Debug (commands): Adding command: user (0.016s)
Debug (commands): Adding command: application-password in user Namespace (0.016s)
Debug (commands): Adding command: meta in user Namespace (0.016s)
Debug (commands): Adding command: session in user Namespace (0.016s)
Debug (commands): Adding command: term in user Namespace (0.016s)
Debug (commands): Adding command: network (0.016s)
Debug (hooks): Processing hook "after_add_command:network" with 1 callbacks (0.017s)
Debug (hooks): On hook "after_add_command:network": Closure in file /home/thelovekesh/Desktop/work/travelopia/moorings/vendor/wp-cli/wp-cli/php/class-wp-cli.php at line 695 (0.017s)
Debug (commands): Adding command: meta in network Namespace (0.017s)
Debug (commands): Adding command: plugin (0.018s)
Debug (commands): Adding command: auto-updates in plugin Namespace (0.018s)
Debug (commands): Adding command: theme (0.019s)
Debug (commands): Adding command: auto-updates in theme Namespace (0.019s)
Debug (commands): Adding command: mod in theme Namespace (0.019s)
Debug (bootstrap): Attaching command 'package' to hook before_wp_load (0.02s)
Debug (commands): Adding command: package (0.02s)
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\RegisterFrameworkCommands (0.02s)
Debug (bootstrap): Adding framework command: /home/thelovekesh/Desktop/work/travelopia/moorings/vendor/wp-cli/wp-cli/php/commands/cli.php (0.02s)
Debug (bootstrap): Attaching command 'cli' to hook before_wp_load (0.021s)
Debug (bootstrap): Attaching command 'cli has-command' to hook after_wp_load (0.021s)
Debug (commands): Adding command: cli (0.021s)
Debug (bootstrap): Attaching command 'cli cache' to hook before_wp_load (0.021s)
Debug (commands): Adding command: cache in cli Namespace (0.021s)
Debug (bootstrap): Attaching command 'cli alias' to hook before_wp_load (0.021s)
Debug (commands): Adding command: alias in cli Namespace (0.021s)
Debug (bootstrap): Adding framework command: /home/thelovekesh/Desktop/work/travelopia/moorings/vendor/wp-cli/wp-cli/php/commands/help.php (0.021s)
Debug (commands): Adding command: help (0.021s)
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\RegisterDeferredCommands (0.021s)
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\InitializeContexts (0.021s)
Debug (bootstrap): Processing bootstrap step: WP_CLI\Bootstrap\LaunchRunner (0.021s)
Debug (bootstrap): No readable global config found (0.022s)
Debug (bootstrap): No project config found (0.022s)
Debug (bootstrap): argv: /home/thelovekesh/Desktop/work/travelopia/moorings/vendor/wp-cli/wp-cli/bin/../php/boot-fs.php --debug --ssh=wordpress:/my/path --version (0.022s)
Debug (bootstrap): SSH scheme:  (0.022s)
Debug (bootstrap): SSH user:  (0.022s)
Debug (bootstrap): SSH host: wordpress (0.022s)
Debug (bootstrap): SSH port:  (0.022s)
Debug (bootstrap): SSH path: /my/path (0.022s)
Debug (bootstrap): SSH key:  (0.022s)
Debug (bootstrap): SSH proxyjump:  (0.022s)
Debug (bootstrap): Running SSH command: ssh -T -vvv 'wordpress' 'cd '\''/my/path'\''; wp '\''--debug'\'' '\''--version'\''' (0.022s)
OpenSSH_8.9p1 Ubuntu-3ubuntu0.4, OpenSSL 3.0.2 15 Mar 2022
debug1: Reading configuration data /etc/ssh/ssh_config
debug1: /etc/ssh/ssh_config line 19: include /etc/ssh/ssh_config.d/*.conf matched no files
debug1: /etc/ssh/ssh_config line 21: Applying options for *
debug3: expanded UserKnownHostsFile '~/.ssh/known_hosts' -> '/home/thelovekesh/.ssh/known_hosts'
debug3: expanded UserKnownHostsFile '~/.ssh/known_hosts2' -> '/home/thelovekesh/.ssh/known_hosts2'
debug2: resolving "wordpress" port 22
debug3: resolve_host: lookup wordpress:22
ssh: Could not resolve hostname wordpress: Temporary failure in name resolution
Error: Cannot connect over SSH using provided configuration.
Script wp handling the wp event returned with error code 255
```

</details> 