### PR TITLE
Add JSON schema validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "wp-cli/php-cli-tools": "~0.12.4"
     },
     "require-dev": {
+        "justinrainbow/json-schema": "^6.3",
         "roave/security-advisories": "dev-latest",
         "wp-cli/db-command": "^1.3 || ^2",
         "wp-cli/entity-command": "^1.2 || ^2",

--- a/schemas/wp-cli-config.json
+++ b/schemas/wp-cli-config.json
@@ -193,7 +193,7 @@
       ],
       "description": "Aliases to other WordPress installs (e.g. `wp @staging rewrite flush`)"
     },
-    "^[a-z]+(\\s?[a-z-])*$": {
+    "^[a-z]+[a-z-]*\\s[a-z-]+.*$": {
       "type": "object",
       "additionalProperties": true,
       "description": "Subcommand defaults (e.g. `wp config create`)"

--- a/schemas/wp-cli-config.json
+++ b/schemas/wp-cli-config.json
@@ -4,6 +4,10 @@
   "description": "JSON Schema for validating wp-cli.yml configuration files",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema reference"
+    },
     "path": {
       "type": "string",
       "description": "Path to the WordPress files.",

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -13,22 +13,28 @@ class SchemaValidationTest extends TestCase {
 
 		// Load schema once
 		$schema_content = file_get_contents( $schema_path );
-		$schema         = json_decode( $schema_content );
+		$this->assertNotFalse( $schema_content, 'Schema file should be readable' );
 
+		$schema = json_decode( $schema_content );
 		$this->assertNotNull( $schema, 'Schema should be valid JSON' );
 
 		// Find all .yml files in the schemas directory
 		$yaml_files = glob( $schemas_dir . '/*.yml' );
+		$this->assertNotFalse( $yaml_files, 'Should be able to glob for YAML files' );
 
 		foreach ( $yaml_files as $yaml_file ) {
 			// Load and parse the YAML file
 			$yaml_content = file_get_contents( $yaml_file );
-			$yaml_data    = \Mustangostang\Spyc::YAMLLoadString( $yaml_content );
+			$this->assertNotFalse( $yaml_content, 'YAML file should be readable: ' . basename( $yaml_file ) );
 
+			$yaml_data = \Mustangostang\Spyc::YAMLLoadString( $yaml_content );
 			$this->assertIsArray( $yaml_data, 'YAML should parse to an array/object: ' . basename( $yaml_file ) );
 
 			// Convert YAML data to object for validation
-			$data = json_decode( json_encode( $yaml_data ) );
+			$json_string = json_encode( $yaml_data );
+			$this->assertNotFalse( $json_string, 'YAML data should convert to JSON string: ' . basename( $yaml_file ) );
+
+			$data = json_decode( $json_string );
 			$this->assertNotNull( $data, 'YAML data should convert to JSON object: ' . basename( $yaml_file ) );
 
 			// Validate using JSON Schema validator

--- a/tests/SchemaValidationTest.php
+++ b/tests/SchemaValidationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
+
+class SchemaValidationTest extends TestCase {
+	/**
+	 * Test validation of example YAML files against the JSON schema.
+	 */
+	public function testExampleYamlFilesValidateAgainstSchema(): void {
+		$schemas_dir = dirname( __DIR__ ) . '/schemas';
+		$schema_path = $schemas_dir . '/wp-cli-config.json';
+
+		// Load schema once
+		$schema_content = file_get_contents( $schema_path );
+		$schema         = json_decode( $schema_content );
+
+		$this->assertNotNull( $schema, 'Schema should be valid JSON' );
+
+		// Find all .yml files in the schemas directory
+		$yaml_files = glob( $schemas_dir . '/*.yml' );
+
+		foreach ( $yaml_files as $yaml_file ) {
+			// Load and parse the YAML file
+			$yaml_content = file_get_contents( $yaml_file );
+			$yaml_data    = \Mustangostang\Spyc::YAMLLoadString( $yaml_content );
+
+			$this->assertIsArray( $yaml_data, 'YAML should parse to an array/object: ' . basename( $yaml_file ) );
+
+			// Convert YAML data to object for validation
+			$data = json_decode( json_encode( $yaml_data ) );
+			$this->assertNotNull( $data, 'YAML data should convert to JSON object: ' . basename( $yaml_file ) );
+
+			// Validate using JSON Schema validator
+			$validator = new Validator();
+			$validator->validate( $data, $schema );
+
+			$this->assertTrue(
+				$validator->isValid(),
+				$this->formatValidationErrors( basename( $yaml_file ), $validator->getErrors() )
+			);
+		}
+	}
+
+	/**
+	 * Format validation errors into a readable message.
+	 *
+	 * @param string $filename The YAML filename being validated.
+	 * @param array  $errors   Array of validation errors from JsonSchema\Validator.
+	 * @return string Formatted error message.
+	 */
+	private function formatValidationErrors( string $filename, array $errors ): string {
+		if ( empty( $errors ) ) {
+			return "YAML file {$filename} should validate against schema.";
+		}
+
+		$message = "YAML file {$filename} failed schema validation:\n";
+
+		foreach ( $errors as $error ) {
+			$property = isset( $error['property'] ) ? $error['property'] : 'unknown';
+			$pointer  = isset( $error['pointer'] ) ? $error['pointer'] : '';
+			$msg      = isset( $error['message'] ) ? $error['message'] : 'Unknown error';
+
+			$message .= sprintf(
+				"  - Property '%s' (at %s): %s\n",
+				$property,
+				$pointer ?: 'root',
+				$msg
+			);
+		}
+
+		return rtrim( $message );
+	}
+}


### PR DESCRIPTION
A JSON schema and example wp-cli.yml file were added in #6095. This adds JSON schema validation for the YAML file (and any others that are added to that directory) using `justinrainbow/json-schema`. Notably, this package is already a transient dependency as it's used by `composer/composer`, so although this is now an explicit dependency it's not an additional dependency.

Two fixes are made to the schema:

1. Support for the `$schema` property
2. A more specific regex for the subcommand properties so it's not matched by single word keys