### PR TITLE
Handle process spawn failures in `WP_CLI::runcommand()`

### DIFF
--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -361,6 +361,50 @@ Feature: Run a WP-CLI command
       | proc_open  |
       | proc_close |
 
+  # This only exercises the regression when the test suite runs as a non-root
+  # user, as root can enter the locked directory regardless of its permissions.
+  @skip-windows
+  Scenario: Launch a command from a working directory the process cannot enter
+    Given a locked-cwd.php file:
+      """
+      <?php
+      WP_CLI::add_command(
+        'locked-cwd',
+        function () {
+          $dir = getcwd() . '/locked';
+          mkdir( $dir );
+          chdir( $dir );
+
+          // Make sure the test run directory can be cleaned up again.
+          register_shutdown_function(
+            static function () use ( $dir ) {
+              chmod( $dir, 0755 );
+            }
+          );
+
+          chmod( $dir, 0000 );
+
+          $version = WP_CLI::runcommand( 'cli version', array( 'launch' => true, 'return' => true ) );
+
+          WP_CLI::log( 'returned: ' . $version );
+        },
+        array( 'when' => 'before_wp_load' )
+      );
+      """
+    And a wp-cli.yml file:
+      """
+      require:
+        - locked-cwd.php
+      """
+
+    When I run `wp locked-cwd`
+    Then STDOUT should contain:
+      """
+      returned: WP-CLI
+      """
+    And STDERR should be empty
+    And the return code should be 0
+
   Scenario: Check that command_args provided to runcommand are used in command
     Given a WP installation
     And a custom-cmd.php file:

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1596,7 +1596,15 @@ class WP_CLI {
 			 * @phpstan-var array<int, resource> $pipes
 			 */
 			$pipes = [];
-			$proc  = Utils\proc_open_compat( $runcommand, $descriptors, $pipes, getcwd() ?: null );
+
+			// The child process inherits the current working directory, so it is not
+			// passed along explicitly: as of PHP 8.3 that makes the spawn fail
+			// outright whenever the child cannot enter that directory.
+			$proc = Utils\proc_open_compat( $runcommand, $descriptors, $pipes );
+
+			if ( ! $proc ) {
+				self::error( "Failed to launch a new process for the command: {$command}" );
+			}
 
 			$stdout = '';
 			$stderr = '';
@@ -1607,7 +1615,7 @@ class WP_CLI {
 				$stderr = (string) stream_get_contents( $pipes[2] );
 				fclose( $pipes[2] );
 			}
-			$return_code = $proc ? proc_close( $proc ) : -1;
+			$return_code = proc_close( $proc );
 			if ( -1 === $return_code ) {
 				self::warning( 'Spawned process returned exit code -1, which could be caused by a custom compiled version of PHP that uses the --enable-sigchild option.' );
 			} elseif ( $return_code && $exit_error ) {


### PR DESCRIPTION
See #6367.

## Problem

`WP_CLI::runcommand()` never checks whether `proc_open()` actually created a process. When it returns `false`, `$pipes` is left empty and the very next lines dereference it:

```php
$proc = Utils\proc_open_compat( $runcommand, $descriptors, $pipes, getcwd() ?: null );

if ( $return ) {
    $stdout = (string) stream_get_contents( $pipes[1] );   // $pipes is []
```

which produces the cascade reported in #6367 — `Undefined array key 1`, then an uncaught `TypeError` from `stream_get_contents()`, and (because this runs after WP is loaded) WP's fatal error handler printing "There has been a critical error on this website."

This is the only spawn site in the framework missing that guard; `Utils\run_mysql_command()`, `Process::run()` and `Utils\launch_editor_for_input()` all check it. `trunk` already had `$proc ? proc_close( $proc ) : -1`, but the crash happens above that line.

## Why the spawn fails

As of PHP 8.3, `proc_open()` uses `posix_spawn()` and applies the `$cwd` argument via `posix_spawn_file_actions_addchdir_np()`. If the child cannot enter that directory, the whole spawn fails with `EACCES`. Before 8.3 the forked child did `php_ignore_value(VCWD_CHDIR(cwd))` — a failing `chdir()` was silently ignored and the command ran anyway.

`runcommand()` passed `getcwd()` along, so under `sudo -u apache wp … --network` started from a directory that user cannot traverse (e.g. `/root`, where Ansible's `command`/`shell` modules run by default), the spawn fails. The subtlety is that `getcwd()` still succeeds in the parent — a process can name the directory it is sitting in without being able to re-enter it, since permission is only checked at `chdir()` time and these credentials were dropped after the fact:

```
$ cd /root/privdir && sudo -u nobody php demo.php
euid            : 65534
getcwd()        : '/root/privdir'
chdir(getcwd()) : false      # cannot enter the directory it is standing in
```

## Changes

Stop passing the working directory to `proc_open()`. The child inherits it either way, so the argument was only ever a no-op that added a failure mode — `Zend/zend_virtual_cwd.h` defines `VIRTUAL_DIR` under `#ifdef ZTS`, so on non-thread-safe builds `getcwd()` is simply the process CWD.

Bail out with a proper error when the spawn fails for any other reason, instead of crashing on the missing pipes. `$return_code = $proc ? proc_close( $proc ) : -1;` becomes a plain `proc_close( $proc )` — with that guard above it, the ternary is dead code and PHPStan reports it as always-true (it infers `never` from `WP_CLI::error()`'s conditional return type, same as the narrowing `Runner::…` relies on at `php/WP_CLI/Runner.php:2822`).

## Tests

Added a `@skip-windows` scenario to `features/runcommand.feature` that `chdir`s into a directory, `chmod`s it `0000`, and then launches a command from there. Before this change it dies with the `TypeError`; after it, the child inherits the directory and returns normally. A shutdown function restores the permissions so the run directory can still be cleaned up.

As noted in a comment above the scenario, it only exercises the regression when the suite runs as a non-root user — root can enter a `0000` directory either way, so under Docker-as-root it degrades to a trivial pass.

The scenario registers its command through `wp-cli.yml`'s `require:` rather than `--require`, because a relative `--require` is persisted into the child's runtime config verbatim and the child cannot resolve it from an unreadable working directory.

## Caveat

I could not run `composer test` in my environment — `composer install` fails there with "Could not authenticate against github.com" for both dist and source downloads, so PHPCS/PHPStan/Behat never got installed. `php -l` passes on the modified file and on the feature's inline PHP; everything else is riding on CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MijN2BZtkwtkT3sF7qrcyT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution when the current working directory is inaccessible or unavailable.
  * Commands now launch more reliably across supported platforms in challenging directory conditions.
  * Process-launch failures are reported clearly instead of failing silently.
  * Ensured command processes are closed reliably after execution.
  * Added regression coverage confirming successful version output without unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->