### PR TITLE
Fix failing test involving `blockline` theme

### DIFF
--- a/features/skip-themes.feature
+++ b/features/skip-themes.feature
@@ -149,7 +149,7 @@ Feature: Skipping themes
       """
     And STDERR should be empty
 
-  @require-wp-6.1
+  @require-wp-6.1 @require-php-7.4
   Scenario: Skip a theme using block patterns
     Given a WP installation
     And I run `wp theme install blockline --activate`


### PR DESCRIPTION
The theme now requires PHP 7,4+

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated theme-skipping test requirements to run only with PHP 7.4+ and WordPress 6.1+.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->