### PR TITLE
Use 0755 instead of 0700 for cache and extraction directories

### DIFF
--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -367,9 +367,6 @@ class Extractor {
 	 */
 	private static function ensure_dir_exists( $dir ) {
 		if ( ! is_dir( $dir ) ) {
-			// 0755, not 0700: this is called on the *destination* of an extraction, which is
-			// frequently a WordPress document root or a plugin/theme directory that the web
-			// server user has to be able to read.
 			if ( ! @mkdir( $dir, 0755, true ) ) {
 				$error = error_get_last();
 				WP_CLI::warning(

--- a/php/WP_CLI/Extractor.php
+++ b/php/WP_CLI/Extractor.php
@@ -203,7 +203,7 @@ class Extractor {
 		$error = 0;
 
 		if ( ! is_dir( $dest ) ) {
-			mkdir( $dest, 0777, true );
+			mkdir( $dest, 0755, true );
 		}
 
 		/**
@@ -215,7 +215,7 @@ class Extractor {
 
 			if ( $item->isDir() ) {
 				if ( ! is_dir( $dest_path ) ) {
-					mkdir( $dest_path );
+					mkdir( $dest_path, 0755 );
 				}
 			} elseif ( file_exists( $dest_path ) && is_writable( $dest_path ) ) {
 					copy( $item, $dest_path );
@@ -367,7 +367,10 @@ class Extractor {
 	 */
 	private static function ensure_dir_exists( $dir ) {
 		if ( ! is_dir( $dir ) ) {
-			if ( ! @mkdir( $dir, 0700, true ) ) {
+			// 0755, not 0700: this is called on the *destination* of an extraction, which is
+			// frequently a WordPress document root or a plugin/theme directory that the web
+			// server user has to be able to read.
+			if ( ! @mkdir( $dir, 0755, true ) ) {
 				$error = error_get_last();
 				WP_CLI::warning(
 					sprintf(

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -396,7 +396,11 @@ class FileCache {
 				return false;
 			}
 
-			if ( ! @mkdir( $dir, 0700, true ) ) {
+			// 0755, not 0700: the risk being guarded against is another local user *writing*
+			// into the cache, whose contents get extracted and executed. Read access was never
+			// the problem, and revoking it breaks setups that point `WP_CLI_CACHE_DIR` at a
+			// location shared between users.
+			if ( ! @mkdir( $dir, 0755, true ) ) {
 				$message = "Failed to create directory '{$dir}'";
 				$error   = error_get_last();
 				if ( is_array( $error ) ) {

--- a/php/WP_CLI/FileCache.php
+++ b/php/WP_CLI/FileCache.php
@@ -396,10 +396,6 @@ class FileCache {
 				return false;
 			}
 
-			// 0755, not 0700: the risk being guarded against is another local user *writing*
-			// into the cache, whose contents get extracted and executed. Read access was never
-			// the problem, and revoking it breaks setups that point `WP_CLI_CACHE_DIR` at a
-			// location shared between users.
 			if ( ! @mkdir( $dir, 0755, true ) ) {
 				$message = "Failed to create directory '{$dir}'";
 				$error   = error_get_last();

--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -352,7 +352,14 @@ class ExtractorTest extends TestCase {
 		$this->assertTrue( $result );
 		$this->assertTrue( is_dir( $dir ) );
 		if ( ! Utils\is_windows() ) {
-			$this->assertSame( '0700', substr( sprintf( '%o', fileperms( $dir ) ), -4 ) );
+			// Assert the write bits rather than a literal mode: the exact result depends on the
+			// umask, and what matters is that no other local user can write into the directory.
+			$perms = fileperms( $dir ) & 0777;
+			$this->assertSame(
+				0,
+				$perms & 0022,
+				sprintf( 'Extraction directory must not be group- or world-writable, got %o.', $perms )
+			);
 		}
 
 		rmdir( $dir );

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -58,7 +58,14 @@ class FileCacheTest extends TestCase {
 		$this->assertTrue( $result );
 		$this->assertTrue( is_dir( $cache_dir . '/test1' ) );
 		if ( ! Utils\is_windows() ) {
-			$this->assertSame( '0700', substr( sprintf( '%o', fileperms( $cache_dir . '/test1' ) ), -4 ) );
+			// Assert the write bits rather than a literal mode: the exact result depends on the
+			// umask, and what matters is that no other local user can write into the cache.
+			$perms = fileperms( $cache_dir . '/test1' ) & 0777;
+			$this->assertSame(
+				0,
+				$perms & 0022,
+				sprintf( 'Cache directory must not be group- or world-writable, got %o.', $perms )
+			);
 		}
 
 		// Try to create the same directory again. it should return true.


### PR DESCRIPTION
Follow-up to #6373. Two problems with `0700` there, plus one spot that change missed.

## `Extractor::ensure_dir_exists()` is called on the extraction *destination*

Not only on temp directories:

```php
private static function extract_zip( $zipfile, $dest ) {
    if ( ! self::ensure_dir_exists( $dest ) ) { …
```

A `0700` WordPress document root or plugin/theme directory is unreadable by the web server user. Nothing breaks today only because `core-command` pre-creates the download directory with `mkdir( $download_dir, 0777, true )` before calling `Extractor::extract()`, so the `is_dir()` guard short-circuits — but `Extractor` is framework API and callers aren't obliged to do that.

## `FileCache::ensure_dir_exists()` breaks shared cache directories

Same shape as the packages directory (wp-cli/package-command#244): an installation pointing `WP_CLI_CACHE_DIR` at a location shared between users gets a cache owned by whoever created it first.

## Why 0755 is enough

In both cases the risk being guarded against is another local user **writing** into a directory whose contents get extracted, autoloaded, or executed. Read access was never part of that. `0755` removes group and world write outright, and a umask can only clear further bits, so the result is never group- or world-writable:

| umask | old `mkdir(0777)` | new `mkdir(0755)` |
|---|---|---|
| 022 (default) | 0755 | 0755 |
| 002 (shared group) | **0775** | 0755 |
| 000 (common in containers) | **0777** | 0755 |
| 077 | 0700 | 0700 |

## Also: the two `mkdir()` calls #6373 missed

`Extractor::copy_overwrite_files()` still had `mkdir( $dest, 0777, true )` and a bare `mkdir( $dest_path )`. Those build the destination tree itself — for `wp package install` that's the directory that ends up autoloaded — so they were the loosest modes in the chain. Both are now `0755`.

## Deliberately unchanged

Per-invocation temp directories should stay at `0700`. `make_temp_dir()` and `make_temp_file()` in #6374 briefly hold unverified downloads and extracted archive contents, and nothing shares a temp directory, so there's no reason to widen them.

## Test changes

Both unit tests asserted the literal string `0700`, which is umask-dependent. They now assert that the group and other write bits are unset — the invariant that actually matters, and one that holds under any umask.

## Testing

`php -l` passes on all four files. I could not run PHPUnit in my environment — `composer install` cannot authenticate to github.com for the dev dependencies — so CI is the real check here. I did verify the permission behaviour and both assertion styles directly across the four umasks in the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qPfx7yCg9xCTys3XXXRkU

---
_Generated by [Claude Code](https://claude.ai/code/session_014qPfx7yCg9xCTys3XXXRkU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for extracted files and cached data with safer directory permissions.
  * Prevented group and world write access while preserving compatibility with system umask settings.

* **Tests**
  * Updated permission checks to validate secure access controls without requiring an exact permission mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->