### PR TITLE
Admin Context: Fix PHP fatals when admin.php has CRLF line endings

### DIFF
--- a/features/context.feature
+++ b/features/context.feature
@@ -176,3 +176,20 @@ Feature: Context handling via --context global flag
       """
       custom context was added
       """
+
+  Scenario: Core wp-admin/admin.php with CRLF lines does not fail.
+    Given a WP install
+    And a modify-wp-admin.php file:
+    """
+    <?php
+    $admin_php_file = file( __DIR__ . '/wp-admin/admin.php' );
+    $admin_php_file = implode( "\r\n", array_map( 'trim', $admin_php_file ) );
+    file_put_contents( __DIR__ . '/wp-admin/admin.php', $admin_php_file );
+    unset( $admin_php_file );
+    """
+
+    When I run `wp --require=modify-wp-admin.php --context=admin eval 'var_export( is_admin() );'`
+    And STDOUT should be:
+    """
+    true
+    """

--- a/php/WP_CLI/Context/Admin.php
+++ b/php/WP_CLI/Context/Admin.php
@@ -114,7 +114,7 @@ final class Admin implements Context {
 		$admin_php_file = preg_replace( '/\s+\?>$/', '', $admin_php_file );
 
 		// Then we remove the loading of either wp-config.php or wp-load.php.
-		$admin_php_file = preg_replace( '/^\s*(?:include|require).*[\'"]\/?wp-(?:load|config)\.php[\'"]\s*\)?;$/m', '', $admin_php_file );
+		$admin_php_file = preg_replace( '/^\s*(?:include|require).*[\'"]\/?wp-(?:load|config)\.php[\'"]\s*\)?;\s*$/m', '', $admin_php_file );
 
 		// We also remove the authentication redirect.
 		$admin_php_file = preg_replace( '/^\s*auth_redirect\(\);$/m', '', $admin_php_file );


### PR DESCRIPTION
If `wp-admin/admin.php` has CRLF line endings, running `wp --context=admin` with any command results in a PHP fatal error because the regular expression to strip the wp-load.php require statement

Fixes https://github.com/wp-cli/wp-cli/issues/5844 Props @willrowe for the regex fix.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
