### PR TITLE
PHP 8.3 | ReportWidthTest: fix deprecation notices for ReflectionProperty::setValue()

### DIFF
--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -454,7 +454,7 @@ class UtilsTest extends TestCase {
 		$prev_logger = WP_CLI::get_logger();
 
 		// Enable exit exception.
-		$class_wp_cli_capture_exit->setValue( true );
+		$class_wp_cli_capture_exit->setValue( null, true );
 
 		$logger = new Loggers\Execution();
 		WP_CLI::set_logger( $logger );
@@ -472,7 +472,7 @@ class UtilsTest extends TestCase {
 		$this->assertTrue( 0 === strpos( $logger->stderr, 'Error: Failed to get url' ) );
 
 		// Restore.
-		$class_wp_cli_capture_exit->setValue( $prev_capture_exit );
+		$class_wp_cli_capture_exit->setValue( null, $prev_capture_exit );
 		WP_CLI::set_logger( $prev_logger );
 	}
 
@@ -675,7 +675,7 @@ class UtilsTest extends TestCase {
 		$prev_logger = WP_CLI::get_logger();
 
 		// Enable exit exception.
-		$class_wp_cli_capture_exit->setValue( true );
+		$class_wp_cli_capture_exit->setValue( null, true );
 
 		$logger = new Loggers\Execution();
 		WP_CLI::set_logger( $logger );
@@ -691,7 +691,7 @@ class UtilsTest extends TestCase {
 		$this->assertSame( $stderr, $logger->stderr );
 
 		// Restore.
-		$class_wp_cli_capture_exit->setValue( $prev_capture_exit );
+		$class_wp_cli_capture_exit->setValue( null, $prev_capture_exit );
 		WP_CLI::set_logger( $prev_logger );
 	}
 


### PR DESCRIPTION
The `ReflectionProperty::setValue()` method supports three method signatures, two of which are deprecated as of PHP 8.3.

This adjusts the call to `ReflectionProperty::setValue()` in various methods in the `UtilsTest` class to pass `null` as the "object" for setting the value of a static property to make the method calls cross-version compatible.

**_Note: these deprecations were visible in the test summary, but the tests - as they currently are - are not set up correctly to fail builds on deprecation notices, which is probably why this went unnoticed._**

Ref: https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#reflectionpropertysetvalue