### PR TITLE
Detect MariaDB vs MySQL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "wp-cli/entity-command": "^1.2 || ^2",
         "wp-cli/extension-command": "^1.1 || ^2",
         "wp-cli/package-command": "^1 || ^2",
-        "wp-cli/wp-cli-tests": "^4.3.10"
+        "wp-cli/wp-cli-tests": "dev-try/fix/mariadb-support as 4.3.13"
     },
     "suggest": {
         "ext-readline": "Include for a better --prompt implementation",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "wp-cli/entity-command": "^1.2 || ^2",
         "wp-cli/extension-command": "^1.1 || ^2",
         "wp-cli/package-command": "^1 || ^2",
-        "wp-cli/wp-cli-tests": "dev-try/fix/mariadb-support as 4.3.13"
+        "wp-cli/wp-cli-tests": "dev-fix/mariadb-support as 4.3.13"
     },
     "suggest": {
         "ext-readline": "Include for a better --prompt implementation",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "wp-cli/entity-command": "^1.2 || ^2",
         "wp-cli/extension-command": "^1.1 || ^2",
         "wp-cli/package-command": "^1 || ^2",
-        "wp-cli/wp-cli-tests": "dev-fix/mariadb-support as 4.3.13"
+        "wp-cli/wp-cli-tests": "^4.3.10"
     },
     "suggest": {
         "ext-readline": "Include for a better --prompt implementation",

--- a/features/utils.feature
+++ b/features/utils.feature
@@ -31,7 +31,7 @@ Feature: Utilities that do NOT depend on WordPress code
 
   @require-mysql
   Scenario: Check that `Utils\run_mysql_command()` uses STDOUT and STDERR by default
-    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}", "execute" => "SHOW DATABASES;" ] );'`
+    When I run `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "{MYSQL_BINARY} --no-defaults", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}", "execute" => "SHOW DATABASES;" ] );'`
     Then STDOUT should contain:
       """
       Database
@@ -42,7 +42,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDERR should be empty
 
-    When I try `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}", "execute" => "broken query" ]);'`
+    When I try `wp --skip-wordpress eval 'WP_CLI\Utils\run_mysql_command( "{MYSQL_BINARY} --no-defaults", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}", "execute" => "broken query" ]);'`
     Then STDOUT should be empty
     And STDERR should contain:
       """
@@ -51,7 +51,7 @@ Feature: Utilities that do NOT depend on WordPress code
 
   @require-mysql
   Scenario: Check that `Utils\run_mysql_command()` can return data and errors if requested
-    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr, $exit_code ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}", "execute" => "SHOW DATABASES;" ], null, false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
+    When I run `wp --skip-wordpress eval 'list( $stdout, $stderr, $exit_code ) = WP_CLI\Utils\run_mysql_command( "{MYSQL_BINARY} --no-defaults", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}", "execute" => "SHOW DATABASES;" ], null, false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
     Then STDOUT should not contain:
       """
       Database
@@ -70,7 +70,7 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And STDERR should be empty
 
-    When I try `wp --skip-wordpress eval 'list( $stdout, $stderr, $exit_code ) = WP_CLI\Utils\run_mysql_command( "/usr/bin/env mysql --no-defaults", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}", "execute" => "broken query" ], null, false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
+    When I try `wp --skip-wordpress eval 'list( $stdout, $stderr, $exit_code ) = WP_CLI\Utils\run_mysql_command( "{MYSQL_BINARY} --no-defaults", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}", "execute" => "broken query" ], null, false ); fwrite( STDOUT, strtoupper( $stdout ) ); fwrite( STDERR, strtoupper( $stderr ) );'`
     Then STDOUT should be empty
     And STDERR should not contain:
       """
@@ -149,19 +149,19 @@ Feature: Utilities that do NOT depend on WordPress code
       """
     And save STDOUT as {DB_HOST_STRING}
 
