### PR TITLE
Wait for both coverage uploads before reporting to Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+# Coverage for this repository is reported from two separate CI uploads:
+#
+#   * `unit`    – PHPUnit tests (fast, finishes in ~1 minute).
+#   * `feature` – Behat functional tests (slow, can take ~45 minutes).
+#
+# Much of the framework is only exercised through the functional tests. Because
+# the Behat upload lands long after the unit upload, Codecov would otherwise
+# evaluate the commit/patch status (and post its comment) on unit-only data and
+# report a spurious failure for code that is actually covered once the functional
+# tests finish. Waiting for both uploads before reporting fixes that.
+#
+# Note: this repository normally produces exactly two coverage uploads. If the
+# feature job ever fails to upload, the Codecov status may stay pending until the
+# next push. A fully count-independent fix (aggregating both reports into a
+# single upload, or a `manual_trigger` finalizer step) would need to live in the
+# shared CI workflow rather than here.
+
+codecov:
+  notify:
+    after_n_builds: 2
+
+comment:
+  after_n_builds: 2


### PR DESCRIPTION
## Problem

`codecov/patch` fails spuriously on PRs, reporting newly added lines as uncovered even when they are exercised by the functional (Behat) test suite.

## Root cause

Coverage is reported from **two separate CI uploads**, both from the single `coverage: true` matrix combo:

- `unit` — PHPUnit (`--coverage-clover`), fast (~1 min)
- `feature` — Behat functional tests (each `wp` subprocess self-instruments), slow (up to ~45 min)

Much of the framework is only exercised through the functional tests. Because the Behat upload lands long after the unit upload, Codecov evaluates the commit/patch status (and posts its comment) on **unit-only data**, then reports a spurious failure for code that is actually covered once the functional tests finish.

This is a timing/upload-order issue, **not** a path-mapping one. Verified against the Codecov API + GitHub check-runs on #6343:

- At a commit where **both** the `unit` and `feature` reports had uploaded (2 sessions) → `codecov/patch` was **success**.
- At the next commit where only the fast `unit` report had landed so far (1 session, Behat still running) → `codecov/patch` was **failure**, with the new files showing 0%.
- Per-file/flag data confirms `feature` coverage maps to `php/` correctly (e.g. `Subcommand.php` ~89%, `Help_Command.php` ~81% on `main`).

## Fix

Add a `codecov.yml` that sets `after_n_builds: 2`, so Codecov waits for both uploads before computing statuses and posting the comment.

```yaml
codecov:
  notify:
    after_n_builds: 2
comment:
  after_n_builds: 2
```

## Notes / trade-offs

- This repository normally produces exactly two coverage uploads, so `2` is correct here. It is intentionally **not** applied org-wide: repos without `phpunit.xml.dist` or `behat.yml` produce a single upload and a global `after_n_builds: 2` would leave their Codecov status pending forever.
- If the feature job ever fails to upload, the Codecov status may stay pending until the next push (there is no YAML-level timeout). `codecov/patch` is not currently a required check, so this does not hard-block merges. A fully count-independent solution (aggregating both reports into one upload, or a `manual_trigger` + `codecovcli send-notifications` finalizer step) would belong in the shared `wp-cli/.github` workflow rather than here, and can be a follow-up.
- Deliberately scoped to the timing fix only: no `flags`/`carryforward` (mapping already works, and carryforward can serve stale coverage) and no coverage-threshold policy changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code coverage reporting by coordinating unit and feature test results before evaluating status.
  * Coverage comments and checks now wait for all expected reports, reducing premature or misleading results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->