### PR TITLE
Update `wp-cli/php-cli-tools`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "mustache/mustache": "^2.14.1",
         "symfony/finder": ">2.7",
         "wp-cli/mustangostang-spyc": "^0.6.3",
-        "wp-cli/php-cli-tools": "~0.11.2"
+        "wp-cli/php-cli-tools": "~0.12.1"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",


### PR DESCRIPTION
Use a more recent version of `php-cli-tools` to address PHP 8.4 warnings.

Without this PR:

```
bor0:~/dev/www$ ~/dev/wp-cli/bin/wp plugin list
PHP Deprecated:  cli\Table::__construct(): Implicitly marking parameter $headers as nullable is deprecated, the explicit nullable type must be used instead in /Users/bor0/dev/wp-cli/vendor/wp-cli/php-cli-tools/lib/cli/Table.php on line 47
Deprecated: cli\Table::__construct(): Implicitly marking parameter $headers as nullable is deprecated, the explicit nullable type must be used instead in /Users/bor0/dev/wp-cli/vendor/wp-cli/php-cli-tools/lib/cli/Table.php on line 47
PHP Deprecated:  cli\Table::__construct(): Implicitly marking parameter $rows as nullable is deprecated, the explicit nullable type must be used instead in /Users/bor0/dev/wp-cli/vendor/wp-cli/php-cli-tools/lib/cli/Table.php on line 47
Deprecated: cli\Table::__construct(): Implicitly marking parameter $rows as nullable is deprecated, the explicit nullable type must be used instead in /Users/bor0/dev/wp-cli/vendor/wp-cli/php-cli-tools/lib/cli/Table.php on line 47
PHP Deprecated:  cli\Table::__construct(): Implicitly marking parameter $footers as nullable is deprecated, the explicit nullable type must be used instead in /Users/bor0/dev/wp-cli/vendor/wp-cli/php-cli-tools/lib/cli/Table.php on line 47
Deprecated: cli\Table::__construct(): Implicitly marking parameter $footers as nullable is deprecated, the explicit nullable type must be used instead in /Users/bor0/dev/wp-cli/vendor/wp-cli/php-cli-tools/lib/cli/Table.php on line 47
+------------------------------------------+----------+------------------------------+-----------+----------------+-------------+
| name                                     | status   | update                       | version   | update_version | auto_update |
+------------------------------------------+----------+------------------------------+-----------+----------------+-------------+
| Basic-Auth                               | inactive | none                         | 0.1       |                | off         |
| keyring                                  | inactive | none                         | 3.0       |                | off         |
| woocommerce                              | inactive | version higher than expected | 9.6.0-dev |                | off         |
+------------------------------------------+----------+------------------------------+-----------+----------------+-------------+
```

With this PR, the warnings are gone.