### PR TITLE
Fix tests against WordPress trunk

### DIFF
--- a/features/requests.feature
+++ b/features/requests.feature
@@ -78,10 +78,10 @@ Feature: Requests integration with both v1 and v2
 
     Scenario: Current version with WordPress-bundled Requests v2
     Given a WP installation
-    And I run `wp core update --version=6.2 --force`
     # Switch themes because twentytwentyfive requires a version newer than 6.2
     # and it would otherwise cause a fatal error further down.
     And I run `wp theme activate twentytwentythree`
+    And I run `wp core update --version=6.2 --force`
 
     When I run `wp core version`
     Then STDOUT should contain:

--- a/features/requests.feature
+++ b/features/requests.feature
@@ -81,7 +81,7 @@ Feature: Requests integration with both v1 and v2
     And I run `wp core update --version=6.2 --force`
     # Switch themes because twentytwentyfive requires a version newer than 6.2
     # and it would otherwise cause a fatal error further down.
-    And I run `wp theme activate twentytwentyone`
+    And I run `wp theme activate twentytwentythree`
 
     When I run `wp core version`
     Then STDOUT should contain:

--- a/features/requests.feature
+++ b/features/requests.feature
@@ -79,6 +79,9 @@ Feature: Requests integration with both v1 and v2
     Scenario: Current version with WordPress-bundled Requests v2
     Given a WP installation
     And I run `wp core update --version=6.2 --force`
+    # Switch themes because twentytwentyfive requires a version newer than 6.2
+    # and it would otherwise cause a fatal error further down.
+    And I run `wp theme activate twentytwentyone`
 
     When I run `wp core version`
     Then STDOUT should contain:


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

Switch themes because `twentytwentyfive` (which is part of WP 6.7 / trunk now) requires a version newer than 6.2 and it would otherwise cause a fatal error further down.
