### PR TITLE
Fix PHP deprecation warnings

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -916,7 +916,7 @@ class WP_CLI {
 
 		if ( $return_code ) {
 			if ( self::$capture_exit ) {
-				throw new ExitException( null, $return_code );
+				throw new ExitException( '', $return_code );
 			}
 			exit( $return_code );
 		}
@@ -935,7 +935,7 @@ class WP_CLI {
 	 */
 	public static function halt( $return_code ) {
 		if ( self::$capture_exit ) {
-			throw new ExitException( null, $return_code );
+			throw new ExitException( '', $return_code );
 		}
 		exit( $return_code );
 	}


### PR DESCRIPTION
Please see #5896 for details and code to replicate.

tl;dr In versions of PHP greater than 8.1.x, when `WP_CLI::error()` and `WP_CLI::halt()` are called in a separate command via `WP_CLI::runcommand()`, then `PHP Deprecated` notices are written to the logs. Passing an empty string is compatible with the signature of the `Exception` constructor and avoids the warnings.

Edit: since there are no functional changes in this PR, I haven't included tests.