### PR TITLE
Improve argument alias parsing and `--prompt` support

### DIFF
--- a/features/arg-aliases.feature
+++ b/features/arg-aliases.feature
@@ -238,3 +238,116 @@ Feature: Argument aliases support
       """
       [--format=<format>|f]
       """
+
+  Scenario: Prompting for required parameter with alias (value spec on canonical)
+    Given a WP install
+    And a custom-command.php file:
+      """
+      <?php
+      /**
+       * Test command with required parameter and alias.
+       *
+       * ## OPTIONS
+       *
+       * --type=<type>|t
+       * : Required type parameter.
+       */
+      $test_command = function( $args, $assoc_args ) {
+        WP_CLI::success( 'type is ' . $assoc_args['type'] );
+      };
+      WP_CLI::add_command( 'test-alias', $test_command );
+      """
+    And a session file:
+      """
+      post
+      """
+
+    When I run `wp --require=custom-command.php test-alias --prompt=type < session`
+    Then STDOUT should contain:
+      """
+      Success: type is post
+      """
+
+  Scenario: Prompting for required parameter with alias (value spec on alias)
+    Given a WP install
+    And a custom-command.php file:
+      """
+      <?php
+      /**
+       * Test command with required parameter and alias (value spec on alias).
+       *
+       * ## OPTIONS
+       *
+       * --admin_password|admin_pass=<password>
+       * : Admin password.
+       */
+      $test_command = function( $args, $assoc_args ) {
+        WP_CLI::success( 'password is ' . $assoc_args['admin_password'] );
+      };
+      WP_CLI::add_command( 'test-alias', $test_command );
+      """
+    And a session file:
+      """
+      wpcli
+      """
+
+    When I run `wp --require=custom-command.php test-alias --prompt=admin_password < session`
+    Then STDOUT should contain:
+      """
+      Success: password is wpcli
+      """
+
+  Scenario: Prompting using alias name
+    Given a WP install
+    And a custom-command.php file:
+      """
+      <?php
+      /**
+       * Test command with required parameter and alias.
+       *
+       * ## OPTIONS
+       *
+       * --type=<type>|t
+       * : Required type parameter.
+       */
+      $test_command = function( $args, $assoc_args ) {
+        WP_CLI::success( 'type is ' . $assoc_args['type'] );
+      };
+      WP_CLI::add_command( 'test-alias', $test_command );
+      """
+    And a session file:
+      """
+      page
+      """
+
+    When I run `wp --require=custom-command.php test-alias --prompt=t < session`
+    Then STDOUT should contain:
+      """
+      Success: type is page
+      """
+
+  Scenario: Passing alias on command line bypasses prompt
+    Given a WP install
+    And a custom-command.php file:
+      """
+      <?php
+      /**
+       * Test command with required parameter and alias.
+       *
+       * ## OPTIONS
+       *
+       * --type=<type>|t
+       * : Required type parameter.
+       */
+      $test_command = function( $args, $assoc_args ) {
+        WP_CLI::success( 'type is ' . $assoc_args['type'] );
+      };
+      WP_CLI::add_command( 'test-alias', $test_command );
+      """
+
+    When I run `wp --require=custom-command.php test-alias -t=post --prompt=type`
+    Then STDOUT should contain:
+      """
+      Success: type is post
+      """
+

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -254,7 +254,16 @@ class Subcommand extends CompositeCommand {
 				if ( 'assoc' !== $spec_arg['type'] ) {
 					continue;
 				}
-				if ( ! in_array( $spec_arg['name'], $prompt_args, true ) ) {
+				$matched = in_array( $spec_arg['name'], $prompt_args, true );
+				if ( ! $matched && ! empty( $spec_arg['aliases'] ) ) {
+					foreach ( $spec_arg['aliases'] as $alias ) {
+						if ( in_array( $alias, $prompt_args, true ) ) {
+							$matched = true;
+							break;
+						}
+					}
+				}
+				if ( ! $matched ) {
 					continue;
 				}
 			}

--- a/php/WP_CLI/SynopsisParser.php
+++ b/php/WP_CLI/SynopsisParser.php
@@ -152,10 +152,6 @@ class SynopsisParser {
 	private static function classify_token( $token ) {
 		list( $optional, $token )  = self::is_optional( $token );
 		list( $repeating, $token ) = self::is_repeating( $token );
-		list( $aliases, $token )   = self::extract_aliases( $token );
-
-		$p_name  = '([a-z-_0-9]+)';
-		$p_value = '([a-zA-Z-_|,0-9]+)';
 
 		if ( '--<field>=<value>' === $token ) {
 			return [
@@ -163,7 +159,26 @@ class SynopsisParser {
 				'optional'  => $optional,
 				'repeating' => $repeating,
 			];
-		} elseif ( preg_match( "/^<($p_value)>$/", $token, $matches ) ) {
+		}
+
+		$value_name     = null;
+		$value_optional = false;
+		if ( preg_match( '/\\[=<([a-zA-Z-_|,0-9]+)>\\]/', $token, $matches ) ) {
+			$value_name     = $matches[1];
+			$value_optional = true;
+			$token          = str_replace( $matches[0], '', $token );
+		} elseif ( preg_match( '/=<([a-zA-Z-_|,0-9]+)>/', $token, $matches ) ) {
+			$value_name     = $matches[1];
+			$value_optional = false;
+			$token          = str_replace( $matches[0], '', $token );
+		}
+
+		list( $aliases, $token ) = self::extract_aliases( $token );
+
+		$p_name  = '([a-z-_0-9]+)';
+		$p_value = '([a-zA-Z-_|,0-9]+)';
+
+		if ( preg_match( "/^<($p_value)>$/", $token, $matches ) ) {
 			return [
 				'type'      => 'positional',
 				'name'      => $matches[1],
@@ -171,7 +186,25 @@ class SynopsisParser {
 				'repeating' => $repeating,
 			];
 		} elseif ( preg_match( "/^--(?:\\[no-\\])?$p_name/", $token, $matches ) ) {
-			$name  = $matches[1];
+			$name = $matches[1];
+
+			if ( null !== $value_name ) {
+				$param = [
+					'type'      => 'assoc',
+					'name'      => $name,
+					'optional'  => $optional,
+					'repeating' => $repeating,
+					'value'     => [
+						'optional' => $value_optional,
+						'name'     => $value_name,
+					],
+				];
+				if ( ! empty( $aliases ) ) {
+					$param['aliases'] = $aliases;
+				}
+				return $param;
+			}
+
 			$value = substr( $token, strlen( $matches[0] ) );
 
 			// substr can return false <= PHP 8.0.


### PR DESCRIPTION
This is a follow-up to #6176

I noticed this bug in https://github.com/wp-cli/core-command/pull/335