### PR TITLE
Respect fields order in formatter output 

### DIFF
--- a/features/formatter.feature
+++ b/features/formatter.feature
@@ -153,3 +153,59 @@ Feature: Format output
       | [33mgaa/gaa-log[0m      | *          | [32m✔[0m      |
       | [33mgaa/gaa-nonsense[0m | v3.0.11    | [31m🛇[0m      |
       | [33mgaa/gaa-100%new[0m  | v100%new   | [32m✔[0m      |
+
+  Scenario: Display ordered output for an object item
+    Given an empty directory
+    And a file.php file:
+      """
+      <?php
+      $custom_obj = (object) [
+        'name'    => 'Custom Name',
+        'author'  => 'John Doe',
+        'version' => '1.0'
+      ];
+
+      $assoc_args = [
+        'format' => 'csv',
+        'fields' => [ 'version', 'author', 'name' ],
+      ];
+
+      $formatter = new WP_CLI\Formatter( $assoc_args );
+      $formatter->display_item( $custom_obj );
+      """
+
+    When I run `wp eval-file file.php --skip-wordpress`
+    Then STDOUT should contain:
+      """
+      version,1.0
+      author,"John Doe"
+      name,"Custom Name"
+      """
+
+  Scenario: Display ordered output for an array item
+    Given an empty directory
+    And a file.php file:
+      """
+      <?php
+      $custom_obj = [
+        'name'    => 'Custom Name',
+        'author'  => 'John Doe',
+        'version' => '1.0'
+      ];
+
+      $assoc_args = [
+        'format' => 'csv',
+        'fields' => [ 'version', 'author', 'name' ],
+      ];
+
+      $formatter = new WP_CLI\Formatter( $assoc_args );
+      $formatter->display_item( $custom_obj );
+      """
+
+    When I run `wp eval-file file.php --skip-wordpress`
+    Then STDOUT should contain:
+      """
+      version,1.0
+      author,"John Doe"
+      name,"Custom Name"
+      """

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -261,11 +261,17 @@ class Formatter {
 			}
 		}
 
+		$ordered_data = [];
+
+		foreach ( $this->args['fields'] as $field ) {
+			$ordered_data[ $field ] = ( is_object( $data ) ) ? $data->$field : $data[ $field ];
+		}
+
 		switch ( $format ) {
 
 			case 'table':
 			case 'csv':
-				$rows   = $this->assoc_array_to_rows( $data );
+				$rows   = $this->assoc_array_to_rows( $ordered_data );
 				$fields = [ 'Field', 'Value' ];
 				if ( 'table' === $format ) {
 					self::show_table( $rows, $fields, $ascii_pre_colorized );
@@ -277,7 +283,7 @@ class Formatter {
 			case 'yaml':
 			case 'json':
 				WP_CLI::print_value(
-					$data,
+					$ordered_data,
 					[
 						'format' => $format,
 					]


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/5941

Fields order like `[ 'version', 'author', 'name' ]` is respected in the output.

Example `file.php`:

```php
<?php
      $custom_obj = [
        'name'    => 'Custom Name',
        'author'  => 'John Doe',
        'version' => '1.0'
      ];

      $assoc_args = [
        'format' => 'csv',
        'fields' => [ 'version', 'author', 'name' ],
      ];

      $formatter = new WP_CLI\Formatter( $assoc_args );
      $formatter->display_item( $custom_obj );
```

Command: `wp eval-file file.php --skip-wordpress`

Output:
```
version,1.0
author,"John Doe"
name,"Custom Name"
```