### PR TITLE
Fix Formatter throwing Error on objects with private/protected properties

### DIFF
--- a/features/formatter.feature
+++ b/features/formatter.feature
@@ -902,3 +902,43 @@ Feature: Format output
       """
     And the return code should be 0
 
+  Scenario: Format an object containing protected and private properties
+    Given an empty directory
+    And a test-object-properties.php file:
+      """
+      <?php
+      class TestObjectWithProperties {
+      	public $public_prop       = 'public_value';
+      	protected $protected_prop = 'protected_value';
+      	private $private_prop     = 'private_value';
+      }
+
+      /**
+       * Test command for object properties formatting
+       *
+       * @when before_wp_load
+       */
+      $test_command = function ( $args, $assoc_args ) {
+      	$item      = new TestObjectWithProperties();
+      	$fields    = array( 'public_prop', 'protected_prop', 'private_prop' );
+      	$formatter = new \WP_CLI\Formatter( $assoc_args, $fields );
+      	$formatter->display_item( $item );
+      };
+      WP_CLI::add_command( 'test-object-properties', $test_command );
+      """
+
+    When I try `wp --require=test-object-properties.php test-object-properties --format=json`
+    Then STDOUT should be:
+      """
+      {"public_prop":"public_value"}
+      """
+    And STDERR should contain:
+      """
+      Warning: Field not found in item: protected_prop.
+      """
+    And STDERR should contain:
+      """
+      Warning: Field not found in item: private_prop.
+      """
+    And the return code should be 0
+

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -656,20 +656,10 @@ class Formatter {
 			}
 		}
 
-		foreach ( array_keys( (array) $data ) as $key ) {
-			if ( ! in_array( $key, $true_fields, true ) ) {
-				if ( is_array( $data ) ) {
-					unset( $data[ $key ] );
-				} elseif ( is_object( $data ) ) {
-					unset( $data->$key );
-				}
-			}
-		}
-
 		$ordered_data = [];
 
 		foreach ( $true_fields as $field ) {
-			$ordered_data[ $field ] = ( ( (array) $data )[ $field ] );
+			$ordered_data[ $field ] = is_object( $data ) ? $data->$field : $data[ $field ];
 		}
 
 		// Check if a formatter is registered for this format

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -607,6 +607,29 @@ class Formatter {
 	}
 
 	/**
+	 * Check if an object property is accessible.
+	 *
+	 * @param object $item
+	 * @param string $key
+	 * @return bool
+	 */
+	private function is_object_property_accessible( $item, $key ): bool {
+		if ( ! is_object( $item ) ) {
+			return false;
+		}
+
+		if ( isset( $item->$key ) ) {
+			return true;
+		}
+
+		if ( property_exists( $item, $key ) ) {
+			return ( new \ReflectionProperty( $item, $key ) )->isPublic();
+		}
+
+		return false;
+	}
+
+	/**
 	 * Find an object's key.
 	 * If $prefix is set, a key with that prefix will be prioritized.
 	 *
@@ -618,7 +641,7 @@ class Formatter {
 	private function find_item_key( $item, $field, $lenient = false ) {
 		foreach ( [ $field, $this->prefix . '_' . $field ] as $maybe_key ) {
 			if (
-				( is_object( $item ) && ( property_exists( $item, $maybe_key ) || isset( $item->$maybe_key ) ) ) ||
+				( is_object( $item ) && $this->is_object_property_accessible( $item, $maybe_key ) ) ||
 				( is_array( $item ) && array_key_exists( $maybe_key, $item ) )
 			) {
 				$key = $maybe_key;

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -317,4 +317,32 @@ class FormatterTest extends TestCase {
 		// Should match var_export output
 		$this->assertStringContainsString( "'nested' => 'value'", $result );
 	}
+
+	public function test_display_item_object_with_protected_properties(): void {
+		Formatter::register_builtin_formats();
+
+		$dummy = new class() {
+			/** @var string */
+			public $public_prop = 'public_val';
+
+			/** @var string */
+			protected $protected_prop = 'protected_val';
+
+			/** @var string */
+			private $private_prop = 'private_val';
+
+			public function get_private_prop(): string {
+				return $this->private_prop;
+			}
+		};
+
+		$assoc_args = [ 'format' => 'json' ];
+		$formatter  = new Formatter( $assoc_args, [ 'public_prop' ] );
+
+		ob_start();
+		$formatter->display_item( $dummy );
+		$output = ob_get_clean();
+
+		$this->assertSame( '{"public_prop":"public_val"}', $output );
+	}
 }

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -345,4 +345,71 @@ class FormatterTest extends TestCase {
 
 		$this->assertSame( '{"public_prop":"public_val"}', $output );
 	}
+
+	public function test_display_item_object_inaccessible_protected_property_issues_warning(): void {
+		Formatter::register_builtin_formats();
+
+		$prev_logger = WP_CLI::get_logger();
+		$logger      = new WP_CLI\Loggers\Execution();
+		WP_CLI::set_logger( $logger );
+
+		$dummy = new class() {
+			/** @var string */
+			public $public_prop = 'public_val';
+
+			/** @var string */
+			protected $protected_prop = 'protected_val';
+		};
+
+		try {
+			$assoc_args = [ 'format' => 'json' ];
+			$formatter  = new Formatter( $assoc_args, [ 'public_prop', 'protected_prop' ] );
+
+			ob_start();
+			$formatter->display_item( $dummy );
+			$output = ob_get_clean();
+
+			$this->assertSame( '{"public_prop":"public_val"}', $output );
+			$this->assertStringContainsString( 'Field not found in item: protected_prop.', $logger->stderr );
+		} finally {
+			WP_CLI::set_logger( $prev_logger );
+		}
+	}
+
+	public function test_display_item_object_with_magic_getter(): void {
+		Formatter::register_builtin_formats();
+
+		$dummy = new class() {
+			/** @var string */
+			protected $protected_prop = 'protected_val';
+
+			/**
+			 * @param string $name
+			 * @return mixed
+			 */
+			public function __get( $name ) {
+				if ( 'protected_prop' === $name ) {
+					return $this->protected_prop;
+				}
+				return null;
+			}
+
+			/**
+			 * @param string $name
+			 * @return bool
+			 */
+			public function __isset( $name ) {
+				return 'protected_prop' === $name;
+			}
+		};
+
+		$assoc_args = [ 'format' => 'json' ];
+		$formatter  = new Formatter( $assoc_args, [ 'protected_prop' ] );
+
+		ob_start();
+		$formatter->display_item( $dummy );
+		$output = ob_get_clean();
+
+		$this->assertSame( '{"protected_prop":"protected_val"}', $output );
+	}
 }


### PR DESCRIPTION
Fixes an issue where `WP_CLI\Formatter::show_multiple_fields()` threw a fatal error (`Cannot access property starting with "\0"`) when passed an object (such as `WP_Comment`) containing private or protected properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON output when selecting specific fields from objects.
  * Protected and private properties are now excluded unless safely accessible.
  * Warnings are shown when requested properties cannot be accessed.
  * Original object data remains unchanged while formatting selected fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->