### PR TITLE
Include any non default hook information in CompositeCommand

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -51,15 +51,16 @@ Feature: Get help about WP-CLI commands
       """
       wp post list
       """
-      And STDERR should be empty
+    And STDERR should be empty
 
-    When I try `wp help db`
+    When I try `COLUMNS=80 wp help db`
     Then STDOUT should contain:
       """
-      This command runs when the 'after_wp_config_load' hook is called, after wp-config.php has been loaded into scope.
+        This command runs when the 'after_wp_config_load' hook is called, after
+        wp-config.php has been loaded into scope.
       """
 
-    When I try `wp help db size`
+    When I try `COLUMNS=150 wp help db size`
     Then STDOUT should contain:
       """
       This command runs when the 'after_wp_load' hook is called, just after the WP load process has completed.

--- a/features/help.feature
+++ b/features/help.feature
@@ -56,20 +56,20 @@ Feature: Get help about WP-CLI commands
   Scenario: Include when the command is run if a non-standard hook.
     Given an empty directory
 
-    When I try `COLUMNS=80 wp help db`
+    When I run `COLUMNS=80 wp help db`
     Then STDOUT should contain:
       """
         Unless overridden, these commands run on the 'after_wp_config_load' hook,
         after wp-config.php has been loaded into scope.
       """
 
-    When I try `COLUMNS=150 wp help db check`
+    When I run `COLUMNS=150 wp help db check`
     Then STDOUT should contain:
       """
       This command runs on the 'after_wp_config_load' hook, after wp-config.php has been loaded into scope.
       """
 
-    When I try `COLUMNS=150 wp help db size`
+    When I run `COLUMNS=150 wp help db size`
     Then STDOUT should not contain:
       """
       This command runs on the

--- a/features/help.feature
+++ b/features/help.feature
@@ -51,7 +51,19 @@ Feature: Get help about WP-CLI commands
       """
       wp post list
       """
-    And STDERR should be empty
+      And STDERR should be empty
+
+    When I try `wp help db`
+    Then STDOUT should contain:
+      """
+      This command runs when the 'after_wp_config_load' hook is called, after wp-config.php has been loaded into scope.
+      """
+
+    When I try `wp help db size`
+    Then STDOUT should contain:
+      """
+      This command runs when the 'after_wp_load' hook is called, just after the WP load process has completed.
+      """
 
   Scenario: Hide Global parameters when requested
     Given an empty directory

--- a/features/help.feature
+++ b/features/help.feature
@@ -53,17 +53,20 @@ Feature: Get help about WP-CLI commands
       """
     And STDERR should be empty
 
+  Scenario: Include when the command is run if a non-standard hook.
+    Given an empty directory
+
     When I try `COLUMNS=80 wp help db`
     Then STDOUT should contain:
       """
-        This command runs when the 'after_wp_config_load' hook is called, after
-        wp-config.php has been loaded into scope.
+        Unless overridden, these commands run on the 'after_wp_config_load' hook,
+        after wp-config.php has been loaded into scope.
       """
 
     When I try `COLUMNS=150 wp help db size`
     Then STDOUT should contain:
       """
-      This command runs when the 'after_wp_load' hook is called, just after the WP load process has completed.
+      This command runs on the 'after_wp_load' hook, just after the WP load process has completed.
       """
 
   Scenario: Hide Global parameters when requested

--- a/features/help.feature
+++ b/features/help.feature
@@ -63,10 +63,16 @@ Feature: Get help about WP-CLI commands
         after wp-config.php has been loaded into scope.
       """
 
-    When I try `COLUMNS=150 wp help db size`
+    When I try `COLUMNS=150 wp help db check`
     Then STDOUT should contain:
       """
-      This command runs on the 'after_wp_load' hook, just after the WP load process has completed.
+      This command runs on the 'after_wp_config_load' hook, after wp-config.php has been loaded into scope.
+      """
+
+    When I try `COLUMNS=150 wp help db size`
+    Then STDOUT should not contain:
+      """
+      This command runs on the
       """
 
   Scenario: Hide Global parameters when requested

