### PR TITLE
Use has_config() in get_config() to prevent warnings on null values

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1254,7 +1254,7 @@ class WP_CLI {
 			return self::get_runner()->config;
 		}
 
-		if ( ! isset( self::get_runner()->config[ $key ] ) ) {
+		if ( ! self::has_config( $key ) ) {
 			self::warning( "Unknown config option '$key'." );
 			return null;
 		}

--- a/tests/test-configurator.php
+++ b/tests/test-configurator.php
@@ -1,6 +1,7 @@
 <?php
 
 use WP_CLI\Configurator;
+use WP_CLI\Loggers;
 use WP_CLI\Tests\TestCase;
 
 class ConfiguratorTest extends TestCase {
@@ -57,5 +58,31 @@ class ConfiguratorTest extends TestCase {
 
 		$this->assertEquals( 'test', $args[1][0][0] );
 		$this->assertEquals( 'text--text', $args[1][0][1] );
+	}
+
+	/**
+	 * WP_CLI::get_config does not show warnings for null values.
+	 */
+	public function testNullGetConfig() {
+		// Init config so there is a config to check.
+		$runner = WP_CLI::get_runner();
+		$runner->init_config();
+
+		// Previous
+		$prev_logger = WP_CLI::get_logger();
+
+		$logger = new Loggers\Execution();
+		WP_CLI::set_logger( $logger );
+
+		$has_config = WP_CLI::has_config( 'url' );
+		$get_config = WP_CLI::get_config( 'url' );
+
+		$this->assertTrue( $has_config, 'has_config() is not true' );
+		$this->assertTrue( false === strpos( $logger->stderr, 'Warning' ), 'Logger contains a "Warning"' );
+		$this->assertNull( $get_config, 'get_config() is not null' );
+
+		// Restore
+		WP_CLI::set_logger( $prev_logger );
+
 	}
 }

--- a/tests/test-configurator.php
+++ b/tests/test-configurator.php
@@ -83,6 +83,5 @@ class ConfiguratorTest extends TestCase {
 
 		// Restore
 		WP_CLI::set_logger( $prev_logger );
-
 	}
 }


### PR DESCRIPTION
In get_config(), use has_config() to test for key existence instead of equivalent isset() which throws a warning for null values.

A null value can occur if the option is present, but without a value. Certain config values, such as --url, default to null causing has_config() to be true, while throwing a warning in get_config(). This change provides consistency between has_config() and get_config().

Fixes #5353.