### PR TITLE
`cli update`: Use deterministic package url

### DIFF
--- a/features/cli-check-update.feature
+++ b/features/cli-check-update.feature
@@ -132,7 +132,7 @@ Feature: Check for updates
               "url": "https://api.github.com/repos/wp-cli/wp-cli/releases/assets/184590231",
               "id": 184590231,
               "node_id": "RA_kwDOACQFs84LAJ-X",
-              "name": "wp-cli-777.7.7.phar",
+              "name": "wp-cli-777.7.7.manifest.json",
               "label": null,
               "content_type": "application/octet-stream",
               "state": "uploaded",
@@ -140,7 +140,7 @@ Feature: Check for updates
               "download_count": 722639,
               "created_at": "2024-08-08T03:51:05Z",
               "updated_at": "2024-08-08T03:51:08Z",
-              "browser_download_url": "https://github.com/wp-cli/wp-cli/releases/download/v777.7.7/wp-cli-777.7.7.phar"
+              "browser_download_url": "https://github.com/wp-cli/wp-cli/releases/download/v777.7.7/wp-cli-777.7.7.manifest.json"
             },
             {
               "url": "https://api.github.com/repos/wp-cli/wp-cli/releases/assets/184590231",
@@ -154,7 +154,7 @@ Feature: Check for updates
               "download_count": 722639,
               "created_at": "2024-08-08T03:51:05Z",
               "updated_at": "2024-08-08T03:51:08Z",
-              "browser_download_url": "https://github.com/wp-cli/wp-cli/releases/download/v777.7.7/wp-cli-777.7.7.manifest.json"
+              "browser_download_url": "https://github.com/wp-cli/wp-cli/releases/download/v777.7.7/wp-cli-777.7.7.phar"
             }
           ],
           "tarball_url": "https://api.github.com/repos/wp-cli/wp-cli/tarball/v777.7.7",

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -737,7 +737,7 @@ class CLI_Command extends WP_CLI_Command {
 				$updates_unavailable[] = [
 					'version'      => $release_version,
 					'update_type'  => $update_type,
-					'package_url'  => $release->assets[0]->browser_download_url,
+					'package_url'  => $package_url,
 					'status'       => 'unavailable',
 					'requires_php' => $manifest_data->requires_php,
 				];
@@ -745,7 +745,7 @@ class CLI_Command extends WP_CLI_Command {
 				$updates[ $update_type ] = [
 					'version'      => $release_version,
 					'update_type'  => $update_type,
-					'package_url'  => $release->assets[0]->browser_download_url,
+					'package_url'  => $package_url,
 					'status'       => 'available',
 					'requires_php' => isset( $manifest_data->requires_php ) ? $manifest_data->requires_php : '',
 				];


### PR DESCRIPTION
Line 710 resolves `$package_url` from the `.phar` correctly, then 740/748 discard it and use `assets[0]`. Works today only by luck of upload order.