### PR TITLE
 docker scheme: working-directory and stdin passing (reroll of #5974)

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -355,7 +355,7 @@ Feature: Global flags
       """
 
   Scenario: SSH flag should support Docker
-    When I try `wp --debug --ssh=docker:user@wordpress --version`
+    When I try `WP_CLI_DOCKER_NO_INTERACTIVE=1 wp --debug --ssh=docker:user@wordpress --version`
     Then STDERR should contain:
       """
       Running SSH command: docker exec --user 'user' 'wordpress' sh -c

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -593,7 +593,7 @@ class Runner {
 				$bits['user'] ? '--user ' . escapeshellarg( $bits['user'] ) . ' ' : '',
 				$bits['path'] ? '--workdir ' . escapeshellarg( $bits['path'] ) . ' ' : '',
 				$is_stdout_tty && ! getenv( 'WP_CLI_DOCKER_NO_TTY' ) ? '-t  ' : '',
-				$is_stdin_tty || getenv( 'WP_CLI_DOCKER_NO_INTERACTIVE' ) || getenv( 'BEHAT_RUN' ) ? '' : '-i ',
+				$is_stdin_tty || getenv( 'WP_CLI_DOCKER_NO_INTERACTIVE' ) ? '' : '-i ',
 				escapeshellarg( $bits['host'] ),
 				escapeshellarg( $wp_command )
 			);
@@ -622,7 +622,7 @@ class Runner {
 				$bits['user'] ? '--user ' . escapeshellarg( $bits['user'] ) . ' ' : '',
 				$bits['path'] ? '--workdir ' . escapeshellarg( $bits['path'] ) . ' ' : '',
 				$is_stdout_tty || getenv( 'WP_CLI_DOCKER_NO_TTY' ) ? '' : '-T ',
-				$is_stdin_tty || getenv( 'WP_CLI_DOCKER_NO_INTERACTIVE' ) || getenv( 'BEHAT_RUN' ) ? '' : '-i ',
+				$is_stdin_tty || getenv( 'WP_CLI_DOCKER_NO_INTERACTIVE' ) ? '' : '-i ',
 				escapeshellarg( $bits['host'] ),
 				$wp_command
 			);

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -503,9 +503,6 @@ class Runner {
 
 			$pre_cmd = rtrim( $pre_cmd, ';' ) . '; ';
 		}
-		if ( ! empty( $bits['path'] ) ) {
-			$pre_cmd .= 'cd ' . escapeshellarg( $bits['path'] ) . '; ';
-		}
 
 		$env_vars = '';
 		if ( getenv( 'WP_CLI_STRICT_ARGS_MODE' ) ) {
@@ -575,48 +572,65 @@ class Runner {
 			WP_CLI::debug( 'SSH ' . $bit . ': ' . $bits[ $bit ], 'bootstrap' );
 		}
 
-		$is_tty                        = function_exists( 'posix_isatty' ) && posix_isatty( STDOUT );
+		/*
+		 * posix_isatty(STDIN) is generally true unless something was passed on stdin
+		 * If autodetection leads to false (fd on stdin), then `-i` is passed to `docker` cmd
+		 * (unless WP_CLI_DOCKER_NO_INTERACTIVE is set)
+		 */
+		$is_stdout_tty = function_exists( 'posix_isatty' ) && posix_isatty( STDOUT );
+		$is_stdin_tty  = function_exists( 'posix_isatty' ) ? posix_isatty( STDIN ) : true;
+
 		$docker_compose_v2_version_cmd = Utils\esc_cmd( Utils\force_env_on_nix_systems( 'docker' ) . ' compose %s', 'version' );
 		$docker_compose_cmd            = ! empty( Process::create( $docker_compose_v2_version_cmd )->run()->stdout )
 			? 'docker compose'
 			: 'docker-compose';
 
 		if ( 'docker' === $bits['scheme'] ) {
-			$command = 'docker exec %s%s%s sh -c %s';
+			$command = 'docker exec %s%s%s%s%s sh -c %s';
 
 			$escaped_command = sprintf(
 				$command,
 				$bits['user'] ? '--user ' . escapeshellarg( $bits['user'] ) . ' ' : '',
-				$is_tty ? '-t ' : '',
+				$bits['path'] ? '--workdir ' . escapeshellarg( $bits['path'] ) . ' ' : '',
+				$is_stdout_tty && ! getenv( 'WP_CLI_DOCKER_NO_TTY' ) ? '-t  ' : '',
+				$is_stdin_tty || getenv( 'WP_CLI_DOCKER_NO_INTERACTIVE' ) || getenv( 'BEHAT_RUN' ) ? '' : '-i ',
 				escapeshellarg( $bits['host'] ),
 				escapeshellarg( $wp_command )
 			);
 		}
 
 		if ( 'docker-compose' === $bits['scheme'] ) {
-			$command = '%s exec %s%s%s sh -c %s';
+			$command = '%s exec %s%s%s%s sh -c %s';
 
 			$escaped_command = sprintf(
 				$command,
 				$docker_compose_cmd,
 				$bits['user'] ? '--user ' . escapeshellarg( $bits['user'] ) . ' ' : '',
-				$is_tty ? '' : '-T ',
+				$bits['path'] ? '--workdir ' . escapeshellarg( $bits['path'] ) . ' ' : '',
+				$is_stdout_tty || getenv( 'WP_CLI_DOCKER_NO_TTY' ) ? '' : '-T ',
 				escapeshellarg( $bits['host'] ),
 				escapeshellarg( $wp_command )
 			);
 		}
 
 		if ( 'docker-compose-run' === $bits['scheme'] ) {
-			$command = '%s run %s%s%s %s';
+			$command = '%s run %s%s%s%s%s %s';
 
 			$escaped_command = sprintf(
 				$command,
 				$docker_compose_cmd,
 				$bits['user'] ? '--user ' . escapeshellarg( $bits['user'] ) . ' ' : '',
-				$is_tty ? '' : '-T ',
+				$bits['path'] ? '--workdir ' . escapeshellarg( $bits['path'] ) . ' ' : '',
+				$is_stdout_tty || getenv( 'WP_CLI_DOCKER_NO_TTY' ) ? '' : '-T ',
+				$is_stdin_tty || getenv( 'WP_CLI_DOCKER_NO_INTERACTIVE' ) || getenv( 'BEHAT_RUN' ) ? '' : '-i ',
 				escapeshellarg( $bits['host'] ),
 				$wp_command
 			);
+		}
+
+		// For "vagrant" & "ssh" schemes which don't provide a working-directory option, use `cd`
+		if ( $bits['path'] ) {
+			$wp_command = 'cd ' . escapeshellarg( $bits['path'] ) . '; ' . $wp_command;
 		}
 
 		// Vagrant ssh-config.
@@ -675,7 +689,7 @@ class Runner {
 				$bits['proxyjump'] ? sprintf( '-J %s', escapeshellarg( $bits['proxyjump'] ) ) : '',
 				$bits['port'] ? sprintf( '-p %d', (int) $bits['port'] ) : '',
 				$bits['key'] ? sprintf( '-i %s', escapeshellarg( $bits['key'] ) ) : '',
-				$is_tty ? '-t' : '-T',
+				$is_stdout_tty ? '-t' : '-T',
 				WP_CLI::get_config( 'debug' ) ? '-vvv' : '-q',
 			];
 


### PR DESCRIPTION
#5974 reroll

1. `docker exec` and `docker-compose exec` provide an option to cleanly set the working directory before running a command
=> Use it instead and use `cd <...> ;` command-prefixing in vagrant/ssh cases

2. Using `docker` scheme, `wp post update 1 - <<<foo` didn't worked (issue #4972)
* Because STDOUT being a tty, `-t` is passed with no ability to inhibit this
* Because docker `-i` flag is necessary

=> As such:
* docker `-i` (`--interactive`) is introduced (with sensible autodetection)
* `WP_CLI_DOCKER_NO_TTY` and `WP_CLI_DOCKER_NO_INTERACTIVE` environment variables are introduced to optionally inhibit these respective flags


Special case to handle `behat` runs (see #5974)