### PR TITLE
Add utility function get size string from bytes

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -2332,29 +2332,37 @@ function escape_csv_value( $value ) {
 /**
  * Convert a size in bytes to a human-readable format.
  *
- * @param int    $bytes    Size in bytes.
- * @param int    $decimals Optional. Number of decimal places to round to. Default 0.
- * @param string $unit     Optional. Specific unit to use. Default is auto-detect.
+ * @param int|float $bytes    Size in bytes.
+ * @param int       $decimals Optional. Number of decimal places to round to. Default 0.
+ * @param string    $unit     Optional. Specific unit to use. Default is auto-detect.
  * @return string Human-readable size.
  */
-function get_size_string_from_bytes( $bytes, $decimals = 0, $unit = '' ) {
-	if ( 0 === $bytes ) {
+function format_bytes_string( $bytes, $decimals = 0, $unit = '' ) {
+	if ( 0 === (int) $bytes ) {
 		return '0 B';
 	}
 
-	$sizes    = [ 'B', 'KB', 'MB', 'GB', 'TB' ];
-	$size_key = 0;
+	$sizes = [ 'B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB' ];
 
-	if ( empty( $unit ) ) {
-		$size_key = (int) floor( log( $bytes ) / log( 1000 ) );
-		$unit     = isset( $sizes[ $size_key ] ) ? $sizes[ $size_key ] : $sizes[0];
-	} else {
+	// Use absolute value for calculating log exponent metrics cleanly.
+	$abs_bytes = abs( (float) $bytes );
+
+	// Resolve the specific target unit manually.
+	$size_key = false;
+	if ( ! empty( $unit ) ) {
 		$unit     = strtoupper( $unit );
-		$size_key = (int) array_search( $unit, $sizes, true );
+		$size_key = array_search( $unit, $sizes, true );
 	}
 
-	$divisor             = pow( 1000, $size_key );
-	$size_format_display = $unit;
+	// Calculate and bound the auto-detect unit size string if no valid unit was requested.
+	if ( false === $size_key ) {
+		$size_key = (int) floor( log( $abs_bytes ) / log( 1000 ) );
+		$size_key = min( $size_key, count( $sizes ) - 1 ); // Prevent out of bounds
 
-	return round( $bytes / $divisor, $decimals ) . ' ' . $size_format_display;
+		$unit = $sizes[ $size_key ];
+	}
+
+	$divisor = pow( 1000, $size_key );
+
+	return round( $bytes / $divisor, $decimals ) . ' ' . $unit;
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -1211,9 +1211,20 @@ class UtilsTest extends TestCase {
 		];
 	}
 
-	public function testGetSizeStringFromBytes() {
-		$test_cases = [
+	/**
+	 * @dataProvider dataFormatBytesString
+	 */
+	#[DataProvider( 'dataFormatBytesString' )] // phpcs:ignore PHPCompatibility.Attributes.NewAttributes.PHPUnitAttributeFound
+	public function testFormatBytesString( $bytes, $decimals, $unit, $expected ) {
+		$actual = Utils\format_bytes_string( $bytes, $decimals, $unit );
+		$this->assertSame( $expected, $actual, "Failed asserting that format_bytes_string($bytes, $decimals, '$unit') equals '$expected'." );
+	}
+
+	public static function dataFormatBytesString(): array {
+		return [
 			[ 0, 2, '', '0 B' ],
+			[ '0', 2, '', '0 B' ],
+			[ -0, 2, '', '0 B' ],
 			[ 500, 2, '', '500 B' ],
 			[ 1000, 2, '', '1 KB' ],
 			[ 1500, 2, '', '1.5 KB' ],
@@ -1227,13 +1238,11 @@ class UtilsTest extends TestCase {
 			[ 1000000, 0, 'MB', '1 MB' ],
 			[ 1000000000, 0, 'GB', '1 GB' ],
 			[ 1000000000000, 0, 'TB', '1 TB' ],
+			[ -1000000, 0, 'MB', '-1 MB' ],
+			[ -1536, 1, '', '-1.5 KB' ],
+			[ 5000, 0, 'FOO', '5 KB' ],
+			[ 1.5e26, 0, '', '150 YB' ],
 		];
-
-		foreach ( $test_cases as $case ) {
-			list( $bytes, $decimals, $unit, $expected ) = $case;
-			$actual                                     = Utils\get_size_string_from_bytes( $bytes, $decimals, $unit );
-			$this->assertSame( $expected, $actual, "Failed asserting that size_format($bytes, $decimals, '$unit') equals '$expected'." );
-		}
 	}
 
 	public function testExpandTildePath(): void {


### PR DESCRIPTION
Fixes: [#5978](https://github.com/wp-cli/wp-cli/issues/5978)

This PR adds a new utility function, `get_size_string_from_bytes`, to the WP-CLI codebase. 

The function converts a size in bytes to a human-readable format (units such as B, KB, MB, GB, and TB) and return string output. Allows for optional specification of decimal precision and unit preference.

Unit Tests: Added unit tests for the new function.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
