### PR TITLE
Add hook to `http_request()` util

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -830,6 +830,8 @@ function http_request( $method, $url, $data = null, $headers = [], $options = []
 		$options['verify'] = ! empty( ini_get( 'curl.cainfo' ) ) ? ini_get( 'curl.cainfo' ) : true;
 	}
 
+	$options = WP_CLI::do_hook( 'http_request_options', $options );
+
 	RequestsLibrary::register_autoloader();
 
 	$request_method = [ RequestsLibrary::get_class_name(), 'request' ];


### PR DESCRIPTION
Facilitates HTTP request mocking in tests

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

See https://github.com/wp-cli/wp-cli-tests/issues/210
