### PR TITLE
Fix newly reported PHPStan errors

### DIFF
--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -4,8 +4,8 @@ namespace WP_CLI;
 
 use cli\Colors;
 use cli\Table;
-use Iterator;
 use Mustangostang\Spyc;
+use Traversable;
 use WP_CLI;
 
 /**
@@ -385,8 +385,8 @@ class Formatter {
 		if ( $this->args['field'] ) {
 			$this->show_single_field( $items, $this->args['field'] );
 		} else {
-			// Convert iterator to array early to avoid consumption issues and enable validation
-			if ( $items instanceof Iterator ) {
+			// Convert Traversable to array early to avoid consumption issues and enable validation
+			if ( $items instanceof Traversable ) {
 				$items = iterator_to_array( $items );
 			}
 
@@ -404,7 +404,7 @@ class Formatter {
 			}
 
 			if ( in_array( $this->args['format'], [ 'table', 'csv' ], true ) ) {
-				/** @var array<int, array<string, mixed>|object> $transformed */
+				/** @var array<int, mixed> $transformed */
 				$transformed = array_map(
 					function ( $item ) {
 						return $this->transform_item_values_to_json( is_object( $item ) ? clone $item : $item );
@@ -480,13 +480,16 @@ class Formatter {
 				if ( is_array( $item ) || is_object( $item ) ) {
 					$formatted_items[] = Utils\pick_fields( $item, $fields );
 				} else {
-					WP_CLI::debug( 'Skipping item that is neither array nor object in format handler.', 'formatter' );
+					$formatted_items[] = $item;
 				}
 			}
 
 			// Truncate cell values exactly once for table/CSV output
 			if ( in_array( $this->args['format'], [ 'table', 'csv' ], true ) ) {
 				foreach ( $formatted_items as &$row ) {
+					if ( ! is_array( $row ) && ! is_object( $row ) ) {
+						continue;
+					}
 					foreach ( $row as $key => $value ) {
 						if ( is_string( $value ) && strlen( $value ) > self::MAX_CELL_WIDTH ) {
 							$row[ $key ] = substr( $value, 0, self::MAX_CELL_WIDTH ) . '...';
@@ -509,7 +512,7 @@ class Formatter {
 	/**
 	 * Show a single field from a list of items.
 	 *
-	 * @param iterable<mixed> $items Array of objects to show fields from
+	 * @param iterable<mixed> $items An iterable of items to show fields from.
 	 * @param string          $field The field to show
 	 */
 	private function show_single_field( $items, $field ): void {

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -377,8 +377,8 @@ class Formatter {
 	/**
 	 * Display multiple items according to the output arguments.
 	 *
-	 * @param iterable<int, array<string, mixed>|object> $items The items to display.
-	 * @param bool|array<int, bool>                      $ascii_pre_colorized Optional. A boolean or an array of booleans to pass to `format()` if items in the table are pre-colorized. Default false.
+	 * @param iterable<mixed>       $items The items to display.
+	 * @param bool|array<int, bool> $ascii_pre_colorized Optional. A boolean or an array of booleans to pass to `format()` if items in the table are pre-colorized. Default false.
 	 * @return void
 	 */
 	public function display_items( $items, $ascii_pre_colorized = false ) {
@@ -455,8 +455,8 @@ class Formatter {
 	/**
 	 * Format items according to arguments.
 	 *
-	 * @param iterable<int, array<string, mixed>|object> $items Items.
-	 * @param bool|array<int, bool>                      $ascii_pre_colorized Optional. A boolean or an array of booleans to pass to `show_table()` if items in the table are pre-colorized. Default false.
+	 * @param iterable<mixed>       $items Items.
+	 * @param bool|array<int, bool> $ascii_pre_colorized Optional. A boolean or an array of booleans to pass to `show_table()` if items in the table are pre-colorized. Default false.
 	 */
 	private function format( $items, $ascii_pre_colorized = false ): void {
 		$fields = $this->args['fields'];
@@ -509,8 +509,8 @@ class Formatter {
 	/**
 	 * Show a single field from a list of items.
 	 *
-	 * @param iterable<int, array<string, mixed>|object> $items Array of objects to show fields from
-	 * @param string                                     $field The field to show
+	 * @param iterable<mixed> $items Array of objects to show fields from
+	 * @param string          $field The field to show
 	 */
 	private function show_single_field( $items, $field ): void {
 		$key         = null;
@@ -559,7 +559,7 @@ class Formatter {
 	 * Warns if a field doesn't exist in any item.
 	 * Also resolves field names to their actual keys (including prefixes).
 	 *
-	 * @param iterable<int, array<string, mixed>|object> $items Items to validate
+	 * @param iterable<mixed> $items Items to validate
 	 */
 	private function validate_fields( $items ): void {
 		// Track which fields have been found and their resolved keys
@@ -633,9 +633,9 @@ class Formatter {
 	 * Find an object's key.
 	 * If $prefix is set, a key with that prefix will be prioritized.
 	 *
-	 * @param array<string, mixed>|object $item
-	 * @param string                      $field
-	 * @param bool                        $lenient If true, return null instead of erroring when field is not found.
+	 * @param mixed  $item
+	 * @param string $field
+	 * @param bool   $lenient If true, return null instead of erroring when field is not found.
 	 * @return string|null
 	 */
 	private function find_item_key( $item, $field, $lenient = false ) {
@@ -784,10 +784,14 @@ class Formatter {
 	 * - Objects and arrays are converted to JSON strings
 	 * - Booleans are converted to "true" or "false"
 	 *
-	 * @param array<string, mixed>|object $item
+	 * @param mixed $item
 	 * @return mixed
 	 */
 	public function transform_item_values_to_json( $item ) {
+		if ( ! is_object( $item ) && ! is_array( $item ) ) {
+			return $item;
+		}
+
 		foreach ( $this->args['fields'] as $field ) {
 			$true_field = $this->find_item_key( $item, $field, true );
 			if ( null === $true_field ) {

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1509,8 +1509,6 @@ class WP_CLI {
 	 * @param string $key Config parameter key to check.
 	 *
 	 * @return bool
-	 *
-	 * @phpstan-assert-if-true key-of<GlobalConfig> $key
 	 */
 	public static function has_config( $key ) {
 		return array_key_exists( $key, self::get_runner()->config );

--- a/tests/ConfiguratorTest.php
+++ b/tests/ConfiguratorTest.php
@@ -131,7 +131,6 @@ class ConfiguratorTest extends TestCase {
 		$logger = new Loggers\Execution();
 		WP_CLI::set_logger( $logger );
 
-		// @phpstan-ignore staticMethod.alreadyNarrowedType
 		$has_config = WP_CLI::has_config( 'url' );
 		$get_config = WP_CLI::get_config( 'url' );
 

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -412,4 +412,54 @@ class FormatterTest extends TestCase {
 
 		$this->assertSame( '{"protected_prop":"protected_val"}', $output );
 	}
+
+	public function test_display_items_with_traversable(): void {
+		Formatter::register_builtin_formats();
+
+		$items = new \ArrayObject(
+			[
+				[
+					'name' => 'Alice',
+					'role' => 'admin',
+				],
+				[
+					'name' => 'Bob',
+					'role' => 'editor',
+				],
+			]
+		);
+
+		$assoc_args = [ 'format' => 'json' ];
+		$formatter  = new Formatter( $assoc_args, [ 'name', 'role' ] );
+
+		ob_start();
+		$formatter->display_items( $items );
+		$output = ob_get_clean();
+
+		$this->assertSame( '[{"name":"Alice","role":"admin"},{"name":"Bob","role":"editor"}]', $output );
+	}
+
+	public function test_display_items_scalar_items_in_json_and_yaml(): void {
+		Formatter::register_builtin_formats();
+
+		$items = [ 1, 2, 3 ];
+
+		$assoc_args = [ 'format' => 'json' ];
+		$formatter  = new Formatter( $assoc_args );
+
+		ob_start();
+		$formatter->display_items( $items );
+		$output = ob_get_clean();
+
+		$this->assertSame( '[1,2,3]', $output );
+
+		$assoc_args = [ 'format' => 'yaml' ];
+		$formatter  = new Formatter( $assoc_args );
+
+		ob_start();
+		$formatter->display_items( $items );
+		$output = ob_get_clean();
+
+		$this->assertSame( "---\n- 1\n- 2\n- 3", trim( (string) $output ) );
+	}
 }


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review (https://make.wordpress.org/cli/handbook/code-review/).
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatter support for scalar values, traversable collections, arrays, and objects.
  * Preserved scalar values correctly in custom, JSON, CSV, and YAML output.
  * Improved handling of structured fields during JSON formatting.

* **Documentation**
  * Clarified supported formatter input types and iterator behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->