### PR TITLE
Avoid PHP deprecation notices in PHP 8.1.x

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -825,7 +825,7 @@ function http_request( $method, $url, $data = null, $headers = [], $options = []
 				if ( $halt_on_error ) {
 					WP_CLI::error( $error_msg );
 				}
-				throw new RuntimeException( $error_msg, null, $exception );
+				throw new RuntimeException( $error_msg, 0, $exception );
 			}
 
 			$warning = sprintf(
@@ -846,7 +846,7 @@ function http_request( $method, $url, $data = null, $headers = [], $options = []
 					if ( $halt_on_error ) {
 						WP_CLI::error( $error_msg );
 					}
-					throw new RuntimeException( $error_msg, null, $exception );
+					throw new RuntimeException( $error_msg, 0, $exception );
 				}
 				throw $exception;
 			}


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

Please see #5898 for details.

tl;dr In versions of PHP greater than 8.1.x, when `Utils\http_request()` fails, then `PHP Deprecated` notices are written to the logs. Passing `(int) 0` is compatible with the signature of the `RuntimeException` constructor and avoids the warnings.

Since there are no functional changes in this PR, I haven't included tests.