### PR TITLE
Fix skipping themes test

### DIFF
--- a/features/skip-themes.feature
+++ b/features/skip-themes.feature
@@ -53,6 +53,8 @@ Feature: Skipping themes
       """
     And STDERR should be empty
 
+  # The Moina theme requires PHP 7.4+.
+  @require-php-7.4
   Scenario: Skip parent and child themes
     Given a WP installation
     And I run `wp theme install moina moina-blog`


### PR DESCRIPTION
The Moina theme requires PHP 7.4+ as of today, which is why this test was suddenly failing.

Instead of finding a new theme, this bumps the PHP requirement of this particular test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented that skipping parent and child themes requires PHP 7.4 or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->