### PR TITLE
Suggest 'network meta' intead of 'network option'

### DIFF
--- a/features/runner.feature
+++ b/features/runner.feature
@@ -68,3 +68,14 @@ Feature: Runner WP-CLI
     """
      The --path parameter cannot be empty when provided
     """
+
+  Scenario: Suggest 'meta' when 'option' subcommand is run
+    Given a WP install
+
+    When I try `wp network option`
+    Then STDERR should contain:
+      """
+      Error: 'option' is not a registered subcommand of 'network'. See 'wp help network' for available subcommands.
+      Did you mean 'meta'?
+      """
+    And the return code should be 1

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -372,6 +372,11 @@ class Runner {
 					$child       = array_pop( $cmd_path );
 					$parent_name = implode( ' ', $cmd_path );
 					$suggestion  = $this->get_subcommand_suggestion( $child, $command );
+
+					if ( 'network' === $parent_name && 'option' === $child ) {
+						$suggestion = 'meta';
+					}
+
 					return sprintf(
 						"'%s' is not a registered subcommand of '%s'. See 'wp help %s' for available subcommands.%s",
 						$child,


### PR DESCRIPTION
This PR suggests using `wp network meta` if the user tries using `wp network option`.

Related to: https://github.com/wp-cli/entity-command/issues/322

I'll submit a separate PR will be submitted to the entity-command repo to add a feature test.