### PR TITLE
Anchor SSH argument safe-set check with \A..\z to reject trailing newlines

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -436,6 +436,18 @@ Feature: Global flags
       Running SSH command: docker exec '--env MY_VAR=value' 'wordpress' sh -c
       """
 
+  @skip-windows @skip-macos
+  Scenario: SSH arguments with a trailing newline should be escaped
+    # A trailing newline used to satisfy the "safe characters" check because
+    # PCRE's $ anchor also matches just before a final newline, letting the
+    # argument reach the remote shell unquoted.
+    When I try `newline_arg="$(printf 'foo\nx')"; wp --debug --ssh=wordpress option get "${newline_arg%x}"`
+    Then STDERR should contain:
+      """
+      Running SSH command: ssh -T -vvv 'wordpress' 'wp --debug option get '\''foo
+      '\'''
+      """
+
   Scenario: SSH connection string with leading hyphen in host should error
     # The payload must not contain a slash, as that would be parsed as the path
     # and thus separated from the host.

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1044,7 +1044,10 @@ class Runner {
 		foreach ( $wp_args as $arg ) {
 			// Quote empty strings and arguments with any characters outside the safe set.
 			// The empty string check is explicit for clarity, though regex would also catch it.
-			if ( '' !== $arg && preg_match( '/^[a-zA-Z0-9_=.\/:-]+$/', $arg ) ) {
+			// Anchor with \A and \z rather than ^ and $: PCRE's $ also matches just before a
+			// trailing newline, which would let a value ending in "\n" skip escaping and smuggle
+			// a command separator into the remote shell command.
+			if ( '' !== $arg && preg_match( '/\A[a-zA-Z0-9_=.\/:-]+\z/', $arg ) ) {
 				$escaped_args[] = $arg;
 			} else {
 				$escaped_args[] = escapeshellarg( $arg );


### PR DESCRIPTION
### Summary

When `run_ssh_command()` assembles the command to run on the remote host, each argument is passed through **unquoted** when it matches a "safe characters" allowlist, and is otherwise wrapped in `escapeshellarg()`. That allowlist regex was anchored with `^…$`.

In PCRE, `$` also matches immediately *before a trailing newline*, so an argument ending in `"\n"` matched the "safe" pattern and was emitted **raw** into the remote shell command — where the newline acts as a command separator.

This changes the anchors to `\A…\z` (which `assoc_args_to_str()` already uses), so any value containing a newline is routed through `escapeshellarg()`.

### Impact

Defense-in-depth only — **not known to be exploitable**. The arguments here come from the operator's own `argv` (`array_slice( $GLOBALS['argv'], 1 )`), so there is no lower-privilege source that can introduce a newline. The change removes a latent quoting bypass and makes newline anchoring consistent with the rest of the codebase.

### Behavior

Only arguments containing a newline change behavior (now escaped); normal arguments are unaffected:

| arg | old (`^…$`) | new (`\A…\z`) |
|---|---|---|
| `user` | passed raw | passed raw |
| `--url=https://e.com/p` | passed raw | passed raw |
| `"foo\n"` | **passed raw** ⚠️ | escaped |
| `"a\nb"` | escaped | escaped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LV1bNtxNCZ3QXujJHYfhZv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LV1bNtxNCZ3QXujJHYfhZv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH command validation to prevent trailing newline characters from bypassing safety checks and enabling unintended shell command injection.
  * Added coverage to verify safe handling of trailing newlines in SSH command arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->