### PR TITLE
Replace duplicate-post with hello-dolly

### DIFF
--- a/features/bootstrap.feature
+++ b/features/bootstrap.feature
@@ -312,7 +312,7 @@ Feature: Bootstrap WP-CLI
       """
     And I run `wp package install {RUN_DIR}/override`
 
-    When I try `wp plugin install duplicate-post`
+    When I try `wp plugin install hello-dolly`
     Then STDERR should contain:
       """
       Error: Plugin installation has been disabled.

--- a/features/requests.feature
+++ b/features/requests.feature
@@ -71,7 +71,7 @@ Feature: Requests integration with both v1 and v2
       """
     And STDERR should be empty
 
-    When I run `wp plugin install duplicate-post`
+    When I run `wp plugin install hello-dolly`
     Then STDOUT should contain:
       """
       Success: Installed 1 of 1 plugins.
@@ -102,7 +102,7 @@ Feature: Requests integration with both v1 and v2
       """
     And STDERR should be empty
 
-    When I run `wp plugin install duplicate-post`
+    When I run `wp plugin install hello-dolly`
     Then STDOUT should contain:
       """
       Success: Installed 1 of 1 plugins.


### PR DESCRIPTION
Fixes test failures due to `duplicate-post` now requiring WP 6.6+.