### PR TITLE
Fix incorrect wp-cli-tests dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "wp-cli/entity-command": "^1.2 || ^2",
         "wp-cli/extension-command": "^1.1 || ^2",
         "wp-cli/package-command": "^1 || ^2",
-        "wp-cli/wp-cli-tests": "dev-add/phpstan-enhancements"
+        "wp-cli/wp-cli-tests": "^4"
     },
     "suggest": {
         "ext-readline": "Include for a better --prompt implementation",


### PR DESCRIPTION
Added in #6096 by accident, forgot to change it before merge.