### PR TITLE
Change branch alias to 3.0.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.13.x-dev"
+            "dev-main": "3.0.x-dev"
         },
         "commands": [
             "cli",


### PR DESCRIPTION
See #6322

AFAICT this change is needed before we can release v3.0.0. But it also means we need to tag new versions of all the packages requiring 3.0, as they currently require 2.13, which will no longer resolve after this is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development branch version alias to reflect the upcoming 3.0 release line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->