### PR TITLE
Use 0700 permissions for cache and extractor directories

### DIFF
--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -367,7 +367,7 @@ class Extractor {
 	 */
 	private static function ensure_dir_exists( $dir ) {
 		if ( ! is_dir( $dir ) ) {
-			if ( ! @mkdir( $dir, 0777, true ) ) {
+			if ( ! @mkdir( $dir, 0700, true ) ) {
 				$error = error_get_last();
 				WP_CLI::warning(
 					sprintf(

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -396,7 +396,7 @@ class FileCache {
 				return false;
 			}
 
-			if ( ! @mkdir( $dir, 0777, true ) ) {
+			if ( ! @mkdir( $dir, 0700, true ) ) {
 				$message = "Failed to create directory '{$dir}'";
 				$error   = error_get_last();
 				if ( is_array( $error ) ) {

--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -339,6 +339,25 @@ class ExtractorTest extends TestCase {
 		$this->assertEmpty( self::$logger->stderr );
 	}
 
+	public function test_ensure_dir_exists(): void {
+		$dir        = Utils\get_temp_dir() . uniqid( 'wp-cli-test-extractor-', true );
+		$test_class = new ReflectionClass( Extractor::class );
+		$method     = $test_class->getMethod( 'ensure_dir_exists' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			// @phpstan-ignore method.deprecated
+			$method->setAccessible( true );
+		}
+
+		$result = $method->invoke( null, $dir );
+		$this->assertTrue( $result );
+		$this->assertTrue( is_dir( $dir ) );
+		if ( ! Utils\is_windows() ) {
+			$this->assertSame( '0700', substr( sprintf( '%o', fileperms( $dir ) ), -4 ) );
+		}
+
+		rmdir( $dir );
+	}
+
 	private static function create_test_directory_structure() {
 		$temp_dir = Utils\get_temp_dir() . uniqid( self::$copy_overwrite_files_prefix, true );
 		mkdir( $temp_dir );

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -57,6 +57,9 @@ class FileCacheTest extends TestCase {
 		$result = $method->invokeArgs( $cache, [ $cache_dir . '/test1' ] );
 		$this->assertTrue( $result );
 		$this->assertTrue( is_dir( $cache_dir . '/test1' ) );
+		if ( ! Utils\is_windows() ) {
+			$this->assertSame( '0700', substr( sprintf( '%o', fileperms( $cache_dir . '/test1' ) ), -4 ) );
+		}
 
 		// Try to create the same directory again. it should return true.
 		$result = $method->invokeArgs( $cache, [ $cache_dir . '/test1' ] );


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by creating newly generated extraction and cache directories with restricted `0700` permissions.

* **Tests**
  * Added coverage to verify directory creation and permissions across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->