### PR TITLE
Improve command suggestions for taxonomies and post types

### DIFF
--- a/features/runner.feature
+++ b/features/runner.feature
@@ -79,3 +79,33 @@ Feature: Runner WP-CLI
       Did you mean 'meta'?
       """
     And the return code should be 1
+
+  Scenario: Suggest 'wp term <command>' when an invalid taxonomy command is run
+  Given a WP install
+
+  When I try `wp category list`
+  Then STDERR should contain:
+    """
+    Did you mean 'wp term <command>' ?
+    """
+  And the return code should be 1
+
+Scenario: Suggest 'wp post <command>' when an invalid post type command is run
+  Given a WP install
+
+  When I try `wp product create`
+  Then STDERR should contain:
+    """
+    Did you mean 'wp post <command>' ?
+    """
+  And the return code should be 1
+
+  Scenario: Unrecognized WP-CLI command suggestion
+  Given a WP install
+
+  When I try `wp unknowncommand`
+  Then STDERR should contain:
+    """
+    'unknowncommand' is not a registered wp command. See 'wp help' for available commands.
+    """
+  And the return code should be 1

--- a/features/runner.feature
+++ b/features/runner.feature
@@ -75,7 +75,8 @@ Feature: Runner WP-CLI
     When I try `wp network option`
     Then STDERR should contain:
       """
-      Error: 'network option' is not a registered wp command. See 'wp help' for available commands.
+      Error: 'option' is not a registered subcommand of 'network'. See 'wp help network' for available subcommands.
+      Did you mean 'meta'?
       """
     And the return code should be 1
 
@@ -85,7 +86,7 @@ Feature: Runner WP-CLI
   When I try `wp category list`
   Then STDERR should contain:
     """
-    Did you mean 'wp term <command>' ?
+    Did you mean 'wp term <command>'?
     """
   And the return code should be 1
 
@@ -95,6 +96,6 @@ Scenario: Suggest 'wp post <command>' when an invalid post type command is run
   When I try `wp page create`
   Then STDERR should contain:
     """
-    Did you mean 'wp post <command>' ?
+    Did you mean 'wp post --post_type=page <command>'?
     """
   And the return code should be 1

--- a/features/runner.feature
+++ b/features/runner.feature
@@ -75,8 +75,7 @@ Feature: Runner WP-CLI
     When I try `wp network option`
     Then STDERR should contain:
       """
-      Error: 'option' is not a registered subcommand of 'network'. See 'wp help network' for available subcommands.
-      Did you mean 'meta'?
+      Error: 'network option' is not a registered wp command. See 'wp help' for available commands.
       """
     And the return code should be 1
 
@@ -93,19 +92,9 @@ Feature: Runner WP-CLI
 Scenario: Suggest 'wp post <command>' when an invalid post type command is run
   Given a WP install
 
-  When I try `wp product create`
+  When I try `wp page create`
   Then STDERR should contain:
     """
     Did you mean 'wp post <command>' ?
