### PR TITLE
Do not use deprecated plugin/theme status commands in tests

### DIFF
--- a/features/skip-plugins.feature
+++ b/features/skip-plugins.feature
@@ -19,10 +19,10 @@ Feature: Skipping plugins
       """
 
     # The specified plugin should still show up as an active plugin
-    When I run `wp --skip-plugins=akismet plugin status akismet`
-    Then STDOUT should contain:
+    When I run `wp --skip-plugins=akismet plugin get akismet --field=status`
+    Then STDOUT should be:
       """
-      Status: Active
+      active
       """
 
     # The un-specified plugin should continue to be loaded

--- a/features/skip-themes.feature
+++ b/features/skip-themes.feature
@@ -38,10 +38,10 @@ Feature: Skipping themes
     And STDERR should be empty
 
     # The specified theme should still show up as an active theme
-    When I run `wp --skip-themes theme status twentyseventeen`
-    Then STDOUT should contain:
+    When I run `wp --skip-themes theme get twentyseventeen --field=status`
+    Then STDOUT should be:
       """
-      Active
+      active
       """
     And STDERR should be empty
 
@@ -124,18 +124,12 @@ Feature: Skipping themes
     And I run `wp theme install default`
 
     # The classic theme should show up as an active theme
-    When I run `wp theme status`
-    Then STDOUT should contain:
-      """
-      A classic
-      """
-    And STDERR should be empty
-
     # The default theme should show up as an installed theme
-    When I run `wp theme status`
+    When I run `wp theme list --fields=name,status --format=csv`
     Then STDOUT should contain:
       """
-      I default
+      classic,active
+      default,inactive
       """
     And STDERR should be empty
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated plugin and theme verification tests to use focused status fields and standardized listing output.
  * Improved coverage for skipped plugins and themes while confirming active and installed states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->