### PR TITLE
docs: Fix comment to reference WP_CLI::error() instead of debug()

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -862,7 +862,7 @@ class WP_CLI {
 	 *
 	 * Warning message is written to STDERR, or discarded when `--quiet` flag is supplied.
 	 *
-	 * Use instead of `WP_CLI::debug()` when script execution should be permitted
+	 * Use instead of `WP_CLI::error()` when script execution should be permitted
 	 * to continue.
 	 *
 	 * ```


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
