### PR TITLE
Fix: ensure YAML output correctly handles scalar values like 0 (#6094)

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1058,13 +1058,16 @@ class WP_CLI {
 	 */
 	public static function print_value( $value, $assoc_args = [] ) {
 		$_value = '';
+
 		if ( Utils\get_flag_value( $assoc_args, 'format' ) === 'json' ) {
 			$_value = json_encode( $value );
 		} elseif ( Utils\get_flag_value( $assoc_args, 'format' ) === 'yaml' ) {
-			/**
-			 * @var array $value
-			 */
-			$_value = Spyc::YAMLDump( $value, 2, 0 );
+			if ( is_scalar( $value ) ) {
+				// Handle scalars (like "0") directly to avoid empty YAML output
+				$_value = "---\n" . (string) $value . "\n";
+			} else {
+				$_value = Spyc::YAMLDump( $value, 2, 0 );
+			}
 		} elseif ( is_array( $value ) || is_object( $value ) ) {
 			$_value = var_export( $value, true );
 		} else {
@@ -1073,6 +1076,7 @@ class WP_CLI {
 
 		echo $_value . "\n";
 	}
+
 
 	/**
 	 * Convert a WP_Error or Exception into a string

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -20,7 +20,6 @@ class FormatterTest extends TestCase {
         $output = ob_get_clean();
 
         $this->assertStringContainsString("value: 0", $output, "YAML scalar 0 should be displayed correctly.");
-
     }
 
     public function test_yaml_outputs_string_value() {
@@ -35,6 +34,14 @@ class FormatterTest extends TestCase {
         $output = ob_get_clean();
 
         $this->assertStringContainsString("value: hello", $output, "YAML string should be displayed correctly.");
+    }
 
+    public function test_print_value_scalar_zero() {
+        ob_start();
+        \WP_CLI::print_value( 0, [ 'format' => 'yaml' ] );
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString("---\n0", $output, "Direct WP_CLI::print_value should render scalar 0 correctly.");
     }
 }
+

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WP_CLI\Formatter;
+
+/**
+ * Tests for WP_CLI\Formatter related to YAML output.
+ */
+class FormatterTest extends TestCase {
+
+    public function test_yaml_outputs_scalar_zero() {
+        $assoc_args = [
+            'format' => 'yaml',
+            'fields' => ['value'],
+        ];
+
+        $formatter = new Formatter( $assoc_args );
+        ob_start();
+        $formatter->display_items( [ [ 'value' => 0 ] ] );
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString("value: 0", $output, "YAML scalar 0 should be displayed correctly.");
+
+    }
+
+    public function test_yaml_outputs_string_value() {
+        $assoc_args = [
+            'format' => 'yaml',
+            'fields' => ['value'],
+        ];
+
+        $formatter = new Formatter( $assoc_args );
+        ob_start();
+        $formatter->display_items( [ [ 'value' => 'hello' ] ] );
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString("value: hello", $output, "YAML string should be displayed correctly.");
+
+    }
+}


### PR DESCRIPTION
Fix: YAML formatter renders scalar values like 0 correctly

Previously, when using `--format=yaml`, scalar values such as `0` were rendered
as empty (`---`) instead of showing their actual value. For example:

    `wp` option get blog_public --format=yaml

returned only:

    ---

instead of the expected:

    ---
    0

### Steps to Reproduce

1. Install WP-CLI from `main`.

2. Run:
   ```bash
   wp option update blog_public 0
   wp option get blog_public --format=yaml

Observe that the output is empty (---) instead of --- 0.

### Environment

- WP-CLI: 2.13.0-alpha
- PHP: 8.1.2
- OS: Ubuntu 22.04 (WSL2)
- Database: MariaDB 10.x

###Results and Impacts

- Expected: Scalar values like 0 should be correctly represented in YAML output.
- Actual: Scalar values are displayed as empty (---).
- Impact: Users relying on scalar values (e.g., boolean-like options) receive misleading YAML output, which can break automation or config pipelines.

### Fix
- Updated `Formatter::print_value()` to detect scalar values (e.g., `0`) and
  output them directly as strings.
- Arrays and objects continue to use `Spyc::YAMLDump` for rendering.

# Verification (After Fix)

```bash
wp option get blog_public --format=yaml
```
```yaml
---
0
```

```bash
wp option get blog_public --format=json
```
```json
"0"
```

```bash
wp option add test_string hello
wp option get test_string --format=yaml
```
```yaml
---
hello
```


### Notes
- Code style auto-fixed with `composer run-script phpcbf`.
- Full test suite (`composer test`) passes locally.

Fixes #6094.
