### PR TITLE
Fix `inherit` path in nested directory

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -476,6 +476,57 @@ Feature: Have a config file
       {"bar":"burrito","apple":"apple"}
       """
 
+  Scenario: Config inheritance in nested folders
+    Given an empty directory
+    And a wp-cli.local.yml file:
+      """
+      @dev:
+        ssh: vagrant@example.test/srv/www/example.com/current
+        path: web/wp
+      """
+    And a site/wp-cli.yml file:
+      """
+      _:
+        inherit: ../wp-cli.local.yml
+      @otherdev:
+        ssh: vagrant@otherexample.test/srv/www/otherexample.com/current
+      """
+    And a site/public/index.php file:
+      """
+      <?php
+      """
+
+    When I run `wp cli alias list`
+    Then STDOUT should contain:
+      """
+      @all: Run command against every registered alias.
+      @dev:
+        path: web/wp
+        ssh: vagrant@example.test/srv/www/example.com/current
+      """
+
+    When I run `cd site && wp cli alias list`
+    Then STDOUT should contain:
+      """
+      @all: Run command against every registered alias.
+      @dev:
+        path: web/wp
+        ssh: vagrant@example.test/srv/www/example.com/current
+      @otherdev:
+        ssh: vagrant@otherexample.test/srv/www/otherexample.com/current
+      """
+
+    When I run `cd site/public && wp cli alias list`
+    Then STDOUT should contain:
+      """
+      @all: Run command against every registered alias.
+      @dev:
+        path: web/wp
+        ssh: vagrant@example.test/srv/www/example.com/current
+      @otherdev:
+        ssh: vagrant@otherexample.test/srv/www/otherexample.com/current
+      """
+
   @require-wp-3.9
   Scenario: WordPress installation with local dev DOMAIN_CURRENT_SITE
     Given a WP multisite installation

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -3,6 +3,10 @@
 namespace WP_CLI;
 
 use Mustangostang\Spyc;
+use SplFileInfo;
+
+use function WP_CLI\Utils\is_path_absolute;
+use function WP_CLI\Utils\normalize_path;
 
 /**
  * Handles file- and runtime-based configuration values.
@@ -253,7 +257,11 @@ class Configurator {
 	public function merge_yml( $path, $current_alias = null ) {
 		$yaml = self::load_yml( $path );
 		if ( ! empty( $yaml['_']['inherit'] ) ) {
-			$this->merge_yml( $yaml['_']['inherit'], $current_alias );
+			$inherit_path = is_path_absolute( $yaml['_']['inherit'] )
+				? $yaml['_']['inherit']
+				: ( new SplFileInfo( normalize_path( dirname( $path ) . '/' . $yaml['_']['inherit'] ) ) )->getRealPath();
+
+			$this->merge_yml( $inherit_path, $current_alias );
 		}
 		// Prepare the base path for absolutized alias paths.
 		$yml_file_dir = $path ? dirname( $path ) : false;

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -257,6 +257,8 @@ class Configurator {
 	public function merge_yml( $path, $current_alias = null ) {
 		$yaml = self::load_yml( $path );
 		if ( ! empty( $yaml['_']['inherit'] ) ) {
+			// Refactor with the WP-CLI `Path` class, once it's available.
+			// See: https://github.com/wp-cli/wp-cli/issues/5007
 			$inherit_path = is_path_absolute( $yaml['_']['inherit'] )
 				? $yaml['_']['inherit']
 				: ( new SplFileInfo( normalize_path( dirname( $path ) . '/' . $yaml['_']['inherit'] ) ) )->getRealPath();


### PR DESCRIPTION
This Pull Request aims to fix issue #4958, where the inherited config using the `inherit` option is not properly merged when a command is run in nested directories. Currently, when running WP-CLI under sub-directories, like `./site/web/app/themes/mytheme/`, it only reads configuration from the `wp-cli.yml` file and fails to merge the configs from `../wp-cli.local.yml`.

For example, with the given directory structure:

```
.
├── wp-cli.local.yml
├── site
│   ├── wp-cli.yml
│   └── web
│       ├── app
│       │   ├── themes
│       │   ├── upgrade
│       │   └── uploads
│       └── wp
│           ├── wp-admin
│           ├── wp-content
│           └── wp-includes
└── trellis
```

And the configurations:

```
# wp-cli.local.yml
@dev:
  ssh: vagrant@example.test/srv/www/example.com/current
  path: web/wp
```

```
# wp-cli.yml
path: web/wp

_:
  inherit: ../wp-cli.local.yml
@otherdev:
  ssh: vagrant@otherexample.test/srv/www/otherexample.com/current
```

After applying the updates in this Pull Request, we expect the configuration from `../wp-cli.local.yml` to be merged as well. So, when running WP-CLI under sub-directories, the same command would return:

```
@all: Run command against every registered alias.
@dev:
  path: web/wp
  ssh: vagrant@example.test/srv/www/example.com/current
@otherdev:
  ssh: vagrant@otherexample.test/srv/www/otherexample.com/current
```