### PR TITLE
Added PHPDoc for cmd_starts_with() method

### DIFF
--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -344,6 +344,14 @@ class Runner {
 		return false;
 	}
 
+	/**
+	 * Checks if the command arguments start with a given prefix.
+	 *
+	 * @param array $prefix An array of strings representing the expected prefix of the command arguments.
+	 *                      For example, `['wp', 'user']` would check if the command starts with `wp user`.
+	 *
+	 * @return bool `true` if the command arguments start with the given prefix, `false` otherwise.
+	 */
 	private function cmd_starts_with( $prefix ) {
 		return array_slice( $this->arguments, 0, count( $prefix ) ) === $prefix;
 	}


### PR DESCRIPTION
Fix: https://github.com/wp-cli/wp-cli/issues/6033

Add PHPDoc for `cmd_starts_with()` method in `Runner` class to improve code readability, align with WordPress coding standards, and help developers understand the purpose and behaviour of the function.