### PR TITLE
Correct completion case when ends in =

### DIFF
--- a/features/cli-bash-completion.feature
+++ b/features/cli-bash-completion.feature
@@ -101,6 +101,12 @@ Feature: `wp cli completions` tasks
       """
 
     When I run `wp cli completions --line='wp config create --dbname=' --point=100`
+    Then STDOUT should not contain:
+      """
+      --dbname=
+      """
+
+    When I run `wp cli completions --line='wp config create --dbname' --point=100`
     Then STDOUT should contain:
       """
       --dbname=

--- a/php/WP_CLI/Completions.php
+++ b/php/WP_CLI/Completions.php
@@ -120,8 +120,8 @@ class Completions {
 		end( $words );
 		$last_arg_i = key( $words );
 		foreach ( $words as $i => $arg ) {
-			if ( preg_match( '|^--([^=]+)=?|', $arg, $matches ) ) {
-				if ( $i === $last_arg_i ) {
+			if ( preg_match( '|^--([^=]+)(=?)|', $arg, $matches ) ) {
+				if ( $i === $last_arg_i && '' === $matches[2] ) {
 					continue;
 				}
 				$assoc_args[ $matches[1] ] = true;


### PR DESCRIPTION
Further to #5873, I incorrectly handled options that end in `=` and have already been completed. Any candidates offered immediately after such an option are treated by shells as possible values to concatenate, not possible names of the current option. Consequently, this
```sh
wp config create --dbname=
```
will tab-complete to
```sh
wp config create --dbname=--dbname=
```
I have added an extra condition to prevent that case.