### PR TITLE
Return empty string from get_sql_dump_command() and get_sql_check_command() when binaries are missing

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -2171,7 +2171,7 @@ function get_mysql_version() {
  * For MariaDB, prefers `mariadb-dump` (available since MariaDB 10.5) but falls
  * back to `mysqldump` if the command is not found on the system.
  *
- * @return string The appropriate dump command.
+ * @return string The appropriate dump command, or an empty string if not found.
  */
 function get_sql_dump_command() {
 	static $command = null;
@@ -2180,14 +2180,37 @@ function get_sql_dump_command() {
 		return $command;
 	}
 
-	$command = 'mysqldump';
+	$command = '';
 
-	if ( 'mariadb' === get_db_type() ) {
-		$find_cmd = is_windows() ? 'where mariadb-dump' : '/usr/bin/env which mariadb-dump';
-		$result   = Process::create( $find_cmd, null, null )->run();
+	if ( is_windows() ) {
+		$mariadb = Process::create( 'where mariadb-dump', null, null )->run();
+		$mysql   = Process::create( 'where mysqldump', null, null )->run();
+	} else {
+		$mariadb = Process::create( '/usr/bin/env which mariadb-dump', null, null )->run();
+		$mysql   = Process::create( '/usr/bin/env which mysqldump', null, null )->run();
+	}
 
-		if ( 0 === $result->return_code && '' !== trim( $result->stdout ) ) {
-			$command = 'mariadb-dump';
+	$mariadb_binary = trim( explode( "\n", $mariadb->stdout )[0] );
+	$mysql_binary   = trim( explode( "\n", $mysql->stdout )[0] );
+
+	if ( 'mariadb' === get_db_type() && 0 === $mariadb->return_code && '' !== $mariadb_binary ) {
+		$result = Process::create( escapeshellarg( $mariadb_binary ) . ' --version', null, null )->run();
+		if ( 0 === $result->return_code ) {
+			$command = $mariadb_binary;
+		}
+	}
+
+	if ( '' === $command && 0 === $mysql->return_code && '' !== $mysql_binary ) {
+		$result = Process::create( escapeshellarg( $mysql_binary ) . ' --version', null, null )->run();
+		if ( 0 === $result->return_code ) {
+			$command = $mysql_binary;
+		}
+	}
+
+	if ( '' === $command && 0 === $mariadb->return_code && '' !== $mariadb_binary ) {
+		$result = Process::create( escapeshellarg( $mariadb_binary ) . ' --version', null, null )->run();
+		if ( 0 === $result->return_code ) {
+			$command = $mariadb_binary;
 		}
 	}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -2119,8 +2119,11 @@ function get_mysql_binary_path() {
 		if ( 0 === $result->return_code ) {
 			$path = $mysql_binary;
 			// It's actually MariaDB disguised as MySQL.
-			if ( false !== strpos( $result->stdout, 'MariaDB' ) && 0 === $mariadb->return_code ) {
-				$path = $mariadb_binary;
+			if ( false !== strpos( $result->stdout, 'MariaDB' ) && 0 === $mariadb->return_code && '' !== $mariadb_binary ) {
+				$mariadb_result = Process::create( escapeshellarg( $mariadb_binary ) . ' --version', null, null )->run();
+				if ( 0 === $mariadb_result->return_code ) {
+					$path = $mariadb_binary;
+				}
 			}
 		}
 	}

--- a/php/utils.php
+++ b/php/utils.php
@@ -2114,18 +2114,22 @@ function get_mysql_binary_path() {
 	$mysql_binary   = trim( explode( "\n", $mysql->stdout )[0] );
 	$mariadb_binary = trim( explode( "\n", $mariadb->stdout )[0] );
 
-	if ( 0 === $mysql->return_code ) {
-		if ( '' !== $mysql_binary ) {
-			$path   = $mysql_binary;
-			$result = Process::create( escapeshellarg( $mysql_binary ) . ' --version', null, null )->run();
-
+	if ( 0 === $mysql->return_code && '' !== $mysql_binary ) {
+		$result = Process::create( escapeshellarg( $mysql_binary ) . ' --version', null, null )->run();
+		if ( 0 === $result->return_code ) {
+			$path = $mysql_binary;
 			// It's actually MariaDB disguised as MySQL.
-			if ( 0 === $result->return_code && false !== strpos( $result->stdout, 'MariaDB' ) && 0 === $mariadb->return_code ) {
+			if ( false !== strpos( $result->stdout, 'MariaDB' ) && 0 === $mariadb->return_code ) {
 				$path = $mariadb_binary;
 			}
 		}
-	} elseif ( 0 === $mariadb->return_code ) {
-		$path = $mariadb_binary;
+	}
+
+	if ( '' === $path && 0 === $mariadb->return_code && '' !== $mariadb_binary ) {
+		$result = Process::create( escapeshellarg( $mariadb_binary ) . ' --version', null, null )->run();
+		if ( 0 === $result->return_code ) {
+			$path = $mariadb_binary;
+		}
 	}
 
 	return $path;

--- a/php/utils.php
+++ b/php/utils.php
@@ -2223,7 +2223,7 @@ function get_sql_dump_command() {
  * For MariaDB, prefers `mariadb-check` (available since MariaDB 10.5) but falls
  * back to `mysqlcheck` if the command is not found on the system.
  *
- * @return string The appropriate check command.
+ * @return string The appropriate check command, or an empty string if not found.
  */
 function get_sql_check_command() {
 	static $command = null;
@@ -2232,14 +2232,37 @@ function get_sql_check_command() {
 		return $command;
 	}
 
-	$command = 'mysqlcheck';
+	$command = '';
 
-	if ( 'mariadb' === get_db_type() ) {
-		$find_cmd = is_windows() ? 'where mariadb-check' : '/usr/bin/env which mariadb-check';
-		$result   = Process::create( $find_cmd, null, null )->run();
+	if ( is_windows() ) {
+		$mariadb = Process::create( 'where mariadb-check', null, null )->run();
+		$mysql   = Process::create( 'where mysqlcheck', null, null )->run();
+	} else {
+		$mariadb = Process::create( '/usr/bin/env which mariadb-check', null, null )->run();
+		$mysql   = Process::create( '/usr/bin/env which mysqlcheck', null, null )->run();
+	}
 
-		if ( 0 === $result->return_code && '' !== trim( $result->stdout ) ) {
-			$command = 'mariadb-check';
+	$mariadb_binary = trim( explode( "\n", $mariadb->stdout )[0] );
+	$mysql_binary   = trim( explode( "\n", $mysql->stdout )[0] );
+
+	if ( 'mariadb' === get_db_type() && 0 === $mariadb->return_code && '' !== $mariadb_binary ) {
+		$result = Process::create( escapeshellarg( $mariadb_binary ) . ' --version', null, null )->run();
+		if ( 0 === $result->return_code ) {
+			$command = $mariadb_binary;
+		}
+	}
+
+	if ( '' === $command && 0 === $mysql->return_code && '' !== $mysql_binary ) {
+		$result = Process::create( escapeshellarg( $mysql_binary ) . ' --version', null, null )->run();
+		if ( 0 === $result->return_code ) {
+			$command = $mysql_binary;
+		}
+	}
+
+	if ( '' === $command && 0 === $mariadb->return_code && '' !== $mariadb_binary ) {
+		$result = Process::create( escapeshellarg( $mariadb_binary ) . ' --version', null, null )->run();
+		if ( 0 === $result->return_code ) {
+			$command = $mariadb_binary;
 		}
 	}
 


### PR DESCRIPTION
Currently, `Utils\get_sql_dump_command()` and `Utils\get_sql_check_command()` default to returning `'mysqldump'` and `'mysqlcheck'` respectively, even when those client binaries do not exist on system `PATH`. In contrast, `Utils\get_mysql_binary_path()` returns an empty string (`""`) when `mysql`/`mariadb` binaries are absent or fail execution.

This PR aligns the binary resolution functions in `Utils` by:
1. Verifying that binary `--version` probe execution returns exit code `0` in `get_mysql_binary_path()`, returning `""` if execution fails (e.g. non-functional shims/wrappers).
2. Updating `get_sql_dump_command()` and `get_sql_check_command()` to probe for `mariadb-dump`/`mysqldump` and `mariadb-check`/`mysqlcheck` binaries and verify their `--version` exit code, returning an empty string (`""`) when missing or non-functional.

This allows package commands (such as `wp db export`, `wp db check`, etc.) to reliably detect binary availability and provide clean user-facing error messages instead of attempting shell execution with empty path strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when detecting MySQL and MariaDB client tools.
  * SQL dump and database-check commands are now selected only after confirming the corresponding tools are present and respond successfully.
  * Added safer MariaDB fallback handling when MySQL-derived options are unavailable.
  * Prevented unavailable commands from being chosen by default (may now return no command when tools aren’t found).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->