### PR TITLE
Reject invalid keys in `assoc_args_to_str`

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -12,6 +12,7 @@ use Closure;
 use Composer\Semver\Comparator;
 use Composer\Semver\Semver;
 use Exception;
+use InvalidArgumentException;
 use Iterator;
 use Mustache\Engine as Mustache_Engine;
 use ReflectionFunction;
@@ -367,11 +368,21 @@ function args_to_str( $args ) {
  * @param array<string, mixed> $assoc_args Associative arguments to compose.
  * @param array<string> $sensitive_args Optional. Array of argument keys that should be masked.
  * @return string
+ * @throws InvalidArgumentException If an argument key contains invalid characters.
  */
 function assoc_args_to_str( $assoc_args, $sensitive_args = [] ) {
 	$str = '';
 
 	foreach ( $assoc_args as $key => $value ) {
+		if ( ! preg_match( '/^[a-zA-Z0-9_:\.-]+$/', (string) $key ) ) {
+			throw new InvalidArgumentException(
+				sprintf(
+					"Invalid associative argument key '%s'.",
+					$key
+				)
+			);
+		}
+
 		if ( true === $value ) {
 			$str .= " --$key";
 		} elseif ( is_array( $value ) ) {

--- a/php/utils.php
+++ b/php/utils.php
@@ -374,7 +374,7 @@ function assoc_args_to_str( $assoc_args, $sensitive_args = [] ) {
 	$str = '';
 
 	foreach ( $assoc_args as $key => $value ) {
-		if ( ! preg_match( '/^[a-zA-Z0-9_:\.-]+$/', (string) $key ) ) {
+		if ( ! preg_match( '/\A[a-zA-Z0-9_:\.-]+\z/', (string) $key ) ) {
 			throw new InvalidArgumentException(
 				sprintf(
 					"Invalid associative argument key '%s'.",

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -402,6 +402,13 @@ class UtilsTest extends TestCase {
 		$this->assertStringNotContainsString( 'token2', $actual );
 	}
 
+	public function testAssocArgsToStringWithInvalidKeys(): void {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( "Invalid associative argument key '$(id -u)'." );
+
+		Utils\assoc_args_to_str( [ '$(id -u)' => true ] );
+	}
+
 	public function testMysqlHostToCLIArgs(): void {
 		// Test hostname only, with and without 'p:' modifier.
 		$expected = [


### PR DESCRIPTION
Applying some slight hardening here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for command argument keys, rejecting unsupported characters before command construction.
  * Improved handling of potentially unsafe shell-command substitution patterns.
  * Invalid keys now produce a clear argument error instead of being processed.

* **Tests**
  * Added coverage confirming invalid argument keys are rejected consistently with the expected error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->