### PR TITLE
Prevent missing file extensions from throwing errors

### DIFF
--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -157,12 +157,17 @@ class FileCache {
 	 *
 	 * @param string $key    cache key
 	 * @param string $source source filename
+	 *
 	 * @return bool
 	 */
 	public function import( $key, $source ) {
 		$filename = $this->prepare_write( $key );
 
 		if ( $filename ) {
+			$ext = pathinfo( $filename, PATHINFO_EXTENSION );
+			if ( '' === $ext ) {
+				return false;
+			}
 			return copy( $source, $filename ) && touch( $filename );
 		}
 


### PR DESCRIPTION
Some file URL do not include the common .zip extension and therefore are missing their extension when reaching the `import` method of `FileCache`.

This issue is commonly seen with Premium plugins which use a custom URL to provide access to a keyed download file.

Running `wp plugin update <name of premium plugin>` was throwing a "Warning: copy(-<version>.): Failed to open stream: Permission denied". 

Instead of assuming the extension is valid nor trying to guess the extension is `.zip` simply bypass the storing of cache when the extension is not available.