### PR TITLE
Utils: Fix `SHOW TABLES` filtering for SQLite

### DIFF
--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -540,7 +540,7 @@ function wp_get_table_names( $args, $assoc_args = [] ) {
 
 		// Note: BC change 1.5.0, tables are sorted (via TABLES view).
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses esc_sql_ident() and $wpdb->_escape().
-		$tables = $wpdb->get_col( 'SHOW TABLES' );
+		$tables = $wpdb->get_col( sprintf( "SHOW TABLES WHERE %s IN ('%s')", esc_sql_ident( 'Tables_in_' . $wpdb->dbname ), implode( "', '", $wpdb->_escape( $wp_tables ) ) ) );
 
 		// Filter tables after the query for improved SQLite compatibility.
 		// See https://github.com/WordPress/sqlite-database-integration/issues/319.


### PR DESCRIPTION
See https://github.com/wp-cli/db-command/pull/299 / https://github.com/wp-cli/db-command/issues/234 for context.

Also: https://github.com/WordPress/sqlite-database-integration/issues/319