### PR TITLE
Extractor: Prefer `tar` over `PharData`

### DIFF
--- a/features/extractor.feature
+++ b/features/extractor.feature
@@ -1,0 +1,13 @@
+Feature: Extractor
+
+  Scenario: Extracts tar.gz files with long path names
+    Given an empty directory
+
+    When I run `wp core download https://downloads.wordpress.org/release/wordpress-7.0.tar.gz --force`
+    Then the {RUN_DIR} directory should contain:
+    """
+    index.php
+    license.txt
+    """
+    And the wp-includes/php-ai-client/src/Providers/Models/TextToSpeechConversion/Contracts/TextToSpee file should not exist
+    And the wp-includes/php-ai-client/src/Providers/Models/TextToSpeechConversion/Contracts/TextToSpeechConversionOperationModelInterface.php file should exist

--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -95,48 +95,71 @@ class Extractor {
 			throw new Exception( "Could not create folder '{$dest}'." );
 		}
 
-		if ( class_exists( 'PharData' ) ) {
-			try {
-				$phar    = new PharData( $tarball );
-				$name    = Path::basename( $tarball );
-				$tempdir = Utils\get_temp_dir()
-							. uniqid( 'wp-cli-extract-tarball-', true )
-							. "-{$name}";
-
-				$phar->extractTo( $tempdir );
-
-				self::copy_overwrite_files(
-					self::get_first_subfolder( $tempdir ),
-					$dest
-				);
-
-				self::rmdir( $tempdir );
-				return;
-			} catch ( Exception $e ) {
-				WP_CLI::warning(
-					"PharData failed, falling back to 'tar xz' ("
-					. $e->getMessage() . ')'
-				);
-				// Fall through to trying `tar xz` below.
-			}
-		}
-
 		$tarball_absolute = realpath( $tarball );
 		if ( ! $tarball_absolute ) {
 			throw new Exception( "Invalid tarball '{$tarball}'." );
 		}
-		$tarball = $tarball_absolute;
 
