### PR TITLE
Fix update step for nightlies

### DIFF
--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -318,18 +318,18 @@ class CLI_Command extends WP_CLI_Command {
 
 			$updates = $this->get_updates( $assoc_args );
 
-			if ( empty( $updates ) ) {
+			$newest = $this->array_find(
+				$updates,
+				static function ( $update ) {
+					return $update['status'] === 'available';
+				}
+			);
+
+			if ( ! $newest ) {
 				$update_type = $this->get_update_type_str( $assoc_args );
 				WP_CLI::success( "WP-CLI is at the latest{$update_type}version." );
 				return;
 			}
-
-			$newest = $this->array_find(
-				$updates,
-				static function ( $update ) {
-					return $update['available'];
-				}
-			);
 
 			WP_CLI::confirm( sprintf( 'You have version %s. Would you like to update to %s?', WP_CLI_VERSION, $newest['version'] ), $assoc_args );
 

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -321,7 +321,7 @@ class CLI_Command extends WP_CLI_Command {
 			$newest = $this->array_find(
 				$updates,
 				static function ( $update ) {
-					return $update['status'] === 'available';
+					return 'available' === $update['status'];
 				}
 			);
 


### PR DESCRIPTION
When using a currently nightly build and running `wp cli update` without any arguments, it couldn't find any version, which caused some PHP warnings.

```
$ wp cli update
PHP Warning:  Undefined array key "available" in phar:///Users/pascalb/.local/bin/wp/vendor/wp-cli/wp-cli/php/commands/src/CLI_Command.php on line 330

Warning: Undefined array key "available" in phar:///Users/pascalb/.local/bin/wp/vendor/wp-cli/wp-cli/php/commands/src/CLI_Command.php on line 330
PHP Warning:  Trying to access array offset on null in phar:///Users/pascalb/.local/bin/wp/vendor/wp-cli/wp-cli/php/commands/src/CLI_Command.php on line 334

Warning: Trying to access array offset on null in phar:///Users/pascalb/.local/bin/wp/vendor/wp-cli/wp-cli/php/commands/src/CLI_Command.php on line 334
You have version 2.12.0-alpha-842fe5d. Would you like to update to ? [y/n]
```

That's because `$update['available']` doesn't exist. The right array key & check is `$update['status'] === 'available'` 🤦 