### PR TITLE
WIP: Fix line break issue for table view

### DIFF
--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -309,7 +309,21 @@ class Formatter {
 		$table->setHeaders( $fields );
 
 		foreach ( $items as $item ) {
-			$table->addRow( array_values( Utils\pick_fields( $item, $fields ) ) );
+			if ( ! empty( $item->meta_value ) && ( false !== strpos( $item->meta_value, "\n" ) || false !== strpos( $item->meta_value, "\r\n" ) ) ) {
+				$lines = explode( "\n", $item->meta_value );
+				$c     = 0;
+				foreach ( $lines as $line ) {
+					$line_item = array(
+						'post_id'    => 0 === $c ? $item->post_id : '',
+						'meta_key'   => 0 === $c ? $item->meta_key : '',
+						'meta_value' => $line,
+					);
+					$table->addRow( array_values( Utils\pick_fields( $line_item, $fields ) ) );
+					$c++;
+				}
+			} else {
+				$table->addRow( array_values( Utils\pick_fields( $item, $fields ) ) );
+			}
 		}
 
 		foreach ( $table->getDisplayLines() as $line ) {


### PR DESCRIPTION
Fixes: https://github.com/wp-cli/entity-command/issues/262


**Before**:


<img width="602" alt="Image" src="https://github.com/user-attachments/assets/848814ac-78f4-42f9-901a-50e7e9748581" />



**After I modified `Formatter.php`**



<img width="595" alt="Image" src="https://github.com/user-attachments/assets/46f85e56-105d-478e-8a90-70e23ee04d0d" />

---

This is I am marking as WIP as I need some help to improve this.
I've addes some static keys ( `post_id` 317 , `meta_key` 318 , `meta_value` 319 ) for the array manipulation in the loop.
This should be coming from `$fields` I guess.
