### PR TITLE
Docs: Fixes for inline comments

### DIFF
--- a/tests/test-commandfactory.php
+++ b/tests/test-commandfactory.php
@@ -99,7 +99,7 @@ class CommandFactoryTests extends TestCase {
 			require __DIR__ . '/data/commandfactory-doc_comment-class-win.php';
 		}
 
-		// Class 1
+		// Class 1.
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_1_Command' );
 		$expected   = $reflection->getDocComment();
@@ -107,7 +107,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 1
+		// Class method 1.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command1' );
 		$expected   = $reflection->getDocComment();
@@ -115,7 +115,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 2
+		// Class method 2.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command2' );
 		$expected   = $reflection->getDocComment();
@@ -123,7 +123,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 3
+		// Class method 3.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command3' );
 		$expected   = $reflection->getDocComment();
@@ -131,7 +131,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 4
+		// Class method 4.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command4' );
 		$expected   = $reflection->getDocComment();
@@ -140,7 +140,7 @@ class CommandFactoryTests extends TestCase {
 		$this->assertSame( $expected, $actual );
 		$this->assertFalse( $actual );
 
-		// Class 1 Windows
+		// Class 1 Windows.
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win' );
 		$expected   = $reflection->getDocComment();
@@ -148,7 +148,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 1
+		// Class method 1.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command1' );
 		$expected   = $reflection->getDocComment();
@@ -156,7 +156,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 2
+		// Class method 2.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command2' );
 		$expected   = $reflection->getDocComment();
@@ -164,7 +164,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 3
+		// Class method 3.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command3' );
 		$expected   = $reflection->getDocComment();
@@ -172,7 +172,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 4
+		// Class method 4.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command4' );
 		$expected   = $reflection->getDocComment();
@@ -181,7 +181,7 @@ class CommandFactoryTests extends TestCase {
 		$this->assertSame( $expected, $actual );
 		$this->assertFalse( $actual );
 
-		// Class 2
+		// Class 2.
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_2_Command' );
 		$expected   = $reflection->getDocComment();
@@ -189,7 +189,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 1
+		// Class method 1.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_2_Command', 'command1' );
 		$expected   = $reflection->getDocComment();
@@ -198,7 +198,7 @@ class CommandFactoryTests extends TestCase {
 		$this->assertSame( $expected, $actual );
 		$this->assertFalse( $actual );
 
-		// Class 2 Windows
+		// Class 2 Windows.
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_2_Command_Win' );
 		$expected   = $reflection->getDocComment();
@@ -206,7 +206,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 1
+		// Class method 1.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_2_Command_Win', 'command1' );
 		$expected   = $reflection->getDocComment();
@@ -215,11 +215,11 @@ class CommandFactoryTests extends TestCase {
 		$this->assertSame( $expected, $actual );
 		$this->assertFalse( $actual );
 
-		// Functions
+		// Functions.
 
 		require __DIR__ . '/data/commandfactory-doc_comment-function.php';
 
-		// Function 1
+		// Function 1.
 
 		$reflection = new \ReflectionFunction( 'commandfactorytests_get_doc_comment_func_1' );
 		$expected   = $reflection->getDocComment();
@@ -227,7 +227,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Function 2
+		// Function 2.
 
 		$reflection = new \ReflectionFunction( 'commandfactorytests_get_doc_comment_func_2' );
 		$expected   = $reflection->getDocComment();
@@ -235,7 +235,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Function 3
+		// Function 3.
 
 		$reflection = new \ReflectionFunction( $commandfactorytests_get_doc_comment_func_3 );
 		$expected   = $reflection->getDocComment();
@@ -267,7 +267,7 @@ class CommandFactoryTests extends TestCase {
 			require __DIR__ . '/data/commandfactory-doc_comment-class-win.php';
 		}
 
-		// Class 1
+		// Class 1.
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_1_Command' );
 		$expected   = $reflection->getDocComment();
@@ -275,7 +275,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 1
+		// Class method 1.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command1' );
 		$expected   = $reflection->getDocComment();
@@ -283,7 +283,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 2
+		// Class method 2.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command2' );
 		$expected   = $reflection->getDocComment();
@@ -291,7 +291,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 3
+		// Class method 3.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command3' );
 		$expected   = $reflection->getDocComment();
@@ -299,7 +299,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 4
+		// Class method 4.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command', 'command4' );
 		$expected   = $reflection->getDocComment();
@@ -308,7 +308,7 @@ class CommandFactoryTests extends TestCase {
 		$this->assertSame( $expected, $actual );
 		$this->assertFalse( $actual );
 
-		// Class 1 Windows
+		// Class 1 Windows.
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win' );
 		$expected   = $reflection->getDocComment();
@@ -316,7 +316,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 1
+		// Class method 1.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command1' );
 		$expected   = $reflection->getDocComment();
@@ -324,7 +324,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 2
+		// Class method 2.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command2' );
 		$expected   = $reflection->getDocComment();
@@ -332,7 +332,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 3
+		// Class method 3.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command3' );
 		$expected   = $reflection->getDocComment();
@@ -340,7 +340,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 4
+		// Class method 4.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_1_Command_Win', 'command4' );
 		$expected   = $reflection->getDocComment();
@@ -349,7 +349,7 @@ class CommandFactoryTests extends TestCase {
 		$this->assertSame( $expected, $actual );
 		$this->assertFalse( $actual );
 
-		// Class 2
+		// Class 2.
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_2_Command' );
 		$expected   = $reflection->getDocComment();
@@ -357,7 +357,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 1
+		// Class method 1.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_2_Command', 'command1' );
 		$expected   = $reflection->getDocComment();
@@ -366,7 +366,7 @@ class CommandFactoryTests extends TestCase {
 		$this->assertSame( $expected, $actual );
 		$this->assertFalse( $actual );
 
-		// Class 2 Windows
+		// Class 2 Windows.
 
 		$reflection = new \ReflectionClass( 'CommandFactoryTests_Get_Doc_Comment_2_Command_Win' );
 		$expected   = $reflection->getDocComment();
@@ -374,7 +374,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Class method 1
+		// Class method 1.
 
 		$reflection = new \ReflectionMethod( 'CommandFactoryTests_Get_Doc_Comment_2_Command_Win', 'command1' );
 		$expected   = $reflection->getDocComment();
@@ -383,11 +383,11 @@ class CommandFactoryTests extends TestCase {
 		$this->assertSame( $expected, $actual );
 		$this->assertFalse( $actual );
 
-		// Functions
+		// Functions.
 
 		require __DIR__ . '/data/commandfactory-doc_comment-function-win.php';
 
-		// Function 1 Windows
+		// Function 1 Windows.
 
 		$reflection = new \ReflectionFunction( 'commandfactorytests_get_doc_comment_func_1_win' );
 		$expected   = $reflection->getDocComment();
@@ -395,7 +395,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Function 2
+		// Function 2.
 
 		$reflection = new \ReflectionFunction( 'commandfactorytests_get_doc_comment_func_2_win' );
 		$expected   = $reflection->getDocComment();
@@ -403,7 +403,7 @@ class CommandFactoryTests extends TestCase {
 		$actual = $get_doc_comment->invoke( null, $reflection );
 		$this->assertSame( $expected, $actual );
 
-		// Function 3
+		// Function 3.
 
 		$reflection = new \ReflectionFunction( $commandfactorytests_get_doc_comment_func_3_win );
 		$expected   = $reflection->getDocComment();

--- a/tests/test-configurator.php
+++ b/tests/test-configurator.php
@@ -68,7 +68,7 @@ class ConfiguratorTest extends TestCase {
 		$runner = WP_CLI::get_runner();
 		$runner->init_config();
 
-		// Previous
+		// Previous.
 		$prev_logger = WP_CLI::get_logger();
 
 		$logger = new Loggers\Execution();
@@ -81,7 +81,7 @@ class ConfiguratorTest extends TestCase {
 		$this->assertTrue( false === strpos( $logger->stderr, 'Warning' ), 'Logger contains a "Warning"' );
 		$this->assertNull( $get_config, 'get_config() is not null' );
 
-		// Restore
+		// Restore.
 		WP_CLI::set_logger( $prev_logger );
 	}
 }

--- a/tests/test-file-cache.php
+++ b/tests/test-file-cache.php
@@ -74,7 +74,7 @@ class FileCacheTest extends TestCase {
 		$expected = "/^Warning: Failed to create directory '.+': mkdir\(\): File exists\.$/";
 		$this->assertMatchesRegularExpression( $expected, $logger->stderr );
 
-		// Restore
+		// Restore.
 		chmod( $cache_dir . '/test1', 0755 );
 		rmdir( $cache_dir . '/test1' );
 		unlink( $cache_dir . '/test2' );

--- a/tests/test-inflector.php
+++ b/tests/test-inflector.php
@@ -14,9 +14,9 @@ class InflectorTest extends TestCase {
 
 	public function dataProviderPluralize() {
 		return [
-			[ 'string', 'strings' ], // regular
-			[ 'person', 'people' ],  // irregular
-			[ 'scissors', 'scissors' ], // uncountable
+			[ 'string', 'strings' ], // Regular.
+			[ 'person', 'people' ],  // Irregular.
+			[ 'scissors', 'scissors' ], // Uncountable.
 		];
 	}
 
@@ -29,9 +29,9 @@ class InflectorTest extends TestCase {
 
 	public function dataProviderSingularize() {
 		return [
-			[ 'strings', 'string' ], // regular
-			[ 'people', 'person' ],  // irregular
-			[ 'scissors', 'scissors' ], // uncountable
+			[ 'strings', 'string' ], // Regular.
+			[ 'people', 'person' ],  // Irregular.
+			[ 'scissors', 'scissors' ], // Uncountable.
 		];
 	}
 }

--- a/tests/test-synopsis.php
+++ b/tests/test-synopsis.php
@@ -34,7 +34,7 @@ class SynopsisParserTest extends TestCase {
 		$this->assertEquals( 'flag', $param['type'] );
 		$this->assertTrue( $param['optional'] );
 
-		// flags can't be mandatory
+		// Flags can't be mandatory.
 		$r = SynopsisParser::parse( '--foo' );
 
 		$this->assertCount( 1, $r );

--- a/tests/test-utils.php
+++ b/tests/test-utils.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/mock-requests-transport.php';
 class UtilsTest extends TestCase {
 
 	public function testIncrementVersion() {
-		// keyword increments
+		// Keyword increments.
 		$this->assertEquals(
 			Utils\increment_version( '1.2.3-pre', 'same' ),
 			'1.2.3-pre'
@@ -32,7 +32,7 @@ class UtilsTest extends TestCase {
 			'2.0.0'
 		);
 
-		// custom version string
+		// Custom version string.
 		$this->assertEquals(
 			Utils\increment_version( '1.2.3-pre', '4.5.6-alpha1' ),
 			'4.5.6-alpha1'
@@ -128,7 +128,7 @@ class UtilsTest extends TestCase {
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( '~/path/to/dir', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 
-		// No host
+		// No host.
 		$testcase = '~/path/to/dir';
 		$this->assertEquals( [], Utils\parse_ssh_url( $testcase ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
@@ -137,7 +137,7 @@ class UtilsTest extends TestCase {
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 
-		// host and path, no port, with scp notation
+		// Host and path, no port, with scp notation.
 		$testcase = 'foo.com:~/path/to/dir';
 		$expected = [
 			'host' => 'foo.com',
@@ -163,7 +163,7 @@ class UtilsTest extends TestCase {
 		$this->assertEquals( '2222', Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( '~/path/to/dir', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 
-		// explicit scheme, user, host, path, no port
+		// Explicit scheme, user, host, path, no port.
 		$testcase = 'ssh:bar@foo.com:~/path/to/dir';
 		$expected = [
 			'scheme' => 'ssh',
@@ -178,7 +178,7 @@ class UtilsTest extends TestCase {
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( '~/path/to/dir', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 
-		// container scheme
+		// Container scheme
 		$testcase = 'docker:wordpress';
 		$expected = [
 			'scheme' => 'docker',
@@ -191,7 +191,7 @@ class UtilsTest extends TestCase {
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 
-		// container scheme with user, and host
+		// Container scheme with user, and host.
 		$testcase = 'docker:bar@wordpress';
 		$expected = [
 			'scheme' => 'docker',
@@ -205,7 +205,7 @@ class UtilsTest extends TestCase {
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 
-		// container scheme with user, host, and path
+		// Container scheme with user, host, and path.
 		$testcase = 'docker-compose:bar@wordpress:~/path/to/dir';
 		$expected = [
 			'scheme' => 'docker-compose',
@@ -220,7 +220,7 @@ class UtilsTest extends TestCase {
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( '~/path/to/dir', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 
-		// container scheme with user, host, and path
+		// Container scheme with user, host, and path.
 		$testcase = 'docker-compose-run:bar@wordpress:~/path/to/dir';
 		$expected = [
 			'scheme' => 'docker-compose-run',
@@ -235,7 +235,7 @@ class UtilsTest extends TestCase {
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( '~/path/to/dir', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 
-		// vagrant scheme
+		// Vagrant scheme.
 		$testcase = 'vagrant:default';
 		$expected = [
 			'scheme' => 'vagrant',
@@ -248,7 +248,7 @@ class UtilsTest extends TestCase {
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 
-		// vagrant scheme
+		// Vagrant scheme.
 		$testcase = 'vagrant:/var/www/html';
 		$expected = [
 			'scheme' => 'vagrant',
@@ -262,7 +262,7 @@ class UtilsTest extends TestCase {
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_PORT ) );
 		$this->assertEquals( '/var/www/html', Utils\parse_ssh_url( $testcase, PHP_URL_PATH ) );
 
-		// unsupported scheme, should not match
+		// Unsupported scheme, should not match.
 		$testcase = 'foo:bar';
 		$this->assertEquals( [], Utils\parse_ssh_url( $testcase ) );
 		$this->assertEquals( null, Utils\parse_ssh_url( $testcase, PHP_URL_SCHEME ) );
@@ -324,7 +324,7 @@ class UtilsTest extends TestCase {
 	}
 
 	public function testMysqlHostToCLIArgs() {
-		// Test hostname only, with and without 'p:' modifier
+		// Test hostname only, with and without 'p:' modifier.
 		$expected = [
 			'host' => 'hostname',
 		];
@@ -346,7 +346,7 @@ class UtilsTest extends TestCase {
 		$testcase = 'p:hostname:3306';
 		$this->assertEquals( $expected, Utils\mysql_host_to_cli_args( $testcase ) );
 
-		// Test hostname with socket path, with and without 'p:' modifier
+		// Test hostname with socket path, with and without 'p:' modifier.
 		$expected = [
 			'host'   => 'hostname',
 			'socket' => '/path/to/socket',
@@ -374,7 +374,7 @@ class UtilsTest extends TestCase {
 
 	public function testGetHomeDir() {
 
-		// save environments
+		// Save environments.
 		$home      = getenv( 'HOME' );
 		$homedrive = getenv( 'HOMEDRIVE' );
 		$homepath  = getenv( 'HOMEPATH' );
@@ -394,7 +394,7 @@ class UtilsTest extends TestCase {
 		putenv( 'HOMEPATH=\\Windows\\User\\HOGE\\' );
 		$this->assertSame( 'D:\\Windows\\User\\HOGE', Utils\get_home_dir() );
 
-		// restore environments
+		// Restore environments.
 		putenv( false === $home ? 'HOME' : "HOME=$home" );
 		putenv( false === $homedrive ? 'HOMEDRIVE' : "HOME=$homedrive" );
 		putenv( false === $homepath ? 'HOMEPATH' : "HOME=$homepath" );
@@ -417,18 +417,18 @@ class UtilsTest extends TestCase {
 	public function dataNormalizePath() {
 		return [
 			[ '', '' ],
-			// Windows paths
+			// Windows paths.
 			[ 'C:\\www\\path\\', 'C:/www/path/' ],
 			[ 'C:\\www\\\\path\\', 'C:/www/path/' ],
 			[ 'c:/www/path', 'C:/www/path' ],
-			[ 'c:\\www\\path\\', 'C:/www/path/' ], // uppercase drive letter
+			[ 'c:\\www\\path\\', 'C:/www/path/' ], // Uppercase drive letter.
 			[ 'c:', 'C:' ],
 			[ 'c:\\', 'C:/' ],
 			[ 'c:\\\\www\\path\\', 'C:/www/path/' ],
 			[ '\\\\Domain\\DFSRoots\\share\\path\\', '//Domain/DFSRoots/share/path/' ],
 			[ '\\\\Server\\share\\path', '//Server/share/path' ],
 			[ '\\\\Server\\share', '//Server/share' ],
-			// Linux paths
+			// Linux paths.
 			[ '/', '/' ],
 			[ '/www/path/', '/www/path/' ],
 			[ '/www/path/////', '/www/path/' ],
@@ -780,11 +780,11 @@ class UtilsTest extends TestCase {
 	 */
 	public function test_esc_like() {
 		$inputs   = [
-			'howdy%', //Single Percent
-			'howdy_', //Single Underscore
-			'howdy\\', //Single slash
-			'howdy\\howdy%howdy_', //The works
-			'howdy\'"[[]*#[^howdy]!+)(*&$#@!~|}{=--`/.,<>?', //Plain text
+			'howdy%', // Single Percent.
+			'howdy_', // Single Underscore.
+			'howdy\\', // Single slash.
+			'howdy\\howdy%howdy_', // The works.
+			'howdy\'"[[]*#[^howdy]!+)(*&$#@!~|}{=--`/.,<>?', // Plain text.
 		];
 		$expected = [
 			'howdy\\%',


### PR DESCRIPTION
Issue related: #5909
I updated inline documentation according to [PHP Documentation Standards -  Inline Comments ](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#5-inline-comments)
