### PR TITLE
Modify `root` warning to take account of system user

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1188,6 +1188,10 @@ class Runner {
 
 		$script_path = $GLOBALS['argv'][0];
 
+		$wp_cli_config_path = (string) getenv( 'WP_CLI_CONFIG_PATH' );
+
+		if ( $wp_cli_config_path ) {
+			$config_path = $wp_cli_config_path;
 		} else {
 			$config_path = Utils\get_home_dir() . '/.wp-cli/config.yml';
 		}


### PR DESCRIPTION
The user running a WP installation can often be a system user with no login shell. In such cases, using the `-i` flag would be met with a message like `This account is currently not available.`, which doesn’t really help someone not already familiar with `sudo` to figure out what’s going on.

This PR adds a note to take account of this common scenario.