### PR TITLE
Escape script paths when launching subprocesses

### DIFF
--- a/features/class-wp-cli.feature
+++ b/features/class-wp-cli.feature
@@ -15,6 +15,40 @@ Feature: Various utilities for WP-CLI commands
       | proc_open  |
       | proc_close |
 
+  @skip-windows
+  Scenario: Escape the script path when launching subprocesses
+    Given an empty directory
+    And a wp-cli-bootstrap.php file:
+      """
+      <?php
+      define( 'WP_CLI_ROOT', '{FRAMEWORK_ROOT}' );
+      require_once WP_CLI_ROOT . '/php/wp-cli.php';
+      """
+    And a launch-subprocesses.php file:
+      """
+      <?php
+      $launch_self_exit_code = WP_CLI::launch_self( 'cli', [ 'version' ], [], false );
+      $runcommand_exit_code  = WP_CLI::runcommand(
+        'cli version',
+        [
+          'launch'     => true,
+          'exit_error' => false,
+          'return'     => 'return_code',
+        ]
+      );
+
+      WP_CLI::log( "{$launch_self_exit_code},{$runcommand_exit_code}" );
+      """
+
+    When I run `cp wp-cli-bootstrap.php "wp cli"`
+    And I run `php "wp cli" --skip-wordpress eval-file launch-subprocesses.php`
+    Then STDOUT should be:
+      """
+      0,0
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
   Scenario: HTTP URL scheme clears pre-existing HTTPS server variable
     Given an empty directory
     And a test.php file:

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1402,7 +1402,7 @@ class WP_CLI {
 		 */
 		$argv = $GLOBALS['argv'];
 
-		$script_path = $argv[0];
+		$script_path = escapeshellarg( $argv[0] );
 
 		$wp_cli_config_path = (string) getenv( 'WP_CLI_CONFIG_PATH' );
 
@@ -1570,7 +1570,7 @@ class WP_CLI {
 			 */
 
 			$php_bin     = escapeshellarg( Utils\get_php_binary() );
-			$script_path = $argv[0];
+			$script_path = escapeshellarg( $argv[0] );
 
 			// Persist runtime arguments unless they've been specified otherwise.
 			$configurator = self::get_configurator();


### PR DESCRIPTION
WP-CLI currently passes its script path unescaped when `WP_CLI::launch_self()` or the launching path in `WP_CLI::runcommand()` starts a subprocess. As a result, invoking WP-CLI from a script path containing spaces prevents the subprocess from starting correctly.

Escape the script path consistently with the PHP binary and other command arguments.

Add Behat coverage that invokes WP-CLI from a script path containing spaces and exercises both subprocess APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command execution when the WP-CLI script path contains spaces.
  * Improved subprocess launching by safely quoting executable paths.
  * Added coverage to verify successful execution and clean error output in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->