### PR TITLE
PHP 8.4 | wp_debug_mode(): remove use of `E_STRICT`

### DIFF
--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -47,7 +47,7 @@ function wp_debug_mode() {
 			define( 'WP_DEBUG', true );
 		}
 
-		error_reporting( E_ALL & ~E_DEPRECATED & ~E_STRICT );
+		error_reporting( E_ALL & ~E_DEPRECATED );
 	} else {
 		if ( WP_DEBUG ) {
 			error_reporting( E_ALL );


### PR DESCRIPTION
The `E_STRICT` constant is deprecated as of PHP 8.4 and will be removed in PHP 9.0 (commit went in today).

The error level hasn't been in use since PHP 8.0 anyway and was only barely still used in PHP 7.x, so removing the exclusion from the `error_reporting()` setting in the example code shouldn't really make any difference in practice.

Ref:
* https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant