### PR TITLE
Don't warn for missing fields on empty lists

### DIFF
--- a/features/formatter.feature
+++ b/features/formatter.feature
@@ -350,6 +350,42 @@ Feature: Format output
       | Session 1 |             | 2018-09-15 |
       | Session 2 |             | 2018-09-16 |
 
+  Scenario: No warning for missing field with empty list
+    Given an empty directory
+    And an empty-list-field.php file:
+      """
+      <?php
+      $items = array();
+      $assoc_args = array( 'format' => 'json', 'field' => 'name' );
+      $formatter = new WP_CLI\Formatter( $assoc_args, array( 'name' ) );
+      $formatter->display_items( $items );
+      """
+
+    When I run `wp eval-file empty-list-field.php --skip-wordpress`
+    Then STDOUT should be:
+      """
+      []
+      """
+    And STDERR should be empty
+
+  Scenario: No warning for missing fields with empty list
+    Given an empty directory
+    And an empty-list-fields.php file:
+      """
+      <?php
+      $items = array();
+      $assoc_args = array( 'format' => 'json', 'fields' => 'name,login' );
+      $formatter = new WP_CLI\Formatter( $assoc_args, array( 'name', 'login' ) );
+      $formatter->display_items( $items );
+      """
+
+    When I run `wp eval-file empty-list-fields.php --skip-wordpress`
+    Then STDOUT should be:
+      """
+      []
+      """
+    And STDERR should be empty
+
   Scenario: Display ordered output for an object item
     Given an empty directory
     And a file.php file:

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -242,8 +242,10 @@ class Formatter {
 		$key         = null;
 		$values      = [];
 		$field_found = false;
+		$item_count  = 0;
 
 		foreach ( $items as $item ) {
+			++$item_count;
 			$item = (object) $item;
 
 			// Resolve the key on first item that has the field
@@ -269,7 +271,7 @@ class Formatter {
 			}
 		}
 
-		if ( ! $field_found && 0 !== count( $items ) ) {
+		if ( ! $field_found && $item_count > 0 ) {
 			WP_CLI::warning( "Field not found in any item: $field." );
 		}
 
@@ -291,9 +293,11 @@ class Formatter {
 		$resolved_fields = [];
 		$fields_count    = count( $fields_to_find );
 		$found_count     = 0;
+		$item_count      = 0;
 
 		// Iterate through items once and check all fields
 		foreach ( $items as $item ) {
+			++$item_count;
 			// Check each field that hasn't been found yet
 			foreach ( $fields_to_find as $field => $_ ) {
 				$key = $this->find_item_key( $item, $field, true );
@@ -319,9 +323,12 @@ class Formatter {
 		}
 		unset( $field ); // Break the reference to avoid issues with subsequent foreach loops
 
-		// Warn about any fields that weren't found in any item
-		foreach ( $fields_to_find as $missing_field => $_ ) {
-			WP_CLI::warning( "Field not found in any item: $missing_field." );
+		// Only warn about missing fields if there were items to check
+		if ( $item_count > 0 ) {
+			// Warn about any fields that weren't found in any item
+			foreach ( $fields_to_find as $missing_field => $_ ) {
+				WP_CLI::warning( "Field not found in any item: $missing_field." );
+			}
 		}
 	}
 


### PR DESCRIPTION
This is a follow-up to #6196

Seeing some test failures because the warnings were emitted for empty lists, which is of course wrong.

Example:

```
        $ wp plugin list --recently-active --field=name --format=json
        []
        Warning: Field not found in any item: name.
```