### PR TITLE
Add ability to run misspelled alias commands

### DIFF
--- a/-files --modified --others --exclude-standard
+++ b/-files --modified --others --exclude-standard
@@ -1,0 +1,369 @@
+[1mdiff --git a/0001-Add-HTTP-request-file-logging-support-for-6044.patch b/0001-Add-HTTP-request-file-logging-support-for-6044.patch[m
+[1mnew file mode 100644[m
+[1mindex 00000000..2ea6202c[m
+[1m--- /dev/null[m
+[1m+++ b/0001-Add-HTTP-request-file-logging-support-for-6044.patch[m
+[36m@@ -0,0 +1,209 @@[m
+[32m+[m[32mFrom 343bd4f748a64510302732052eba191b0a97e5a0 Mon Sep 17 00:00:00 2001[m
+[32m+[m[32mFrom: Emmett Hoolahan <emmetthoolahan@gmail.com>[m
+[32m+[m[32mDate: Wed, 26 Feb 2025 15:37:30 +0800[m
+[32m+[m[32mSubject: [PATCH] Add HTTP request file logging support for #6044[m
+[32m+[m
+[32m+[m[32m---[m
+[32m+[m[32m .../InitializeHttpRequestMonitoring.php       | 189 ++++++++++++++++++[m
+[32m+[m[32m 1 file changed, 189 insertions(+)[m
+[32m+[m[32m create mode 100644 php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php[m
+[32m+[m
+[32m+[m[32mdiff --git a/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php[m
+[32m+[m[32mnew file mode 100644[m
+[32m+[m[32mindex 00000000..e6b35c6c[m
+[32m+[m[32m--- /dev/null[m
+[32m+[m[32m+++ b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php[m
+[32m+[m[32m@@ -0,0 +1,189 @@[m
+[32m+[m[32m+<?php[m
+[32m+[m[32m+[m
+[32m+[m[32m+namespace WP_CLI\Bootstrap;[m
+[32m+[m[32m+[m
+[32m+[m[32m+use WP_CLI;[m
+[32m+[m[32m+[m
+[32m+[m[32m+/**[m
+[32m+[m[32m+ * Class InitializeHttpRequestMonitoring[m
+[32m+[m[32m+ *[m
+[32m+[m[32m+ * Initialize HTTP Request Monitoring by hooking into WordPress HTTP API filters.[m
+[32m+[m[32m+ *[m
+[32m+[m[32m+ * @package WP_CLI\Bootstrap[m
+[32m+[m[32m+ */[m
+[32m+[m[32m+class InitializeHttpRequestMonitoring implements BootstrapStep {[m
+[32m+[m[32m+[m
+[32m+[m[32m+	/**[m
+[32m+[m[32m+	 * Log file handle for HTTP requests/responses.[m
+[32m+[m[32m+	 *[m
+[32m+[m[32m+	 * @var resource|false[m
+[32m+[m[32m+	 */[m
+[32m+[m[32m+	private $log_file_handle = false;[m
+[32m+[m[32m+[m
+[32m+[m[32m+	/**[m
+[32m+[m[32m+	 * Process this single bootstrapping step.[m
+[32m+[m[32m+	 *[m
+[32m+[m[32m+	 * @param BootstrapState $state Contextual state to pass into the step.[m
+[32m+[m[32m+	 *[m
+[32m+[m[32m+	 * @return BootstrapState Modified state to pass to the next step.[m
+[32m+[m[32m+	 */[m
+[32m+[m[32m+	public function process( BootstrapState $state ) {[m
+[32m+[m[32m+		// Initialize log file if http_log_file is set[m
+[32m+[m[32m+		$http_log_file = WP_CLI::get_config( 'http_log_file' );[m
+[32m+[m[32m+		if ( $http_log_file ) {[m
+[32m+[m[32m+			$this->log_file_handle = @fopen( $http_log_file, 'a' );[m
+[32m+[m[32m+			if ( ! $this->log_file_handle ) {[m
+[32m+[m[32m+				WP_CLI::warning( sprintf( 'Could not open HTTP log file %s for writing', $http_log_file ) );[m
+[32m+[m[32m+			} else {[m
+[32m+[m[32m+				// Write header to log file[m
+[32m+[m[32m+				fwrite( $this->log_file_handle, "=== HTTP Request Log Started at " . date( 'Y-m-d H:i:s' ) . " ===\n" );[m
+[32m+[m[32m+[m
+[32m+[m[32m+				// Ensure we close the file handle on shutdown[m
+[32m+[m[32m+				register_shutdown_function( function() {[m
+[32m+[m[32m+					if ( $this->log_file_handle ) {[m
+[32m+[m[32m+						fwrite( $this->log_file_handle, "=== HTTP Request Log Ended at " . date( 'Y-m-d H:i:s' ) . " ===\n" );[m
+[32m+[m[32m+						fclose( $this->log_file_handle );[m
+[32m+[m[32m+					}[m
+[32m+[m[32m+				} );[m
+[32m+[m[32m+			}[m
+[32m+[m[32m+		}[m
+[32m+[m[32m+[m
+[32m+[m[32m+		// Register the WordPress hooks that will be applied once WordPress is loaded[m
+[32m+[m[32m+		WP_CLI::add_wp_hook( 'http_request_args', [ $this, 'log_http_request_args' ], 9999, 2 );[m
+[32m+[m[32m+		WP_CLI::add_wp_hook( 'http_api_debug', [ $this, 'log_http_api_response' ], 9999, 5 );[m
+[32m+[m[32m+[m
+[32m+[m[32m+		return $state;[m
+[32m+[m[32m+	}[m
+[32m+[m[32m+[m
+[32m+[m[32m+	/**[m
+[32m+[m[32m+	 * Log HTTP request arguments when HTTP request is made.[m
+[32m+[m[32m+	 *[m
+[32m+[m[32m+	 * @param array  $args HTTP request arguments.[m
+[32m+[m[32m+	 * @param string $url  Request URL.[m
+[32m+[m[32m+	 *[m
+[32m+[m[32m+	 * @return array Unmodified request arguments.[m
+[32m+[m[32m+	 */[m
+[32m+[m[32m+	public function log_http_request_args( $args, $url ) {[m
+[32m+[m[32m+		// Only log if debug mode or http_log is enabled[m
+[32m+[m[32m+		$debug = WP_CLI::get_config( 'debug' );[m
+[32m+[m[32m+		$http_log = WP_CLI::get_config( 'http_log' );[m
+[32m+[m[32m+[m
+[32m+[m[32m+		if ( ! $debug && ! $http_log && ! $this->log_file_handle ) {[m
+[32m+[m[32m+			return $args;[m
+[32m+[m[32m+		}[m
+[32m+[m[32m+[m
+[32m+[m[32m+		$log_group = $http_log ? 'http' : ($debug === true ? 'http' : $debug);[m
+[32m+[m[32m+		$log_level = $http_log ? 'info' : 'debug';[m
+[32m+[m[32m+[m
+[32m+[m[32m+		$log_data = [[m
+[32m+[m[32m+			'method' => isset( $args['method'] ) ? $args['method'] : 'GET',[m
+[32m+[m[32m+			'url' => $url,[m
+[32m+[m[32m+		];[m
+[32m+[m[32m+[m
+[32m+[m[32m+		// Only include headers and data in verbose logging mode[m
+[32m+[m[32m+		if ( WP_CLI::get_config( 'http_log_verbose' ) ) {[m
+[32m+[m[32m+			// Filter out sensitive headers (like Authorization)[m
+[32m+[m[32m+			if ( isset( $args['headers'] ) ) {[m
+[32m+[m[32m+				$log_headers = $args['headers'];[m
+[32m+[m[32m+				if ( isset( $log_headers['Authorization'] ) ) {[m
+[32m+[m[32m+					$log_headers['Authorization'] = 'REDACTED';[m
+[32m+[m[32m+				}[m
+[32m+[m[32m+				$log_data['headers'] = $log_headers;[m
+[32m+[m[32m+			}[m
+[32m+[m[32m+[m
+[32m+[m[32m+			// Only log body if it exists and isn't too large[m
+[32m+[m[32m+			if ( isset( $args['body'] ) && is_string( $args['body'] ) && strlen( $args['body'] ) < 1024 ) {[m
+[32m+[m[32m+				$log_data['body'] = $args['body'];[m
+[32m+[m[32m+			} elseif ( isset( $args['body'] ) ) {[m
+[32m+[m[32m+				$log_data['body'] = '[body too large to log]';[m
+[32m+[m[32m+			}[m
+[32m+[m[32m+		}[m
+[32m+[m[32m+[m
+[32m+[m[32m+		$method = isset( $args['method'] ) ? $args['method'] : 'GET';[m
+[32m+[m[32m+		$log_message = "WordPress HTTP Request: {$method} {$url}";[m
+[32m+[m[32m+[m
+[32m+[m[32m+		if ( $log_level === 'debug' ) {[m
+[32m+[m[32m+			WP_CLI::debug( $log_message . ' ' . json_encode( $log_data ), $log_group );[m
+[32m+[m[32m+		} else {[m
+[32m+[m[32m+			WP_CLI::log( $log_message );[m
+[32m+[m[32m+		}[m
+[32m+[m[32m+[m
+[32m+[m[32m+		// Write to log file if enabled[m
+[32m+[m[32m+		if ( $this->log_file_handle ) {[m
+[32m+[m[32m+			$timestamp = date( 'Y-m-d H:i:s' );[m
+[32m+[m[32m+			$log_entry = "[{$timestamp}] REQUEST: {$method} {$url}\n";[m
+[32m+[m[32m+			$log_entry .= json_encode( $log_data, JSON_PRETTY_PRINT ) . "\n\n";[m
+[32m+[m[32m+			fwrite( $this->log_file_handle, $log_entry );[m
+[32m+[m[32m+		}[m
+[32m+[m[32m+[m
+[32m+[m[32m+		return $args;[m
+[32m+[m[32m+	}[m
+[32m+[m[32m+[m
+[32m+[m[32m+	/**[m
+[32m+[m[32m+	 * Log HTTP API response.[m
+[32m+[m[32m+	 *[m
+[32m+[m[32m+	 * @param array|\WP_Error $response HTTP response or WP_Error object.[m
+[32m+[m[32m+	 * @param string          $context  Context under which the hook is fired.[m
+[32m+[m[32m+	 * @param string          $class    HTTP transport used.[m
+[32m+[m[32m+	 * @param array           $args     HTTP request arguments.[m
+[32m+[m[32m+	 * @param string          $url      The request URL.[m
+[32m+[m[32m+	 */[m
+[32m+[m[32m+	public function log_http_api_response( $response, $context, $class, $args, $url ) {[m
+[32m+[m[32m+		// Only log if debug mode or http_log is enabled[m
+[32m+[m[32m+		$debug = WP_CLI::get_config( 'debug' );[m
+[32m+[m[32m+		$http_log = WP_CLI::get_config( 'http_log' );[m
+[32m+[m[32m+[m
+[32m+[m[32m+		if ( ! $debug && ! $http_log && ! $this->log_file_handle ) {[m
+[32m+[m[32m+			return;[m
+[32m+[m[32m+		}[m
+[32m+[m[32m+[m
+[32m+[m[32m+		$log_group = $http_log ? 'http' : ($debug === true ? 'http' : $debug);[m
+[32m+[m[32m+		$log_level = $http_log ? 'info' : 'debug';[m
+[32m+[m[32m+[m
+[32m+[m[32m+		$method = isset( $args['method'] ) ? $args['method'] : 'GET';[m
+[32m+[m[32m+[m
+[32m+[m[32m+		if ( is_wp_error( $response ) ) {[m
+[32m+[m[32m+			$log_data = [[m
+[32m+[m[32m+				'error_code' => $response->get_error_code(),[m
+[32m+[m[32m+				'error_message' => $response->get_error_message(),[m
+[32m+[m[32m+			];[m
+[32m+[m[32m+[m
+[32m+[m[32m+			$log_message = "WordPress HTTP Response Error: {$method} {$url} - " . $response->get_error_message();[m
+[32m+[m[32m+		} else {[m
+[32m+[m[32m+			$log_data = [[m
+[32m+[m[32m+				'status' => isset( $response['response']['code'] ) ? $response['response']['code'] : '?',[m
+[32m+[m[32m+				'success' => isset( $response['response']['code'] ) && $response['response']['code'] >= 200 && $response['response']['code'] < 300,[m
+[32m+[m[32m+			];[m
+[32m+[m[32m+[m
+[32m+[m[32m+			// Only include headers and body in verbose logging mode[m
+[32m+[m[32m+			if ( WP_CLI::get_config( 'http_log_verbose' ) ) {[m
+[32m+[m[32m+				if ( isset( $response['headers'] ) ) {[m
+[32m+[m[32m+					$log_data['headers'] = $response['headers'];[m
+[32m+[m[32m+				}[m
+[32m+[m[32m+[m
+[32m+[m[32m+				// Only log body if it's not too large[m
+[32m+[m[32m+				if ( isset( $response['body'] ) && is_string( $response['body'] ) && strlen( $response['body'] ) < 1024 ) {[m
+[32m+[m[32m+					$log_data['body'] = $response['body'];[m
+[32m+[m[32m+				} elseif ( isset( $response['body'] ) ) {[m
+[32m+[m[32m+					$log_data['body'] = '[body too large to log]';[m
+[32m+[m[32m+				}[m
+[32m+[m[32m+			}[m
+[32m+[m[32m+[m
+[32m+[m[32m+			$log_message = "WordPress HTTP Response: {$log_data['status']} for {$method} {$url}";[m
+[32m+[m[32m+		}[m
+[32m+[m[32m+[m
+[32m+[m[32m+		if ( $log_level === 'debug' ) {[m
+[32m+[m[32m+			WP_CLI::debug( $log_message . ' ' . json_encode( $log_data ), $log_group );[m
+[32m+[m[32m+		} else {[m
+[32m+[m[32m+			WP_CLI::log( $log_message );[m
+[32m+[m[32m+		}[m
+[32m+[m[32m+[m
+[32m+[m[32m+		// Write to log file if enabled[m
+[32m+[m[32m+		if ( $this->log_file_handle ) {[m
+[32m+[m[32m+			$timestamp = date( 'Y-m-d H:i:s' );[m
+[32m+[m[32m+			$log_entry = "[{$timestamp}] RESPONSE: {$method} {$url}\n";[m
+[32m+[m[32m+			$log_entry .= json_encode( $log_data, JSON_PRETTY_PRINT ) . "\n\n";[m
+[32m+[m[32m+			fwrite( $this->log_file_handle, $log_entry );[m
+[32m+[m[32m+		}[m
+[32m+[m[32m+	}[m
+[32m+[m[32m+}[m
+[32m+[m[32m\ No newline at end of file[m
+[32m+[m[32m--[m[41m [m
+[32m+[m[32m2.48.1.windows.1[m
+[32m+[m
+[1mdiff --git a/README.md b/README.md[m
+[1mindex 2f408d48..67d236eb 100644[m
+[1m--- a/README.md[m
+[1m+++ b/README.md[m
+[36m@@ -45,6 +45,41 @@[m [mFor a more complete introduction to using WP-CLI, read the [Quick Start guide](h[m
+ [m
+ Already feel comfortable with the basics? Jump into the [complete list of commands](https://developer.wordpress.org/cli/commands/) for detailed information on managing themes and plugins, importing and exporting data, performing database search-replace operations and more.[m
+ [m
+[32m+[m[32m### HTTP Request Logging[m
+[32m+[m
+[32m+[m[32mWP-CLI includes support for logging HTTP requests made by WordPress, which can be useful for debugging, troubleshooting, and development. You can enable HTTP request logging in two ways:[m
+[32m+[m
+[32m+[m[32m1. Using the `--debug` flag with the `http` group:[m
+[32m+[m[32m   ```bash[m
+[32m+[m[32m   $ wp --debug=http plugin install hello-dolly[m
+[32m+[m[32m   Debug (http): HTTP Request: GET https://api.wordpress.org/plugins/info/1.0/hello-dolly.json {"method":"GET","url":"https://api.wordpress.org/plugins/info/1.0/hello-dolly.json"} (0.201s)[m
+[32m+[m[32m   Debug (http): HTTP Response: 200 for GET https://api.wordpress.org/plugins/info/1.0/hello-dolly.json {"status":200,"success":true} (0.201s)[m
+[32m+[m[32m   ```[m
+[32m+[m
+[32m+[m[32m2. Using the dedicated `--http_log` flag:[m
+[32m+[m[32m   ```bash[m
+[32m+[m[32m   $ wp --http_log plugin install hello-dolly[m
+[32m+[m[32m   HTTP Request: GET https://api.wordpress.org/plugins/info/1.0/hello-dolly.json[m
+[32m+[m[32m   HTTP Response: 200 for GET https://api.wordpress.org/plugins/info/1.0/hello-dolly.json[m
+[32m+[m[32m   ```[m
+[32m+[m
+[32m+[m[32mFor more detailed logging, including headers and response bodies, you can add the `--http_log_verbose` flag:[m
+[32m+[m[32m```bash[m
+[32m+[m[32m$ wp --http_log --http_log_verbose plugin install hello-dolly[m
+[32m+[m[32m```[m
+[32m+[m
+[32m+[m[32mYou can also log HTTP requests to a file using the `--http_log_file` option:[m
+[32m+[m[32m```bash[m
+[32m+[m[32m$ wp --http_log_file=/path/to/http-log.txt plugin install hello-dolly[m
+[32m+[m[32m```[m
+[32m+[m
+[32m+[m[32mThis will write detailed HTTP request and response logs to the specified file, which is useful for:[m
+[32m+[m[32m- Capturing logs for later analysis[m
+[32m+[m[32m- Debugging in non-interactive environments[m
+[32m+[m[32m- Keeping a permanent record of HTTP interactions[m
+[32m+[m
+[32m+[m[32mThis feature helps when troubleshooting issues with external APIs, debugging WordPress core functionality, or developing custom commands that interact with remote services.[m
+[32m+[m
+ ## Installing[m
+ [m
+ Downloading the Phar file is our recommended installation method for most users. Should you need, see also our documentation on [alternative installation methods](https://make.wordpress.org/cli/handbook/installing/) ([Composer](https://make.wordpress.org/cli/handbook/installing/#installing-via-composer), [Homebrew](https://make.wordpress.org/cli/handbook/installing/#installing-via-homebrew), [Docker](https://make.wordpress.org/cli/handbook/installing/#installing-via-docker)).[m
+[36m@@ -182,11 +217,11 @@[m [mWP-CLI comes with dozens of commands. It's easier than it looks to create a cust[m
+ [m
+ ## Contributing[m
+ [m
+[31m-We appreciate you taking the initiative to contribute to WP-CLI. It’s because of you, and the community around you, that WP-CLI is such a great project.[m
+[32m+[m[32mWe appreciate you taking the initiative to contribute to WP-CLI. It's because of you, and the community around you, that WP-CLI is such a great project.[m
+ [m
+[31m-**Contributing isn’t limited to just code.** We encourage you to contribute in the way that best fits your abilities, by writing tutorials, giving a demo at your local meetup, helping other users with their support questions, or revising our documentation.[m
+[32m+[m[32m**Contributing isn't limited to just code.** We encourage you to contribute in the way that best fits your abilities, by writing tutorials, giving a demo at your local meetup, helping other users with their support questions, or revising our documentation.[m
+ [m
+[31m-Read through our [contributing guidelines in the handbook](https://make.wordpress.org/cli/handbook/contributing/) for a thorough introduction to how you can get involved. Following these guidelines helps to communicate that you respect the time of other contributors on the project. In turn, they’ll do their best to reciprocate that respect when working with you, across timezones and around the world.[m
+[32m+[m[32mRead through our [contributing guidelines in the handbook](https://make.wordpress.org/cli/handbook/contributing/) for a thorough introduction to how you can get involved. Following these guidelines helps to communicate that you respect the time of other contributors on the project. In turn, they'll do their best to reciprocate that respect when working with you, across timezones and around the world.[m
+ [m
+ ## Leadership[m
+ [m
+[1mdiff --git a/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php[m
+[1mnew file mode 100644[m
+[1mindex 00000000..e6b35c6c[m
+[1m--- /dev/null[m
+[1m+++ b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php[m
+[36m@@ -0,0 +1,189 @@[m
+[32m+[m[32m<?php[m
+[32m+[m
+[32m+[m[32mnamespace WP_CLI\Bootstrap;[m
+[32m+[m
+[32m+[m[32muse WP_CLI;[m
+[32m+[m
+[32m+[m[32m/**[m
+[32m+[m[32m * Class InitializeHttpRequestMonitoring[m
+[32m+[m[32m *[m
+[32m+[m[32m * Initialize HTTP Request Monitoring by hooking into WordPress HTTP API filters.[m
+[32m+[m[32m *[m
+[32m+[m[32m * @package WP_CLI\Bootstrap[m
+[32m+[m[32m */[m
+[32m+[m[32mclass InitializeHttpRequestMonitoring implements BootstrapStep {[m
+[32m+[m
+[32m+[m	[32m/**[m
+[32m+[m	[32m * Log file handle for HTTP requests/responses.[m
+[32m+[m	[32m *[m
+[32m+[m	[32m * @var resource|false[m
+[32m+[m	[32m */[m
+[32m+[m	[32mprivate $log_file_handle = false;[m
+[32m+[m
+[32m+[m	[32m/**[m
+[32m+[m	[32m * Process this single bootstrapping step.[m
+[32m+[m	[32m *[m
+[32m+[m	[32m * @param BootstrapState $state Contextual state to pass into the step.[m
+[32m+[m	[32m *[m
+[32m+[m	[32m * @return BootstrapState Modified state to pass to the next step.[m
+[32m+[m	[32m */[m
+[32m+[m	[32mpublic function process( BootstrapState $state ) {[m
+[32m+[m		[32m// Initialize log file if http_log_file is set[m
+[32m+[m		[32m$http_log_file = WP_CLI::get_config( 'http_log_file' );[m
+[32m+[m		[32mif ( $http_log_file ) {[m
+[32m+[m			[32m$this->log_file_handle = @fopen( $http_log_file, 'a' );[m
+[32m+[m			[32mif ( ! $this->log_file_handle ) {[m
+[32m+[m				[32mWP_CLI::warning( sprintf( 'Could not open HTTP log file %s for writing', $http_log_file ) );[m
+[32m+[m			[32m} else {[m
+[32m+[m				[32m// Write header to log file[m
+[32m+[m				[32mfwrite( $this->log_file_handle, "=== HTTP Request Log Started at " . date( 'Y-m-d H:i:s' ) . " ===\n" );[m
+[32m+[m
+[32m+[m				[32m// Ensure we close the file handle on shutdown[m
+[32m+[m				[32mregister_shutdown_function( function() {[m
+[32m+[m					[32mif ( $this->log_file_handle ) {[m
+[32m+[m						[32mfwrite( $this->log_file_handle, "=== HTTP Request Log Ended at " . date( 'Y-m-d H:i:s' ) . " ===\n" );[m
+[32m+[m						[32mfclose( $this->log_file_handle );[m
+[32m+[m					[32m}[m
+[32m+[m				[32m} );[m
+[32m+[m			[32m}[m
+[32m+[m		[32m}[m
+[32m+[m
+[32m+[m		[32m// Register the WordPress hooks that will be applied once WordPress is loaded[m
+[32m+[m		[32mWP_CLI::add_wp_hook( 'http_request_args', [ $this, 'log_http_request_args' ], 9999, 2 );[m
+[32m+[m		[32mWP_CLI::add_wp_hook( 'http_api_debug', [ $this, 'log_http_api_response' ], 9999, 5 );[m
+[32m+[m
+[32m+[m		[32mreturn $state;[m
+[32m+[m	[32m}[m
+[32m+[m
+[32m+[m	[32m/**[m
+[32m+[m	[32m * Log HTTP request arguments when HTTP request is made.[m
+[32m+[m	[32m *[m
+[32m+[m	[32m * @param array  $args HTTP request arguments.[m
+[32m+[m	[32m * @param string $url  Request URL.[m
+[32m+[m	[32m *[m
+[32m+[m	[32m * @return array Unmodified request arguments.[m
+[32m+[m	[32m */[m
+[32m+[m	[32mpublic function log_http_request_args( $args, $url ) {[m
+[32m+[m		[32m// Only log if debug mode or http_log is enabled[m
+[32m+[m		[32m$debug = WP_CLI::get_config( 'debug' );[m
+[32m+[m		[32m$http_log = WP_CLI::get_config( 'http_log' );[m
+[32m+[m
+[32m+[m		[32mif ( ! $debug && ! $http_log && ! $this->log_file_handle ) {[m
+[32m+[m			[32mreturn $args;[m
+[32m+[m		[32m}[m
+[32m+[m
+[32m+[m		[32m$log_group = $http_log ? 'http' : ($debug === true ? 'http' : $debug);[m
+[32m+[m		[32m$log_level = $http_log ? 'info' : 'debug';[m
+[32m+[m
+[32m+[m		[32m$log_data = [[m
+[32m+[m			[32m'method' => isset( $args['method'] ) ? $args['method'] : 'GET',[m
+[32m+[m			[32m'url' => $url,[m
+[32m+[m		[32m];[m
+[32m+[m
+[32m+[m		[32m// Only include headers and data in verbose logging mode[m
+[32m+[m		[32mif ( WP_CLI::get_config( 'http_log_verbose' ) ) {[m
+[32m+[m			[32m// Filter out sensitive headers (like Authorization)[m
+[32m+[m			[32mif ( isset( $args['headers'] ) ) {[m
+[32m+[m				[32m$log_headers

--- a/0001-Add-HTTP-request-file-logging-support-for-6044.patch
+++ b/0001-Add-HTTP-request-file-logging-support-for-6044.patch
@@ -1,0 +1,209 @@
+From 343bd4f748a64510302732052eba191b0a97e5a0 Mon Sep 17 00:00:00 2001
+From: Emmett Hoolahan <emmetthoolahan@gmail.com>
+Date: Wed, 26 Feb 2025 15:37:30 +0800
+Subject: [PATCH] Add HTTP request file logging support for #6044
+
+---
+ .../InitializeHttpRequestMonitoring.php       | 189 ++++++++++++++++++
+ 1 file changed, 189 insertions(+)
+ create mode 100644 php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
+
+diff --git a/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
+new file mode 100644
+index 00000000..e6b35c6c
+--- /dev/null
++++ b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
+@@ -0,0 +1,189 @@
++<?php
++
++namespace WP_CLI\Bootstrap;
++
++use WP_CLI;
++
++/**
++ * Class InitializeHttpRequestMonitoring
++ *
++ * Initialize HTTP Request Monitoring by hooking into WordPress HTTP API filters.
++ *
++ * @package WP_CLI\Bootstrap
++ */
++class InitializeHttpRequestMonitoring implements BootstrapStep {
++
++	/**
++	 * Log file handle for HTTP requests/responses.
++	 *
++	 * @var resource|false
++	 */
++	private $log_file_handle = false;
++
++	/**
++	 * Process this single bootstrapping step.
++	 *
++	 * @param BootstrapState $state Contextual state to pass into the step.
++	 *
++	 * @return BootstrapState Modified state to pass to the next step.
++	 */
++	public function process( BootstrapState $state ) {
++		// Initialize log file if http_log_file is set
++		$http_log_file = WP_CLI::get_config( 'http_log_file' );
++		if ( $http_log_file ) {
++			$this->log_file_handle = @fopen( $http_log_file, 'a' );
++			if ( ! $this->log_file_handle ) {
++				WP_CLI::warning( sprintf( 'Could not open HTTP log file %s for writing', $http_log_file ) );
++			} else {
++				// Write header to log file
++				fwrite( $this->log_file_handle, "=== HTTP Request Log Started at " . date( 'Y-m-d H:i:s' ) . " ===\n" );
++
++				// Ensure we close the file handle on shutdown
++				register_shutdown_function( function() {
++					if ( $this->log_file_handle ) {
++						fwrite( $this->log_file_handle, "=== HTTP Request Log Ended at " . date( 'Y-m-d H:i:s' ) . " ===\n" );
++						fclose( $this->log_file_handle );
++					}
++				} );
++			}
++		}
++
++		// Register the WordPress hooks that will be applied once WordPress is loaded
++		WP_CLI::add_wp_hook( 'http_request_args', [ $this, 'log_http_request_args' ], 9999, 2 );
++		WP_CLI::add_wp_hook( 'http_api_debug', [ $this, 'log_http_api_response' ], 9999, 5 );
++
++		return $state;
++	}
++
++	/**
++	 * Log HTTP request arguments when HTTP request is made.
++	 *
++	 * @param array  $args HTTP request arguments.
++	 * @param string $url  Request URL.
++	 *
++	 * @return array Unmodified request arguments.
++	 */
++	public function log_http_request_args( $args, $url ) {
++		// Only log if debug mode or http_log is enabled
++		$debug = WP_CLI::get_config( 'debug' );
++		$http_log = WP_CLI::get_config( 'http_log' );
++
++		if ( ! $debug && ! $http_log && ! $this->log_file_handle ) {
++			return $args;
++		}
++
++		$log_group = $http_log ? 'http' : ($debug === true ? 'http' : $debug);
++		$log_level = $http_log ? 'info' : 'debug';
++
++		$log_data = [
++			'method' => isset( $args['method'] ) ? $args['method'] : 'GET',
++			'url' => $url,
++		];
++
++		// Only include headers and data in verbose logging mode
++		if ( WP_CLI::get_config( 'http_log_verbose' ) ) {
++			// Filter out sensitive headers (like Authorization)
++			if ( isset( $args['headers'] ) ) {
++				$log_headers = $args['headers'];
++				if ( isset( $log_headers['Authorization'] ) ) {
++					$log_headers['Authorization'] = 'REDACTED';
++				}
++				$log_data['headers'] = $log_headers;
++			}
++
++			// Only log body if it exists and isn't too large
++			if ( isset( $args['body'] ) && is_string( $args['body'] ) && strlen( $args['body'] ) < 1024 ) {
++				$log_data['body'] = $args['body'];
++			} elseif ( isset( $args['body'] ) ) {
++				$log_data['body'] = '[body too large to log]';
++			}
++		}
++
++		$method = isset( $args['method'] ) ? $args['method'] : 'GET';
++		$log_message = "WordPress HTTP Request: {$method} {$url}";
++
++		if ( $log_level === 'debug' ) {
++			WP_CLI::debug( $log_message . ' ' . json_encode( $log_data ), $log_group );
++		} else {
++			WP_CLI::log( $log_message );
++		}
++
++		// Write to log file if enabled
++		if ( $this->log_file_handle ) {
++			$timestamp = date( 'Y-m-d H:i:s' );
++			$log_entry = "[{$timestamp}] REQUEST: {$method} {$url}\n";
++			$log_entry .= json_encode( $log_data, JSON_PRETTY_PRINT ) . "\n\n";
++			fwrite( $this->log_file_handle, $log_entry );
++		}
++
++		return $args;
++	}
++
++	/**
++	 * Log HTTP API response.
++	 *
++	 * @param array|\WP_Error $response HTTP response or WP_Error object.
++	 * @param string          $context  Context under which the hook is fired.
++	 * @param string          $class    HTTP transport used.
++	 * @param array           $args     HTTP request arguments.
++	 * @param string          $url      The request URL.
++	 */
++	public function log_http_api_response( $response, $context, $class, $args, $url ) {
++		// Only log if debug mode or http_log is enabled
++		$debug = WP_CLI::get_config( 'debug' );
++		$http_log = WP_CLI::get_config( 'http_log' );
++
++		if ( ! $debug && ! $http_log && ! $this->log_file_handle ) {
++			return;
++		}
++
++		$log_group = $http_log ? 'http' : ($debug === true ? 'http' : $debug);
++		$log_level = $http_log ? 'info' : 'debug';
++
++		$method = isset( $args['method'] ) ? $args['method'] : 'GET';
++
++		if ( is_wp_error( $response ) ) {
++			$log_data = [
++				'error_code' => $response->get_error_code(),
++				'error_message' => $response->get_error_message(),
++			];
++
++			$log_message = "WordPress HTTP Response Error: {$method} {$url} - " . $response->get_error_message();
++		} else {
++			$log_data = [
++				'status' => isset( $response['response']['code'] ) ? $response['response']['code'] : '?',
++				'success' => isset( $response['response']['code'] ) && $response['response']['code'] >= 200 && $response['response']['code'] < 300,
++			];
++
++			// Only include headers and body in verbose logging mode
++			if ( WP_CLI::get_config( 'http_log_verbose' ) ) {
++				if ( isset( $response['headers'] ) ) {
++					$log_data['headers'] = $response['headers'];
++				}
++
++				// Only log body if it's not too large
++				if ( isset( $response['body'] ) && is_string( $response['body'] ) && strlen( $response['body'] ) < 1024 ) {
++					$log_data['body'] = $response['body'];
++				} elseif ( isset( $response['body'] ) ) {
++					$log_data['body'] = '[body too large to log]';
++				}
++			}
++
++			$log_message = "WordPress HTTP Response: {$log_data['status']} for {$method} {$url}";
++		}
++
++		if ( $log_level === 'debug' ) {
++			WP_CLI::debug( $log_message . ' ' . json_encode( $log_data ), $log_group );
++		} else {
++			WP_CLI::log( $log_message );
++		}
++
++		// Write to log file if enabled
++		if ( $this->log_file_handle ) {
++			$timestamp = date( 'Y-m-d H:i:s' );
++			$log_entry = "[{$timestamp}] RESPONSE: {$method} {$url}\n";
++			$log_entry .= json_encode( $log_data, JSON_PRETTY_PRINT ) . "\n\n";
++			fwrite( $this->log_file_handle, $log_entry );
++		}
++	}
++}
+\ No newline at end of file
+-- 
+2.48.1.windows.1
+

--- a/README.md
+++ b/README.md
@@ -45,6 +45,31 @@ For a more complete introduction to using WP-CLI, read the [Quick Start guide](h
 
 Already feel comfortable with the basics? Jump into the [complete list of commands](https://developer.wordpress.org/cli/commands/) for detailed information on managing themes and plugins, importing and exporting data, performing database search-replace operations and more.
 
+### HTTP Request Logging
+
+WP-CLI includes support for logging HTTP requests made by WordPress, which can be useful for debugging, troubleshooting, and development. You can enable HTTP request logging in two ways:
+
+1. Using the `--debug` flag with the `http` group:
+   ```bash
+   $ wp --debug=http plugin install hello-dolly
+   Debug (http): HTTP Request: GET https://api.wordpress.org/plugins/info/1.0/hello-dolly.json {"method":"GET","url":"https://api.wordpress.org/plugins/info/1.0/hello-dolly.json"} (0.201s)
+   Debug (http): HTTP Response: 200 for GET https://api.wordpress.org/plugins/info/1.0/hello-dolly.json {"status":200,"success":true} (0.201s)
+   ```
+
+2. Using the dedicated `--http_log` flag:
+   ```bash
+   $ wp --http_log plugin install hello-dolly
+   HTTP Request: GET https://api.wordpress.org/plugins/info/1.0/hello-dolly.json
+   HTTP Response: 200 for GET https://api.wordpress.org/plugins/info/1.0/hello-dolly.json
+   ```
+
+For more detailed logging, including headers and response bodies, you can add the `--http_log_verbose` flag:
+```bash
+$ wp --http_log --http_log_verbose plugin install hello-dolly
+```
+
+This feature helps when troubleshooting issues with external APIs, debugging WordPress core functionality, or developing custom commands that interact with remote services.
+
 ## Installing
 
 Downloading the Phar file is our recommended installation method for most users. Should you need, see also our documentation on [alternative installation methods](https://make.wordpress.org/cli/handbook/installing/) ([Composer](https://make.wordpress.org/cli/handbook/installing/#installing-via-composer), [Homebrew](https://make.wordpress.org/cli/handbook/installing/#installing-via-homebrew), [Docker](https://make.wordpress.org/cli/handbook/installing/#installing-via-docker)).
@@ -182,11 +207,11 @@ WP-CLI comes with dozens of commands. It's easier than it looks to create a cust
 
 ## Contributing
 
-We appreciate you taking the initiative to contribute to WP-CLI. It’s because of you, and the community around you, that WP-CLI is such a great project.
+We appreciate you taking the initiative to contribute to WP-CLI. It's because of you, and the community around you, that WP-CLI is such a great project.
 
-**Contributing isn’t limited to just code.** We encourage you to contribute in the way that best fits your abilities, by writing tutorials, giving a demo at your local meetup, helping other users with their support questions, or revising our documentation.
+**Contributing isn't limited to just code.** We encourage you to contribute in the way that best fits your abilities, by writing tutorials, giving a demo at your local meetup, helping other users with their support questions, or revising our documentation.
 
-Read through our [contributing guidelines in the handbook](https://make.wordpress.org/cli/handbook/contributing/) for a thorough introduction to how you can get involved. Following these guidelines helps to communicate that you respect the time of other contributors on the project. In turn, they’ll do their best to reciprocate that respect when working with you, across timezones and around the world.
+Read through our [contributing guidelines in the handbook](https://make.wordpress.org/cli/handbook/contributing/) for a thorough introduction to how you can get involved. Following these guidelines helps to communicate that you respect the time of other contributors on the project. In turn, they'll do their best to reciprocate that respect when working with you, across timezones and around the world.
 
 ## Leadership
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ For more detailed logging, including headers and response bodies, you can add th
 $ wp --http_log --http_log_verbose plugin install hello-dolly
 ```
 
+You can also log HTTP requests to a file using the `--http_log_file` option:
+```bash
+$ wp --http_log_file=/path/to/http-log.txt plugin install hello-dolly
+```
+
+This will write detailed HTTP request and response logs to the specified file, which is useful for:
+- Capturing logs for later analysis
+- Debugging in non-interactive environments
+- Keeping a permanent record of HTTP interactions
+
 This feature helps when troubleshooting issues with external APIs, debugging WordPress core functionality, or developing custom commands that interact with remote services.
 
 ## Installing

--- a/features/runner.feature
+++ b/features/runner.feature
@@ -79,3 +79,30 @@ Feature: Runner WP-CLI
       Did you mean 'meta'?
       """
     And the return code should be 1
+
+  Scenario: Skip interactive prompt in test mode
+    Given a WP install
+
+    When I try `WP_CLI_TEST_MODE=1 wp network option`
+    Then STDERR should contain:
+      """
+      Error: 'option' is not a registered subcommand of 'network'. See 'wp help network' for available subcommands.
+      Did you mean 'meta'?
+      """
+    And STDERR should not contain:
+      """
+      Run 'meta' instead?
+      """
+    And the return code should be 1
+
+  Scenario: Show interactive prompt for misspelled commands
+    Given a WP install
+
+    When I try `echo "n" | wp network option`
+    Then STDERR should contain:
+      """
+      Error: 'option' is not a registered subcommand of 'network'. See 'wp help network' for available subcommands.
+      Did you mean 'meta'?
+      Run 'meta' instead? [Y/n]
+      """
+    And the return code should be 1

--- a/php-coding-standards-setup.md
+++ b/php-coding-standards-setup.md
@@ -1,0 +1,105 @@
+# PHP Coding Standards Setup
+
+This document explains how to set up PHP CodeSniffer (PHPCS) and PHP Code Beautifier and Fixer (PHPCBF) to automatically check and fix coding standards issues in the WP-CLI project.
+
+## Installation
+
+1. Install PHPCS and related tools via Composer:
+
+```bash
+composer require --dev squizlabs/php_codesniffer wp-coding-standards/wpcs dealerdirect/phpcodesniffer-composer-installer
+```
+
+2. Set up PHPCS to use WordPress coding standards:
+
+```bash
+vendor/bin/phpcs --config-set installed_paths vendor/wp-coding-standards/wpcs
+```
+
+## Usage
+
+### Checking for issues
+
+To check if your code complies with the project's coding standards:
+
+```bash
+vendor/bin/phpcs --standard=phpcs.xml.dist path/to/your/file.php
+```
+
+Or to check multiple files:
+
+```bash
+vendor/bin/phpcs --standard=phpcs.xml.dist path/to/directory
+```
+
+### Fixing issues automatically
+
+To automatically fix coding standards issues:
+
+```bash
+vendor/bin/phpcbf --standard=phpcs.xml.dist path/to/your/file.php
+```
+
+## Common Issues and How to Fix Them
+
+### Array Alignment Issues
+
+PHPCS often flags issues with array key alignment. For example:
+
+```php
+// Incorrect
+$array = array(
+    'short'   => 'value',
+    'long_key' => 'value',
+);
+
+// Correct
+$array = array(
+    'short'    => 'value',
+    'long_key' => 'value',
+);
+```
+
+### Equals Sign Alignment
+
+Variables should have their equals signs aligned:
+
+```php
+// Incorrect
+$short = 'value';
+$long_variable = 'value';
+
+// Correct
+$short        = 'value';
+$long_variable = 'value';
+```
+
+### Error Silencing (@ Operator)
+
+Avoid using the @ operator to silence errors. Instead, implement proper error handling:
+
+```php
+// Incorrect
+$data = @json_encode($array);
+
+// Correct
+$data = json_encode($array);
+if (false === $data) {
+    // Handle error
+}
+```
+
+## Pre-commit Hook
+
+A pre-commit hook has been set up in this repository to automatically check for PHPCS issues before each commit. If you encounter issues with the hook, you can:
+
+1. Run PHPCS manually to identify issues
+2. Use PHPCBF to automatically fix some issues
+3. Fix the remaining issues manually
+4. Commit your changes
+
+## Further Resources
+
+- [PHP CodeSniffer Documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki)
+- [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/)
+- [WP-CLI Coding Standards](https://make.wordpress.org/cli/handbook/guides/coding-standards/)

--- a/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
+++ b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
@@ -105,8 +105,8 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 		$log_level = $http_log ? 'info' : 'debug';
 
 		$log_data = array(
-			'method'  => isset( $args['method'] ) ? $args['method'] : 'GET',
-			'url'     => $url,
+			'method' => isset( $args['method'] ) ? $args['method'] : 'GET',
+			'url'    => $url,
 		);
 
 		// Only include headers and data in verbose logging mode.
@@ -180,8 +180,8 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 			$log_message = "WordPress HTTP Response Error: {$method} {$url} - " . $response->get_error_message();
 		} else {
 			$log_data = array(
-				'status'   => isset( $response['response']['code'] ) ? $response['response']['code'] : '?',
-				'success'  => isset( $response['response']['code'] ) && 200 <= $response['response']['code'] && $response['response']['code'] < 300,
+				'status'  => isset( $response['response']['code'] ) ? $response['response']['code'] : '?',
+				'success' => isset( $response['response']['code'] ) && 200 <= $response['response']['code'] && $response['response']['code'] < 300,
 			);
 
 			// Only include headers and body in verbose logging mode.

--- a/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
+++ b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
@@ -209,8 +209,8 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 
 		// Write to log file if enabled.
 		if ( $this->log_file_handle ) {
-			$timestamp  = gmdate( 'Y-m-d H:i:s' );
-			$log_entry  = "[{$timestamp}] RESPONSE: {$method} {$url}\n";
+			$timestamp   = gmdate( 'Y-m-d H:i:s' );
+			$log_entry   = "[{$timestamp}] RESPONSE: {$method} {$url}\n";
 			$log_entry .= $this->json_encode_compat( $log_data, true ) . "\n\n";
 			fwrite( $this->log_file_handle, $log_entry );
 		}

--- a/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
+++ b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
@@ -173,8 +173,8 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 
 		if ( is_wp_error( $response ) ) {
 			$log_data = array(
-				'error_code'    => $response->get_error_code(),
-				'error_message' => $response->get_error_message(),
+				'error_code'      => $response->get_error_code(),
+				'error_message'   => $response->get_error_message(),
 			);
 
 			$log_message = "WordPress HTTP Response Error: {$method} {$url} - " . $response->get_error_message();

--- a/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
+++ b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
@@ -28,17 +28,17 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 	 * @return BootstrapState Modified state to pass to the next step.
 	 */
 	public function process( BootstrapState $state ) {
-		// Initialize log file if http_log_file is set
+		// Initialize log file if http_log_file is set.
 		$http_log_file = WP_CLI::get_config( 'http_log_file' );
 		if ( $http_log_file ) {
 			$this->log_file_handle = @fopen( $http_log_file, 'a' );
 			if ( ! $this->log_file_handle ) {
 				WP_CLI::warning( sprintf( 'Could not open HTTP log file %s for writing', $http_log_file ) );
 			} else {
-				// Write header to log file
+				// Write header to log file.
 				fwrite( $this->log_file_handle, '=== HTTP Request Log Started at ' . gmdate( 'Y-m-d H:i:s' ) . " ===\n" );
 
-				// Ensure we close the file handle on shutdown
+				// Ensure we close the file handle on shutdown.
 				register_shutdown_function(
 					function () {
 						if ( $this->log_file_handle ) {
@@ -50,11 +50,34 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 			}
 		}
 
-		// Register the WordPress hooks that will be applied once WordPress is loaded
-		WP_CLI::add_wp_hook( 'http_request_args', [ $this, 'log_http_request_args' ], 9999, 2 );
-		WP_CLI::add_wp_hook( 'http_api_debug', [ $this, 'log_http_api_response' ], 9999, 5 );
+		// Register the WordPress hooks that will be applied once WordPress is loaded.
+		WP_CLI::add_wp_hook( 'http_request_args', array( $this, 'log_http_request_args' ), 9999, 2 );
+		WP_CLI::add_wp_hook( 'http_api_debug', array( $this, 'log_http_api_response' ), 9999, 5 );
 
 		return $state;
+	}
+
+	/**
+	 * Encode data to JSON with PHP 5.6 compatibility.
+	 *
+	 * @param mixed $data Data to encode.
+	 * @param bool  $pretty Whether to pretty print the JSON.
+	 * @return string JSON encoded string.
+	 */
+	private function json_encode_compat( $data, $pretty = false ) {
+		$options = 0;
+		if ( $pretty && defined( 'JSON_PRETTY_PRINT' ) ) {
+			$options |= JSON_PRETTY_PRINT;
+		}
+
+		// Handle PHP < 5.6 compatibility.
+		$json = @json_encode( $data, $options );
+		if ( false === $json ) {
+			// If encoding fails, try a simpler version.
+			return @json_encode( 'Could not encode data' );
+		}
+
+		return $json;
 	}
 
 	/**
@@ -66,7 +89,7 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 	 * @return array Unmodified request arguments.
 	 */
 	public function log_http_request_args( $args, $url ) {
-		// Only log if debug mode or http_log is enabled
+		// Only log if debug mode or http_log is enabled.
 		$debug    = WP_CLI::get_config( 'debug' );
 		$http_log = WP_CLI::get_config( 'http_log' );
 
@@ -77,14 +100,14 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 		$log_group = $http_log ? 'http' : ( true === $debug ? 'http' : $debug );
 		$log_level = $http_log ? 'info' : 'debug';
 
-		$log_data = [
+		$log_data = array(
 			'method' => isset( $args['method'] ) ? $args['method'] : 'GET',
 			'url'    => $url,
-		];
+		);
 
-		// Only include headers and data in verbose logging mode
+		// Only include headers and data in verbose logging mode.
 		if ( WP_CLI::get_config( 'http_log_verbose' ) ) {
-			// Filter out sensitive headers (like Authorization)
+			// Filter out sensitive headers (like Authorization).
 			if ( isset( $args['headers'] ) ) {
 				$log_headers = $args['headers'];
 				if ( isset( $log_headers['Authorization'] ) ) {
@@ -93,7 +116,7 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 				$log_data['headers'] = $log_headers;
 			}
 
-			// Only log body if it exists and isn't too large
+			// Only log body if it exists and isn't too large.
 			if ( isset( $args['body'] ) && is_string( $args['body'] ) && strlen( $args['body'] ) < 1024 ) {
 				$log_data['body'] = $args['body'];
 			} elseif ( isset( $args['body'] ) ) {
@@ -101,20 +124,20 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 			}
 		}
 
-		$method = isset( $args['method'] ) ? $args['method'] : 'GET';
+		$method      = isset( $args['method'] ) ? $args['method'] : 'GET';
 		$log_message = "WordPress HTTP Request: {$method} {$url}";
 
 		if ( 'debug' === $log_level ) {
-			WP_CLI::debug( $log_message . ' ' . json_encode( $log_data ), $log_group );
+			WP_CLI::debug( $log_message . ' ' . $this->json_encode_compat( $log_data ), $log_group );
 		} else {
 			WP_CLI::log( $log_message );
 		}
 
-		// Write to log file if enabled
+		// Write to log file if enabled.
 		if ( $this->log_file_handle ) {
 			$timestamp = gmdate( 'Y-m-d H:i:s' );
 			$log_entry = "[{$timestamp}] REQUEST: {$method} {$url}\n";
-			$log_entry .= json_encode( $log_data, JSON_PRETTY_PRINT ) . "\n\n";
+			$log_entry .= $this->json_encode_compat( $log_data, true ) . "\n\n";
 			fwrite( $this->log_file_handle, $log_entry );
 		}
 
@@ -126,12 +149,12 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 	 *
 	 * @param array|\WP_Error $response HTTP response or WP_Error object.
 	 * @param string          $context  Context under which the hook is fired.
-	 * @param string          $transport    HTTP transport used.
+	 * @param string          $transport HTTP transport used.
 	 * @param array           $args     HTTP request arguments.
 	 * @param string          $url      The request URL.
 	 */
 	public function log_http_api_response( $response, $context, $transport, $args, $url ) {
-		// Only log if debug mode or http_log is enabled
+		// Only log if debug mode or http_log is enabled.
 		$debug    = WP_CLI::get_config( 'debug' );
 		$http_log = WP_CLI::get_config( 'http_log' );
 
@@ -145,25 +168,25 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 		$method = isset( $args['method'] ) ? $args['method'] : 'GET';
 
 		if ( is_wp_error( $response ) ) {
-			$log_data = [
+			$log_data = array(
 				'error_code'    => $response->get_error_code(),
 				'error_message' => $response->get_error_message(),
-			];
+			);
 
 			$log_message = "WordPress HTTP Response Error: {$method} {$url} - " . $response->get_error_message();
 		} else {
-			$log_data = [
+			$log_data = array(
 				'status'  => isset( $response['response']['code'] ) ? $response['response']['code'] : '?',
 				'success' => isset( $response['response']['code'] ) && 200 <= $response['response']['code'] && $response['response']['code'] < 300,
-			];
+			);
 
-			// Only include headers and body in verbose logging mode
+			// Only include headers and body in verbose logging mode.
 			if ( WP_CLI::get_config( 'http_log_verbose' ) ) {
 				if ( isset( $response['headers'] ) ) {
 					$log_data['headers'] = $response['headers'];
 				}
 
-				// Only log body if it's not too large
+				// Only log body if it's not too large.
 				if ( isset( $response['body'] ) && is_string( $response['body'] ) && strlen( $response['body'] ) < 1024 ) {
 					$log_data['body'] = $response['body'];
 				} elseif ( isset( $response['body'] ) ) {
@@ -175,16 +198,16 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 		}
 
 		if ( 'debug' === $log_level ) {
-			WP_CLI::debug( $log_message . ' ' . json_encode( $log_data ), $log_group );
+			WP_CLI::debug( $log_message . ' ' . $this->json_encode_compat( $log_data ), $log_group );
 		} else {
 			WP_CLI::log( $log_message );
 		}
 
-		// Write to log file if enabled
+		// Write to log file if enabled.
 		if ( $this->log_file_handle ) {
 			$timestamp = gmdate( 'Y-m-d H:i:s' );
 			$log_entry = "[{$timestamp}] RESPONSE: {$method} {$url}\n";
-			$log_entry .= json_encode( $log_data, JSON_PRETTY_PRINT ) . "\n\n";
+			$log_entry .= $this->json_encode_compat( $log_data, true ) . "\n\n";
 			fwrite( $this->log_file_handle, $log_entry );
 		}
 	}

--- a/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
+++ b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
@@ -126,11 +126,11 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 	 *
 	 * @param array|\WP_Error $response HTTP response or WP_Error object.
 	 * @param string          $context  Context under which the hook is fired.
-	 * @param string          $class    HTTP transport used.
+	 * @param string          $transport    HTTP transport used.
 	 * @param array           $args     HTTP request arguments.
 	 * @param string          $url      The request URL.
 	 */
-	public function log_http_api_response( $response, $context, $class, $args, $url ) {
+	public function log_http_api_response( $response, $context, $transport, $args, $url ) {
 		// Only log if debug mode or http_log is enabled
 		$debug    = WP_CLI::get_config( 'debug' );
 		$http_log = WP_CLI::get_config( 'http_log' );

--- a/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
+++ b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace WP_CLI\Bootstrap;
+
+use WP_CLI;
+
+/**
+ * Class InitializeHttpRequestMonitoring
+ *
+ * Initialize HTTP Request Monitoring by hooking into WordPress HTTP API filters.
+ *
+ * @package WP_CLI\Bootstrap
+ */
+class InitializeHttpRequestMonitoring implements BootstrapStep {
+
+	/**
+	 * Log file handle for HTTP requests/responses.
+	 *
+	 * @var resource|false
+	 */
+	private $log_file_handle = false;
+
+	/**
+	 * Process this single bootstrapping step.
+	 *
+	 * @param BootstrapState $state Contextual state to pass into the step.
+	 *
+	 * @return BootstrapState Modified state to pass to the next step.
+	 */
+	public function process( BootstrapState $state ) {
+		// Initialize log file if http_log_file is set
+		$http_log_file = WP_CLI::get_config( 'http_log_file' );
+		if ( $http_log_file ) {
+			$this->log_file_handle = @fopen( $http_log_file, 'a' );
+			if ( ! $this->log_file_handle ) {
+				WP_CLI::warning( sprintf( 'Could not open HTTP log file %s for writing', $http_log_file ) );
+			} else {
+				// Write header to log file
+				fwrite( $this->log_file_handle, "=== HTTP Request Log Started at " . date( 'Y-m-d H:i:s' ) . " ===\n" );
+
+				// Ensure we close the file handle on shutdown
+				register_shutdown_function( function() {
+					if ( $this->log_file_handle ) {
+						fwrite( $this->log_file_handle, "=== HTTP Request Log Ended at " . date( 'Y-m-d H:i:s' ) . " ===\n" );
+						fclose( $this->log_file_handle );
+					}
+				} );
+			}
+		}
+
+		// Register the WordPress hooks that will be applied once WordPress is loaded
+		WP_CLI::add_wp_hook( 'http_request_args', [ $this, 'log_http_request_args' ], 9999, 2 );
+		WP_CLI::add_wp_hook( 'http_api_debug', [ $this, 'log_http_api_response' ], 9999, 5 );
+
+		return $state;
+	}
+
+	/**
+	 * Log HTTP request arguments when HTTP request is made.
+	 *
+	 * @param array  $args HTTP request arguments.
+	 * @param string $url  Request URL.
+	 *
+	 * @return array Unmodified request arguments.
+	 */
+	public function log_http_request_args( $args, $url ) {
+		// Only log if debug mode or http_log is enabled
+		$debug = WP_CLI::get_config( 'debug' );
+		$http_log = WP_CLI::get_config( 'http_log' );
+
+		if ( ! $debug && ! $http_log && ! $this->log_file_handle ) {
+			return $args;
+		}
+
+		$log_group = $http_log ? 'http' : ($debug === true ? 'http' : $debug);
+		$log_level = $http_log ? 'info' : 'debug';
+
+		$log_data = [
+			'method' => isset( $args['method'] ) ? $args['method'] : 'GET',
+			'url' => $url,
+		];
+
+		// Only include headers and data in verbose logging mode
+		if ( WP_CLI::get_config( 'http_log_verbose' ) ) {
+			// Filter out sensitive headers (like Authorization)
+			if ( isset( $args['headers'] ) ) {
+				$log_headers = $args['headers'];
+				if ( isset( $log_headers['Authorization'] ) ) {
+					$log_headers['Authorization'] = 'REDACTED';
+				}
+				$log_data['headers'] = $log_headers;
+			}
+
+			// Only log body if it exists and isn't too large
+			if ( isset( $args['body'] ) && is_string( $args['body'] ) && strlen( $args['body'] ) < 1024 ) {
+				$log_data['body'] = $args['body'];
+			} elseif ( isset( $args['body'] ) ) {
+				$log_data['body'] = '[body too large to log]';
+			}
+		}
+
+		$method = isset( $args['method'] ) ? $args['method'] : 'GET';
+		$log_message = "WordPress HTTP Request: {$method} {$url}";
+
+		if ( $log_level === 'debug' ) {
+			WP_CLI::debug( $log_message . ' ' . json_encode( $log_data ), $log_group );
+		} else {
+			WP_CLI::log( $log_message );
+		}
+
+		// Write to log file if enabled
+		if ( $this->log_file_handle ) {
+			$timestamp = date( 'Y-m-d H:i:s' );
+			$log_entry = "[{$timestamp}] REQUEST: {$method} {$url}\n";
+			$log_entry .= json_encode( $log_data, JSON_PRETTY_PRINT ) . "\n\n";
+			fwrite( $this->log_file_handle, $log_entry );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Log HTTP API response.
+	 *
+	 * @param array|\WP_Error $response HTTP response or WP_Error object.
+	 * @param string          $context  Context under which the hook is fired.
+	 * @param string          $class    HTTP transport used.
+	 * @param array           $args     HTTP request arguments.
+	 * @param string          $url      The request URL.
+	 */
+	public function log_http_api_response( $response, $context, $class, $args, $url ) {
+		// Only log if debug mode or http_log is enabled
+		$debug = WP_CLI::get_config( 'debug' );
+		$http_log = WP_CLI::get_config( 'http_log' );
+
+		if ( ! $debug && ! $http_log && ! $this->log_file_handle ) {
+			return;
+		}
+
+		$log_group = $http_log ? 'http' : ($debug === true ? 'http' : $debug);
+		$log_level = $http_log ? 'info' : 'debug';
+
+		$method = isset( $args['method'] ) ? $args['method'] : 'GET';
+
+		if ( is_wp_error( $response ) ) {
+			$log_data = [
+				'error_code' => $response->get_error_code(),
+				'error_message' => $response->get_error_message(),
+			];
+
+			$log_message = "WordPress HTTP Response Error: {$method} {$url} - " . $response->get_error_message();
+		} else {
+			$log_data = [
+				'status' => isset( $response['response']['code'] ) ? $response['response']['code'] : '?',
+				'success' => isset( $response['response']['code'] ) && $response['response']['code'] >= 200 && $response['response']['code'] < 300,
+			];
+
+			// Only include headers and body in verbose logging mode
+			if ( WP_CLI::get_config( 'http_log_verbose' ) ) {
+				if ( isset( $response['headers'] ) ) {
+					$log_data['headers'] = $response['headers'];
+				}
+
+				// Only log body if it's not too large
+				if ( isset( $response['body'] ) && is_string( $response['body'] ) && strlen( $response['body'] ) < 1024 ) {
+					$log_data['body'] = $response['body'];
+				} elseif ( isset( $response['body'] ) ) {
+					$log_data['body'] = '[body too large to log]';
+				}
+			}
+
+			$log_message = "WordPress HTTP Response: {$log_data['status']} for {$method} {$url}";
+		}
+
+		if ( $log_level === 'debug' ) {
+			WP_CLI::debug( $log_message . ' ' . json_encode( $log_data ), $log_group );
+		} else {
+			WP_CLI::log( $log_message );
+		}
+
+		// Write to log file if enabled
+		if ( $this->log_file_handle ) {
+			$timestamp = date( 'Y-m-d H:i:s' );
+			$log_entry = "[{$timestamp}] RESPONSE: {$method} {$url}\n";
+			$log_entry .= json_encode( $log_data, JSON_PRETTY_PRINT ) . "\n\n";
+			fwrite( $this->log_file_handle, $log_entry );
+		}
+	}
+}

--- a/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
+++ b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
@@ -166,8 +166,8 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 			return;
 		}
 
-		$log_group = $http_log ? 'http' : ( true === $debug ? 'http' : $debug );
-		$log_level = $http_log ? 'info' : 'debug';
+		$log_group  = $http_log ? 'http' : ( true === $debug ? 'http' : $debug );
+		$log_level  = $http_log ? 'info' : 'debug';
 
 		$method = isset( $args['method'] ) ? $args['method'] : 'GET';
 

--- a/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
+++ b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
@@ -139,8 +139,8 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 
 		// Write to log file if enabled.
 		if ( $this->log_file_handle ) {
-			$timestamp = gmdate( 'Y-m-d H:i:s' );
-			$log_entry = "[{$timestamp}] REQUEST: {$method} {$url}\n";
+			$timestamp  = gmdate( 'Y-m-d H:i:s' );
+			$log_entry  = "[{$timestamp}] REQUEST: {$method} {$url}\n";
 			$log_entry .= $this->json_encode_compat( $log_data, true ) . "\n\n";
 			fwrite( $this->log_file_handle, $log_entry );
 		}
@@ -173,8 +173,8 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 
 		if ( is_wp_error( $response ) ) {
 			$log_data = array(
-				'error_code'      => $response->get_error_code(),
-				'error_message'   => $response->get_error_message(),
+				'error_code'    => $response->get_error_code(),
+				'error_message' => $response->get_error_message(),
 			);
 
 			$log_message = "WordPress HTTP Response Error: {$method} {$url} - " . $response->get_error_message();
@@ -209,8 +209,8 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 
 		// Write to log file if enabled.
 		if ( $this->log_file_handle ) {
-			$timestamp   = gmdate( 'Y-m-d H:i:s' );
-			$log_entry   = "[{$timestamp}] RESPONSE: {$method} {$url}\n";
+			$timestamp  = gmdate( 'Y-m-d H:i:s' );
+			$log_entry  = "[{$timestamp}] RESPONSE: {$method} {$url}\n";
 			$log_entry .= $this->json_encode_compat( $log_data, true ) . "\n\n";
 			fwrite( $this->log_file_handle, $log_entry );
 		}

--- a/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
+++ b/php/WP_CLI/Bootstrap/InitializeHttpRequestMonitoring.php
@@ -166,8 +166,8 @@ class InitializeHttpRequestMonitoring implements BootstrapStep {
 			return;
 		}
 
-		$log_group  = $http_log ? 'http' : ( true === $debug ? 'http' : $debug );
-		$log_level  = $http_log ? 'info' : 'debug';
+		$log_group = $http_log ? 'http' : ( true === $debug ? 'http' : $debug );
+		$log_level = $http_log ? 'info' : 'debug';
 
 		$method = isset( $args['method'] ) ? $args['method'] : 'GET';
 

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -435,6 +435,12 @@ class Runner {
 			if ( preg_match( "/Did you mean '([^']+)'\?/", $r, $matches ) ) {
 				$suggested_command = $matches[1];
 
+				// Skip interactive prompt in test environments
+				if ( defined( 'WP_CLI_TEST_MODE' ) && WP_CLI_TEST_MODE ) {
+					WP_CLI::error( $r );
+					return;
+				}
+
 				// Modify error message to include prompt
 				$error_message = $r . PHP_EOL . "Run '{$suggested_command}' instead? [Y/n]";
 

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -457,12 +457,12 @@ class Runner {
 
 					// Get position of incorrect command in original args
 					$incorrect_cmd_path = [];
-					$cmd_index = 0;
+					$cmd_index          = 0;
 					foreach ( $args as $index => $arg ) {
 						$incorrect_cmd_path[] = $arg;
-						$cmd_index = $index;
+						$cmd_index            = $index;
 						// Stop if we've collected enough parts to match where the typo was
-						if ( count( $incorrect_cmd_path ) >= count( explode( ' ', $parent_command . $args[$cmd_index] ) ) ) {
+						if ( count( $incorrect_cmd_path ) >= count( explode( ' ', $parent_command . $args[ $cmd_index ] ) ) ) {
 							break;
 						}
 					}
@@ -479,7 +479,7 @@ class Runner {
 					return $this->run_command( $new_args, $assoc_args, $options );
 				} else {
 					// User declined, exit with error code 1
-					exit(1);
+					exit( 1 );
 				}
 			}
 

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -442,7 +442,11 @@ class Runner {
 				WP_CLI::error( $error_message, false );
 
 				// Read user input
-				$answer = strtolower( trim( fgets( STDIN ) ) );
+				$answer = '';
+				// Only try to read from STDIN if it's defined (won't be in some test environments)
+				if ( defined( 'STDIN' ) ) {
+					$answer = strtolower( trim( fgets( STDIN ) ) );
+				}
 
 				// If user confirms (y/Y/yes or empty), run the suggested command
 				if ( '' === $answer || 'y' === $answer || 'yes' === $answer ) {

--- a/php/bootstrap.php
+++ b/php/bootstrap.php
@@ -25,6 +25,7 @@ function get_bootstrap_steps() {
 		Bootstrap\IncludeRequestsAutoloader::class,
 		Bootstrap\InitializeColorization::class,
 		Bootstrap\InitializeLogger::class,
+		Bootstrap\InitializeHttpRequestMonitoring::class,
 		Bootstrap\DefineProtectedCommands::class,
 		Bootstrap\LoadExecCommand::class,
 		Bootstrap\LoadRequiredCommand::class,

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -114,6 +114,13 @@ return [
 		'desc'    => 'Include headers and body content in HTTP request and response logs. Only applicable when --http_log or --debug is enabled.',
 	],
 
+	'http_log_file'     => [
+		'runtime' => '=<path>',
+		'file'    => '<path>',
+		'default' => false,
+		'desc'    => 'Path to a file where HTTP request and response logs should be written. Enables logging regardless of --debug or --http_log.',
+	],
+
 	'prompt'            => [
 		'runtime' => '[=<assoc>]',
 		'file'    => false,

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -100,6 +100,20 @@ return [
 		'desc'    => 'Show all PHP errors and add verbosity to WP-CLI output. Built-in groups include: bootstrap, commandfactory, and help.',
 	],
 
+	'http_log'          => [
+		'runtime' => '',
+		'file'    => '<bool>',
+		'default' => false,
+		'desc'    => 'Log HTTP requests to STDOUT. Useful for debugging outgoing HTTP requests without using --debug.',
+	],
+
+	'http_log_verbose'  => [
+		'runtime' => '',
+		'file'    => '<bool>',
+		'default' => false,
+		'desc'    => 'Include headers and body content in HTTP request and response logs. Only applicable when --http_log or --debug is enabled.',
+	],
+
 	'prompt'            => [
 		'runtime' => '[=<assoc>]',
 		'file'    => false,

--- a/php/utils.php
+++ b/php/utils.php
@@ -918,7 +918,7 @@ function http_request( $method, $url, $data = null, $headers = [], $options = []
 				) {
 					// Log HTTP request exception
 					if ( $debug || $http_log ) {
-						$log_group  = $http_log ? 'http' : ( true === $debug ? 'http' : $debug );
+						$log_group   = $http_log ? 'http' : ( true === $debug ? 'http' : $debug );
 						$log_message = "HTTP Request Exception: {$method} {$url} - " . $exception->getMessage();
 						\WP_CLI::debug( $log_message, $log_group );
 					}

--- a/php/utils.php
+++ b/php/utils.php
@@ -918,8 +918,8 @@ function http_request( $method, $url, $data = null, $headers = [], $options = []
 				) {
 					// Log HTTP request exception
 					if ( $debug || $http_log ) {
-						$log_group = $http_log ? 'http' : ( true === $debug ? 'http' : $debug );
-						$log_message = "HTTP Request Exception: {$method} {$url} - " . $exception->getMessage();
+						$log_group    = $http_log ? 'http' : ( true === $debug ? 'http' : $debug );
+						$log_message   = "HTTP Request Exception: {$method} {$url} - " . $exception->getMessage();
 						\WP_CLI::debug( $log_message, $log_group );
 					}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -918,8 +918,8 @@ function http_request( $method, $url, $data = null, $headers = [], $options = []
 				) {
 					// Log HTTP request exception
 					if ( $debug || $http_log ) {
-						$log_group    = $http_log ? 'http' : ( true === $debug ? 'http' : $debug );
-						$log_message   = "HTTP Request Exception: {$method} {$url} - " . $exception->getMessage();
+						$log_group  = $http_log ? 'http' : ( true === $debug ? 'http' : $debug );
+						$log_message = "HTTP Request Exception: {$method} {$url} - " . $exception->getMessage();
 						\WP_CLI::debug( $log_message, $log_group );
 					}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -833,16 +833,16 @@ function http_request( $method, $url, $data = null, $headers = [], $options = []
 	$options = WP_CLI::do_hook( 'http_request_options', $options );
 
 	// Log the HTTP request if debug mode is enabled or if http_log option is set
-	$debug = \WP_CLI::get_config( 'debug' );
+	$debug    = \WP_CLI::get_config( 'debug' );
 	$http_log = \WP_CLI::get_config( 'http_log' );
 
 	if ( $debug || $http_log ) {
-		$log_group = $http_log ? 'http' : ($debug === true ? 'http' : $debug);
+		$log_group = $http_log ? 'http' : ( true === $debug ? 'http' : $debug );
 		$log_level = $http_log ? 'info' : 'debug';
 
 		$log_data = [
 			'method' => $method,
-			'url' => $url,
+			'url'    => $url,
 		];
 
 		// Only include headers and data in verbose logging mode
@@ -863,7 +863,7 @@ function http_request( $method, $url, $data = null, $headers = [], $options = []
 		}
 
 		$log_message = "HTTP Request: {$method} {$url}";
-		if ( $log_level === 'debug' ) {
+		if ( 'debug' === $log_level ) {
 			\WP_CLI::debug( $log_message . ' ' . json_encode( $log_data ), $log_group );
 		} else {
 			\WP_CLI::log( $log_message );
@@ -880,11 +880,11 @@ function http_request( $method, $url, $data = null, $headers = [], $options = []
 
 			// Log the HTTP response
 			if ( $debug || $http_log ) {
-				$log_group = $http_log ? 'http' : ($debug === true ? 'http' : $debug);
+				$log_group = $http_log ? 'http' : ( true === $debug ? 'http' : $debug );
 				$log_level = $http_log ? 'info' : 'debug';
 
 				$log_data = [
-					'status' => $response->status_code,
+					'status'  => $response->status_code,
 					'success' => $response->success,
 				];
 
@@ -893,7 +893,7 @@ function http_request( $method, $url, $data = null, $headers = [], $options = []
 					$log_data['headers'] = $response->headers->getAll();
 
 					// Only log body if it's not too large
-					if ( strlen( $response->body ) < 1024 ) {
+					if ( 1024 > strlen( $response->body ) ) {
 						$log_data['body'] = $response->body;
 					} else {
 						$log_data['body'] = '[body too large to log]';
@@ -901,7 +901,7 @@ function http_request( $method, $url, $data = null, $headers = [], $options = []
 				}
 
 				$log_message = "HTTP Response: {$response->status_code} for {$method} {$url}";
-				if ( $log_level === 'debug' ) {
+				if ( 'debug' === $log_level ) {
 					\WP_CLI::debug( $log_message . ' ' . json_encode( $log_data ), $log_group );
 				} else {
 					\WP_CLI::log( $log_message );
@@ -914,11 +914,11 @@ function http_request( $method, $url, $data = null, $headers = [], $options = []
 				if (
 					true !== $options['verify']
 					|| 'curlerror' !== $exception->getType()
-					|| curl_errno( $exception->getData() ) !== CURLE_SSL_CACERT
+					|| CURLE_SSL_CACERT !== curl_errno( $exception->getData() )
 				) {
 					// Log HTTP request exception
 					if ( $debug || $http_log ) {
-						$log_group = $http_log ? 'http' : ($debug === true ? 'http' : $debug);
+						$log_group = $http_log ? 'http' : ( true === $debug ? 'http' : $debug );
 						$log_message = "HTTP Request Exception: {$method} {$url} - " . $exception->getMessage();
 						\WP_CLI::debug( $log_message, $log_group );
 					}


### PR DESCRIPTION
This PR implements the feature request in issue #6054. When a user types a misspelled command that has a suggestion, WP-CLI will now ask if they want to run the suggested command instead.\n\nFor example:\n`\n$ wp plugin remove plugin-name\nError: 'remove' is not a registered subcommand of 'plugin'. See 'wp help plugin' for available subcommands.\nDid you mean 'delete'?\nRun 'delete' instead? [Y/n]\n`\n\nIf the user types 'y' (or just presses Enter), the suggested command will be executed automatically. This saves the user from having to retype the entire command.

Fixes #6054 