### PR TITLE
Allow collecting PHPUnit coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ phpcs.xml
 composer.lock
 .phpunit.result.cache
 .phpunit.cache
+/build/logs

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,9 +16,9 @@
 		<directory suffix="Test.php">tests</directory>
 	</testsuite>
 
-	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="true">
+	<coverage processUncoveredFiles="false">
+		<include>
 			<directory suffix=".php">src</directory>
-		</whitelist>
-	</filter>
+		</include>
+	</coverage>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,7 +20,7 @@
 
 	<coverage processUncoveredFiles="false">
 		<include>
-			<directory suffix=".php">src</directory>
+			<directory suffix=".php">php</directory>
 		</include>
 	</coverage>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,9 +12,11 @@
 		 convertDeprecationsToExceptions="true"
 		 colors="true"
 		 verbose="true">
-	<testsuite name="wp-cli/wp-cli tests">
-		<directory suffix="Test.php">tests</directory>
-	</testsuite>
+	<testsuites>
+		<testsuite name="wp-cli/wp-cli tests">
+			<directory suffix="Test.php">tests</directory>
+		</testsuite>
+	</testsuites>
 
 	<coverage processUncoveredFiles="false">
 		<include>


### PR DESCRIPTION
Fixes a currently failing code coverage job because the PHPUnit config is outdated.

See https://github.com/wp-cli/wp-cli/issues/6035

The PHP 5.6 failures are known, see #6018
