### PR TITLE
Fix typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/1-BUG_REPORT.md
@@ -90,4 +90,4 @@ Just leave this section out if you don't know how to fix it.
 
 Add any other context about the problem here.
 
-If applicable, add screenshots to help explain (you can just drag&drop images into the Github issue).
+If applicable, add screenshots to help explain (you can just drag&drop images into the GitHub issue).

--- a/.github/ISSUE_TEMPLATE/5-PATCH_RELEASE_CHECKLIST.md
+++ b/.github/ISSUE_TEMPLATE/5-PATCH_RELEASE_CHECKLIST.md
@@ -113,7 +113,7 @@ assignees: 'schlessera'
     git commit -m "Update stable to v1.x.0"
     ```
 
-- [ ] Create a release on Github: <https://github.com/wp-cli/wp-cli/releases>. Make sure to upload the Phar from the builds directory.
+- [ ] Create a release on GitHub: <https://github.com/wp-cli/wp-cli/releases>. Make sure to upload the Phar from the builds directory.
 
     ```
     cp wp-cli.phar wp-cli-1.x.0.phar

--- a/bundle/rmccue/requests/README.md
+++ b/bundle/rmccue/requests/README.md
@@ -155,7 +155,7 @@ Contribute
 ----------
 
 1. Check for open issues or open a new issue for a feature request or a bug.
-2. Fork [the repository][] on Github to start making your changes to the
+2. Fork [the repository][] on GitHub to start making your changes to the
     `develop` branch (or branch off of it).
 3. Write one or more tests which show that the bug was fixed or that the feature works as expected.
 4. Send in a pull request.

--- a/features/utils-wp.feature
+++ b/features/utils-wp.feature
@@ -567,7 +567,7 @@ Feature: Utilities that depend on WordPress code
       """
     And save STDOUT as {ALL_TABLES_WITH_PREFIX_STDOUT}
 
-    # Network overriden by all-tables-with-prefix.
+    # Network overridden by all-tables-with-prefix.
     When I run `wp --require=table_names.php get_table_names --all-tables-with-prefix --network`
     Then STDOUT should contain:
       """
@@ -583,7 +583,7 @@ Feature: Utilities that depend on WordPress code
       """
     And save STDOUT as {ALL_TABLES_STDOUT}
 
-    # Network overriden by all-tables.
+    # Network overridden by all-tables.
     When I run `wp --require=table_names.php get_table_names --all-tables --network`
     Then STDOUT should be:
       """

--- a/php/WP_CLI/Inflector.php
+++ b/php/WP_CLI/Inflector.php
@@ -341,11 +341,11 @@ class Inflector {
 	}
 
 	/**
-	 * Uppercases words with configurable delimeters between words.
+	 * Uppercases words with configurable delimiters between words.
 	 *
 	 * Takes a string and capitalizes all of the words, like PHP's built-in
 	 * ucwords function.  This extends that behavior, however, by allowing the
-	 * word delimeters to be configured, rather than only separating on
+	 * word delimiters to be configured, rather than only separating on
 	 * whitespace.
 	 *
 	 * Here is an example:
@@ -363,7 +363,7 @@ class Inflector {
 	 * @param string $string The string to operate on.
 	 * @param string $delimiters A list of word separators.
 	 *
-	 * @return string The string with all delimeter-separated words capitalized.
+	 * @return string The string with all delimiter-separated words capitalized.
 	 */
 	public static function ucwords( $string, $delimiters = " \n\t\r\0\x0B-" ) {
 		return preg_replace_callback(

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -180,7 +180,7 @@ class CLI_Command extends WP_CLI_Command {
 	/**
 	 * Checks to see if there is a newer version of WP-CLI available.
 	 *
-	 * Queries the Github releases API. Returns available versions if there are
+	 * Queries the GitHub releases API. Returns available versions if there are
 	 * updates available, or success message if using the latest release.
 	 *
 	 * ## OPTIONS

--- a/php/utils.php
+++ b/php/utils.php
@@ -1384,7 +1384,7 @@ function glob_brace( $pattern, $dummy_flags = null ) { // phpcs:ignore Generic.C
 }
 
 /**
- * Get the closest suggestion for a mis-typed target term amongst a list of
+ * Get the closest suggestion for a mistyped target term amongst a list of
  * options.
  *
  * Uses the Levenshtein algorithm to calculate the relative "distance" between


### PR DESCRIPTION
Found few misspellings.

`typos` could find typos in other WP-CLI repos.
