### PR TITLE
Add WP_CLI_REQUIRE env var for including extra php files

### DIFF
--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -338,3 +338,41 @@ Feature: Run a WP-CLI command
       """
       The used path is: /bad/path/
       """
+
+  Scenario: Check that required files are used from command arguments and ENV VAR
+    Given a WP installation
+    And a custom-cmd.php file:
+      """
+      <?php
+      class Custom_Command extends WP_CLI_Command {
+        /**
+         * Custom command to test passing command_args via runcommand options
+         *
+         * @when after_wp_load
+         */
+         public function echo_test( $args ) {
+         echo "test" . PHP_EOL;
+        }
+      }
+      WP_CLI::add_command( 'custom-command', 'Custom_Command' );
+      """
+      And a env.php file:
+      """
+      <?php
+      echo 'ENVIRONMENT REQUIRE' . PHP_EOL;
+      """
+
+    When I run `WP_CLI_REQUIRE=env.php wp eval 'return null;' --skip-wordpress`
+    Then STDOUT should be:
+      """
+      ENVIRONMENT REQUIRE
+      """
+
+    When I run `WP_CLI_REQUIRE=env.php wp --require=custom-cmd.php custom-command echo_test`
+    Then STDOUT should be:
+      """
+      ENVIRONMENT REQUIRE
+      test
+      """
+
+

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -361,6 +361,11 @@ Feature: Run a WP-CLI command
       <?php
       echo 'ENVIRONMENT REQUIRE' . PHP_EOL;
       """
+      And a env-2.php file:
+      """
+      <?php
+      echo 'ENVIRONMENT REQUIRE 2' . PHP_EOL;
+      """
 
     When I run `WP_CLI_REQUIRE=env.php wp eval 'return null;' --skip-wordpress`
     Then STDOUT should be:
@@ -372,6 +377,14 @@ Feature: Run a WP-CLI command
     Then STDOUT should be:
       """
       ENVIRONMENT REQUIRE
+      test
+      """
+
+    When I run `WP_CLI_REQUIRE='env.php,env-2.php' wp --require=custom-cmd.php custom-command echo_test`
+    Then STDOUT should be:
+      """
+      ENVIRONMENT REQUIRE
+      ENVIRONMENT REQUIRE 2
       test
       """
 

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -84,6 +84,17 @@ class Configurator {
 
 			$this->config[ $key ] = $details['default'];
 		}
+
+		$env_files = getenv( 'WP_CLI_REQUIRE' )
+		? array_filter( array_map( 'trim', explode( ',', getenv( 'WP_CLI_REQUIRE' ) ) ) )
+		: [];
+
+		if ( ! empty( $env_files ) ) {
+			if ( ! isset( $this->config['require'] ) ) {
+				$this->config['require'] = [];
+			}
+			$this->config['require'] = array_unique( array_merge( $env_files, $this->config['require'] ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
As a companion to `WP_CLI_EARLY_REQUIRE` but doesn't include the files until after wp has been through the boostrap process. This is the same as using `--require` from the command line, or require in a yaml config file. The purpose for another way of requiring a file is for use in codecov testing, where it otherwise is not practical to conditionally include a php file at normal runtime using the existing methods in a testing environment.

See https://github.com/wp-cli/wp-cli-tests/issues/241 for more conversation. This is what https://github.com/wp-cli/wp-cli/pull/6065 was meant to address, but it didn't end up working out for this specific case since we can't include our codcov generate files that early on before wp has been through bootstrap