### PR TITLE
Fix: Update outdated AJAX documentation link

### DIFF
--- a/php/wp-settings-cli.php
+++ b/php/wp-settings-cli.php
@@ -458,7 +458,7 @@ if ( is_multisite() && ! defined( 'WP_INSTALLING' ) ) {
  * AJAX requests should use wp-admin/admin-ajax.php. admin-ajax.php can handle requests for
  * users not logged in.
  *
- * @link https://codex.wordpress.org/AJAX_in_Plugins
+ * @link https://developer.wordpress.org/plugins/javascript/ajax/
  *
  * @since 3.0.0
  */


### PR DESCRIPTION
Fix: https://github.com/wp-cli/wp-cli/issues/6030

Replaced the deprecated link `https://codex.wordpress.org/AJAX_in_Plugins` 
with the updated link `https://developer.wordpress.org/plugins/javascript/ajax/`.
