### PR TITLE
Update expected error message in unit tests

### DIFF
--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -483,12 +483,12 @@ class UtilsTest extends TestCase {
 			'default request'  => [
 				[],
 				RuntimeException::class,
-				'Failed to get url \'https://example.com\': cURL error 77: error setting certificate verify locations:',
+				'Failed to get url \'https://example.com\': cURL error 77: error setting certificate',
 			],
 			'secure request'   => [
 				[ 'insecure' => false ],
 				RuntimeException::class,
-				'Failed to get url \'https://example.com\': cURL error 77: error setting certificate verify locations:',
+				'Failed to get url \'https://example.com\': cURL error 77: error setting certificate',
 			],
 			'insecure request' => [
 				[ 'insecure' => true ],


### PR DESCRIPTION
Looks like the error message returned by cURL changed from `Failed to get url 'https://example.com': cURL error 77: error setting certificate verify locations:` to `Failed to get url 'https://example.com': cURL error 77: error setting certificate file:`.

See https://github.com/wp-cli/wp-cli/actions/runs/12924442519/job/36043450327#step:8:97

This fixes the failing unit tests.

Note: we still have some other unrelated failing tests, see #6018