### PR TITLE
feat(db): add robust support for WP_CLI_MYSQLDUMP override with fallback handling

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -2058,34 +2058,52 @@ function get_mysql_dump_binary() {
 	// Honour explicit override when provided.
 	if ( is_string( $env ) && '' !== $env ) {
 
-		// Absolute path override: only trust when executable.
-		if ( is_path_absolute( $env ) ) {
-			if ( is_executable( $env ) ) {
-				WP_CLI::debug( sprintf(
-					'Using dump command from WP_CLI_MYSQLDUMP: %s',
+		// Command name override: allow system PATH resolution.
+		if ( ! is_path_absolute( $env ) ) {
+			WP_CLI::debug(
+				sprintf(
+					'Using dump command from WP_CLI_MYSQLDUMP via PATH: %s',
 					$env
-				), 'db' );
-
-				return $env;
-			}
-		} else {
-			// Command name override: allow system PATH resolution.
-			WP_CLI::debug( sprintf(
-				'Using dump command from WP_CLI_MYSQLDUMP via PATH: %s',
-				$env
-			), 'db' );
+				),
+				'db'
+			);
 
 			return $env;
 		}
+
+		// Absolute path override: only trust when executable.
+		if ( is_executable( $env ) ) {
+			WP_CLI::debug(
+				sprintf(
+					'Using dump command from WP_CLI_MYSQLDUMP: %s',
+					$env
+				),
+				'db'
+			);
+
+			return $env;
+		}
+
+		// Absolute path but not executable → log skip so users know why it was ignored.
+		WP_CLI::debug(
+			sprintf(
+				'Ignoring non-executable dump command from WP_CLI_MYSQLDUMP: %s',
+				$env
+			),
+			'db'
+		);
 	}
 
 	// Fallback: detect DB type and choose the appropriate default binary.
 	$binary = ( 'mariadb' === get_db_type() ) ? 'mariadb-dump' : 'mysqldump';
 
-	WP_CLI::debug( sprintf(
-		'Final MySQL command: %s',
-		$binary
-	), 'db' );
+	WP_CLI::debug(
+		sprintf(
+			'Using default dump command: %s',
+			$binary
+		),
+		'db'
+	);
 
 	return $binary;
 }

--- a/php/utils.php
+++ b/php/utils.php
@@ -2029,12 +2029,74 @@ function get_mysql_version() {
 }
 
 /**
+ * Determine which SQL dump binary should be used for export operations.
+ *
+ * This helper allows environments to override the dump binary used by WP-CLI
+ * by defining the `WP_CLI_MYSQLDUMP` environment variable.
+ *
+ * Behaviour:
+ * - If `WP_CLI_MYSQLDUMP` is set to an absolute path, it will be used only
+ *   when the file exists and is executable.
+ * - If the variable is set to a bare command name (e.g., "mysqldump"),
+ *   WP-CLI will defer to the system `PATH` resolver without further checks.
+ * - If the variable is not set or unusable, WP-CLI falls back to:
+ *      • `mariadb-dump` on MariaDB systems
+ *      • `mysqldump` otherwise
+ *
+ * Examples:
+ *     # Use a specific absolute path
+ *     WP_CLI_MYSQLDUMP=/usr/local/bin/mysqldump wp db export
+ *
+ *     # Force mysqldump even on MariaDB systems
+ *     WP_CLI_MYSQLDUMP=mysqldump wp db export
+ *
+ * @return string The executable (binary or absolute path) to use for SQL dump operations.
+ */
+function get_mysql_dump_binary() {
+	$env = getenv( 'WP_CLI_MYSQLDUMP' );
+
+	// Honour explicit override when provided.
+	if ( is_string( $env ) && '' !== $env ) {
+
+		// Absolute path override: only trust when executable.
+		if ( is_path_absolute( $env ) ) {
+			if ( is_executable( $env ) ) {
+				WP_CLI::debug( sprintf(
+					'Using dump command from WP_CLI_MYSQLDUMP: %s',
+					$env
+				), 'db' );
+
+				return $env;
+			}
+		} else {
+			// Command name override: allow system PATH resolution.
+			WP_CLI::debug( sprintf(
+				'Using dump command from WP_CLI_MYSQLDUMP via PATH: %s',
+				$env
+			), 'db' );
+
+			return $env;
+		}
+	}
+
+	// Fallback: detect DB type and choose the appropriate default binary.
+	$binary = ( 'mariadb' === get_db_type() ) ? 'mariadb-dump' : 'mysqldump';
+
+	WP_CLI::debug( sprintf(
+		'Final MySQL command: %s',
+		$binary
+	), 'db' );
+
+	return $binary;
+}
+
+/**
  * Returns the correct `dump` command based on the detected database type.
  *
  * @return string The appropriate dump command.
  */
 function get_sql_dump_command() {
-	return 'mariadb' === get_db_type() ? 'mariadb-dump' : 'mysqldump';
+	return get_mysql_dump_binary();
 }
 
 /**


### PR DESCRIPTION
This PR improves the SQL dump binary resolution logic used by `wp db export`.

## What this change does

- Adds safe, explicit support for overriding the dump client via the
  `WP_CLI_MYSQLDUMP` environment variable.
- Correctly handles both:
  - absolute executable paths
  - plain command names resolved through `PATH`
- Ignores invalid or non-executable absolute paths to avoid breaking `wp db export`.
- Falls back reliably to the appropriate default:
  - `mariadb-dump` on MariaDB installs
  - `mysqldump` otherwise

## Why this is useful

Many Docker-based or custom server environments provide only one of the dump
clients, or store it in a non-standard location. This update makes `wp db export`
more predictable and easier to configure across those setups.

## Testing

The change was tested in multiple scenarios:

1. **Valid absolute override**  
   `WP_CLI_MYSQLDUMP=/usr/bin/mysqldump` → export succeeds, correct binary selected.

2. **Invalid absolute override**  
   Non-existent file → ignored, fallback selected correctly.

3. **No environment override**  
   MariaDB installation correctly defaults to `mariadb-dump`.

All scenarios produced valid export files and correct debug messages.

---

Happy to adjust anything if needed. Thanks for reviewing!
