### PR TITLE
Add configurable user agent to WP-CLI to detect in firewall logs

### DIFF
--- a/php/wp-cli.php
+++ b/php/wp-cli.php
@@ -19,7 +19,7 @@ require_once WP_CLI_ROOT . '/php/compat.php';
 
 // Set common headers, to prevent warnings from plugins.
 $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.0';
-$_SERVER['HTTP_USER_AGENT'] = '';
+$_SERVER['HTTP_USER_AGENT'] = ( !empty(getenv('WP_CLI_USER_AGENT')) ? getenv('WP_CLI_USER_AGENT') : 'WP CLI' . ' version ' . WP_CLI_VERSION );
 $_SERVER['REQUEST_METHOD']  = 'GET';
 $_SERVER['REMOTE_ADDR']     = '127.0.0.1';
 

--- a/php/wp-cli.php
+++ b/php/wp-cli.php
@@ -19,7 +19,7 @@ require_once WP_CLI_ROOT . '/php/compat.php';
 
 // Set common headers, to prevent warnings from plugins.
 $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.0';
-$_SERVER['HTTP_USER_AGENT'] = ( !empty(getenv('WP_CLI_USER_AGENT')) ? getenv('WP_CLI_USER_AGENT') : 'WP CLI' . ' version ' . WP_CLI_VERSION );
+$_SERVER['HTTP_USER_AGENT'] = ( ! empty( getenv( 'WP_CLI_USER_AGENT' ) ) ? getenv( 'WP_CLI_USER_AGENT' ) : 'WP CLI ' . WP_CLI_VERSION );
 $_SERVER['REQUEST_METHOD']  = 'GET';
 $_SERVER['REMOTE_ADDR']     = '127.0.0.1';
 


### PR DESCRIPTION
To make requests identifiable in firewall logs and do not trigger false alarms, this allows setting a user agent in ENV VARS or defaults to a generic user agent.