### PR TITLE
Replace GitHub Actions expression interpolation with environment variables

### DIFF
--- a/.github/workflows/update-requests.yml
+++ b/.github/workflows/update-requests.yml
@@ -82,6 +82,8 @@ jobs:
         if: steps.latest_release.outputs.tag != steps.current_version.outputs.tag
         env:
           GH_TOKEN: ${{ github.token }}
+          LATEST_TAG: ${{ steps.latest_release.outputs.tag }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
           BRANCH_NAME: "update/requests-${{ steps.latest_release.outputs.tag }}"
           PR_BODY: |
             This automated PR updates the bundled [Requests](https://github.com/WordPress/Requests) library from `${{ steps.current_version.outputs.tag }}` to `${{ steps.latest_release.outputs.tag }}`.
@@ -93,23 +95,23 @@ jobs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git checkout -b "$BRANCH_NAME"
             git add utils/install-requests.sh bundle/rmccue/requests/
-            git commit -m "Update bundled Requests library to ${{ steps.latest_release.outputs.tag }}"
+            git commit -m "Update bundled Requests library to ${LATEST_TAG}"
             git push -f origin "$BRANCH_NAME"
             
             PR_NUMBER=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number // empty')
             if [ -z "$PR_NUMBER" ]; then
               gh pr create \
-                --title "Update bundled Requests library to ${{ steps.latest_release.outputs.tag }}" \
+                --title "Update bundled Requests library to ${LATEST_TAG}" \
                 --body "$PR_BODY" \
                 --label "Requests" \
-                --base "${{ github.event.repository.default_branch }}" \
+                --base "$BASE_BRANCH" \
                 --head "$BRANCH_NAME"
             else
               gh pr edit "$PR_NUMBER" \
-                --title "Update bundled Requests library to ${{ steps.latest_release.outputs.tag }}" \
+                --title "Update bundled Requests library to ${LATEST_TAG}" \
                 --body "$PR_BODY" \
                 --add-label "Requests" \
-                --base "${{ github.event.repository.default_branch }}"
+                --base "$BASE_BRANCH"
             fi
           fi
 


### PR DESCRIPTION
Hardens this workflow file by replacing direct GitHub Actions expression interpolation with environment variables.

Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/github-actions/#template-injection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated pull request creation and updates for bundled Requests library updates.
  * Ensured generated pull requests consistently target the default branch and use the latest release in their title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->