### PR TITLE
PHP 8.1 | WP_CLI\Iterators\CSV: fix "missing return type" deprecation warnings

### DIFF
--- a/php/WP_CLI/Iterators/CSV.php
+++ b/php/WP_CLI/Iterators/CSV.php
@@ -4,6 +4,7 @@ namespace WP_CLI\Iterators;
 
 use Countable;
 use Iterator;
+use ReturnTypeWillChange;
 use SplFileObject;
 use WP_CLI;
 
@@ -33,6 +34,7 @@ class CSV implements Countable, Iterator {
 		$this->delimiter = $delimiter;
 	}
 
+	#[ReturnTypeWillChange]
 	public function rewind() {
 		rewind( $this->file_pointer );
 
@@ -42,14 +44,17 @@ class CSV implements Countable, Iterator {
 		$this->next();
 	}
 
+	#[ReturnTypeWillChange]
 	public function current() {
 		return $this->current_element;
 	}
 
+	#[ReturnTypeWillChange]
 	public function key() {
 		return $this->current_index;
 	}
 
+	#[ReturnTypeWillChange]
 	public function next() {
 		$this->current_element = false;
 
@@ -76,12 +81,14 @@ class CSV implements Countable, Iterator {
 		}
 	}
 
+	#[ReturnTypeWillChange]
 	public function count() {
 		$file = new SplFileObject( $this->filename, 'r' );
 		$file->seek( PHP_INT_MAX );
 		return $file->key() + 1;
 	}
 
+	#[ReturnTypeWillChange]
 	public function valid() {
 		return is_array( $this->current_element );
 	}


### PR DESCRIPTION
As of PHP 8.1, PHP started throwing deprecation warnings along the lines of:
```
Deprecated:  Return type of [CLASS]::[METHOD]() should either be compatible with [PHP NATIVE INTERFACE]::[METHOD](): [TYPE], or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

These type of deprecation notices relate to the [Return types for internal methods RFC](https://wiki.php.net/rfc/internal_method_return_types) in PHP 8.1.

Basically, as of PHP 8.1, these methods in classes which implement PHP native interfaces are expected to have a return type declared. The return type can be the same as used in PHP itself or a more specific type. This complies with the Liskov principle of covariance, which allows the return type of a child overloaded method to be more specific than that of the parent.

As this package still has a minimum PHP requirement of PHP 5.6, the return type (PHP 7.0 feature) can not be added, so I've added the attribute instead.

While attributes are a PHP 8.0 feature only, due to the syntax choice for `#[]`, they will ignored in PHP < 8 and can be safely added.

**_Note: these deprecations were visible in the test summary, but the tests - as they currently are - are not set up correctly to fail builds on deprecation notices, which is probably why this went unnoticed._**
