### PR TITLE
PHP 8.4 | Fix implicitly nullable parameters

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1948,16 +1948,19 @@ class Runner {
 	 * Get a suggestion on similar (sub)commands when the user entered an
 	 * unknown (sub)command.
 	 *
-	 * @param string           $entry        User entry that didn't match an
-	 *                                       existing command.
-	 * @param CompositeCommand $root_command Root command to start search for
-	 *                                       suggestions at.
+	 * @param string                $entry        User entry that didn't match an
+	 *                                            existing command.
+	 * @param CompositeCommand|null $root_command Root command to start search for
+	 *                                            suggestions at.
 	 *
 	 * @return string Suggestion that fits the user entry, or an empty string.
 	 */
-	private function get_subcommand_suggestion( $entry, CompositeCommand $root_command = null ) {
+	private function get_subcommand_suggestion( $entry, $root_command = null ) {
 		$commands = [];
-		$this->enumerate_commands( $root_command ?: WP_CLI::get_root_command(), $commands );
+		if ( ( $root_command instanceof CompositeCommand ) === false ) {
+			$root_command = WP_CLI::get_root_command();
+		}
+		$this->enumerate_commands( $root_command, $commands );
 
 		return Utils\get_suggestion( $entry, $commands, $threshold = 2 );
 	}


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable parameters, i.e. typed parameters with a `null` default value, which are not explicitly declared as nullable.

As the minimums supported PHP version of this code base is PHP 5.6, adding the nullability operator to the type declaration is not an option at this time.

In this case, however, the parameter is found in the declaration of a `private` method, so removing the type declaration in favour of in-function type checking solves the deprecation without breaking BC (as `private`).

Includes updating the documentation to match (where relevant, i.e. only existing documentation has been touched).

Ref: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types
