### PR TITLE
Deprecate legacy back_compat_conversions syntaxes

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -157,12 +157,16 @@ Feature: Create shortcuts to specific WordPress installs
         path: {TEST_DIR}/foo
       """
 
-    When I run `wp cli aliases`
+    When I try `wp cli aliases`
     Then STDOUT should be YAML containing:
       """
       @all: Run command against every registered alias.
       @foo:
         path: {TEST_DIR}/foo
+      """
+    And STDERR should contain:
+      """
+      The 'wp cli aliases' syntax is deprecated and will be removed in WP-CLI 4.0. Use 'wp cli alias list' instead.
       """
 
     When I run `wp cli alias list --format=json`
@@ -171,10 +175,14 @@ Feature: Create shortcuts to specific WordPress installs
       {"@all":"Run command against every registered alias.","@foo":{"path":"{TEST_DIR}/foo"}}
       """
 
-    When I run `wp cli aliases --format=json`
+    When I try `wp cli aliases --format=json`
     Then STDOUT should be JSON containing:
       """
       {"@all":"Run command against every registered alias.","@foo":{"path":"{TEST_DIR}/foo"}}
+      """
+    And STDERR should contain:
+      """
+      The 'wp cli aliases' syntax is deprecated and will be removed in WP-CLI 4.0. Use 'wp cli alias list' instead.
       """
 
   Scenario: Get alias information

--- a/features/back-compat.feature
+++ b/features/back-compat.feature
@@ -1,0 +1,46 @@
+Feature: Deprecated command and flag syntaxes still work but warn
+
+  A set of pre-1.0 command and flag syntaxes are rewritten to their modern form
+  by the framework for backward compatibility. As of WP-CLI 3.0 they emit a
+  deprecation warning naming the modern form, and are scheduled for removal in
+  4.0. The rewrite itself keeps working throughout the 3.x cycle.
+
+  Scenario: A deprecated top-level command alias warns
+    Given an empty directory
+
+    When I try `wp sql`
+    Then STDERR should contain:
+      """
+      The 'wp sql' syntax is deprecated and will be removed in WP-CLI 4.0. Use 'wp db' instead.
+      """
+
+  Scenario: A deprecated subcommand syntax warns
+    Given an empty directory
+
+    When I try `wp plugin update-all`
+    Then STDERR should contain:
+      """
+      The 'wp plugin update-all' syntax is deprecated and will be removed in WP-CLI 4.0. Use 'wp plugin update --all' instead.
+      """
+
+  Scenario: A deprecated flag warns
+    Given an empty directory
+
+    When I try `wp post list --ids`
+    Then STDERR should contain:
+      """
+      The '--ids' syntax is deprecated and will be removed in WP-CLI 4.0. Use '--format=ids' instead.
+      """
+
+  Scenario: Retained shorthands are not treated as deprecated
+    Given an empty directory
+
+    When I run `wp --version`
+    Then STDOUT should contain:
+      """
+      WP-CLI
+      """
+    And STDERR should not contain:
+      """
+      is deprecated
+      """

--- a/features/config.feature
+++ b/features/config.feature
@@ -209,7 +209,7 @@ Feature: Have a config file
           define( 'WP_POST_REVISIONS', 50 );
       """
 
-    When I run `wp config create --skip-check`
+    When I try `wp core config --skip-check`
     And I run `grep WP_POST_REVISIONS wp-config.php`
     Then STDOUT should not be empty
 

--- a/features/config.feature
+++ b/features/config.feature
@@ -196,12 +196,12 @@ Feature: Have a config file
     When I run `wp cli has-command core`
     Then the return code should be 0
 
-  Scenario: 'core config' parameters
+  Scenario: 'config create' parameters
     Given an empty directory
     And WP files
     And a wp-cli.yml file:
       """
-      core config:
+      config create:
         dbname: wordpress
         dbuser: root
         extra-php: |
@@ -209,7 +209,7 @@ Feature: Have a config file
           define( 'WP_POST_REVISIONS', 50 );
       """
 
-    When I try `wp core config --skip-check`
+    When I run `wp config create --skip-check`
     And I run `grep WP_POST_REVISIONS wp-config.php`
     Then STDOUT should not be empty
 

--- a/features/config.feature
+++ b/features/config.feature
@@ -209,7 +209,7 @@ Feature: Have a config file
           define( 'WP_POST_REVISIONS', 50 );
       """
 