-		if ( ! is_readable( $tarball )
-			|| filesize( $tarball ) <= 0 ) {
+		if ( ! is_readable( $tarball_absolute )
+			|| filesize( $tarball_absolute ) <= 0 ) {
 			throw new Exception( "Invalid tarball '{$tarball}'." );
 		}
 
+		// Prefer the system `tar` binary because PharData silently truncates paths longer than 100 characters.
+		// See https://github.com/php/php-src/issues/19311 and https://github.com/wp-cli/wp-cli/issues/6320.
+		if ( self::system_tar_available() ) {
+			try {
+				self::extract_tarball_with_system_tar( $tarball_absolute, $dest );
+				return;
+			} catch ( Exception $e ) {
+				if ( ! class_exists( 'PharData' ) ) {
+					throw $e;
+				}
+
+				WP_CLI::warning(
+					"Failed to extract with 'tar xz', falling back to PharData ("
+					. $e->getMessage() . ')'
+				);
+			}
+		}
+
+		if ( class_exists( 'PharData' ) ) {
+			self::extract_tarball_with_phar_data( $tarball, $dest );
+			return;
+		}
+
+		throw new Exception( 'Extracting a tarball requires the tar binary or PharData.' );
+	}
+
+	/**
+	 * Check whether the system `tar` binary is available.
+	 *
+	 * @return bool
+	 */
+	private static function system_tar_available() {
+		if ( ! Utils\check_proc_available( null, true ) ) {
+			return false;
+		}
+
+		$return_var = -1;
+		exec( 'tar --version 2>&1', $output, $return_var );
+
+		return 0 === $return_var;
+	}
+
+	/**
+	 * Extract a tarball using the system `tar` binary.
+	 *
+	 * @param string $tarball Absolute path to the tarball.
+	 * @param string $dest    Destination directory.
+	 */
+	private static function extract_tarball_with_system_tar( $tarball, $dest ) {
 		// Note: directory must exist for tar --directory to work.
-		$cmd = Utils\esc_cmd(
-			'tar xz --strip-components=1 --directory=%s -f %s',
-			$dest,
-			$tarball
+		$force_local = Utils\is_windows() ? ' --force-local' : '';
+		$cmd         = Utils\esc_cmd(
+			"tar xz{$force_local} --strip-components=1 --directory=%s -f %s",
+			Path::normalize( $dest ),
+			Path::normalize( $tarball )
 		);
 
 		$process_run = WP_CLI::launch(
@@ -154,6 +177,29 @@ class Extractor {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Extract a tarball using PharData.
+	 *
+	 * @param string $tarball Path to the tarball.
+	 * @param string $dest    Destination directory.
+	 */
+	private static function extract_tarball_with_phar_data( $tarball, $dest ) {
+		$phar    = new PharData( $tarball );
+		$name    = Path::basename( $tarball );
+		$tempdir = Utils\get_temp_dir()
+					. uniqid( 'wp-cli-extract-tarball-', true )
+					. "-{$name}";
+
+		$phar->extractTo( $tempdir );
+
+		self::copy_overwrite_files(
+			self::get_first_subfolder( $tempdir ),
+			$dest
+		);
+
+		self::rmdir( $tempdir );
 	}
 
 	/**

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1315,12 +1315,9 @@ class WP_CLI {
 	 * Launch an arbitrary external process that takes over I/O.
 	 *
 	 * ```
-	 * # `wp core download` falls back to the `tar` binary when PharData isn't available
-	 * if ( ! class_exists( 'PharData' ) ) {
-	 *     $cmd = "tar xz --strip-components=1 --directory=%s -f $tarball";
-	 *     WP_CLI::launch( Utils\esc_cmd( $cmd, $dest ) );
-	 *     return;
-	 * }
+	 * # `wp core download` prefers the `tar` binary over PharData when extracting tarballs
+	 * $cmd = "tar xz --strip-components=1 --directory=%s -f $tarball";
+	 * WP_CLI::launch( Utils\esc_cmd( $cmd, $dest ) );
 	 * ```
 	 *
 	 * @access public

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1316,8 +1316,8 @@ class WP_CLI {
 	 *
 	 * ```
 	 * # `wp core download` prefers the `tar` binary over PharData when extracting tarballs
-	 * $cmd = "tar xz --strip-components=1 --directory=%s -f $tarball";
-	 * WP_CLI::launch( Utils\esc_cmd( $cmd, $dest ) );
+	 * $cmd = "tar xz --strip-components=1 --directory=%s -f %s";
+	 * WP_CLI::launch( Utils\esc_cmd( $cmd, $dest, $tarball ) );
 	 * ```
 	 *
 	 * @access public

--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -199,25 +199,6 @@ class ExtractorTest extends TestCase {
 		Extractor::rmdir( $temp_dir );
 	}
 
-	public function test_extract_tarball_with_phar_data(): void {
-		if ( ! class_exists( 'PharData' ) ) {
-			$this->markTestSkipped( 'PharData not installed.' );
-		}
-
-		list( $temp_dir, $tarball, $dest_dir ) = self::create_test_tarball();
-
-		$reflection = new ReflectionClass( Extractor::class );
-		$method     = $reflection->getMethod( 'extract_tarball_with_phar_data' );
-		$method->setAccessible( true );
-		$method->invoke( null, $tarball, $dest_dir );
-
-		$files = self::recursive_scandir( $dest_dir );
-		$this->assertSame( self::$expected_wp, $files );
-		$this->assertTrue( empty( self::$logger->stderr ) );
-
-		Extractor::rmdir( $temp_dir );
-	}
-
 	public function test_extract_tarball_with_phar_data_when_tar_unavailable(): void {
 		if ( ! class_exists( 'PharData' ) ) {
 			$this->markTestSkipped( 'PharData not installed.' );
@@ -280,37 +261,6 @@ class ExtractorTest extends TestCase {
 		} finally {
 			putenv( 'PATH=' . $old_path );
 		}
-
-		Extractor::rmdir( $temp_dir );
-	}
-
-	public function test_err_extract_tarball_with_system_tar(): void {
-		if ( ! exec( 'tar --version' ) ) {
-			$this->markTestSkipped( 'tar not installed.' );
-		}
-
-		$temp_dir = Utils\get_temp_dir() . uniqid( self::$copy_overwrite_files_prefix, true );
-		mkdir( $temp_dir );
-
-		$dest_dir = $temp_dir . '/dest';
-		mkdir( $dest_dir );
-
-		$corrupt_tarball = $temp_dir . '/corrupt.tar.gz';
-		file_put_contents( $corrupt_tarball, 'invalid gzip archive' );
-
-		$reflection = new ReflectionClass( Extractor::class );
-		$method     = $reflection->getMethod( 'extract_tarball_with_system_tar' );
-		$method->setAccessible( true );
-
-		$msg = '';
-		try {
-			$method->invoke( null, realpath( $corrupt_tarball ), $dest_dir );
-		} catch ( \Exception $e ) {
-			$msg = $e->getMessage();
-		}
-
-		$this->assertTrue( false !== strpos( $msg, 'Failed to execute' ) );
-		$this->assertTrue( empty( self::$logger->stderr ) );
 
 		Extractor::rmdir( $temp_dir );
 	}

--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -162,8 +162,7 @@ class ExtractorTest extends TestCase {
 		}
 
 		$this->assertTrue( false !== strpos( $msg, 'no-such-tar' ) );
-		$this->assertTrue( 0 === strpos( self::$logger->stderr, 'Warning: PharData failed' ) );
-		$this->assertTrue( false !== strpos( self::$logger->stderr, 'no-such-tar' ) );
+		$this->assertTrue( empty( self::$logger->stderr ) );
 
 		// Reset logger.
 		self::$logger->stderr = '';
@@ -181,8 +180,42 @@ class ExtractorTest extends TestCase {
 		unlink( $zero_tar );
 
 		$this->assertTrue( false !== strpos( $msg, 'zero-tar' ) );
-		$this->assertTrue( 0 === strpos( self::$logger->stderr, 'Warning: PharData failed' ) );
-		$this->assertTrue( false !== strpos( self::$logger->stderr, 'zero-tar' ) );
+		$this->assertTrue( empty( self::$logger->stderr ) );
+	}
+
+	public function test_extract_tarball_long_path(): void {
+		if ( ! exec( 'tar --version' ) ) {
+			$this->markTestSkipped( 'tar not installed.' );
+		}
+
+		$temp_dir = Utils\get_temp_dir() . uniqid( self::$copy_overwrite_files_prefix, true );
+		mkdir( $temp_dir );
+
+		$src_dir = $temp_dir . '/src';
+		mkdir( $src_dir );
+
+		$wp_dir = $src_dir . '/wordpress';
+		mkdir( $wp_dir );
+
+		$long_path = 'wp-includes/php-ai-client/third-party/Http/Discovery/Exception/PuliUnavailableException.php';
+		mkdir( $wp_dir . '/' . dirname( $long_path ), 0777, true );
+		touch( $wp_dir . '/' . $long_path );
+
+		$tarball  = $temp_dir . '/test-long-path.tar.gz';
+		$dest_dir = $temp_dir . '/dest';
+
+		$output     = [];
+		$return_var = -1;
+		$cmd        = 'tar czvf %1$s' . ( Utils\is_windows() ? ' --force-local' : '' ) . ' --directory=%2$s/src wordpress 2>&1';
+		exec( Utils\esc_cmd( $cmd, $tarball, $temp_dir ), $output, $return_var );
+		$this->assertSame( 0, $return_var );
+
+		Extractor::extract( $tarball, $dest_dir );
+
+		$this->assertFileExists( $dest_dir . '/' . $long_path );
+		$this->assertTrue( empty( self::$logger->stderr ) );
+
+		Extractor::rmdir( $temp_dir );
 	}
 
 	public function test_extract_zip(): void {

--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -188,31 +188,128 @@ class ExtractorTest extends TestCase {
 			$this->markTestSkipped( 'tar not installed.' );
 		}
 
-		$temp_dir = Utils\get_temp_dir() . uniqid( self::$copy_overwrite_files_prefix, true );
-		mkdir( $temp_dir );
-
-		$src_dir = $temp_dir . '/src';
-		mkdir( $src_dir );
-
-		$wp_dir = $src_dir . '/wordpress';
-		mkdir( $wp_dir );
-
-		$long_path = 'wp-includes/php-ai-client/third-party/Http/Discovery/Exception/PuliUnavailableException.php';
-		mkdir( $wp_dir . '/' . dirname( $long_path ), 0777, true );
-		touch( $wp_dir . '/' . $long_path );
-
-		$tarball  = $temp_dir . '/test-long-path.tar.gz';
-		$dest_dir = $temp_dir . '/dest';
-
-		$output     = [];
-		$return_var = -1;
-		$cmd        = 'tar czvf %1$s' . ( Utils\is_windows() ? ' --force-local' : '' ) . ' --directory=%2$s/src wordpress 2>&1';
-		exec( Utils\esc_cmd( $cmd, $tarball, $temp_dir ), $output, $return_var );
-		$this->assertSame( 0, $return_var );
+		$long_path                             = 'wp-includes/php-ai-client/third-party/Http/Discovery/Exception/PuliUnavailableException.php';
+		list( $temp_dir, $tarball, $dest_dir ) = self::create_test_tarball( [ $long_path ] );
 
 		Extractor::extract( $tarball, $dest_dir );
 
 		$this->assertFileExists( $dest_dir . '/' . $long_path );
+		$this->assertTrue( empty( self::$logger->stderr ) );
+
+		Extractor::rmdir( $temp_dir );
+	}
+
+	public function test_extract_tarball_with_phar_data(): void {
+		if ( ! class_exists( 'PharData' ) ) {
+			$this->markTestSkipped( 'PharData not installed.' );
+		}
+
+		list( $temp_dir, $tarball, $dest_dir ) = self::create_test_tarball();
+
+		$reflection = new ReflectionClass( Extractor::class );
+		$method     = $reflection->getMethod( 'extract_tarball_with_phar_data' );
+		$method->setAccessible( true );
+		$method->invoke( null, $tarball, $dest_dir );
+
+		$files = self::recursive_scandir( $dest_dir );
+		$this->assertSame( self::$expected_wp, $files );
+		$this->assertTrue( empty( self::$logger->stderr ) );
+
+		Extractor::rmdir( $temp_dir );
+	}
+
+	public function test_extract_tarball_with_phar_data_when_tar_unavailable(): void {
+		if ( ! class_exists( 'PharData' ) ) {
+			$this->markTestSkipped( 'PharData not installed.' );
+		}
+
+		if ( Utils\is_windows() ) {
+			$this->markTestSkipped( 'PATH manipulation is not reliable on Windows.' );
+		}
+
+		list( $temp_dir, $tarball, $dest_dir ) = self::create_test_tarball();
+
+		$old_path = getenv( 'PATH' );
+		putenv( 'PATH=' );
+
+		try {
+			Extractor::extract( $tarball, $dest_dir );
+
+			$files = self::recursive_scandir( $dest_dir );
+			$this->assertSame( self::$expected_wp, $files );
+			$this->assertTrue( empty( self::$logger->stderr ) );
+		} finally {
+			putenv( 'PATH=' . $old_path );
+		}
+
+		Extractor::rmdir( $temp_dir );
+	}
+
+	public function test_extract_tarball_falls_back_to_phar_data_when_tar_fails(): void {
+		if ( ! class_exists( 'PharData' ) ) {
+			$this->markTestSkipped( 'PharData not installed.' );
+		}
+
+		if ( Utils\is_windows() ) {
+			$this->markTestSkipped( 'Fake tar binary test is not supported on Windows.' );
+		}
+
+		if ( ! exec( 'tar --version' ) ) {
+			$this->markTestSkipped( 'tar not installed.' );
+		}
+
+		list( $temp_dir, $tarball, $dest_dir ) = self::create_test_tarball();
+
+		$fake_bin = $temp_dir . '/fakebin';
+		mkdir( $fake_bin );
+		file_put_contents(
+			"{$fake_bin}/tar",
+			"#!/bin/sh\nif [ \"\$1\" = \"--version\" ]; then exit 0; fi\nexit 1\n"
+		);
+		chmod( "{$fake_bin}/tar", 0755 );
+
+		$old_path = getenv( 'PATH' );
+		putenv( 'PATH=' . $fake_bin . PATH_SEPARATOR . $old_path );
+
+		try {
+			Extractor::extract( $tarball, $dest_dir );
+
+			$files = self::recursive_scandir( $dest_dir );
+			$this->assertSame( self::$expected_wp, $files );
+			$this->assertTrue( 0 === strpos( self::$logger->stderr, 'Warning: Failed to extract with \'tar xz\'' ) );
+		} finally {
+			putenv( 'PATH=' . $old_path );
+		}
+
+		Extractor::rmdir( $temp_dir );
+	}
+
+	public function test_err_extract_tarball_with_system_tar(): void {
+		if ( ! exec( 'tar --version' ) ) {
+			$this->markTestSkipped( 'tar not installed.' );
+		}
+
+		$temp_dir = Utils\get_temp_dir() . uniqid( self::$copy_overwrite_files_prefix, true );
+		mkdir( $temp_dir );
+
+		$dest_dir = $temp_dir . '/dest';
+		mkdir( $dest_dir );
+
+		$corrupt_tarball = $temp_dir . '/corrupt.tar.gz';
+		file_put_contents( $corrupt_tarball, 'invalid gzip archive' );
+
+		$reflection = new ReflectionClass( Extractor::class );
+		$method     = $reflection->getMethod( 'extract_tarball_with_system_tar' );
+		$method->setAccessible( true );
+
+		$msg = '';
+		try {
+			$method->invoke( null, realpath( $corrupt_tarball ), $dest_dir );
+		} catch ( \Exception $e ) {
+			$msg = $e->getMessage();
+		}
+
+		$this->assertTrue( false !== strpos( $msg, 'Failed to execute' ) );
 		$this->assertTrue( empty( self::$logger->stderr ) );
 
 		Extractor::rmdir( $temp_dir );
@@ -297,6 +394,48 @@ class ExtractorTest extends TestCase {
 		}
 		$this->assertSame( "Extraction only supported for '.zip' and '.tar.gz' file types.", $msg );
 		$this->assertTrue( empty( self::$logger->stderr ) );
+	}
+
+	private static function create_test_tarball( $extra_files = [] ) {
+		$temp_dir = Utils\get_temp_dir() . uniqid( self::$copy_overwrite_files_prefix, true );
+		mkdir( $temp_dir );
+
+		$src_dir = $temp_dir . '/src';
+		mkdir( $src_dir );
+
+		$wp_dir = $src_dir . '/wordpress';
+		mkdir( $wp_dir );
+
+		foreach ( self::$expected_wp as $file ) {
+			if ( 0 === substr_compare( $file, '/', -1 ) ) {
+				mkdir( $wp_dir . '/' . $file );
+			} else {
+				touch( $wp_dir . '/' . $file );
+			}
+		}
+
+		foreach ( $extra_files as $relative_path ) {
+			$full_path = $wp_dir . '/' . $relative_path;
+			$dir       = dirname( $full_path );
+			if ( ! is_dir( $dir ) ) {
+				mkdir( $dir, 0777, true );
+			}
+			touch( $full_path );
+		}
+
+		$tarball  = $temp_dir . '/test.tar.gz';
+		$dest_dir = $temp_dir . '/dest';
+
+		$output     = [];
+		$return_var = -1;
+		$cmd        = 'tar czvf %1$s' . ( Utils\is_windows() ? ' --force-local' : '' ) . ' --directory=%2$s/src wordpress 2>&1';
+		exec( Utils\esc_cmd( $cmd, $tarball, $temp_dir ), $output, $return_var );
+
+		if ( 0 !== $return_var ) {
+			throw new \RuntimeException( 'Failed to create test tarball.' );
+		}
+
+		return [ $temp_dir, $tarball, $dest_dir ];
 	}
 
 	private static function create_test_directory_structure() {


### PR DESCRIPTION
Fixes https://github.com/wp-cli/wp-cli/issues/6320
Related: https://core.trac.wordpress.org/ticket/65320

## Summary

- Prefer the system `tar` binary over `PharData` when extracting `.tar.gz` archives in `Extractor::extract_tarball()`.
- PharData silently truncates archive-internal paths longer than 100 characters (see [php/php-src#19311](https://github.com/php/php-src/issues/19311)), which breaks `wp core download` for WordPress 7.0+ files under `wp-includes/php-ai-client/`.
- PharData is retained only as a fallback when `tar` is unavailable or fails.
- Adds `--force-local` on Windows and uses `Path::normalize()` for tar command paths.

## Test plan

- [x] `vendor/bin/phpunit --bootstrap ./vendor/wp-cli/wp-cli-tests/tests/bootstrap.php tests/ExtractorTest.php` — all 10 tests pass
- [x] `composer phpcs` — passes
- [x] `composer lint` — passes
- [ ] `composer behat -- features/extractor.feature` — downloads WordPress 7.0 and verifies long-path files extract correctly
- [ ] Manual: `wp core download --version=7.0` then `wp core verify-checksums` — should pass with no truncated filenames