### PR TITLE
Remove erroneous assumption that `less` exists on non-Windows systems

### DIFF
--- a/php/commands/src/Help_Command.php
+++ b/php/commands/src/Help_Command.php
@@ -108,6 +108,12 @@ class Help_Command extends WP_CLI_Command {
 		return implode( "\n", $lines );
 	}
 
+	/**
+	 * Pass a given set of output through the system's terminal pager.
+	 *
+	 * @param string $out The output to be run through the pager.
+	 * @return mixed Termination status of the pager as reported by https://www.php.net/manual/en/function.proc-close.php
+	 */
 	private static function pass_through_pager( $out ) {
 
 		if ( ! Utils\check_proc_available( null /*context*/, true /*return*/ ) ) {

--- a/php/commands/src/Help_Command.php
+++ b/php/commands/src/Help_Command.php
@@ -118,7 +118,7 @@ class Help_Command extends WP_CLI_Command {
 
 		$pager = getenv( 'PAGER' );
 		if ( false === $pager ) {
-			$pager = Utils\is_windows() ? 'more' : 'less -R';
+			$pager = 'more';
 		}
 
 		// For Windows 7 need to set code page to something other than Unicode (65001) to get around "Not enough memory." error with `more.com` on PHP 7.1+.


### PR DESCRIPTION
## Problem

in the corner case where:

1. `wp-cli` is running on a non-Windows system
2. the `PAGER` environment variable is not set
3. the command `less` is not installed
4. the user triggers output of the `wp help` command, such as by running that command explicitly or by running an invalid `wp-cli` command

wp-cli crashes, as documented in https://github.com/wp-cli/wp-cli/issues/5333

An example of such an environment is many "minimalist" Docker server containers.

## Changes

- Fixes https://github.com/wp-cli/wp-cli/issues/5333 by removing the assumption that `less` exists in non-Windows environments when the environment variable `$PAGER` is not set. Instead, in all environments, the fallback pager is `more`, which is part of the POSIX definition and additionally exists in Windows: https://en.wikipedia.org/wiki/More_(command)
- Adds a docblock to `Help_Command::pass_through_pager()`

### Alternatives considered

#### Replacing `less -R` with `cat`

This would replace a pager with a non-pager, which seems like a feature regression

#### Directly checking whether `less` exists

I started a branch with this intent, at https://github.com/wp-cli/wp-cli/commit/7c5999512131c8e6b63d1200dedd53984078ce2c , but this approach proved nonviable.

To accurately test whether `less` exists:

- On Windows, we would need to add a test to wp-cli to determine whether wp-cli is running in `cmd.exe` or Powershell, as `cmd.exe` can use `where` to determine whether a command exists, but Powershell needs to use a different command
- On POSIX systems, where `command -v` accurately determines whether a command exists, we would _also_ need to check for the existence of an [`alias`](https://en.wikipedia.org/wiki/Alias_(command)#Viewing_currently_defined_aliases), which is a separate can of worms
- In all cases, we would need to perform extensive checks on the return of the check, because [`proc_close()` isn't guaranteed to return the command's exit code](https://www.php.net/manual/en/function.proc-close.php#56798)

This seemed like way too much scope creep, introducing too much code, requiring too much testing, for a _fallback_ scenario around displaying a help message.

## Testing

The existing tests in https://github.com/wp-cli/wp-cli/blob/main/features/help.feature do not care about whether `more` or `less` is used.

If additional tests are needed for this change, I'm open to suggestions on what should be tested.
