### PR TITLE
Update log and warning logger functions comment according to the actual functionality

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -770,7 +770,7 @@ class WP_CLI {
 	/**
 	 * Display success message prefixed with "Success: ".
 	 *
-	 * Success message is written to STDOUT.
+	 * Success message is written to STDOUT, or discarded when `--quiet` flag is supplied.
 	 *
 	 * Typically recommended to inform user of successful script conclusion.
 	 *
@@ -850,7 +850,7 @@ class WP_CLI {
 	/**
 	 * Display warning message prefixed with "Warning: ".
 	 *
-	 * Warning message is written to STDERR.
+	 * Warning message is written to STDERR, or discarded when `--quiet` flag is supplied.
 	 *
 	 * Use instead of `WP_CLI::debug()` when script execution should be permitted
 	 * to continue.


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
## What?
Update `log` and `warning` logger functions comment according to the actual functionality.

In this PR I'm updating those 2 function comments to state that as the other logging function being muted by the `--quiet` command. Example: https://github.com/wp-cli/wp-cli/blob/0a48e09e78353508102dcc30004a3bec8d436314/php/class-wp-cli.php#L773



## Why?
Both functions log nothing when running wp-cli with `--quiet` option. 

Reference:
https://github.com/wp-cli/wp-cli/blob/0a48e09e78353508102dcc30004a3bec8d436314/php/WP_CLI/Loggers/Quiet.php#L37-L44