### PR TITLE
Fix breaking multi-line CSV values on reading

### DIFF
--- a/php/WP_CLI/Iterators/CSV.php
+++ b/php/WP_CLI/Iterators/CSV.php
@@ -54,13 +54,11 @@ class CSV implements Countable, Iterator {
 		$this->current_element = false;
 
 		while ( true ) {
-			$str = fgets( $this->file_pointer );
+			$row = fgetcsv( $this->file_pointer, self::ROW_SIZE, $this->delimiter );
 
-			if ( false === $str ) {
+			if ( false === $row ) {
 				break;
 			}
-
-			$row = str_getcsv( $str, $this->delimiter );
 
 			$element = [];
 			foreach ( $this->columns as $i => $key ) {

--- a/tests/WP_CLI/Iterators/CSVTest.php
+++ b/tests/WP_CLI/Iterators/CSVTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace WP_CLI\Tests\CSV;
+
+use WP_CLI\Tests\TestCase;
+use WP_CLI\Iterators\CSV;
+
+class CSVTest extends TestCase {
+
+	public function test_it_can_iterate_over_a_csv_file() {
+		$filename = $this->create_csv_file(
+			array(
+				array( 'foo', 'bar' ),
+				array( 'baz', 'qux' ),
+			)
+		);
+
+		$expected = array(
+			0 => array(
+				'foo' => 'baz',
+				'bar' => 'qux',
+			),
+		);
+
+		foreach ( new CSV( $filename ) as $index => $row ) {
+			$this->assertEquals( $expected[ $index ], $row );
+		}
+	}
+
+	public function test_it_can_iterate_over_a_csv_file_with_custom_delimiter() {
+		$filename = $this->create_csv_file(
+			array(
+				array( 'foo|bar' ),
+				array( 'baz|qux' ),
+			),
+			'|'
+		);
+
+		$expected = array(
+			0 => array(
+				'foo|bar' => 'baz|qux',
+			),
+		);
+
+		foreach ( new CSV( $filename, '|' ) as $index => $row ) {
+			$this->assertEquals( $expected[ $index ], $row );
+		}
+	}
+
+	public function test_it_can_iterate_over_a_csv_file_with_multiple_lines_in_a_value() {
+		$filename = $this->create_csv_file(
+			array(
+				array( 'foo', "bar\nbaz" ),
+				array( 'qux', "quux\nquuz" ),
+			)
+		);
+
+		$expected = array(
+			0 => array(
+				'foo'      => 'qux',
+				"bar\nbaz" => "quux\nquuz",
+			),
+		);
+
+		foreach ( new CSV( $filename ) as $index => $row ) {
+			$this->assertEquals( $expected[ $index ], $row );
+		}
+	}
+
+	public function test_it_can_iterate_over_a_csv_file_with_multiple_lines_and_comma_in_a_value() {
+		$filename = $this->create_csv_file(
+			array(
+				array( 'foo', "bar\nbaz,qux" ),
+				array( 'quux', "quuz\ncorge,grault" ),
+			)
+		);
+
+		$expected = array(
+			0 => array(
+				'foo'          => 'quux',
+				"bar\nbaz,qux" => "quuz\ncorge,grault",
+			),
+		);
+
+		foreach ( new CSV( $filename ) as $index => $row ) {
+			$this->assertEquals( $expected[ $index ], $row );
+		}
+	}
+
+	private function create_csv_file( $data, $delimiter = ',' ) {
+		$filename = tempnam( sys_get_temp_dir(), 'wp-cli-tests-' );
+
+		$fp = fopen( $filename, 'wb' );
+
+		foreach ( $data as $row ) {
+			fputcsv( $fp, $row, $delimiter );
+		}
+
+		fclose( $fp );
+
+		register_shutdown_function(
+			function () use ( $filename ) {
+				unlink( $filename );
+			}
+		);
+
+		return $filename;
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/5412
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