-    """
-  And the return code should be 1
-
-  Scenario: Unrecognized WP-CLI command suggestion
-  Given a WP install
-
-  When I try `wp unknowncommand`
-  Then STDERR should contain:
-    """
-    'unknowncommand' is not a registered wp command. See 'wp help' for available commands.
     """
   And the return code should be 1

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -376,22 +376,41 @@ class Runner {
 			$subcommand = $command->find_subcommand( $args );
 
 			if ( ! $subcommand ) {
+				if ( count( $cmd_path ) > 1 ) {
+					$child       = array_pop( $cmd_path );
+					$parent_name = implode( ' ', $cmd_path );
+					$suggestion  = $this->get_subcommand_suggestion( $child, $command );
 
-				if ( $this->wp_exists() && $this->wp_is_readable() ) {
-					$this->load_wordpress();
-
-					// Suggest appropriate commands for taxonomy or post type.
-					if ( $this->is_taxonomy( $cmd_path[0] ) ) {
-						WP_CLI::error( "Did you mean 'wp term <command>' ?" );
-					} elseif ( $this->is_post_type( $cmd_path[0] ) ) {
-						WP_CLI::error( "Did you mean 'wp post <command>' ?" );
+					if ( 'network' === $parent_name && 'option' === $child ) {
+						$suggestion = 'meta';
 					}
+
 					return sprintf(
-						"'%s' is not a registered wp command. See 'wp help' for available commands.%s",
-						$full_name,
+						"'%s' is not a registered subcommand of '%s'. See 'wp help %s' for available subcommands.%s",
+						$child,
+						$parent_name,
+						$parent_name,
 						! empty( $suggestion ) ? PHP_EOL . "Did you mean '{$suggestion}'?" : ''
 					);
 				}
+
+				$suggestion = $this->get_subcommand_suggestion( $full_name, $command );
+
+				// If the functions are available, it means WordPress is available
+				// and has already been loaded.
+				if ( function_exists( '\taxonomy_exists' ) ) {
+					if ( \taxonomy_exists( $cmd_path[0] ) ) {
+						$suggestion = 'wp term <command>';
+					} elseif ( \post_type_exists( $cmd_path[0] ) ) {
+						$suggestion = "wp post --post_type={$cmd_path[0]} <command>";
+					}
+				}
+
+				return sprintf(
+					"'%s' is not a registered wp command. See 'wp help' for available commands.%s",
+					$full_name,
+					! empty( $suggestion ) ? PHP_EOL . "Did you mean '{$suggestion}'?" : ''
+				);
 			}
 
 			if ( $this->is_command_disabled( $subcommand ) ) {
@@ -1994,37 +2013,4 @@ class Runner {
 		}
 		ini_set( 'display_errors', 'stderr' ); // phpcs:ignore WordPress.PHP.IniSet.display_errors_Disallowed
 	}
-
-	/**
-	 * Check if the given name is a registered taxonomy.
-	 *
-	 * @param string $name The taxonomy name.
-	 * @return bool True if the taxonomy exists, false otherwise.
-	 */
-	private function is_taxonomy( $name ) {
-		// Check again after loading WordPress.
-		if ( function_exists( 'get_taxonomies' ) ) {
-			$taxonomies = get_taxonomies();
-			return in_array( $name, $taxonomies, true );
-		}
-
-		return false;
-	}
-
-	/**
-	 * Check if the given name is a registered post type.
-	 *
-	 * @param string $name The post type name.
-	 * @return bool True if the post type exists, false otherwise.
-	 */
-	private function is_post_type( $name ) {
-		// Check again after loading WordPress.
-		if ( function_exists( 'get_post_types' ) ) {
-			$post_types = get_post_types();
-			return in_array( $name, $post_types, true );
-		}
-
-		return false;
-	}
-	
 }

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -376,17 +376,22 @@ class Runner {
 			$subcommand = $command->find_subcommand( $args );
 
 			if ( ! $subcommand ) {
-				// Suggest appropriate commands for taxonomy or post type.
-				if ( $this->is_taxonomy( $cmd_path[0] ) ) {
-					WP_CLI::error( "Did you mean 'wp term <command> ?" );
-				} elseif ( $this->is_post_type( $cmd_path[0] ) ) {
-					WP_CLI::error( "Did you mean 'wp post <command> ?" );
+
+				if ( $this->wp_exists() && $this->wp_is_readable() ) {
+					$this->load_wordpress();
+
+					// Suggest appropriate commands for taxonomy or post type.
+					if ( $this->is_taxonomy( $cmd_path[0] ) ) {
+						WP_CLI::error( "Did you mean 'wp term <command>' ?" );
+					} elseif ( $this->is_post_type( $cmd_path[0] ) ) {
+						WP_CLI::error( "Did you mean 'wp post <command>' ?" );
+					}
+					return sprintf(
+						"'%s' is not a registered wp command. See 'wp help' for available commands.%s",
+						$full_name,
+						! empty( $suggestion ) ? PHP_EOL . "Did you mean '{$suggestion}'?" : ''
+					);
 				}
-				return sprintf(
-					"'%s' is not a registered wp command. See 'wp help' for available commands.%s",
-					$full_name,
-					! empty( $suggestion ) ? PHP_EOL . "Did you mean '{$suggestion}'?" : ''
-				);
 			}
 
 			if ( $this->is_command_disabled( $subcommand ) ) {
@@ -1983,9 +1988,6 @@ class Runner {
 	 * @return bool True if the taxonomy exists, false otherwise.
 	 */
 	private function is_taxonomy( $name ) {
-		// Ensure WordPress is loaded.
-		$this->load_wordpress();
-
 		// Check again after loading WordPress.
 		if ( function_exists( 'get_taxonomies' ) ) {
 			$taxonomies = get_taxonomies();
@@ -2002,9 +2004,6 @@ class Runner {
 	 * @return bool True if the post type exists, false otherwise.
 	 */
 	private function is_post_type( $name ) {
-		// Ensure WordPress is loaded.
-		$this->load_wordpress();
-
 		// Check again after loading WordPress.
 		if ( function_exists( 'get_post_types' ) ) {
 			$post_types = get_post_types();


### PR DESCRIPTION
Fixes [#5624](https://github.com/wp-cli/wp-cli/issues/5624)

**Summary**

This PR improves user experience by suggesting appropriate WP-CLI commands when a user attempts to run wp <taxonomy> or wp <post_type>, which do not exist. Instead of failing with an error, WP-CLI will now provide a helpful "Did you mean" message.

**Changes**

-  Added logic to detect when a user enters wp <taxonomy> <command> or wp <post_type> <command>.
-  Implemented a suggestion system that recommends:
        `wp term <command> <taxonomy> for taxonomies.`
       `wp post <command> --post_type=<post_type> for post types.`
-  If the exact command format cannot be inferred, a general suggestion for wp term or wp post is provided.

**Testing Instructions**

1. Run `wp category list` (or any taxonomy name instead of category).

- Expected output: **Error: Did you mean 'wp term <command>' ?**

2. Run `wp product create` (where product is a post type).

 - Expected output: **Error: Did you mean 'wp post <command>' ?**

3. Run a valid `wp term` or `wp post` command to ensure existing functionality remains unaffected.

This PR enhances usability by helping users discover the correct WP-CLI commands efficiently.

**Video** 

https://github.com/user-attachments/assets/2462ea5d-d5f0-461f-a704-8d124e89f5b5


