### PR TITLE
Ensure code after `wp-settings.php` call is loaded

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -708,7 +708,12 @@ Feature: Have a config file
     And a includes-file.php file:
       """
       <?php
-      define( 'WP_INC_TRUTH', true );
+      define( 'MY_CONSTANT', true );
+      """
+    And a some-other-file.php file:
+      """
+      <?php
+      define( 'MY_OTHER_CONSTANT', true );
       """
 
     When I try `wp core is-installed`
@@ -717,7 +722,13 @@ Feature: Have a config file
       Error: Strange wp-config.php file: wp-settings.php is not loaded directly.
       """
 
-    When I run `wp eval 'var_export( defined("WP_INC_TRUTH") );'`
+    When I run `wp eval 'var_export( defined("MY_CONSTANT") );'`
+    Then STDOUT should be:
+      """
+      true
+      """
+
+    When I run `wp eval 'var_export( defined("MY_OTHER_CONSTANT") );'`
     Then STDOUT should be:
       """
       true

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -725,15 +725,13 @@ class Runner {
 			}
 		}
 
-		$matches = [];
+		$count = 0;
 
-		preg_match_all( '/\s*require(_once)?\s*.*wp-settings\.php/', $wp_config_code, $matches, PREG_OFFSET_CAPTURE );
+		$wp_config_code = preg_replace( '/\s*require(?:_once)?\s*.*wp-settings\.php.*\s*;/', '', $wp_config_code, -1, $count );
 
-		if ( empty( $matches[0] ) ) {
+		if ( 0 === $count ) {
 			WP_CLI::error( 'Strange wp-config.php file: wp-settings.php is not loaded directly.' );
 		}
-
-		$wp_config_code = substr( $wp_config_code, 0, $matches[0][0][1] );
 
 		$source = Utils\replace_path_consts( $wp_config_code, $wp_config_path );
 		return preg_replace( '|^\s*\<\?php\s*|', '', $source );


### PR DESCRIPTION
Addresses a logical mistake in #6039 that I didn't realize until tests in config-command [started failing](https://github.com/wp-cli/config-command/actions/runs/13064833741/job/36463433686#step:11:72).

Basically, the `wp-settings.php` call needs to be omitted, but the code after that still needs to be eval'd.