### PR TITLE
Resolve intermittent issues finding templates in the phar

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -1465,11 +1465,24 @@ function phar_safe_path( $path ) {
 		return $path;
 	}
 
-	return str_replace(
+	$path = str_replace(
 		PHAR_STREAM_PREFIX . rtrim( WP_CLI_PHAR_PATH, '/' ) . '/',
 		PHAR_STREAM_PREFIX,
 		$path
 	);
+
+	if (
+		defined( 'WP_CLI_PHAR_HOST_FILENAME' ) &&
+		WP_CLI_PHAR_HOST_FILENAME &&
+		WP_CLI_PHAR_HOST_FILENAME !== 'wp-cli.phar'
+	) {
+		$parts = explode( '/' . WP_CLI_PHAR_HOST_FILENAME . '/', $path, 2 );
+		if ( count( $parts ) === 2 ) {
+			$path = $parts[0] . '/wp-cli.phar/' . $parts[1];
+		}
+	}
+
+	return $path;
 }
 
 /**


### PR DESCRIPTION
Fixes #5907 

I [left a comment](https://github.com/wp-cli/wp-cli/issues/5907#issuecomment-2227001059) on that issue diving deeper into what the root of the problem seems to be.

Basically, if the phar isn't named `wp-cli.phar` in the outer filesystem, then the phar itself won't be able to find things like templates in the inner filesystem when they're using `__DIR__` as a reference point.

This has a companion change in wp-cli/wp-cli-bundle that will be coming shortly. That change will set the outer filesystem's filename in a constant inside boot-phar.php. This change checks for the presence of that constant before trying to use it, so there shouldn't be any issues affecting alternative installation/compilation strategies. If the constant exists, it looks for it as a full node in the phar-safe path and if found, replaces it with wp-cli.phar.

I noticed there weren't any tests for `phar_safe_path()`, so I started to write some, but with all the reliance on constants that was already there, it quickly became too difficult even to test the previous functionality, let alone the change. If someone could point me in the right direction of a way to run functional tests on a built phar, that may be an easier way to test this change.