### PR TITLE
Fix typo in CLI_Cache_Command.php documentation.

### DIFF
--- a/php/commands/src/CLI_Cache_Command.php
+++ b/php/commands/src/CLI_Cache_Command.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Manages the internal WP-CLI cache,.
+ * Manages the internal WP-CLI cache.
  *
  * ## EXAMPLES
  *


### PR DESCRIPTION
Found a minor typo in the cache command documentation. Here's the correction.