### PR TITLE
Standardize plaintext format name across CLI commands

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1182,14 +1182,22 @@ class WP_CLI {
 	 */
 	public static function print_value( $value, $assoc_args = [] ) {
 		$_value = '';
-		if ( Utils\get_flag_value( $assoc_args, 'format' ) === 'json' ) {
+		$format = Utils\get_flag_value( $assoc_args, 'format' );
+
+		// Support deprecated 'var_export' format name
+		if ( 'var_export' === $format ) {
+			WP_CLI::warning( "The 'var_export' format is deprecated. Please use 'plaintext' instead." );
+			$format = 'plaintext';
+		}
+
+		if ( 'json' === $format ) {
 			$_value = json_encode( $value );
-		} elseif ( Utils\get_flag_value( $assoc_args, 'format' ) === 'yaml' ) {
+		} elseif ( 'yaml' === $format ) {
 			/**
 			 * @var array $value
 			 */
 			$_value = Spyc::YAMLDump( $value, 2, 0 );
-		} elseif ( is_array( $value ) || is_object( $value ) ) {
+		} elseif ( 'plaintext' === $format || ( is_array( $value ) || is_object( $value ) ) ) {
 			$_value = var_export( $value, true );
 		} else {
 			/**

--- a/php/commands/src/CLI_Alias_Command.php
+++ b/php/commands/src/CLI_Alias_Command.php
@@ -90,7 +90,8 @@ class CLI_Alias_Command extends WP_CLI_Command {
 	 * options:
 	 *   - yaml
 	 *   - json
-	 *   - var_export
+	 *   - plaintext
+	 *   - var_export (deprecated, use plaintext)
 	 * ---
 	 *
 	 * [--raw]

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -771,7 +771,7 @@ class CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Dumps the list of global parameters, as JSON or in var_export format.
+	 * Dumps the list of global parameters, as JSON or in plaintext format.
 	 *
 	 * ## OPTIONS
 	 *
@@ -783,14 +783,14 @@ class CLI_Command extends WP_CLI_Command {
 	 * ---
 	 * default: json
 	 * options:
-	 *   - var_export
+	 *   - plaintext
 	 *   - json
 	 * ---
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Dump the list of global parameters.
-	 *     $ wp cli param-dump --format=var_export
+	 *     $ wp cli param-dump --format=plaintext
 	 *     array (
 	 *       'path' =>
 	 *       array (
@@ -821,7 +821,13 @@ class CLI_Command extends WP_CLI_Command {
 			}
 		}
 
-		if ( 'var_export' === Utils\get_flag_value( $assoc_args, 'format' ) ) {
+		$format = Utils\get_flag_value( $assoc_args, 'format' );
+
+		// Support both 'plaintext' and deprecated 'var_export' format names.
+		if ( 'plaintext' === $format || 'var_export' === $format ) {
+			if ( 'var_export' === $format ) {
+				WP_CLI::warning( "The 'var_export' format is deprecated. Please use 'plaintext' instead." );
+			}
 			var_export( $spec );
 		} else {
 			echo json_encode( $spec );


### PR DESCRIPTION
## Description

Standardizes the format parameter name across WP-CLI commands for consistency.

### Changes

- Rename 'var_export' format to 'plaintext' in param-dump command
- Rename 'var_export' format to 'plaintext' in alias list command
- Update documentation and examples to reflect new format name
- The var_export() function output behavior remains the same

### Motivation

Different commands were using different names for the same plain-text output format, creating inconsistency in the user experience. This PR standardizes on 'plaintext' which is more descriptive.

### Testing

Please verify:
- `wp cli param-dump --format=plaintext` works as expected
- `wp cli alias list --format=plaintext` works as expected
- Old `var_export` format name is no longer accepted (or shows deprecation warning if applicable)

Fixes #4774