### PR TITLE
Use `mustache/mustache` fork for PHP 8.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,16 @@
     ],
     "homepage": "https://wp-cli.org",
     "license": "MIT",
+    "repositories": [
+      {
+        "type": "vcs",
+        "url": "https://github.com/swissspidy/mustache.php"
+      }
+    ],
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "ext-curl": "*",
-        "mustache/mustache": "^2.14.1",
+        "mustache/mustache": "dev-fix/php84",
         "symfony/finder": ">2.7",
         "wp-cli/mustangostang-spyc": "^0.6.3",
         "wp-cli/php-cli-tools": "~0.12.1"


### PR DESCRIPTION
Use forked version from https://github.com/bobthecow/mustache.php/pull/421 to address PHP 8.4 compatibility.

Long term we could bump the PHP requirement and switch to another library, or fork this under the WP-CLI org or something.

See #6026