-    When I try `mysql --database={DB_NAME} --user={DB_ROOT_USER} --password={DB_ROOT_PASSWORD} {DB_HOST_STRING} -e "SET GLOBAL max_allowed_packet=64*1024*1024;"`
+    When I try `{MYSQL_BINARY} --database={DB_NAME} --user={DB_ROOT_USER} --password={DB_ROOT_PASSWORD} {DB_HOST_STRING} -e "SET GLOBAL max_allowed_packet=64*1024*1024;"`
     Then the return code should be 0
 
     # This throws a warning because of the password.
-    When I try `mysql --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
+    When I try `{MYSQL_BINARY} --database={DB_NAME} --user={DB_USER} --password={DB_PASSWORD} {DB_HOST_STRING} < test_db.sql`
     Then the return code should be 0
 
     # The --skip-column-statistics flag is not always present.
-    When I try `mysqldump --help | grep -q 'column-statistics' && echo '--skip-column-statistics'`
+    When I try `{SQL_DUMP_COMMAND} --help | grep -q 'column-statistics' && echo '--skip-column-statistics'`
     Then save STDOUT as {SKIP_COLUMN_STATISTICS_FLAG}
 
     # This throws a warning because of the password.
-    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=50M -ddisable_functions=ini_set} eval '\WP_CLI\Utils\run_mysql_command("/usr/bin/env mysqldump {SKIP_COLUMN_STATISTICS_FLAG} --no-tablespaces {DB_NAME}", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}" ], null, true);'`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=50M -ddisable_functions=ini_set} eval '\WP_CLI\Utils\run_mysql_command("/usr/bin/env {SQL_DUMP_COMMAND} {SKIP_COLUMN_STATISTICS_FLAG} --no-tablespaces {DB_NAME}", [ "user" => "{DB_USER}", "pass" => "{DB_PASSWORD}", "host" => "{DB_HOST}" ], null, true);'`
     Then the return code should be 0
     And STDOUT should not be empty
     And STDOUT should contain:

--- a/php/utils.php
+++ b/php/utils.php
@@ -1877,6 +1877,7 @@ function get_mysql_binary_path() {
 
 	if ( 0 === $mysql->return_code ) {
 		if ( '' !== $mysql_binary ) {
+			$path   = $mysql_binary;
 			$result = Process::create( "$mysql_binary --version", null, null )->run();
 
 			// It's actually MariaDB disguised as MySQL.
@@ -1886,6 +1887,10 @@ function get_mysql_binary_path() {
 		}
 	} elseif ( 0 === $mariadb->return_code ) {
 		$path = $mariadb_binary;
+	}
+
+	if ( '' === $path ) {
+		WP_CLI::Error( 'Could not find mysql binary' );
 	}
 
 	return $path;

--- a/php/utils.php
+++ b/php/utils.php
@@ -1922,6 +1922,24 @@ function get_mysql_version() {
 }
 
 /**
+	* Returns the correct `dump` command based on the detected database type.
+	*
+	* @return string The appropriate dump command.
+	*/
+function get_sql_dump_command() {
+	return 'mariadb' === get_db_type() ? 'mariadb-dump' : 'mysqldump';
+}
+
+/**
+	* Returns the correct `check` command based on the detected database type.
+	*
+	* @return string The appropriate check command.
+	*/
+function get_sql_check_command() {
+	return 'mariadb' === get_db_type() ? 'mariadb-check' : 'mysqlcheck';
+}
+
+/**
  * Get the SQL modes of the MySQL session.
  *
  * @return string[] Array of SQL modes, or an empty array if they couldn't be


### PR DESCRIPTION
See:

* https://github.com/wp-cli/db-command/pull/280#issuecomment-2751656704
* https://github.com/wp-cli/db-command/pull/275
* https://github.com/wp-cli/db-command/issues/271
* https://github.com/wp-cli/.github/issues/123

MariaDB currently adds symlinks for `mysql` to use `mariadb` under the hood, but that is being deprecated and people get warnings like `Deprecated program name. It will be removed in a future release, use 'mariadb' instead`

With this change, the idea is to offer better utils for commands like db-command to pick the right binary.

I suppose that could imply that we officially support MariaDB, but I guess since WordPress core itself [recommends](https://wordpress.org/about/requirements/) it, we should at least test it.