### PR TITLE
Configurator: Add recursion guard to `merge_yml()`

### DIFF
--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -403,16 +403,26 @@ class Configurator {
 	/**
 	 * Load a YAML file of parameters into scope.
 	 *
-	 * @param string $path Path to YAML file.
+	 * @param string      $path Path to YAML file.
+	 * @param string|null $current_alias Optional. Current alias name.
+	 * @param array       $visited Optional. List of visited realpaths.
 	 */
-	public function merge_yml( $path, $current_alias = null ) {
+	public function merge_yml( $path, $current_alias = null, array $visited = [] ) {
+		$realpath = $path ? ( ( new SplFileInfo( $path ) )->getRealPath() ?: $path ) : false;
+		if ( $realpath ) {
+			if ( in_array( $realpath, $visited, true ) ) {
+				return;
+			}
+			$visited[] = $realpath;
+		}
+
 		$yaml = self::load_yml( $path );
 		if ( ! empty( $yaml['_']['inherit'] ) ) {
 			$inherit_path = Path::is_absolute( $yaml['_']['inherit'] )
 				? $yaml['_']['inherit']
 				: ( new SplFileInfo( Path::normalize( dirname( $path ) . '/' . $yaml['_']['inherit'] ) ) )->getRealPath();
 
-			$this->merge_yml( $inherit_path, $current_alias );
+			$this->merge_yml( $inherit_path, $current_alias, $visited );
 		}
 		// Prepare the base path for absolutized alias paths.
 		$yml_file_dir = $path ? dirname( $path ) : '';

--- a/tests/ConfiguratorTest.php
+++ b/tests/ConfiguratorTest.php
@@ -196,4 +196,40 @@ class ConfiguratorTest extends TestCase {
 		$this->assertArrayHasKey( 'verbose', $assoc_args2 );
 		$this->assertFalse( $assoc_args2['verbose'] );
 	}
+
+	public function testMergeYmlSelfInheritRecursionGuard(): void {
+		$temp_dir = sys_get_temp_dir();
+		$file     = tempnam( $temp_dir, 'wp-cli-test-self-' ) . '.yml';
+
+		file_put_contents( $file, "_:\n  inherit: " . basename( $file ) . "\nfoo: bar\n" );
+
+		$configurator = new Configurator( __DIR__ . '/../php/config-spec.php' );
+		$configurator->merge_yml( $file );
+
+		[ $config, $extra_config ] = $configurator->to_array();
+
+		unlink( $file );
+
+		$this->assertEquals( 'bar', $extra_config['foo'] );
+	}
+
+	public function testMergeYmlCircularInheritRecursionGuard(): void {
+		$temp_dir = sys_get_temp_dir();
+		$file1    = tempnam( $temp_dir, 'wp-cli-test-1-' ) . '.yml';
+		$file2    = tempnam( $temp_dir, 'wp-cli-test-2-' ) . '.yml';
+
+		file_put_contents( $file1, "_:\n  inherit: " . basename( $file2 ) . "\nfoo: bar\n" );
+		file_put_contents( $file2, "_:\n  inherit: " . basename( $file1 ) . "\nfoo: baz\nbaz: qux\n" );
+
+		$configurator = new Configurator( __DIR__ . '/../php/config-spec.php' );
+		$configurator->merge_yml( $file1 );
+
+		[ $config, $extra_config ] = $configurator->to_array();
+
+		unlink( $file1 );
+		unlink( $file2 );
+
+		$this->assertEquals( 'bar', $extra_config['foo'] );
+		$this->assertEquals( 'qux', $extra_config['baz'] );
+	}
 }

--- a/tests/ConfiguratorTest.php
+++ b/tests/ConfiguratorTest.php
@@ -199,8 +199,7 @@ class ConfiguratorTest extends TestCase {
 
 	public function testMergeYmlSelfInheritRecursionGuard(): void {
 		$temp_dir = sys_get_temp_dir();
-		$file     = tempnam( $temp_dir, 'wp-cli-test-self-' ) . '.yml';
-
+		$file     = tempnam( $temp_dir, 'wp-cli-test-self-' );
 		file_put_contents( $file, "_:\n  inherit: " . basename( $file ) . "\nfoo: bar\n" );
 
 		$configurator = new Configurator( __DIR__ . '/../php/config-spec.php' );


### PR DESCRIPTION
Slight hardening to prevent stack overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented configuration inheritance from getting stuck when YAML files inherit from themselves or from each other in a cycle.
  * Preserved available local and inherited configuration values while safely stopping recursive processing.

* **Tests**
  * Added coverage for self-referencing and circular YAML inheritance scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->