--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -134,8 +134,6 @@ class CompositeCommand {
 	public function get_hook() {
 		return $this->hook;
 	}
-
-
 	/**
 	 * Set the short description for this composite command.
 	 *

--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -134,6 +134,7 @@ class CompositeCommand {
 	public function get_hook() {
 		return $this->hook;
 	}
+
 	/**
 	 * Set the short description for this composite command.
 	 *

--- a/php/WP_CLI/Dispatcher/CompositeCommand.php
+++ b/php/WP_CLI/Dispatcher/CompositeCommand.php
@@ -18,6 +18,7 @@ class CompositeCommand {
 	protected $shortdesc;
 	protected $longdesc;
 	protected $synopsis;
+	protected $hook;
 	protected $docparser;
 
 	protected $parent;
@@ -38,9 +39,11 @@ class CompositeCommand {
 		$this->shortdesc = $docparser->get_shortdesc();
 		$this->longdesc  = $docparser->get_longdesc();
 		$this->docparser = $docparser;
+		$this->hook      = $parent->get_hook();
 
 		$when_to_invoke = $docparser->get_tag( 'when' );
 		if ( $when_to_invoke ) {
+			$this->hook = $when_to_invoke;
 			WP_CLI::get_runner()->register_early_invoke( $when_to_invoke, $this );
 		}
 	}
@@ -121,6 +124,17 @@ class CompositeCommand {
 	public function get_shortdesc() {
 		return $this->shortdesc;
 	}
+
+	/**
+	 * Get the hook name for this composite
+	 * command.
+	 *
+	 * @return string
+	 */
+	public function get_hook() {
+		return $this->hook;
+	}
+
 
 	/**
 	 * Set the short description for this composite command.

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -39,6 +39,7 @@ class CLI_Command extends WP_CLI_Command {
 			'name'        => $command->get_name(),
 			'description' => $command->get_shortdesc(),
 			'longdesc'    => $command->get_longdesc(),
+			'hook'        => $command->get_hook(),
 		];
 
 		foreach ( $command->get_subcommands() as $subcommand ) {

--- a/php/commands/src/Help_Command.php
+++ b/php/commands/src/Help_Command.php
@@ -157,6 +157,10 @@ class Help_Command extends WP_CLI_Command {
 		if ( $alias ) {
 			$binding['alias'] = $alias;
 		}
+		$hook = $command->get_hook();
+		if ( $hook ) {
+			$binding['hook'] = $hook;
+		}
 
 		if ( $command->can_have_subcommands() ) {
 			$binding['has-subcommands']['subcommands'] = self::render_subcommands( $command );

--- a/php/commands/src/Help_Command.php
+++ b/php/commands/src/Help_Command.php
@@ -160,7 +160,11 @@ class Help_Command extends WP_CLI_Command {
 		$hook_name        = $command->get_hook();
 		$hook_description = $hook_name ? Utils\get_hook_description( $hook_name ) : null;
 		if ( $hook_description ) {
-				$binding['shortdesc'] .= "\n\nThis command runs when the '$hook_name' hook is called, $hook_description";
+			if ( $command->can_have_subcommands() ) {
+				$binding['shortdesc'] .= "\n\nUnless overridden, these commands run on the '$hook_name' hook, $hook_description";
+			} else {
+				$binding['shortdesc'] .= "\n\nThis command runs on the '$hook_name' hook, $hook_description";
+			}
 		}
 
 		if ( $command->can_have_subcommands() ) {

--- a/php/commands/src/Help_Command.php
+++ b/php/commands/src/Help_Command.php
@@ -159,7 +159,7 @@ class Help_Command extends WP_CLI_Command {
 		}
 		$hook_name        = $command->get_hook();
 		$hook_description = $hook_name ? Utils\get_hook_description( $hook_name ) : null;
-		if ( $hook_description ) {
+		if ( $hook_description && 'after_wp_load' !== $hook_name ) {
 			if ( $command->can_have_subcommands() ) {
 				$binding['shortdesc'] .= "\n\nUnless overridden, these commands run on the '$hook_name' hook, $hook_description";
 			} else {

--- a/php/commands/src/Help_Command.php
+++ b/php/commands/src/Help_Command.php
@@ -157,9 +157,10 @@ class Help_Command extends WP_CLI_Command {
 		if ( $alias ) {
 			$binding['alias'] = $alias;
 		}
-		$hook = $command->get_hook();
-		if ( $hook ) {
-			$binding['hook'] = $hook;
+		$hook_name        = $command->get_hook();
+		$hook_description = $hook_name ? Utils\get_hook_description( $hook_name ) : null;
+		if ( $hook_description ) {
+				$binding['shortdesc'] .= "\n\nThis command runs when the '$hook_name' hook is called, $hook_description";
 		}
 
 		if ( $command->can_have_subcommands() ) {

--- a/php/utils.php
+++ b/php/utils.php
@@ -1873,7 +1873,6 @@ function has_stdin() {
  *
  * @return string|null
  */
-
 function get_hook_description( $hook ) {
 	$events = [
 		'find_command_to_run_pre'     => 'just before WP-CLI finds the command to run.',

--- a/php/utils.php
+++ b/php/utils.php
@@ -1865,3 +1865,27 @@ function has_stdin() {
 
 	return 1 === $streams;
 }
+
+/**
+ * Return description of WP_CLI hooks used in @when tag
+ *
+ *  @param string $hook Name of WP_CLI hook
+ *
+ * @return string|null
+ */
+
+function get_hook_description( $hook ) {
+	$events = [
+		'find_command_to_run_pre'     => 'just before WP-CLI finds the command to run.',
+		'before_registering_contexts' => 'before the contexts are registered.',
+		'before_wp_load'              => 'just before the WP load process begins.',
+		'before_wp_config_load'       => 'after wp-config.php has been located.',
+		'after_wp_config_load'        => 'after wp-config.php has been loaded into scope.',
+		'after_wp_load'               => 'just after the WP load process has completed.',
+	];
+
+	if ( array_key_exists( $hook, $events ) ) {
+		return $events[ $hook ];
+	}
+	return null;
+}

--- a/templates/man.mustache
+++ b/templates/man.mustache
@@ -8,6 +8,12 @@
 	{{shortdesc}}
 
 {{/shortdesc}}
+{{#hook}}
+## HOOK
+
+	{{hook}}
+
+{{/hook}}
 ## SYNOPSIS
 
 	{{synopsis}}

--- a/templates/man.mustache
+++ b/templates/man.mustache
@@ -8,12 +8,6 @@
 	{{shortdesc}}
 
 {{/shortdesc}}
-{{#hook}}
-## HOOK
-
-	{{hook}}
-
-{{/hook}}
 ## SYNOPSIS
 
 	{{synopsis}}


### PR DESCRIPTION
This would be a first step towards addressing #5838 and including details on when a specific command is run in the handbook documentation.

I've added the output to the help command as well so there will be parity between that and the handbook. 

If the parent command defines a `@when` tag, that is passed down to all subcommands. If a subcommand has its own `@when` tag, it will take the place of the parent tag. If there is no `@when` tag defined for a parent or subcommand, it won't show any hook information with the existing assumption that everything runs on the default hook unless otherwise specified.

So now a command like `wp help db reset` would output:

```
NAME

  wp db reset

DESCRIPTION

  Removes all tables from the database.

  This command runs when the 'after_wp_config_load' hook is called, after wp-config.php has been loaded into scope.

SYNOPSIS

  wp db reset [--dbuser=<value>] [--dbpass=<value>] [--yes] [--defaults]

  Runs `DROP_DATABASE` and `CREATE_DATABASE` SQL statements using
  `DB_HOST`, `DB_NAME`, `DB_USER` and `DB_PASSWORD` database credentials
  specified in wp-config.php.
```
Where the `after_wp_config_load` hook is inherited from the parent db command.
And `wp help db size` would show:
```
NAME

  wp db size

DESCRIPTION

  Displays the database name and size.

  This command runs when the 'after_wp_load' hook is called, just after the WP load process has completed.

SYNOPSIS

  wp db size [--size_format=<format>] [--tables] [--human-readable] [--format=<format>] [--scope=<scope>] [--network] [--decimals=<decimals>] [--all-tables-with-prefix] [--all-tables] [--order=<order>] [--orderby=<orderby>]

  Display the database name and size for `DB_NAME` specified in wp-config.php.
  The size defaults to a human-readable number.
```
Since it defines a different hook to run on.
