### PR TITLE
Fix LoggingTest PHPUnit warning

### DIFF
--- a/tests/LoggingTest.php
+++ b/tests/LoggingTest.php
@@ -34,15 +34,19 @@ class MockQuietLogger extends WP_CLI\Loggers\Quiet {
 
 class LoggingTest extends TestCase {
 
-	public function testLogDebug(): void {
+	public function testLogDebugRegularLogger(): void {
 		$message = 'This is a test message.';
 
 		$regular_logger = new MockRegularLogger( false );
 		$this->expectOutputRegex( "/Debug: {$message} \(\d+\.*\d*s\)/" );
 		$regular_logger->debug( $message );
+	}
+
+	public function testLogDebugQuietLogger(): void {
+		$message = 'This is a test message.';
 
 		$quiet_logger = new MockQuietLogger();
-		$this->expectOutputRegex( "/Debug: {$message} \(\d+\.*\d*s\)/" );
+		$this->expectOutputString( '' );
 		$quiet_logger->debug( $message );
 	}
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

Only one expectation on output can be configured. expectOutputString() and expectOutputRegex() cannot be combined and must not be called more than once.
