### PR TITLE
Set display_errors to stderr (lowercase) instead of STDERR

### DIFF
--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -87,7 +87,7 @@ function wp_debug_mode() {
 	}
 
 	// XDebug already sends errors to STDERR.
-	ini_set( 'display_errors', function_exists( 'xdebug_debug_zval' ) ? false : 'STDERR' );
+	ini_set( 'display_errors', function_exists( 'xdebug_debug_zval' ) ? false : 'stderr' );
 }
 // phpcs:enable
 


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/6083

Lowercase `stderr` is the expected format: https://www.php.net/manual/en/errorfunc.configuration.php#ini.display-errors