### PR TITLE
allow remote binary customization

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -530,7 +530,7 @@ class Runner {
 			$env_vars .= 'WP_CLI_STRICT_ARGS_MODE=1 ';
 		}
 
-		$wp_binary = 'wp';
+		$wp_binary = getenv( 'WP_CLI_SSH_BINARY' ) ?: 'wp';
 		$wp_args   = array_slice( $GLOBALS['argv'], 1 );
 
 		if ( $this->alias && ! empty( $wp_args[0] ) && $this->alias === $wp_args[0] ) {


### PR DESCRIPTION
Could be set to use `/custom/path/wp` on the remote end but also `sudo -u user /some/wp` to allow running wp under a distinct user.


See also #5974