### PR TITLE
Temporarily remove `roave/security-advisories`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "wp-cli/php-cli-tools": "~0.12.3"
     },
     "require-dev": {
-        "roave/security-advisories": "dev-latest",
         "wp-cli/db-command": "^1.3 || ^2",
         "wp-cli/entity-command": "^1.2 || ^2",
         "wp-cli/extension-command": "^1.1 || ^2",


### PR DESCRIPTION
See #6018

This makes sure the PHP 5.6 tests pass again.

We can re-add it after the v2.12.0 release when we bump the minimum PHP version requirement.