### PR TITLE
Skip Requests v1 test on PHP 8.2+

### DIFF
--- a/features/requests.feature
+++ b/features/requests.feature
@@ -1,7 +1,8 @@
 Feature: Requests integration with both v1 and v2
 
   # This test downgrades to WordPress 5.8, but the SQLite plugin requires 6.0+
-  @require-mysql
+  # WP-CLI 2.7 causes deprecation warnings on PHP 8.2
+  @require-mysql @less-than-php-8.2
   Scenario: Composer stack with Requests v1
     Given an empty directory
     And a composer.json file:


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

This test runs WP-CLI 2.7.0 via Composer, which causes deprecation warnings on PHP 8.2
