### PR TITLE
Properly create missing wp cli config file when needed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "wp-cli/entity-command": "^1.2 || ^2",
         "wp-cli/extension-command": "^1.1 || ^2",
         "wp-cli/package-command": "^1 || ^2",
-        "wp-cli/wp-cli-tests": "^4.3.7"
+        "wp-cli/wp-cli-tests": "^4.3.10"
     },
     "suggest": {
         "ext-readline": "Include for a better --prompt implementation",

--- a/features/config.feature
+++ b/features/config.feature
@@ -733,3 +733,10 @@ Feature: Have a config file
       """
       true
       """
+
+  Scenario: Be able to create a new global config file (including any new parent folders) when one doesn't exist
+    # Delete this folder or else a rerun of the test will fail since the folder/file now exists
+    When I run `[ -n "$HOME" ] && rm -rf "$HOME/doesnotexist"`
+    And I try `WP_CLI_CONFIG_PATH=$HOME/doesnotexist/wp-cli.yml wp cli alias add 1 --debug`
+    Then STDERR should match #Default global config does not exist, creating one in.+/doesnotexist/wp-cli.yml#
+

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -213,7 +213,7 @@ class Runner {
 			$this->project_config_path_debug = 'Using project config: ' . $project_config_path;
 		}
 
-		return $project_config_path;
+		return false;
 	}
 
 	/**

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -160,7 +160,14 @@ class Runner {
 		// If global config doesn't exist create one.
 		if ( true === $create_config_file && ! file_exists( $config_path ) ) {
 			$this->global_config_path_debug = "Default global config doesn't exist, creating one in {$config_path}";
-			Process::create( Utils\esc_cmd( 'touch %s', $config_path ) )->run();
+
+			$dir = dirname( $config_path );
+
+			if ( ! is_dir( $dir ) ) {
+				mkdir( $dir, 0755, true );
+			}
+
+			touch( $config_path );
 		}
 
 		if ( is_readable( $config_path ) ) {

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -207,7 +207,7 @@ class Runner {
 			}
 		);
 
-		if ( $project_config_path === null ) {
+		if ( null === $project_config_path ) {
 			$this->project_config_path_debug = 'No project config found';
 			return false;
 		}

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -207,13 +207,13 @@ class Runner {
 			}
 		);
 
-		$this->project_config_path_debug = 'No project config found';
-
-		if ( ! empty( $project_config_path ) ) {
-			$this->project_config_path_debug = 'Using project config: ' . $project_config_path;
+		if ( $project_config_path === null ) {
+			$this->project_config_path_debug = 'No project config found';
+			return false;
 		}
 
-		return false;
+		$this->project_config_path_debug = 'Using project config: ' . $project_config_path;
+		return $project_config_path;
 	}
 
 	/**

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -168,6 +168,10 @@ class Runner {
 			}
 
 			touch( $config_path );
+
+			if ( file_exists( $config_path ) ) {
+				WP_CLI::debug( "Default global config does not exist, creating one in $config_path" );
+			}
 		}
 
 		if ( is_readable( $config_path ) ) {


### PR DESCRIPTION
While looking into #6053 I saw two bugs:

The first is that we called `touch` to create a config file if it wasn't present. That doesn't work because touch can't create the parent folders when they don't exist.

The only user of this code is the `alias add` command which I then saw had another bug. The function for getting the path of a project config file returned `null` when it couldn't find one instead of `false` as the docblock says it should. This caused a warning later on:

```
PHP  15. Mustangostang\Spyc::YAMLLoad($input = NULL) /Users/isla/source/wp-cli-dev/wp-cli/php/commands/src/CLI_Alias_Command.php:358
PHP  16. Mustangostang\Spyc->_load($input = NULL) /Users/isla/source/wp-cli-dev/spyc/src/Spyc.php:118
PHP  17. Mustangostang\Spyc->loadFromSource($input = NULL) /Users/isla/source/wp-cli-dev/spyc/src/Spyc.php:440
PHP  18. Mustangostang\Spyc->loadFromString($input = NULL) /Users/isla/source/wp-cli-dev/spyc/src/Spyc.php:512
PHP  19. explode($separator = '\n', $string = NULL) /Users/isla/source/wp-cli-dev/spyc/src/Spyc.php:516

Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /Users/isla/source/wp-cli-dev/spyc/src/Spyc.php on line 516
```