### PR TITLE
Fix: network_site_url() returns with HTTP instead of HTTPS

### DIFF
--- a/features/framework.feature
+++ b/features/framework.feature
@@ -269,6 +269,12 @@ Feature: Load WP-CLI
       https://example.com/
       """
 
+    When I run `wp eval "echo network_site_url();"`
+    Then STDOUT should be:
+      """
+      https://example.com/
+      """
+
   # `wp db reset` does not yet work on SQLite,
   # See https://github.com/wp-cli/db-command/issues/234
   @require-mysql

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1719,6 +1719,7 @@ class Runner {
 		);
 
 		// Don't apply set_url_scheme() in network_site_url() function.
+		// Converts HTTP to HTTPS in the response when triggered by CLI.
 		WP_CLI::add_wp_hook(
 			'network_site_url',
 			static function ( $path, $scheme ) {

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1718,6 +1718,28 @@ class Runner {
 			4
 		);
 
+		// Don't apply set_url_scheme() in network_site_url() function.
+		WP_CLI::add_wp_hook(
+			'network_site_url',
+			static function ( $path, $scheme ) {
+				if ( ! is_multisite() ) {
+					return site_url( $path, $scheme );
+				}
+
+				$current_network = get_network();
+
+				if ( 'relative' === $scheme ) {
+					$url = $current_network->path;
+				} else {
+					$url = 'https://' . $current_network->domain . $current_network->path;
+				}
+				
+				return $url;
+			},
+			0,
+			2
+		);
+
 		// Set up hook for plugins and themes to conditionally add WP-CLI commands.
 		WP_CLI::add_wp_hook(
 			'init',


### PR DESCRIPTION
While using CLI, the `$_SERVER['https']` variable is absent which leads to an unexpected behaviour when `site_url` related functions are executed. The previous fix solves the issue in most parts except for the `network_site_url()` function which is utilised by a lot of plugins and cron jobs in multisite installations.

This PR extends the solution implemented in https://github.com/wp-cli/wp-cli/pull/4473 and fixes the issue: https://github.com/wp-cli/wp-cli/issues/5973 which was also raised [here](https://github.com/wp-cli/wp-cli/issues/4459#issuecomment-448340056) 

The following are the changes the PR makes:
```
$ wp option get siteurl
https://example.com

// before PR fix
$ wp eval "echo network_site_url();"
http://example.com

// after PR fix
$ wp eval "echo network_site_url();"
https://example.com
```