### PR TITLE
Fix overrides test by using custom class name

### DIFF
--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -60,12 +60,12 @@ Feature: Bootstrap WP-CLI
         return;
       }
       // Override bundled command.
-      WP_CLI::add_command( 'eval', 'Eval_Command', array( 'when' => 'before_wp_load' ) );
+      WP_CLI::add_command( 'eval', 'Custom_Eval_Command', array( 'when' => 'before_wp_load' ) );
       """
-    And a override/src/Eval_Command.php file:
+    And a override/src/Custom_Eval_Command.php file:
       """
       <?php
-      class Eval_Command extends WP_CLI_Command {
+      class Custom_Eval_Command extends WP_CLI_Command {
         public function __invoke() {
           WP_CLI::success( "WP-Override-Eval" );
         }


### PR DESCRIPTION
So it doesn't clash with an earlier autoloaded `Eval_Command`


See https://github.com/wp-cli/wp-cli-tests/issues/241