### PR TITLE
Add fish shell completion

### DIFF
--- a/utils/wp.fish
+++ b/utils/wp.fish
@@ -1,0 +1,24 @@
+# Fish completion for the `wp` command
+# Check $fish_complete_path for possible install locations
+# Or check the documentation:
+# https://fishshell.com/docs/current/completions.html#where-to-put-completions
+
+function __wp_cli_complete
+    # Get current buffer and cursor
+    set --local COMP_LINE (commandline)
+    set --local COMP_POINT (commandline -C)
+
+    # Get valid completions from wp-cli
+    set --local opts (wp cli completions --line=$COMP_LINE --point=$COMP_POINT)
+
+    # wp-cli will indicate if it needs a file
+    if string match -qe "<file> " -- $opts
+        command ls -1
+    else
+        # Remove unnecesary double spaces that wp-cli splits options with
+        string trim -- $opts
+        # `string` echoes each result on a newline.
+        # Which is then collected for use with the `-a` flag for `complete`.
+    end
+end
+complete -f -a "(__wp_cli_complete)" wp

--- a/utils/wp.fish
+++ b/utils/wp.fish
@@ -15,7 +15,7 @@ function __wp_cli_complete
     if string match -qe "<file> " -- $opts
         command ls -1
     else
-        # Remove unnecesary double spaces that wp-cli splits options with
+        # Remove unnecessary double spaces that wp-cli splits options with
         string trim -- $opts
         # `string` echoes each result on a newline.
         # Which is then collected for use with the `-a` flag for `complete`.


### PR DESCRIPTION
## Summary

This pull request adds a Fish shell completion script for wp-cli.

## Changes

- Adds a Fish completion script for the `wp` command.
- Handles file completions when completions include `<file> `.
- Handles unnecessary whitespace in completions.

## Testing

- Tested in Fish shell version `3.7.1`.
- Verified completions for various `wp` commands and options.
- Works with aliases when in a directory that contains them.

## Documentation

Included a link to the Fish shell documentation for [where to put completions](https://fishshell.com/docs/current/completions.html#where-to-put-completions).
