### PR TITLE
Ensure the alias has the leading `@` symbol when added

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -648,9 +648,9 @@ Feature: Create shortcuts to specific WordPress installs
 
     When I run `wp cli alias add hello --set-path=/path/to/wordpress`
     Then STDOUT should be:
-        """
-        Success: Added '@hello' alias.
-        """
+      """
+      Success: Added '@hello' alias.
+      """
 
     When I run `wp eval --skip-wordpress 'echo realpath( getenv( "RUN_DIR" ) );'`
     Then save STDOUT as {TEST_DIR}

--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -637,3 +637,30 @@ Feature: Create shortcuts to specific WordPress installs
 
     When I try `wp cli alias is-group @foo`
     Then the return code should be 1
+
+  Scenario: Automatically add "@" prefix to an alias
+    Given a WP install
+    And a wp-cli.yml file:
+      """
+      @foo:
+        path: foo
+      """
+
+    When I run `wp cli alias add hello --set-path=/path/to/wordpress`
+    Then STDOUT should be:
+        """
+        Success: Added '@hello' alias.
+        """
+
+    When I run `wp eval --skip-wordpress 'echo realpath( getenv( "RUN_DIR" ) );'`
+    Then save STDOUT as {TEST_DIR}
+
+    When I run `wp cli alias list`
+    Then STDOUT should be YAML containing:
+      """
+      @all: Run command against every registered alias.
+      @hello:
+        path: /path/to/wordpress
+      @foo:
+        path: {TEST_DIR}/foo
+      """

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1090,7 +1090,7 @@ class WP_CLI {
 
 		// PHP 7+: internal and user exceptions must implement Throwable interface.
 		// PHP 5: internal and user exceptions must extend Exception class.
-		if ( interface_exists( 'Throwable' ) && ( $errors instanceof Throwable ) || ( $errors instanceof Exception ) ) {
+		if ( ( interface_exists( 'Throwable' ) && ( $errors instanceof Throwable ) ) || ( $errors instanceof Exception ) ) {
 			return get_class( $errors ) . ': ' . $errors->getMessage();
 		}
 

--- a/php/commands/src/CLI_Alias_Command.php
+++ b/php/commands/src/CLI_Alias_Command.php
@@ -408,6 +408,7 @@ class CLI_Alias_Command extends WP_CLI_Command {
 	 * @return mixed
 	 */
 	private function build_aliases( $aliases, $alias, $assoc_args, $is_grouping, $grouping = '', $is_update = false ) {
+		$alias = $this->normalize_alias( $alias );
 
 		if ( $is_grouping ) {
 			$valid_assoc_args = [ 'config', 'grouping' ];
@@ -507,6 +508,8 @@ class CLI_Alias_Command extends WP_CLI_Command {
 	 * @param string $operation   Current operation string fro message.
 	 */
 	private function process_aliases( $aliases, $alias, $config_path, $operation = '' ) {
+		$alias = $this->normalize_alias( $alias );
+
 		// Convert data to YAML string.
 		$yaml_data = Spyc::YAMLDump( $aliases );
 
@@ -514,5 +517,22 @@ class CLI_Alias_Command extends WP_CLI_Command {
 		if ( file_put_contents( $config_path, $yaml_data ) ) {
 			WP_CLI::success( "$operation '{$alias}' alias." );
 		}
+	}
+
+	/**
+	 * Normalize the alias to an expected format.
+	 *
+	 * - Add @ if not present.
+	 *
+	 * @param string $alias Name of alias.
+	 */
+	private function normalize_alias( $alias ) {
+		// Check if the alias starts with the @.
+		// See: https://github.com/wp-cli/wp-cli/issues/5391
+		if ( strpos( $alias, '@' ) !== 0 ) {
+			$alias = '@' . ltrim( $alias, '@' );
+		}
+
+		return $alias;
 	}
 }


### PR DESCRIPTION
This pull request aims to address the issue reported in #5391 where adding an alias without the `@` symbol would result in the alias being added but missing from the output of the `wp cli alias list` command because it does not have the `@` symbol. With the updates in this pull request, if the user forgets to provide the `@` symbol as the prefix, it will be added behind the scenes to ensure the alias can be listed correctly.
