### PR TITLE
Standard completion of current option

### DIFF
--- a/features/cli-bash-completion.feature
+++ b/features/cli-bash-completion.feature
@@ -101,7 +101,10 @@ Feature: `wp cli completions` tasks
       """
 
     When I run `wp cli completions --line='wp config create --dbname=' --point=100`
-    Then STDOUT should be empty
+    Then STDOUT should contain:
+      """
+      --dbname=
+      """
 
     When I run `wp cli completions --line='wp config create --dbname=foo ' --point=100`
     Then STDOUT should not contain:
@@ -321,7 +324,10 @@ Feature: `wp cli completions` tasks
       """
 
     When I run `wp cli completions --line="wp core download --no-color" --point=100`
-    Then STDOUT should not contain:
+    Then STDOUT should contain:
       """
       --no-color
       """
+
+    When I run `wp cli completions --line="wp core download --no-color --no-color" --point=100`
+    Then STDOUT should be empty

--- a/php/WP_CLI/Completions.php
+++ b/php/WP_CLI/Completions.php
@@ -116,8 +116,14 @@ class Completions {
 		$positional_args = [];
 		$assoc_args      = [];
 
-		foreach ( $words as $arg ) {
+		# Avoid having to polyfill array_key_last().
+		end( $words );
+		$last_arg_i = key( $words );
+		foreach ( $words as $i => $arg ) {
 			if ( preg_match( '|^--([^=]+)=?|', $arg, $matches ) ) {
+				if ( $i === $last_arg_i ) {
+					continue;
+				}
 				$assoc_args[ $matches[1] ] = true;
 			} else {
 				$positional_args[] = $arg;


### PR DESCRIPTION
Make options complete in a manner more consistent with other shell programs.

Closes #5845.

This relies on `array_key_last()` which may need to be polyfilled if it isn't already.