-    When I run `wp core config --skip-check`
+    When I run `wp config create --skip-check`
     And I run `grep WP_POST_REVISIONS wp-config.php`
     Then STDOUT should not be empty
 

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -328,13 +328,16 @@ Feature: Run a WP-CLI command
   Scenario Outline: Apply backwards compat conversions
     Given a WP installation
 
-    When I run `wp <flag> run "term url category 1"`
+    When I try `wp <flag> run "term url category 1"`
     Then STDOUT should be:
       """
       https://example.com/?cat=1
       returned: NULL
       """
-    And STDERR should be empty
+    And STDERR should contain:
+      """
+      The 'wp term url' syntax is deprecated and will be removed in WP-CLI 4.0. Use 'wp term list --field=url' instead.
+      """
     And the return code should be 0
 
     Examples:

--- a/features/validation.feature
+++ b/features/validation.feature
@@ -17,14 +17,14 @@ Feature: Argument validation
     Given an empty directory
     And WP files
 
-    When I try `wp config create --dbprefix=invalid- --dbname=foo --dbpass=bar --dbuser=baz --skip-check`
+    When I try `wp core config --dbprefix=invalid- --dbname=foo --dbpass=bar --dbuser=baz --skip-check`
     Then the return code should be 1
     And STDERR should contain:
       """
       Error: --dbprefix can only contain numbers, letters, and underscores.
       """
 
