### PR TITLE
Make sure existing `esc_like()` takes precedence

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -1674,6 +1674,15 @@ function _proc_open_compat_win_env( $cmd, &$env ) {
  *                or real_escape next.
  */
 function esc_like( $text ) {
+	global $wpdb;
+
+	// Check if the esc_like() method exists on the global $wpdb object.
+	// We need to do this because to ensure compatibilty layers like the
+	// SQLite integration plugin still work.
+	if ( method_exists( $wpdb, 'esc_like' ) ) {
+		return $wpdb->esc_like( $text );
+	}
+
 	return addcslashes( $text, '_%\\' );
 }
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -1679,7 +1679,7 @@ function esc_like( $text ) {
 	// Check if the esc_like() method exists on the global $wpdb object.
 	// We need to do this because to ensure compatibilty layers like the
 	// SQLite integration plugin still work.
-	if ( $wpdb !== null && method_exists( $wpdb, 'esc_like' ) ) {
+	if ( null !== $wpdb && method_exists( $wpdb, 'esc_like' ) ) {
 		return $wpdb->esc_like( $text );
 	}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -1679,7 +1679,7 @@ function esc_like( $text ) {
 	// Check if the esc_like() method exists on the global $wpdb object.
 	// We need to do this because to ensure compatibilty layers like the
 	// SQLite integration plugin still work.
-	if ( method_exists( $wpdb, 'esc_like' ) ) {
+	if ( $wpdb !== null && method_exists( $wpdb, 'esc_like' ) ) {
 		return $wpdb->esc_like( $text );
 	}
 

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -799,9 +799,17 @@ class UtilsTest extends TestCase {
 	 */
 	public function test_esc_like_with_wpdb( $input, $expected ) {
 		global $wpdb;
-		$wpdb = $this->getMockBuilder( 'stdClass' )
-			->addMethods( [ 'esc_like' ] )
-			->getMock();
+		$wpdb = $this->getMockBuilder( 'stdClass' );
+
+		// Handle different PHPUnit versions (5.7 for PHP 5.6 vs newer versions)
+		// This can be simplified if we drop support for PHP 5.6.
+		if ( method_exists( $wpdb, 'addMethods' ) ) {
+			$wpdb = $wpdb->addMethods( [ 'esc_like' ] );
+		} else {
+			$wpdb = $wpdb->setMethods( [ 'esc_like' ] );
+		}
+
+		$wpdb = $wpdb->getMock();
 		$wpdb->method( 'esc_like' )
 			->willReturn( addcslashes( $input, '_%\\' ) );
 		$this->assertEquals( $expected, Utils\esc_like( $input ) );

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -777,28 +777,41 @@ class UtilsTest extends TestCase {
 		];
 	}
 
-	/**
-	 * Copied from core "tests/phpunit/tests/db.php" (adapted to not use `$wpdb`).
-	 */
-	public function test_esc_like() {
-		$inputs   = [
-			'howdy%', // Single Percent.
-			'howdy_', // Single Underscore.
-			'howdy\\', // Single slash.
-			'howdy\\howdy%howdy_', // The works.
-			'howdy\'"[[]*#[^howdy]!+)(*&$#@!~|}{=--`/.,<>?', // Plain text.
+	public static function dataEscLike() {
+		return [
+			[ 'howdy%', 'howdy\\%' ],
+			[ 'howdy_', 'howdy\\_' ],
+			[ 'howdy\\', 'howdy\\\\' ],
+			[ 'howdy\\howdy%howdy_', 'howdy\\\\howdy\\%howdy\\_' ],
+			[ 'howdy\'"[[]*#[^howdy]!+)(*&$#@!~|}{=--`/.,<>?', 'howdy\'"[[]*#[^howdy]!+)(*&$#@!~|}{=--`/.,<>?' ],
 		];
-		$expected = [
-			'howdy\\%',
-			'howdy\\_',
-			'howdy\\\\',
-			'howdy\\\\howdy\\%howdy\\_',
-			'howdy\'"[[]*#[^howdy]!+)(*&$#@!~|}{=--`/.,<>?',
-		];
+	}
 
-		foreach ( $inputs as $key => $input ) {
-			$this->assertEquals( $expected[ $key ], Utils\esc_like( $input ) );
-		}
+	/**
+	 * @dataProvider dataEscLike
+	 */
+	public function test_esc_like( $input, $expected ) {
+		$this->assertEquals( $expected, Utils\esc_like( $input ) );
+	}
+
+	/**
+	 * @dataProvider dataEscLike
+	 */
+	public function test_esc_like_with_wpdb( $input, $expected ) {
+		global $wpdb;
+		$wpdb->esc_like = function ( $text ) {
+			return addslashes( $text );
+		};
+		$this->assertEquals( $expected, Utils\esc_like( $input ) );
+	}
+
+	/**
+	 * @dataProvider dataEscLike
+	 */
+	public function test_esc_like_with_wpdb_being_null( $input, $expected ) {
+		global $wpdb;
+		$wpdb = null;
+		$this->assertEquals( $expected, Utils\esc_like( $input ) );
 	}
 
 	/**

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -799,9 +799,11 @@ class UtilsTest extends TestCase {
 	 */
 	public function test_esc_like_with_wpdb( $input, $expected ) {
 		global $wpdb;
-		$wpdb->esc_like = function ( $text ) {
-			return addslashes( $text );
-		};
+		$wpdb = $this->getMockBuilder( 'wpdb' )->getMock();
+		$wpdb->expects( $this->once() )
+			->method( 'esc_like' )
+			->willReturn( addcslashes( $input, '_%\\' ) );
+		$this->assertEquals( $expected, Utils\esc_like( $input ) );
 		$this->assertEquals( $expected, Utils\esc_like( $input ) );
 	}
 

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -799,7 +799,9 @@ class UtilsTest extends TestCase {
 	 */
 	public function test_esc_like_with_wpdb( $input, $expected ) {
 		global $wpdb;
-		$wpdb = $this->createMock( 'wpdb' );
+		$wpdb = $this->getMockBuilder( 'stdClass' )
+			->addMethods( [ 'esc_like' ] )
+			->getMock();
 		$wpdb->method( 'esc_like' )
 			->willReturn( addcslashes( $input, '_%\\' ) );
 		$this->assertEquals( $expected, Utils\esc_like( $input ) );

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -799,9 +799,8 @@ class UtilsTest extends TestCase {
 	 */
 	public function test_esc_like_with_wpdb( $input, $expected ) {
 		global $wpdb;
-		$wpdb = $this->getMockBuilder( 'wpdb' )->getMock();
-		$wpdb->expects( $this->once() )
-			->method( 'esc_like' )
+		$wpdb = $this->createMock( 'wpdb' );
+		$wpdb->method( 'esc_like' )
 			->willReturn( addcslashes( $input, '_%\\' ) );
 		$this->assertEquals( $expected, Utils\esc_like( $input ) );
 		$this->assertEquals( $expected, Utils\esc_like( $input ) );


### PR DESCRIPTION
As described in https://github.com/wp-cli/cache-command/issues/92#issuecomment-2083462498, we need to let the existing `$wpdb->esc_like()` take precedence in order to allow compatibility layers like the SQLite integration plugin to still have a way to override things.