### PR TITLE
Fix ExtractorTest error-path tests for PHP 8.6

### DIFF
--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -64,13 +64,15 @@ class ExtractorTest extends TestCase {
 	}
 
 	public function test_err_rmdir(): void {
-		$msg = '';
+		$caught = null;
 		try {
 			Extractor::rmdir( 'no-such-dir' );
 		} catch ( \Exception $e ) {
-			$msg = $e->getMessage();
+			$caught = $e;
 		}
-		$this->assertTrue( false !== strpos( $msg, 'no-such-dir' ) );
+		// Not matching the message: PHP 8.6 dropped the path argument from the
+		// RecursiveDirectoryIterator::__construct() exception message.
+		$this->assertInstanceOf( \UnexpectedValueException::class, $caught );
 		$this->assertTrue( empty( self::$logger->stderr ) );
 	}
 
@@ -91,13 +93,15 @@ class ExtractorTest extends TestCase {
 	}
 
 	public function test_err_copy_overwrite_files(): void {
-		$msg = '';
+		$caught = null;
 		try {
 			Extractor::copy_overwrite_files( 'no-such-dir', 'dest-dir' );
 		} catch ( \Exception $e ) {
-			$msg = $e->getMessage();
+			$caught = $e;
 		}
-		$this->assertTrue( false !== strpos( $msg, 'no-such-dir' ) );
+		// Not matching the message: PHP 8.6 dropped the path argument from the
+		// RecursiveDirectoryIterator::__construct() exception message.
+		$this->assertInstanceOf( \UnexpectedValueException::class, $caught );
 		$this->assertTrue( empty( self::$logger->stderr ) );
 	}
 


### PR DESCRIPTION
PHP 8.6 changed the exception thrown by `RecursiveDirectoryIterator::__construct()` for a directory that cannot be opened: the path argument is no longer included in the message.

```
8.5 and earlier:  RecursiveDirectoryIterator::__construct(no-such-dir): Failed to open directory: No such file or directory
8.6.0-dev:        RecursiveDirectoryIterator::__construct(): Failed to open directory: No such file or directory
```

`ExtractorTest::test_err_rmdir` and `::test_err_copy_overwrite_files` asserted `false !== strpos( $msg, 'no-such-dir' )`, so both fail on the `Unit (nightly, trunk, sqlite)` job (PHP 8.6.0-dev). That is currently the only red check on the nightly Unit lane, and it fails identically on `main`. Released PHP (7.2 through 8.5) is unaffected.

The message wording is not stable across versions to begin with (7.2/7.4 say "failed to open dir", 8.0+ say "Failed to open directory", and the path is present on every version except 8.6), so these now assert on the exception type, `UnexpectedValueException`, which both error paths throw on every supported PHP version and platform.

Verified against a PHP 8.6.0-dev build from `php-src` master (commit `f6fe838e`).

Fixes #6349.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage of error handling for directory removal and file overwrite operations.
  * Tests now verify the specific exception type while continuing to ensure no unexpected error output is produced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->