### PR TITLE
Fix heredoc issue

### DIFF
--- a/tests/DocParserTest.php
+++ b/tests/DocParserTest.php
@@ -16,7 +16,7 @@ class DocParserTest extends TestCase {
 
 	public function test_only_tags(): void {
 		$doc = new DocParser(
-			<<<EOB
+			<<<'EOB'
 /**
  * @alias rock-on
  * @subcommand revoke-md5-passwords
@@ -34,7 +34,7 @@ EOB
 
 	public function test_no_longdesc(): void {
 		$doc = new DocParser(
-			<<<EOB
+			<<<'EOB'
 /**
  * Rock and roll!
  * @alias rock-on
@@ -50,7 +50,7 @@ EOB
 
 	public function test_complete(): void {
 		$doc = new DocParser(
-			<<<EOB
+			<<<'EOB'
 /**
  * Rock and roll!
  *
@@ -81,7 +81,7 @@ EOB
 		$this->assertEquals( 'Sets the volume.', $doc->get_param_desc( 'volume' ) );
 		$this->assertEquals( 'rock-on', $doc->get_tag( 'alias' ) );
 
-		$longdesc = <<<EOB
+		$longdesc = <<<'EOB'
 ## OPTIONS
 
 <genre>...
@@ -101,7 +101,7 @@ EOB;
 	}
 
 	public function test_desc_parses_yaml(): void {
-		$longdesc = <<<EOB
+		$longdesc = <<<'EOB'
 Play some music loudly
 
 ```
@@ -154,7 +154,7 @@ EOB;
 	}
 
 	public function test_desc_doesnt_parse_far_params_yaml(): void {
-		$longdesc = <<<EOB
+		$longdesc = <<<'EOB'
 ## OPTIONS
 
 <hook>
@@ -183,7 +183,7 @@ EOB;
 	}
 
 	public function test_desc_doesnt_parse_far_args_yaml(): void {
-		$longdesc = <<<EOB
+		$longdesc = <<<'EOB'
 ## OPTIONS
 
 <hook>

--- a/tests/HelpTest.php
+++ b/tests/HelpTest.php
@@ -18,7 +18,7 @@ class HelpTest extends TestCase {
 		$desc   = 'This is a [reference link](https://wordpress.org/). It should be displayed very nice!';
 		$result = $method->invokeArgs( null, [ $desc ] );
 
-		$expected = <<<EOL
+		$expected = <<<'EOL'
 This is a [reference link][1]. It should be displayed very nice!
 
 ---
@@ -29,7 +29,7 @@ EOL;
 		$desc   = 'This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/). It should be displayed very nice!';
 		$result = $method->invokeArgs( null, [ $desc ] );
 
-		$expected = <<<EOL
+		$expected = <<<'EOL'
 This is a [reference link][1] and [second link][2]. It should be displayed very nice!
 
 ---
@@ -38,13 +38,13 @@ This is a [reference link][1] and [second link][2]. It should be displayed very 
 EOL;
 		$this->assertSame( $expected, $result );
 
-		$desc   = <<<EOL
+		$desc   = <<<'EOL'
 This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/).
 It should be displayed very nice!
 EOL;
 		$result = $method->invokeArgs( null, [ $desc ] );
 
-		$expected = <<<EOL
+		$expected = <<<'EOL'
 This is a [reference link][1] and [second link][2].
 It should be displayed very nice!
 
@@ -55,7 +55,7 @@ EOL;
 
 		$this->assertSame( $expected, $result );
 
-		$desc   = <<<EOL
+		$desc   = <<<'EOL'
 This is a [reference link](https://wordpress.org/) and [second link](http://wp-cli.org/).
 It should be displayed very nice!
 
@@ -65,7 +65,7 @@ It doesn't expect to be link here like [reference link](https://wordpress.org/).
 EOL;
 		$result = $method->invokeArgs( null, [ $desc ] );
 
-		$expected = <<<EOL
+		$expected = <<<'EOL'
 This is a [reference link][1] and [second link][2].
 It should be displayed very nice!
 
@@ -80,14 +80,14 @@ EOL;
 
 		$this->assertSame( $expected, $result );
 
-		$desc   = <<<EOL
+		$desc   = <<<'EOL'
 ## Example
 
 It doesn't expect to be link here like [reference link](https://wordpress.org/).
 EOL;
 		$result = $method->invokeArgs( null, [ $desc ] );
 
-		$expected = <<<EOL
+		$expected = <<<'EOL'
 ## Example
 
 It doesn't expect to be link here like [reference link](https://wordpress.org/).
@@ -95,7 +95,7 @@ EOL;
 
 		$this->assertSame( $expected, $result );
 
-		$desc   = <<<EOL
+		$desc   = <<<'EOL'
 This is a long description.
 It doesn't have any link.
 
@@ -105,7 +105,7 @@ It doesn't expect to be link here like [reference link](https://wordpress.org/).
 EOL;
 		$result = $method->invokeArgs( null, [ $desc ] );
 
-		$expected = <<<EOL
+		$expected = <<<'EOL'
 This is a long description.
 It doesn't have any link.
 


### PR DESCRIPTION
This PR fixes following PHPCS error code:

`Detected heredoc without interpolation or expressions. Use nowdoc syntax instead`