-    When I try `wp config create --invalid --other-invalid`
+    When I try `wp core config --invalid --other-invalid`
     Then the return code should be 1
     And STDERR should contain:
       """

--- a/features/validation.feature
+++ b/features/validation.feature
@@ -17,14 +17,14 @@ Feature: Argument validation
     Given an empty directory
     And WP files
 
-    When I try `wp core config --dbprefix=invalid- --dbname=foo --dbpass=bar --dbuser=baz --skip-check`
+    When I try `wp config create --dbprefix=invalid- --dbname=foo --dbpass=bar --dbuser=baz --skip-check`
     Then the return code should be 1
     And STDERR should contain:
       """
       Error: --dbprefix can only contain numbers, letters, and underscores.
       """
 
-    When I try `wp core config --invalid --other-invalid`
+    When I try `wp config create --invalid --other-invalid`
     Then the return code should be 1
     And STDERR should contain:
       """

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1324,6 +1324,7 @@ class Runner {
 		if ( count( $args ) > 0 ) {
 			foreach ( $top_level_aliases as $old => $new ) {
 				if ( $old === $args[0] ) {
+					self::deprecated_syntax( "wp {$old}", "wp {$new}" );
 					$args[0] = $new;
 					break;
 				}
@@ -1332,6 +1333,7 @@ class Runner {
 
 		// *-meta  ->  * meta
 		if ( ! empty( $args ) && preg_match( '/(post|comment|user|network)-meta/', (string) $args[0], $matches ) ) {
+			self::deprecated_syntax( "wp {$args[0]}", "wp {$matches[1]} meta" );
 			array_shift( $args );
 			array_unshift( $args, 'meta' );
 			array_unshift( $args, $matches[1] );
@@ -1339,36 +1341,43 @@ class Runner {
 
 		// cli aliases  ->  cli alias list
 		if ( [ 'cli', 'aliases' ] === array_slice( $args, 0, 2 ) ) {
+			self::deprecated_syntax( 'wp cli aliases', 'wp cli alias list' );
 			list( $args[0], $args[1], $args[2] ) = [ 'cli', 'alias', 'list' ];
 		}
 
 		// core (multsite-)install --admin_name=  ->  --admin_user=
 		if ( count( $args ) > 0 && 'core' === $args[0] && isset( $assoc_args['admin_name'] ) ) {
+			self::deprecated_syntax( '--admin_name', '--admin_user' );
 			$assoc_args['admin_user'] = $assoc_args['admin_name'];
 			unset( $assoc_args['admin_name'] );
 		}
 
 		// core config  ->  config create
 		if ( [ 'core', 'config' ] === array_slice( $args, 0, 2 ) ) {
+			self::deprecated_syntax( 'wp core config', 'wp config create' );
 			list( $args[0], $args[1] ) = [ 'config', 'create' ];
 		}
 		// core language  ->  language core
 		if ( [ 'core', 'language' ] === array_slice( $args, 0, 2 ) ) {
+			self::deprecated_syntax( 'wp core language', 'wp language core' );
 			list( $args[0], $args[1] ) = [ 'language', 'core' ];
 		}
 
 		// checksum core  ->  core verify-checksums
 		if ( [ 'checksum', 'core' ] === array_slice( $args, 0, 2 ) ) {
+			self::deprecated_syntax( 'wp checksum core', 'wp core verify-checksums' );
 			list( $args[0], $args[1] ) = [ 'core', 'verify-checksums' ];
 		}
 
 		// checksum plugin  ->  plugin verify-checksums
 		if ( [ 'checksum', 'plugin' ] === array_slice( $args, 0, 2 ) ) {
+			self::deprecated_syntax( 'wp checksum plugin', 'wp plugin verify-checksums' );
 			list( $args[0], $args[1] ) = [ 'plugin', 'verify-checksums' ];
 		}
 
 		// site create --site_id=  ->  site create --network_id=
 		if ( count( $args ) >= 2 && 'site' === $args[0] && 'create' === $args[1] && isset( $assoc_args['site_id'] ) ) {
+			self::deprecated_syntax( '--site_id', '--network_id' );
 			$assoc_args['network_id'] = $assoc_args['site_id'];
 			unset( $assoc_args['site_id'] );
 		}
@@ -1377,24 +1386,28 @@ class Runner {
 		if ( count( $args ) > 1 && in_array( $args[0], [ 'plugin', 'theme' ], true )
 			&& 'update-all' === $args[1]
 		) {
+			self::deprecated_syntax( "wp {$args[0]} update-all", "wp {$args[0]} update --all" );
 			$args[1]           = 'update';
 			$assoc_args['all'] = true;
 		}
 
 		// transient delete-expired  ->  transient delete --expired
 		if ( count( $args ) > 1 && 'transient' === $args[0] && 'delete-expired' === $args[1] ) {
+			self::deprecated_syntax( 'wp transient delete-expired', 'wp transient delete --expired' );
 			$args[1]               = 'delete';
 			$assoc_args['expired'] = true;
 		}
 
 		// transient delete-all  ->  transient delete --all
 		if ( count( $args ) > 1 && 'transient' === $args[0] && 'delete-all' === $args[1] ) {
+			self::deprecated_syntax( 'wp transient delete-all', 'wp transient delete --all' );
 			$args[1]           = 'delete';
 			$assoc_args['all'] = true;
 		}
 
 		// plugin scaffold  ->  scaffold plugin
 		if ( [ 'plugin', 'scaffold' ] === array_slice( $args, 0, 2 ) ) {
+			self::deprecated_syntax( 'wp plugin scaffold', 'wp scaffold plugin' );
 			list( $args[0], $args[1] ) = [ $args[1], $args[0] ];
 		}
 
@@ -1409,6 +1422,7 @@ class Runner {
 			&& 'list' === $args[1]
 			&& isset( $assoc_args['ids'] )
 		) {
+			self::deprecated_syntax( '--ids', '--format=ids' );
 			$assoc_args['format'] = 'ids';
 			unset( $assoc_args['ids'] );
 		}
@@ -1433,6 +1447,7 @@ class Runner {
 
 		// (post|comment|site|term) url  --> (post|comment|site|term) list --*__in --field=url
 		if ( count( $args ) >= 2 && in_array( $args[0], [ 'post', 'comment', 'site', 'term' ], true ) && 'url' === $args[1] ) {
+			self::deprecated_syntax( "wp {$args[0]} url", "wp {$args[0]} list --field=url" );
 			switch ( $args[0] ) {
 				case 'post':
 					$post_ids                = array_slice( $args, 2 );
@@ -1493,6 +1508,33 @@ class Runner {
 		}
 
 		return [ $args, $assoc_args ];
+	}
+
+	/**
+	 * Emits a deprecation warning for a legacy command or flag syntax that is
+	 * still rewritten by back_compat_conversions().
+	 *
+	 * The rewrite keeps working throughout the 3.x cycle. These syntaxes were
+	 * never warned about before, so 3.0 is the first release to signal that they
+	 * are on their way out; they are scheduled for removal in WP-CLI 4.0. See
+	 * https://github.com/wp-cli/wp-cli/issues/6353.
+	 *
+	 * The conversion runs during the `ConfigureRunner` bootstrap step, before the
+	 * logger is initialized, so this writes to STDERR directly, matching the
+	 * existing `--blog`-style deprecation notice in Configurator.
+	 *
+	 * @param string $old_syntax The deprecated syntax that was used.
+	 * @param string $new_syntax The modern replacement to use instead.
+	 */
+	private static function deprecated_syntax( $old_syntax, $new_syntax ) {
+		fwrite(
+			STDERR,
+			sprintf(
+				"WP-CLI: The '%s' syntax is deprecated and will be removed in WP-CLI 4.0. Use '%s' instead.\n",
+				$old_syntax,
+				$new_syntax
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #6353.

## What

`Runner::back_compat_conversions()` silently rewrites a set of pre-1.0 command and flag syntaxes to their modern equivalents. This adds a deprecation warning at each genuinely-legacy conversion site, naming the modern form, while keeping the rewrite working. These syntaxes are scheduled for removal in 4.0.

## Why

Nothing ever warned about these rewrites, so a user still on an old syntax has no signal that it is outdated. Removing them outright in 3.0 (the original plan) would break scripts with a bare "unknown command" and no pointer to the replacement, for syntaxes we never told anyone were deprecated. Deprecating in 3.0 and removing in 4.0 starts the clock at the major boundary, which is the first time we have ever signalled these are on the way out.

## Deprecated in 3.0 (warn, keep working; remove in 4.0)

`wp sql`, `wp blog`, `wp {post|comment|user|network}-meta`, `wp cli aliases`, `wp core config`, `wp core language`, `wp checksum core`, `wp checksum plugin`, `--admin_name`, `--site_id`, `wp {plugin|theme} update-all`, `wp transient delete-expired`, `wp transient delete-all`, `wp plugin scaffold`, `{post|user} list --ids`, and `wp {post|comment|site|term} url`.

Each emits, for example:

```
WP-CLI: The 'wp sql' syntax is deprecated and will be removed in WP-CLI 4.0. Use 'wp db' instead.
```

## Left untouched (permanent features, not legacy)

Per #6353 these stay as they are, with no warning:

- `wp <command> --help` -> `wp help <command>` (this is how `--help` is implemented)
- `wp --version` / `wp --info` -> `wp cli version` / `wp cli info`
- `--json` -> `--format=json` (kept as a convenient shorthand)
- Windows PowerShell space-separated numeric ID splitting

## Implementation note

The conversion runs during the `ConfigureRunner` bootstrap step, which is before `InitializeLogger`, so `WP_CLI::warning()` would be lost at that point. The notice is therefore written straight to STDERR through a small `deprecated_syntax()` helper, matching the existing `--blog` deprecation in `Configurator`.

## Out of scope

`back_compat_conversions()` also rewrites `config get --global/--constant` and bare `config get` -> `config list`. That one was not part of #6353's list, so it is deliberately left alone here. Worth a separate decision on whether to deprecate it too.

## Tests

- New `features/back-compat.feature` covers a deprecated top-level alias, a deprecated subcommand, a deprecated flag, and asserts a retained shorthand (`--version`) does not warn.
- The existing `wp cli aliases` scenarios in `features/aliases.feature` now also assert the deprecation notice.
- `wp core config` usages in `features/config.feature` and `features/validation.feature` switch to `wp config create` so they are not testing (and warning on) the deprecated alias.

## Follow-up

The 4.0 removal (turning these into hard errors) is tracked as a task in #6353.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized deprecation warnings for legacy WP-CLI command and flag syntax, emitted to STDERR with guidance to the modern equivalent.

* **Bug Fixes**
  * Deprecated aliases and shorthand forms now consistently report deprecation warnings via STDERR.
  * Confirmed supported shorthand such as `wp --version` remains warning-free.

* **Tests**
  * Expanded backward-compatibility and conversion coverage to assert the new STDERR warnings across relevant deprecated command/flag scenarios, plus updated validation and config-related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->