### PR TITLE
Update docker runner to resolve docker path using `/usr/bin/env`

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -570,7 +570,7 @@ class Runner {
 		}
 
 		$is_tty             = function_exists( 'posix_isatty' ) && posix_isatty( STDOUT );
-		$docker_compose_cmd = ! empty( Process::create( Utils\esc_cmd( 'docker compose %s', 'version' ) )->run()->stdout )
+		$docker_compose_cmd = ! empty( Process::create( Utils\esc_cmd( '/usr/bin/env docker compose %s', 'version' ) )->run()->stdout )
 								? 'docker compose'
 								: 'docker-compose';
 

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -569,10 +569,11 @@ class Runner {
 			WP_CLI::debug( 'SSH ' . $bit . ': ' . $bits[ $bit ], 'bootstrap' );
 		}
 
-		$is_tty             = function_exists( 'posix_isatty' ) && posix_isatty( STDOUT );
-		$docker_compose_cmd = ! empty( Process::create( Utils\esc_cmd( '/usr/bin/env docker compose %s', 'version' ) )->run()->stdout )
-								? 'docker compose'
-								: 'docker-compose';
+		$is_tty                        = function_exists( 'posix_isatty' ) && posix_isatty( STDOUT );
+		$docker_compose_v2_version_cmd = Utils\esc_cmd( Utils\force_env_on_nix_systems( 'docker' ) . ' compose %s', 'version' );
+		$docker_compose_cmd            = ! empty( Process::create( $docker_compose_v2_version_cmd )->run()->stdout )
+			? 'docker compose'
+			: 'docker-compose';
 
 		if ( 'docker' === $bits['scheme'] ) {
 			$command = 'docker exec %s%s%s sh -c %s';


### PR DESCRIPTION
Sometimes, the WP CLI process doesn't have access to PATH and it gives an error. This PR aims to resolve those binary using `env` which is already done for binaries like `mysql`.

Related: https://github.com/wp-cli/wp-cli/issues/5935
