### PR TITLE
UtilsTest: fix the test failure

### DIFF
--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -127,7 +127,7 @@ class Extractor {
 			$tarball = "./{$tarball}";
 		}
 
-		if (! file_exists( $tarball )
+		if ( ! file_exists( $tarball )
 			|| ! is_readable( $tarball )
 			|| filesize( $tarball ) <= 0 ) {
 			throw new Exception( "Invalid zip file '{$tarball}'." );

--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -48,7 +48,7 @@ class Extractor {
 			throw new Exception( "Could not create folder '{$dest}'." );
 		}
 
-		if ( ! file( $zipfile )
+		if ( ! file_exists( $zipfile )
 			|| ! is_readable( $zipfile )
 			|| filesize( $zipfile ) <= 0 ) {
 			throw new Exception( "Invalid zip file '{$zipfile}'." );
@@ -127,7 +127,7 @@ class Extractor {
 			$tarball = "./{$tarball}";
 		}
 
-		if ( ! file( $tarball )
+		if (! file_exists( $tarball )
 			|| ! is_readable( $tarball )
 			|| filesize( $tarball ) <= 0 ) {
 			throw new Exception( "Invalid zip file '{$tarball}'." );

--- a/tests/CommandFactoryTest.php
+++ b/tests/CommandFactoryTest.php
@@ -2,9 +2,11 @@
 
 use WP_CLI\Tests\TestCase;
 
-require_once dirname( __DIR__ ) . '/php/class-wp-cli-command.php';
-
 class CommandFactoryTest extends TestCase {
+
+	public static function set_up_before_class() {
+		require_once dirname( __DIR__ ) . '/php/class-wp-cli-command.php';
+	}
 
 	/**
 	 * @dataProvider dataProviderExtractLastDocComment

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -5,9 +5,11 @@ use WP_CLI\Loggers;
 use WP_CLI\Tests\TestCase;
 use WP_CLI\Utils;
 
-require_once dirname( __DIR__ ) . '/php/class-wp-cli.php';
-
 class FileCacheTest extends TestCase {
+
+	public static function set_up_before_class() {
+		require_once dirname( __DIR__ ) . '/php/class-wp-cli.php';
+	}
 
 	/**
 	 * Test get_root() deals with backslashed directory.

--- a/tests/HelpTest.php
+++ b/tests/HelpTest.php
@@ -2,11 +2,13 @@
 
 use WP_CLI\Tests\TestCase;
 
-require_once dirname( __DIR__ ) . '/php/class-wp-cli.php';
-require_once dirname( __DIR__ ) . '/php/class-wp-cli-command.php';
-require_once dirname( __DIR__ ) . '/php/commands/help.php';
-
 class HelpTest extends TestCase {
+
+	public static function set_up_before_class() {
+		require_once dirname( __DIR__ ) . '/php/class-wp-cli.php';
+		require_once dirname( __DIR__ ) . '/php/class-wp-cli-command.php';
+		require_once dirname( __DIR__ ) . '/php/commands/help.php';
+	}
 
 	public function test_parse_reference_links() {
 		$test_class = new ReflectionClass( 'Help_Command' );

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -5,10 +5,12 @@ use WP_CLI\Loggers;
 use WP_CLI\Tests\TestCase;
 use WP_CLI\Utils;
 
-require_once dirname( __DIR__ ) . '/php/class-wp-cli.php';
-require_once __DIR__ . '/mock-requests-transport.php';
-
 class UtilsTest extends TestCase {
+
+	public static function set_up_before_class() {
+		require_once dirname( __DIR__ ) . '/php/class-wp-cli.php';
+		require_once __DIR__ . '/mock-requests-transport.php';
+	}
 
 	public function testIncrementVersion() {
 		// Keyword increments.

--- a/tests/WP_CLI/WpOrgApiTest.php
+++ b/tests/WP_CLI/WpOrgApiTest.php
@@ -3,9 +3,11 @@
 use WP_CLI\Tests\TestCase;
 use WP_CLI\WpOrgApi;
 
-require_once dirname( __DIR__ ) . '/mock-requests-transport.php';
-
 class WpOrgApiTest extends TestCase {
+
+	public static function set_up_before_class() {
+		require_once dirname( __DIR__ ) . '/mock-requests-transport.php';
+	}
 
 	public static function data_http_request_verify() {
 		return [


### PR DESCRIPTION
### UtilsTest: fix the test failure

Tests on PHP 8.1 and higher (which are running PHPUnit 10+) are failing with the below message:
```
An error occurred inside PHPUnit.

Message:  Interface "WpOrg\Requests\Transport" not found
Location: /home/runner/work/wp-cli/wp-cli/tests/mock-requests-transport.php:6
```

This may be due to the test classes being loaded (to count the number of tests) before the test bootstrap is being run (which includes the autoloaders).

If that "guess" is correct, this patch should fix this.


### Tests: apply the same change to other test files

While these tests are not showing errors at this time, it is still best practice to include files in the test `set_up_before_class()` method, not when the file is being read.

This applies this change to all other test files which were using the anti-pattern.