### PR TITLE
Require `--major` for cross-major `wp cli update`

### DIFF
--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -359,6 +359,12 @@ class CLI_Command extends WP_CLI_Command {
 	 * Default behavior is to check the releases API for the newest stable
 	 * version, and prompt if one is available.
 	 *
+	 * By default the update stays within the current major version: a new major
+	 * release is not offered unless `--major` is passed. This prevents unintentionally
+	 * jumping to a major version that may drop support for the running PHP version or
+	 * change behavior. When a major update is available it is announced, along with the
+	 * `--major` flag needed to install it.
+	 *
 	 * Use `--stable` to install or reinstall the latest stable version.
 	 *
 	 * Use `--nightly` to install the latest built version of the master branch.
@@ -384,7 +390,7 @@ class CLI_Command extends WP_CLI_Command {
 	 * : Only perform minor updates.
 	 *
 	 * [--major]
-	 * : Only perform major updates.
+	 * : Allow updating across a major version. Without this flag, the update stays within the current major version.
 	 *
 	 * [--stable]
 	 * : Update to the latest stable release. Skips update check.
@@ -413,6 +419,16 @@ class CLI_Command extends WP_CLI_Command {
 	 *     Downloading from https://github.com/wp-cli/wp-cli/releases/download/v0.24.1/wp-cli-0.24.1.phar...
 	 *     New version works. Proceeding to replace.
 	 *     Success: Updated WP-CLI to 0.24.1.
+	 *
+	 *     # A new major version is available but withheld by default.
+	 *     $ wp cli update
+	 *     A new major version (3.0.0) is available. Run `wp cli update --major` to update across major versions.
+	 *     Success: WP-CLI is at the latest version.
+	 *
+	 *     # Update across a major version explicitly.
+	 *     $ wp cli update --major
+	 *     You have version 2.12.0. Would you like to update to 3.0.0? [y/n] y
+	 *     Success: Updated WP-CLI to 3.0.0.
 	 *
 	 * @param string[] $args Positional arguments. Unused.
 	 * @param array{patch?: bool, minor?: bool, major?: bool, stable?: bool, nightly?: bool, yes?: bool, insecure?: bool} $assoc_args Associative arguments.
@@ -449,17 +465,24 @@ class CLI_Command extends WP_CLI_Command {
 
 			$updates = $this->get_updates( $assoc_args );
 
+			$include_major = (bool) Utils\get_flag_value( $assoc_args, 'major', false );
+
+			$selection = $this->select_update_offer( is_array( $updates ) ? $updates : [], $include_major );
+
 			/**
 			 * @phpstan-var UpdateOffer|null $newest
 			 */
-			$newest = $this->array_find(
-				$updates,
-				static function ( $update ) {
-					return 'available' === $update['status'];
-				}
-			);
+			$newest = $selection['offer'];
 
 			if ( ! $newest ) {
+				if ( null !== $selection['suppressed_major'] ) {
+					WP_CLI::log(
+						sprintf(
+							'A new major version (%s) is available. Run `wp cli update --major` to update across major versions.',
+							$selection['suppressed_major']['version']
+						)
+					);
+				}
 				$update_type = $this->get_update_type_str( $assoc_args );
 				WP_CLI::success( "WP-CLI is at the latest{$update_type}version." );
 				return;
@@ -812,6 +835,51 @@ class CLI_Command extends WP_CLI_Command {
 		}
 
 		return array_merge( $updates_unavailable, array_values( $updates ) );
+	}
+
+	/**
+	 * Selects which available update to offer, enforcing the major-version boundary.
+	 *
+	 * By default an update must not cross a major version boundary: a major update
+	 * is only offered when it has been explicitly requested via `--major`. This stops
+	 * `wp cli update` from silently jumping to a new major release, which can drop
+	 * support for the running PHP version or otherwise change behavior. When a major
+	 * update is available but withheld, it is returned separately so the caller can
+	 * hint at the `--major` flag.
+	 *
+	 * @param array<array-key, UpdateOffer> $updates       Available updates, as returned by get_updates().
+	 * @param bool                          $include_major Whether a major update may be offered.
+	 * @return array{offer: UpdateOffer|null, suppressed_major: UpdateOffer|null}
+	 */
+	private function select_update_offer( array $updates, bool $include_major ) {
+		$suppressed_major = null;
+		$candidates       = [];
+
+		foreach ( $updates as $update ) {
+			if ( 'major' === $update['update_type'] && ! $include_major ) {
+				if ( null === $suppressed_major && 'available' === $update['status'] ) {
+					$suppressed_major = $update;
+				}
+				continue;
+			}
+
+			$candidates[] = $update;
+		}
+
+		/**
+		 * @phpstan-var UpdateOffer|null $offer
+		 */
+		$offer = $this->array_find(
+			$candidates,
+			static function ( $update ) {
+				return 'available' === $update['status'];
+			}
+		);
+
+		return [
+			'offer'            => $offer,
+			'suppressed_major' => $suppressed_major,
+		];
 	}
 
 	/**

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -361,9 +361,8 @@ class CLI_Command extends WP_CLI_Command {
 	 *
 	 * By default the update stays within the current major version: a new major
 	 * release is not offered unless `--major` is passed. This prevents unintentionally
-	 * jumping to a major version that may drop support for the running PHP version or
-	 * change behavior. When a major update is available it is announced, along with the
-	 * `--major` flag needed to install it.
+	 * accepting breaking changes. When no update within the current major is available,
+	 * a newer major is announced along with the `--major` flag needed to install it.
 	 *
 	 * Use `--stable` to install or reinstall the latest stable version.
 	 *
@@ -390,7 +389,7 @@ class CLI_Command extends WP_CLI_Command {
 	 * : Only perform minor updates.
 	 *
 	 * [--major]
-	 * : Allow updating across a major version. Without this flag, the update stays within the current major version.
+	 * : Only perform major updates, and allow crossing a major-version boundary.
 	 *
 	 * [--stable]
 	 * : Update to the latest stable release. Skips update check.
@@ -467,22 +466,12 @@ class CLI_Command extends WP_CLI_Command {
 
 			$include_major = (bool) Utils\get_flag_value( $assoc_args, 'major', false );
 
-			$selection = $this->select_update_offer( is_array( $updates ) ? $updates : [], $include_major );
-
 			/**
 			 * @phpstan-var UpdateOffer|null $newest
 			 */
-			$newest = $selection['offer'];
+			$newest = $this->select_update_offer( is_array( $updates ) ? $updates : [], $include_major );
 
 			if ( ! $newest ) {
-				if ( null !== $selection['suppressed_major'] ) {
-					WP_CLI::log(
-						sprintf(
-							'A new major version (%s) is available. Run `wp cli update --major` to update across major versions.',
-							$selection['suppressed_major']['version']
-						)
-					);
-				}
 				$update_type = $this->get_update_type_str( $assoc_args );
 				WP_CLI::success( "WP-CLI is at the latest{$update_type}version." );
 				return;
@@ -651,6 +640,8 @@ class CLI_Command extends WP_CLI_Command {
 
 	/**
 	 * Returns update information.
+	 *
+	 * @return array<array-key, UpdateOffer>|false
 	 */
 	private function get_updates( $assoc_args ) {
 		$url = 'https://api.github.com/repos/wp-cli/wp-cli/releases?per_page=100';
@@ -775,11 +766,13 @@ class CLI_Command extends WP_CLI_Command {
 			}
 		}
 
-		foreach ( $updates as $type => $value ) {
-			if ( empty( $value ) ) {
-				unset( $updates[ $type ] );
+		$updates_available = [];
+		foreach ( $updates as $type => $update ) {
+			if ( false !== $update ) {
+				$updates_available[ $type ] = $update;
 			}
 		}
+		$updates = $updates_available;
 
 		foreach ( [ 'major', 'minor', 'patch' ] as $type ) {
 			if ( true === Utils\get_flag_value( $assoc_args, $type ) ) {
@@ -842,14 +835,13 @@ class CLI_Command extends WP_CLI_Command {
 	 *
 	 * By default an update must not cross a major version boundary: a major update
 	 * is only offered when it has been explicitly requested via `--major`. This stops
-	 * `wp cli update` from silently jumping to a new major release, which can drop
-	 * support for the running PHP version or otherwise change behavior. When a major
-	 * update is available but withheld, it is returned separately so the caller can
-	 * hint at the `--major` flag.
+	 * `wp cli update` from silently accepting breaking changes. When a major update
+	 * is available but withheld and no within-major update is available, the user is
+	 * directed to the `--major` flag.
 	 *
 	 * @param array<array-key, UpdateOffer> $updates       Available updates, as returned by get_updates().
 	 * @param bool                          $include_major Whether a major update may be offered.
-	 * @return array{offer: UpdateOffer|null, suppressed_major: UpdateOffer|null}
+	 * @return UpdateOffer|null
 	 */
 	private function select_update_offer( array $updates, bool $include_major ) {
 		$suppressed_major = null;
@@ -876,10 +868,16 @@ class CLI_Command extends WP_CLI_Command {
 			}
 		);
 
-		return [
-			'offer'            => $offer,
-			'suppressed_major' => $suppressed_major,
-		];
+		if ( null === $offer && null !== $suppressed_major ) {
+			WP_CLI::log(
+				sprintf(
+					'A new major version (%s) is available. Run `wp cli update --major` to update across major versions.',
+					$suppressed_major['version']
+				)
+			);
+		}
+
+		return $offer;
 	}
 
 	/**

--- a/tests/CLICommandTest.php
+++ b/tests/CLICommandTest.php
@@ -54,6 +54,100 @@ class CLICommandTest extends TestCase {
 		$method->invoke( $cli_command, $temp, $current_phar );
 	}
 
+	/**
+	 * @param array<array-key, array<string, mixed>> $updates
+	 * @param bool                                    $include_major
+	 * @return array{offer: array<string, mixed>|null, suppressed_major: array<string, mixed>|null}
+	 */
+	private function call_select_update_offer( $updates, $include_major ) {
+		$cli_command = new CLI_Command();
+		$method      = new \ReflectionMethod( $cli_command, 'select_update_offer' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			// @phpstan-ignore method.deprecated
+			$method->setAccessible( true );
+		}
+		return $method->invoke( $cli_command, $updates, $include_major );
+	}
+
+	/**
+	 * @param string $update_type
+	 * @param string $version
+	 * @param string $status
+	 * @return array<string, string>
+	 */
+	private function update_offer( $update_type, $version, $status = 'available' ) {
+		return [
+			'version'      => $version,
+			'update_type'  => $update_type,
+			'package_url'  => "https://example.com/wp-cli-{$version}.phar",
+			'status'       => $status,
+			'requires_php' => '',
+		];
+	}
+
+	public function testSelectUpdateOfferSkipsMajorByDefaultAndPicksMinor(): void {
+		$updates = [
+			'major' => $this->update_offer( 'major', '3.0.0' ),
+			'minor' => $this->update_offer( 'minor', '2.12.0' ),
+			'patch' => $this->update_offer( 'patch', '2.11.5' ),
+		];
+
+		$result = $this->call_select_update_offer( $updates, false );
+
+		$this->assertNotNull( $result['offer'] );
+		$this->assertSame( '2.12.0', $result['offer']['version'] );
+		$this->assertNotNull( $result['suppressed_major'] );
+		$this->assertSame( '3.0.0', $result['suppressed_major']['version'] );
+	}
+
+	public function testSelectUpdateOfferFallsBackToPatchWhenNoMinor(): void {
+		$updates = [
+			'major' => $this->update_offer( 'major', '3.0.0' ),
+			'patch' => $this->update_offer( 'patch', '2.11.5' ),
+		];
+
+		$result = $this->call_select_update_offer( $updates, false );
+
+		$this->assertSame( '2.11.5', $result['offer']['version'] );
+		$this->assertSame( '3.0.0', $result['suppressed_major']['version'] );
+	}
+
+	public function testSelectUpdateOfferReturnsMajorWhenRequested(): void {
+		$updates = [
+			'major' => $this->update_offer( 'major', '3.0.0' ),
+			'minor' => $this->update_offer( 'minor', '2.12.0' ),
+		];
+
+		$result = $this->call_select_update_offer( $updates, true );
+
+		$this->assertSame( '3.0.0', $result['offer']['version'] );
+		$this->assertNull( $result['suppressed_major'] );
+	}
+
+	public function testSelectUpdateOfferWithholdsLoneMajorByDefault(): void {
+		$updates = [
+			'major' => $this->update_offer( 'major', '3.0.0' ),
+		];
+
+		$result = $this->call_select_update_offer( $updates, false );
+
+		$this->assertNull( $result['offer'] );
+		$this->assertNotNull( $result['suppressed_major'] );
+		$this->assertSame( '3.0.0', $result['suppressed_major']['version'] );
+	}
+
+	public function testSelectUpdateOfferDoesNotHintUnavailableMajor(): void {
+		$updates = [
+			'major' => $this->update_offer( 'major', '3.0.0', 'unavailable' ),
+			'minor' => $this->update_offer( 'minor', '2.12.0' ),
+		];
+
+		$result = $this->call_select_update_offer( $updates, false );
+
+		$this->assertSame( '2.12.0', $result['offer']['version'] );
+		$this->assertNull( $result['suppressed_major'] );
+	}
+
 	public function testReplaceCurrentPharNonWindowsSuccess(): void {
 		if ( WP_CLI\Utils\is_windows() ) {
 			$this->markTestSkipped( 'Not applicable on Windows' );

--- a/tests/CLICommandTest.php
+++ b/tests/CLICommandTest.php
@@ -3,6 +3,9 @@
 use WP_CLI\Tests\TestCase;
 use WP_CLI\ExitException;
 
+/**
+ * @phpstan-import-type UpdateOffer from CLI_Command
+ */
 class CLICommandTest extends TestCase {
 
 	private $prev_capture_exit;
@@ -55,9 +58,9 @@ class CLICommandTest extends TestCase {
 	}
 
 	/**
-	 * @param array<array-key, array<string, mixed>> $updates
-	 * @param bool                                    $include_major
-	 * @return array{offer: array<string, mixed>|null, suppressed_major: array<string, mixed>|null}
+	 * @param array<array-key, UpdateOffer> $updates
+	 * @param bool                           $include_major
+	 * @return UpdateOffer|null
 	 */
 	private function call_select_update_offer( $updates, $include_major ) {
 		$cli_command = new CLI_Command();
@@ -66,14 +69,19 @@ class CLICommandTest extends TestCase {
 			// @phpstan-ignore method.deprecated
 			$method->setAccessible( true );
 		}
-		return $method->invoke( $cli_command, $updates, $include_major );
+		/**
+		 * @var UpdateOffer|null $result
+		 */
+		$result = $method->invoke( $cli_command, $updates, $include_major );
+
+		return $result;
 	}
 
 	/**
 	 * @param string $update_type
 	 * @param string $version
 	 * @param string $status
-	 * @return array<string, string>
+	 * @return UpdateOffer
 	 */
 	private function update_offer( $update_type, $version, $status = 'available' ) {
 		return [
@@ -94,10 +102,8 @@ class CLICommandTest extends TestCase {
 
 		$result = $this->call_select_update_offer( $updates, false );
 
-		$this->assertNotNull( $result['offer'] );
-		$this->assertSame( '2.12.0', $result['offer']['version'] );
-		$this->assertNotNull( $result['suppressed_major'] );
-		$this->assertSame( '3.0.0', $result['suppressed_major']['version'] );
+		$this->assertSame( '2.12.0', $result['version'] ?? null );
+		$this->assertSame( '', $this->logger->stdout );
 	}
 
 	public function testSelectUpdateOfferFallsBackToPatchWhenNoMinor(): void {
@@ -108,8 +114,8 @@ class CLICommandTest extends TestCase {
 
 		$result = $this->call_select_update_offer( $updates, false );
 
-		$this->assertSame( '2.11.5', $result['offer']['version'] );
-		$this->assertSame( '3.0.0', $result['suppressed_major']['version'] );
+		$this->assertSame( '2.11.5', $result['version'] ?? null );
+		$this->assertSame( '', $this->logger->stdout );
 	}
 
 	public function testSelectUpdateOfferReturnsMajorWhenRequested(): void {
@@ -120,8 +126,8 @@ class CLICommandTest extends TestCase {
 
 		$result = $this->call_select_update_offer( $updates, true );
 
-		$this->assertSame( '3.0.0', $result['offer']['version'] );
-		$this->assertNull( $result['suppressed_major'] );
+		$this->assertSame( '3.0.0', $result['version'] ?? null );
+		$this->assertSame( '', $this->logger->stdout );
 	}
 
 	public function testSelectUpdateOfferWithholdsLoneMajorByDefault(): void {
@@ -131,9 +137,11 @@ class CLICommandTest extends TestCase {
 
 		$result = $this->call_select_update_offer( $updates, false );
 
-		$this->assertNull( $result['offer'] );
-		$this->assertNotNull( $result['suppressed_major'] );
-		$this->assertSame( '3.0.0', $result['suppressed_major']['version'] );
+		$this->assertNull( $result );
+		$this->assertSame(
+			"A new major version (3.0.0) is available. Run `wp cli update --major` to update across major versions.\n",
+			$this->logger->stdout
+		);
 	}
 
 	public function testSelectUpdateOfferDoesNotHintUnavailableMajor(): void {
@@ -144,8 +152,8 @@ class CLICommandTest extends TestCase {
 
 		$result = $this->call_select_update_offer( $updates, false );
 
-		$this->assertSame( '2.12.0', $result['offer']['version'] );
-		$this->assertNull( $result['suppressed_major'] );
+		$this->assertSame( '2.12.0', $result['version'] ?? null );
+		$this->assertSame( '', $this->logger->stdout );
 	}
 
 	public function testReplaceCurrentPharNonWindowsSuccess(): void {


### PR DESCRIPTION
## What

By default, `wp cli update` no longer crosses a major version boundary. A major update is only performed when `--major` is passed. When a major update is available but withheld, the command announces it and names the `--major` flag.

## Why

Today `wp cli update` picks the newest available release of any type, so a user on 2.x is automatically offered (and with `--yes`, moved to) the next major. A major can raise the minimum PHP version or change behavior, so an unattended `wp cli update` should not step across that line on its own. Requiring `--major` makes crossing a major a deliberate choice, while routine `wp cli update` keeps a user current within their major.

This is a deliberate behavior change for 3.0.0.

## Behavior

Before, on 2.12.0 with 3.0.0 available:

```
$ wp cli update
You have version 2.12.0. Would you like to update to 3.0.0? [y/n]
```

After:

```
$ wp cli update
A new major version (3.0.0) is available. Run `wp cli update --major` to update across major versions.
Success: WP-CLI is at the latest version.

$ wp cli update --major
You have version 2.12.0. Would you like to update to 3.0.0? [y/n]
```

Within-major updates (minor and patch) work exactly as before with no flag.

## Scope

- `--stable` and `--nightly` are unchanged. They are an explicit request for a specific channel or build, not the default "is there an update?" path.
- `wp cli check-update` still lists all available updates, including majors. This PR only changes which update the default `wp cli update` will apply.

## Implementation

The version-selection logic is pulled out of `update()` into `select_update_offer()`, which excludes a major update unless it has been requested and reports a withheld major separately so the caller can hint at `--major`. This keeps the network fetch (`get_updates()`) and the selection policy apart, and makes the policy unit-testable.

## Tests

`tests/CLICommandTest.php` gains unit tests for `select_update_offer()`: the default skips a major and picks the newest minor/patch, falls back to patch when there is no minor, `--major` offers the major, a lone major is withheld with a hint, and an unavailable major produces no hint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Major-version updates are now withheld by default.
  * Use the `--major` option to include major-version updates in update offers.
  * When only a major update is available, the CLI provides guidance to retry with `--major`.

* **Bug Fixes**
  * Update selection now prioritizes eligible minor and patch releases before major upgrades.

* **Documentation**
  * Updated update command help text and examples to explain major-version update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->