### PR TITLE
Fix tests for Hello Dolly

### DIFF
--- a/features/skip-plugins.feature
+++ b/features/skip-plugins.feature
@@ -2,9 +2,10 @@ Feature: Skipping plugins
 
   Scenario: Skipping plugins via global flag
     Given a WP installation
-    And I run `wp plugin activate hello akismet`
+    And I run `wp plugin install https://github.com/wp-cli/sample-plugin/archive/refs/heads/master.zip`
+    And I run `wp plugin activate akismet sample-plugin`
 
-    When I run `wp eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
+    When I run `wp eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "sample_plugin" ) );'`
     Then STDOUT should be:
       """
       truetrue
@@ -25,21 +26,21 @@ Feature: Skipping plugins
       """
 
     # The un-specified plugin should continue to be loaded
-    When I run `wp --skip-plugins=akismet eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
+    When I run `wp --skip-plugins=akismet eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "sample_plugin" ) );'`
     Then STDOUT should be:
       """
       falsetrue
       """
 
     # Can specify multiple plugins to skip
-    When I try `wp eval --skip-plugins=hello,akismet 'echo hello_dolly();'`
+    When I try `wp eval --skip-plugins=sample-plugin,akismet 'echo sample_plugin();'`
     Then STDERR should contain:
       """
-      Call to undefined function hello_dolly()
+      Call to undefined function sample_plugin()
       """
 
     # No plugins should be loaded when --skip-plugins doesn't have a value
-    When I run `wp --skip-plugins eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
+    When I run `wp --skip-plugins eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "sample_plugin" ) );'`
     Then STDOUT should be:
       """
       falsefalse
@@ -47,42 +48,45 @@ Feature: Skipping plugins
 
   Scenario: Skipping multiple plugins via config file
     Given a WP installation
+    And I run `wp plugin install https://github.com/wp-cli/sample-plugin/archive/refs/heads/master.zip`
     And a wp-cli.yml file:
       """
       skip-plugins:
-        - hello
+        - sample-plugin
         - akismet
       """
 
-    When I run `wp plugin activate hello`
-    And I try `wp eval 'echo hello_dolly();'`
+    When I run `wp plugin activate sample-plugin`
+    And I try `wp eval 'echo sample_plugin();'`
     Then STDERR should contain:
       """
-      Call to undefined function hello_dolly()
+      Call to undefined function sample_plugin()
       """
 
   Scenario: Skipping all plugins via config file
     Given a WP installation
+    And I run `wp plugin install https://github.com/wp-cli/sample-plugin/archive/refs/heads/master.zip`
     And a wp-cli.yml file:
       """
       skip-plugins: true
       """
 
-    When I run `wp plugin activate hello`
-    And I try `wp eval 'echo hello_dolly();'`
+    When I run `wp plugin activate sample-plugin`
+    And I try `wp eval 'echo sample_plugin();'`
     Then STDERR should contain:
       """
-      Call to undefined function hello_dolly()
+      Call to undefined function sample_plugin()
       """
 
   Scenario: Skip network active plugins
     Given a WP multisite installation
+    And I run `wp plugin install https://github.com/wp-cli/sample-plugin/archive/refs/heads/master.zip`
 
-    When I try `wp plugin deactivate akismet hello`
+    When I try `wp plugin deactivate akismet sample-plugin`
     Then STDERR should be:
       """
       Warning: Plugin 'akismet' isn't active.
-      Warning: Plugin 'hello' isn't active.
+      Warning: Plugin 'sample-plugin' isn't active.
       """
     And STDOUT should be:
       """
@@ -90,26 +94,26 @@ Feature: Skipping plugins
       """
     And the return code should be 0
 
-    When I run `wp plugin activate --network akismet hello`
-    And I run `wp eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
+    When I run `wp plugin activate --network akismet sample-plugin`
+    And I run `wp eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "sample_plugin" ) );'`
     Then STDOUT should be:
       """
       truetrue
       """
 
-    When I run `wp --skip-plugins eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
+    When I run `wp --skip-plugins eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "sample_plugin" ) );'`
     Then STDOUT should be:
       """
       falsefalse
       """
 
-    When I run `wp --skip-plugins=akismet eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
+    When I run `wp --skip-plugins=akismet eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "sample_plugin" ) );'`
     Then STDOUT should be:
       """
       falsetrue
       """
 
-    When I run `wp --skip-plugins=hello eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "hello_dolly" ) );'`
+    When I run `wp --skip-plugins=sample-plugin eval 'var_export( defined("AKISMET_VERSION") );var_export( function_exists( "sample_plugin" ) );'`
     Then STDOUT should be:
       """
       truefalse


### PR DESCRIPTION
Hello Dolly was moved from a single file to a directory in WordPress 6.9. Trying to make the tests more robust by replacing it with our own sample plugin.

No idea why some other tests are failing though, see for example https://github.com/wp-cli/wp-cli/actions/runs/17459015237/job/49579164998#step:11:138

Those are best handled in a separate PR.