### PR TITLE
 Fix undefined index notice in `debug_backtrace_on_exit`

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1162,7 +1162,7 @@ class WP_CLI {
 	 */
 	private static function debug_backtrace_on_exit() {
 		// Only output backtrace when debug mode is enabled.
-		if ( ! self::$logger || ! self::get_runner()->config['debug'] ) {
+		if ( ! self::$logger || ! self::get_config( 'debug' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Seen at https://github.com/wp-cli/package-command/actions/runs/21981334186/job/63504455650?pr=220#step:8:25

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
