### PR TITLE
Add hints for commands that are not registered

### DIFF
--- a/features/command.feature
+++ b/features/command.feature
@@ -1143,6 +1143,54 @@ Feature: WP-CLI Commands
       Did you mean
       """
 
+  Scenario: WP-CLI shows a hint for a command that is not registered
+    Given a WP installation
+    And a hint.php file:
+      """
+      <?php
+      WP_CLI::add_hook(
+        'unregistered_command_hint',
+        function ( $hint, $command ) {
+          if ( 'ftp' === $command ) {
+            return "The 'ftp' command is provided by the wp-cli/ftp-command package.";
+          }
+
+          if ( 'cli ftp' === $command ) {
+            return "The 'cli ftp' subcommand is provided by the wp-cli/ftp-command package.";
+          }
+
+          return $hint;
+        }
+      );
+      """
+
+    When I try `wp --require=hint.php ftp`
+    Then STDERR should contain:
+      """
+      Error: 'ftp' is not a registered wp command. See 'wp help' for available commands.
+      The 'ftp' command is provided by the wp-cli/ftp-command package.
+      """
+    And the return code should be 1
+
+    When I try `wp --require=hint.php cli ftp`
+    Then STDERR should contain:
+      """
+      Error: 'ftp' is not a registered subcommand of 'cli'. See 'wp help cli' for available subcommands.
+      The 'cli ftp' subcommand is provided by the wp-cli/ftp-command package.
+      """
+    And the return code should be 1
+
+    When I try `wp --require=hint.php nonexistent`
+    Then STDERR should contain:
+      """
+      Error: 'nonexistent' is not a registered wp command. See 'wp help' for available commands.
+      """
+    And STDERR should not contain:
+      """
+      ftp-command
+      """
+    And the return code should be 1
+
   Scenario: WP-CLI suggests matching parameters when user entry contains typos
     Given an empty directory
 

--- a/features/command.feature
+++ b/features/command.feature
@@ -1191,6 +1191,32 @@ Feature: WP-CLI Commands
       """
     And the return code should be 1
 
+  Scenario: WP-CLI shows the hint after the suggestion for a command that is not registered
+    Given a WP installation
+    And a hint.php file:
+      """
+      <?php
+      WP_CLI::add_hook(
+        'unregistered_command_hint',
+        function ( $hint, $command ) {
+          if ( 'category' === $command ) {
+            return "The 'category' command is provided by the acme/category-command package.";
+          }
+
+          return $hint;
+        }
+      );
+      """
+
+    When I try `wp --require=hint.php category list`
+    Then STDERR should contain:
+      """
+      Error: 'category' is not a registered wp command. See 'wp help' for available commands.
+      Did you mean 'wp term <command>'?
+      The 'category' command is provided by the acme/category-command package.
+      """
+    And the return code should be 1
+
   Scenario: WP-CLI suggests matching parameters when user entry contains typos
     Given an empty directory
 

--- a/php/WP_CLI/CommandHints.php
+++ b/php/WP_CLI/CommandHints.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace WP_CLI;
+
+use WP_CLI;
+
+/**
+ * Provides guidance for commands that are not registered.
+ *
+ * Not every WP-CLI installation offers the same set of commands. The `package`
+ * command, for example, ships with the Phar but is an optional dependency of
+ * Composer-based installations. Without further guidance, a user of such an
+ * installation only learns that the command is "not a registered wp command",
+ * which says nothing about why it is missing or how to get it.
+ *
+ * Composer packages can therefore declare a hint for the commands they know
+ * about through the `extra.command-hints` section of their `composer.json`:
+ *
+ * ```
+ * "extra": {
+ *     "command-hints": {
+ *         "package": "The 'package' command is only bundled with the Phar."
+ *     }
+ * }
+ * ```
+ *
+ * The hint is appended to the error whenever the command in question turns out
+ * to be unavailable. Hints for commands that are registered are never shown.
+ *
+ * @package WP_CLI
+ */
+final class CommandHints {
+
+	/**
+	 * Key within a package's `extra` section that holds its hints.
+	 *
+	 * @var string
+	 */
+	const EXTRA_KEY = 'command-hints';
+
+	/**
+	 * Collected hints, keyed by full command name.
+	 *
+	 * Null for as long as the hints have not been collected yet.
+	 *
+	 * @var array<string, string>|null
+	 */
+	private static $hints = null;
+
+	/**
+	 * Get the hint for a command that is not registered.
+	 *
+	 * @param string $command Full name of the command that was not found.
+	 * @return string Hint for the user, or an empty string if there is none.
+	 */
+	public static function get_hint( $command ) {
+		$hints = self::get_hints();
+
+		$hint = array_key_exists( $command, $hints ) ? $hints[ $command ] : '';
+
+		/**
+		 * Filters the hint shown for a command that is not registered.
+		 *
+		 * @param string $hint    Hint to show, or an empty string for none.
+		 * @param string $command Full name of the command that was not found.
+		 */
+		$hint = WP_CLI::do_hook( 'unregistered_command_hint', $hint, $command );
+
+		return is_string( $hint ) ? trim( $hint ) : '';
+	}
+
+	/**
+	 * Get the hints declared by the currently installed Composer packages.
+	 *
+	 * @return array<string, string> Map of full command name to hint.
+	 */
+	private static function get_hints() {
+		if ( null === self::$hints ) {
+			self::$hints = defined( 'WP_CLI_VENDOR_DIR' )
+				? self::get_hints_from_vendor_dir( WP_CLI_VENDOR_DIR )
+				: [];
+		}
+
+		return self::$hints;
+	}
+
+	/**
+	 * Collect the hints declared by the packages within a vendor directory.
+	 *
+	 * @param string $vendor_dir Path to the Composer vendor directory.
+	 * @return array<string, string> Map of full command name to hint.
+	 */
+	private static function get_hints_from_vendor_dir( $vendor_dir ) {
+		$vendor_dir = rtrim( $vendor_dir, '/\\' );
+
+		$hints = [];
+
+		foreach ( self::read_installed_packages( $vendor_dir . '/composer/installed.json' ) as $package ) {
+			$hints = array_merge( $hints, self::extract_hints( $package ) );
+		}
+
+		// The root package is absent from `installed.json`, so it is read separately.
+		$root_package = self::read_json( dirname( $vendor_dir ) . '/composer.json' );
+
+		return array_merge( $hints, self::extract_hints( $root_package ) );
+	}
+
+	/**
+	 * Read the package definitions out of Composer's `installed.json`.
+	 *
+	 * @param string $path Path to the `installed.json` file.
+	 * @return array<array<mixed>> List of package definitions.
+	 */
+	private static function read_installed_packages( $path ) {
+		$data = self::read_json( $path );
+
+		if ( ! isset( $data['packages'] ) || ! is_array( $data['packages'] ) ) {
+			return [];
+		}
+
+		$packages = [];
+
+		foreach ( $data['packages'] as $package ) {
+			if ( is_array( $package ) ) {
+				$packages[] = $package;
+			}
+		}
+
+		return $packages;
+	}
+
+	/**
+	 * Extract the hints declared by a single package definition.
+	 *
+	 * @param array<mixed> $package Decoded `composer.json` or `installed.json` entry.
+	 * @return array<string, string> Map of full command name to hint.
+	 */
+	private static function extract_hints( $package ) {
+		$extra = isset( $package['extra'] ) && is_array( $package['extra'] ) ? $package['extra'] : [];
+
+		if ( ! isset( $extra[ self::EXTRA_KEY ] ) || ! is_array( $extra[ self::EXTRA_KEY ] ) ) {
+			return [];
+		}
+
+		$hints = [];
+
+		foreach ( $extra[ self::EXTRA_KEY ] as $command => $hint ) {
+			if ( ! is_string( $command ) || ! is_string( $hint ) ) {
+				continue;
+			}
+
+			$command = trim( $command );
+			$hint    = trim( $hint );
+
+			if ( '' === $command || '' === $hint ) {
+				continue;
+			}
+
+			$hints[ $command ] = $hint;
+		}
+
+		return $hints;
+	}
+
+	/**
+	 * Read and decode a JSON file.
+	 *
+	 * @param string $path Path to the file.
+	 * @return array<mixed> Decoded data, or an empty array if it could not be read.
+	 */
+	private static function read_json( $path ) {
+		if ( ! is_file( $path ) || ! is_readable( $path ) ) {
+			return [];
+		}
+
+		$contents = file_get_contents( $path );
+
+		if ( false === $contents ) {
+			return [];
+		}
+
+		$data = json_decode( $contents, true );
+
+		return is_array( $data ) ? $data : [];
+	}
+}

--- a/php/WP_CLI/CommandHints.php
+++ b/php/WP_CLI/CommandHints.php
@@ -100,9 +100,54 @@ final class CommandHints {
 		}
 
 		// The root package is absent from `installed.json`, so it is read separately.
-		$root_package = self::read_json( dirname( $vendor_dir ) . '/composer.json' );
+		$root_package = self::read_json( self::get_root_dir( $vendor_dir ) . '/composer.json' );
 
 		return array_merge( $hints, self::extract_hints( $root_package ) );
+	}
+
+	/**
+	 * Locate the directory of the root package that owns a vendor directory.
+	 *
+	 * The vendor directory is not necessarily a direct child of the project
+	 * root, as Composer's `config.vendor-dir` setting can point anywhere.
+	 * Composer 2 records the actual location of the root package in
+	 * `vendor/composer/installed.php`, which is used when available.
+	 *
+	 * @param string $vendor_dir Path to the Composer vendor directory.
+	 * @return string Path to the directory of the root package.
+	 */
+	private static function get_root_dir( $vendor_dir ) {
+		$installed = self::read_installed_php( $vendor_dir . '/composer/installed.php' );
+		$root      = isset( $installed['root'] ) && is_array( $installed['root'] ) ? $installed['root'] : [];
+
+		if ( isset( $root['install_path'] ) && is_string( $root['install_path'] ) ) {
+			$root_dir = rtrim( $root['install_path'], '/\\' );
+
+			if ( '' !== $root_dir && is_dir( $root_dir ) ) {
+				return $root_dir;
+			}
+		}
+
+		return dirname( $vendor_dir );
+	}
+
+	/**
+	 * Read Composer's `installed.php`.
+	 *
+	 * Unlike `installed.json`, this file is PHP code that resolves paths
+	 * relative to its own location, so it has to be included to be read.
+	 *
+	 * @param string $path Path to the `installed.php` file.
+	 * @return array<mixed> Decoded data, or an empty array if it could not be read.
+	 */
+	private static function read_installed_php( $path ) {
+		if ( ! is_file( $path ) || ! is_readable( $path ) ) {
+			return [];
+		}
+
+		$data = include $path;
+
+		return is_array( $data ) ? $data : [];
 	}
 
 	/**

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -734,6 +734,23 @@ class Runner {
 	}
 
 	/**
+	 * Append the hint for an unregistered command to an error message.
+	 *
+	 * @param string $error   Error message stating that the command is unavailable.
+	 * @param string $command Full name of the command that was not found.
+	 * @return string Error message, with the hint appended if there is one.
+	 */
+	private function add_command_hint( $error, $command ) {
+		$hint = CommandHints::get_hint( $command );
+
+		if ( '' === $hint ) {
+			return $error;
+		}
+
+		return $error . PHP_EOL . $hint;
+	}
+
+	/**
 	 * Given positional arguments, find the command to execute.
 	 *
 	 * @param array<int, string> $args
@@ -768,11 +785,14 @@ class Runner {
 						$suggestion = 'meta';
 					}
 
-					$error = sprintf(
-						"'%s' is not a registered subcommand of '%s'. See 'wp help %s' for available subcommands.",
-						$child,
-						$parent_name,
-						$parent_name
+					$error = $this->add_command_hint(
+						sprintf(
+							"'%s' is not a registered subcommand of '%s'. See 'wp help %s' for available subcommands.",
+							$child,
+							$parent_name,
+							$parent_name
+						),
+						$full_name
 					);
 
 					if ( ! empty( $suggestion ) ) {
@@ -813,8 +833,11 @@ class Runner {
 					}
 				}
 
-				$error = sprintf(
-					"'%s' is not a registered wp command. See 'wp help' for available commands.",
+				$error = $this->add_command_hint(
+					sprintf(
+						"'%s' is not a registered wp command. See 'wp help' for available commands.",
+						$full_name
+					),
 					$full_name
 				);
 

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -785,14 +785,11 @@ class Runner {
 						$suggestion = 'meta';
 					}
 
-					$error = $this->add_command_hint(
-						sprintf(
-							"'%s' is not a registered subcommand of '%s'. See 'wp help %s' for available subcommands.",
-							$child,
-							$parent_name,
-							$parent_name
-						),
-						$full_name
+					$error = sprintf(
+						"'%s' is not a registered subcommand of '%s'. See 'wp help %s' for available subcommands.",
+						$child,
+						$parent_name,
+						$parent_name
 					);
 
 					if ( ! empty( $suggestion ) ) {
@@ -815,10 +812,10 @@ class Runner {
 							}
 						}
 
-						return $error . PHP_EOL . $suggestion_text;
+						return $this->add_command_hint( $error . PHP_EOL . $suggestion_text, $full_name );
 					}
 
-					return $error;
+					return $this->add_command_hint( $error, $full_name );
 				}
 
 				$suggestion = $this->get_subcommand_suggestion( $full_name, $command );
@@ -833,11 +830,8 @@ class Runner {
 					}
 				}
 
-				$error = $this->add_command_hint(
-					sprintf(
-						"'%s' is not a registered wp command. See 'wp help' for available commands.",
-						$full_name
-					),
+				$error = sprintf(
+					"'%s' is not a registered wp command. See 'wp help' for available commands.",
 					$full_name
 				);
 
@@ -883,10 +877,10 @@ class Runner {
 						}
 					}
 
-					return $error . PHP_EOL . $suggestion_text;
+					return $this->add_command_hint( $error . PHP_EOL . $suggestion_text, $full_name );
 				}
 
-				return $error;
+				return $this->add_command_hint( $error, $full_name );
 			}
 
 			if ( $this->is_command_disabled( $subcommand ) ) {

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -281,6 +281,8 @@ class WP_CLI {
 	 * * `before_invoke:<command>` (1) - Just before a command is invoked.
 	 * * `after_invoke:<command>` (1) - Just after a command is invoked.
 	 * * `find_command_to_run_pre` - Just before WP-CLI finds the command to run.
+	 * * `unregistered_command_hint` (2) - Filters the hint shown for a command
+	 *   that is not registered.
 	 * * `before_registering_contexts` (1) - Before the contexts are registered.
 	 * * `before_wp_load` - Just before the WP load process begins.
 	 * * `before_wp_config_load` - After wp-config.php has been located.

--- a/tests/CommandHintsTest.php
+++ b/tests/CommandHintsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace WP_CLI\Tests;
+
+use ReflectionClass;
+use WP_CLI\CommandHints;
+
+/**
+ * Tests for the WP_CLI\CommandHints class.
+ */
+final class CommandHintsTest extends TestCase {
+
+	/**
+	 * Collect the hints declared within a fixture directory.
+	 *
+	 * @param string $fixture Name of the directory within `tests/data`.
+	 * @return array<string, string> Map of full command name to hint.
+	 */
+	private function get_hints_from_fixture( string $fixture ): array {
+		$class  = new ReflectionClass( CommandHints::class );
+		$method = $class->getMethod( 'get_hints_from_vendor_dir' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			// @phpstan-ignore method.deprecated
+			$method->setAccessible( true );
+		}
+
+		/**
+		 * @var array<string, string> $hints
+		 */
+		$hints = $method->invoke( null, __DIR__ . '/data/' . $fixture . '/vendor' );
+
+		return $hints;
+	}
+
+	public function testItCollectsHintsFromInstalledPackages(): void {
+		$hints = $this->get_hints_from_fixture( 'command-hints' );
+
+		$this->assertSame( "The 'package' command ships with the Phar only.", $hints['package'] );
+		$this->assertSame( "The 'acme sync' command needs the acme/sync-command package.", $hints['acme sync'] );
+	}
+
+	public function testItCollectsHintsFromTheRootPackage(): void {
+		$hints = $this->get_hints_from_fixture( 'command-hints' );
+
+		$this->assertSame( "The 'root-only' command is declared by the root package.", $hints['root-only'] );
+	}
+
+	public function testTheRootPackageTakesPrecedence(): void {
+		$hints = $this->get_hints_from_fixture( 'command-hints' );
+
+		$this->assertSame( 'Hint coming from the root package.', $hints['overridden'] );
+	}
+
+	public function testItIgnoresIncompleteHints(): void {
+		$hints = $this->get_hints_from_fixture( 'command-hints' );
+
+		$this->assertArrayNotHasKey( '', $hints );
+		$this->assertArrayNotHasKey( 'empty-hint', $hints );
+		$this->assertArrayNotHasKey( 'array-hint', $hints );
+	}
+
+	public function testItHandlesAMissingVendorDirectory(): void {
+		$this->assertSame( [], $this->get_hints_from_fixture( 'command-hints-does-not-exist' ) );
+	}
+}

--- a/tests/CommandHintsTest.php
+++ b/tests/CommandHintsTest.php
@@ -16,7 +16,7 @@ final class CommandHintsTest extends TestCase {
 	 * @param string $fixture Name of the directory within `tests/data`.
 	 * @return array<string, string> Map of full command name to hint.
 	 */
-	private function get_hints_from_fixture( string $fixture ): array {
+	private function get_hints_from_fixture( string $fixture, string $vendor_dir = 'vendor' ): array {
 		$class  = new ReflectionClass( CommandHints::class );
 		$method = $class->getMethod( 'get_hints_from_vendor_dir' );
 		if ( PHP_VERSION_ID < 80100 ) {
@@ -27,7 +27,7 @@ final class CommandHintsTest extends TestCase {
 		/**
 		 * @var array<string, string> $hints
 		 */
-		$hints = $method->invoke( null, __DIR__ . '/data/' . $fixture . '/vendor' );
+		$hints = $method->invoke( null, __DIR__ . '/data/' . $fixture . '/' . $vendor_dir );
 
 		return $hints;
 	}
@@ -57,6 +57,14 @@ final class CommandHintsTest extends TestCase {
 		$this->assertArrayNotHasKey( '', $hints );
 		$this->assertArrayNotHasKey( 'empty-hint', $hints );
 		$this->assertArrayNotHasKey( 'array-hint', $hints );
+	}
+
+	public function testItLocatesTheRootPackageOfANestedVendorDirectory(): void {
+		$hints = $this->get_hints_from_fixture( 'command-hints-nested-vendor', 'build/vendor' );
+
+		$this->assertSame( "The 'package' command ships with the Phar only.", $hints['package'] );
+		$this->assertSame( "The 'root-only' command is declared by the root package.", $hints['root-only'] );
+		$this->assertSame( 'Hint coming from the root package.', $hints['overridden'] );
 	}
 
 	public function testItHandlesAMissingVendorDirectory(): void {

--- a/tests/data/command-hints-nested-vendor/build/vendor/composer/installed.json
+++ b/tests/data/command-hints-nested-vendor/build/vendor/composer/installed.json
@@ -1,0 +1,15 @@
+{
+    "packages": [
+        {
+            "name": "acme/bundle-package",
+            "version": "1.0.0",
+            "extra": {
+                "command-hints": {
+                    "package": "The 'package' command ships with the Phar only.",
+                    "overridden": "Hint coming from an installed package."
+                }
+            }
+        }
+    ],
+    "dev": false
+}

--- a/tests/data/command-hints-nested-vendor/build/vendor/composer/installed.php
+++ b/tests/data/command-hints-nested-vendor/build/vendor/composer/installed.php
@@ -1,0 +1,23 @@
+<?php return array(
+    'root' => array(
+        'name' => 'acme/root-package',
+        'pretty_version' => 'dev-main',
+        'version' => 'dev-main',
+        'reference' => null,
+        'type' => 'project',
+        'install_path' => __DIR__ . '/../../../',
+        'aliases' => array(),
+        'dev' => false,
+    ),
+    'versions' => array(
+        'acme/bundle-package' => array(
+            'pretty_version' => '1.0.0',
+            'version' => '1.0.0.0',
+            'reference' => null,
+            'type' => 'library',
+            'install_path' => __DIR__ . '/../acme/bundle-package',
+            'aliases' => array(),
+            'dev_requirement' => false,
+        ),
+    ),
+);

--- a/tests/data/command-hints-nested-vendor/composer.json
+++ b/tests/data/command-hints-nested-vendor/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "acme/root-package",
+    "config": {
+        "vendor-dir": "build/vendor"
+    },
+    "extra": {
+        "command-hints": {
+            "overridden": "Hint coming from the root package.",
+            "root-only": "The 'root-only' command is declared by the root package."
+        }
+    }
+}

--- a/tests/data/command-hints/composer.json
+++ b/tests/data/command-hints/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "acme/root-package",
+    "extra": {
+        "command-hints": {
+            "overridden": "Hint coming from the root package.",
+            "root-only": "The 'root-only' command is declared by the root package."
+        }
+    }
+}

--- a/tests/data/command-hints/vendor/composer/installed.json
+++ b/tests/data/command-hints/vendor/composer/installed.json
@@ -1,0 +1,34 @@
+{
+    "packages": [
+        {
+            "name": "acme/no-extra-package",
+            "version": "1.0.0"
+        },
+        {
+            "name": "acme/unrelated-extra-package",
+            "version": "1.0.0",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0.x-dev"
+                }
+            }
+        },
+        {
+            "name": "acme/bundle-package",
+            "version": "1.0.0",
+            "extra": {
+                "command-hints": {
+                    "package": "The 'package' command ships with the Phar only.",
+                    "acme sync": "The 'acme sync' command needs the acme/sync-command package.",
+                    "overridden": "Hint coming from an installed package.",
+                    "": "Hints without a command name are ignored.",
+                    "empty-hint": "   ",
+                    "array-hint": [
+                        "Hints that are not strings are ignored."
+                    ]
+                }
+            }
+        }
+    ],
+    "dev": false
+}


### PR DESCRIPTION
## Problem

`'x' is not a registered wp command` says nothing about *why* a command is missing or how to get it. That is fine for typos, where the "Did you mean" suggestion carries the weight, but not for commands that exist and are simply unavailable in the installation at hand.

The motivating case is `wp package`. Since wp-cli/wp-cli-bundle#846 moved `wp-cli/package-command` to `require-dev`, it ships in the Phar but is absent from Composer-based installations. Those users currently get:

```
Error: 'package' is not a registered wp command. See 'wp help' for available commands.
```

…with no indication that the command exists, that their install method is the reason, or that `composer require wp-cli/package-command` fixes it.

## Approach

Packages can declare guidance for commands they know about through an `extra.command-hints` section in their `composer.json`:

```json
"extra": {
  "command-hints": {
    "package": "The 'package' command is bundled with the WP-CLI Phar, but is an optional dependency of Composer-based installations. Run `composer require wp-cli/package-command` to add it, or manage WP-CLI packages as regular Composer dependencies of your project instead."
  }
}
```

Metadata rather than code is deliberate: wp-cli-bundle has no `autoload` section of its own, so declaring this in `composer.json` is the only way it can speak. It also follows the existing `extra.commands` convention, and keeps the framework free of any hardcoded knowledge about which package provides what.

## Changes

- **`WP_CLI\CommandHints`** collects hints from `vendor/composer/installed.json` and the root `composer.json`, with the root taking precedence. Malformed entries (non-string keys or values, blank strings) are skipped.
- **`Runner::find_command_to_run()`** appends a matching hint to the error, on both the top-level and subcommand branches. `wp package install foo` fails on the top-level `package` lookup, so a single hint covers every subcommand.
- **`unregistered_command_hint` filter** (2 args) lets a project supply or override guidance at runtime without Composer metadata.

Disk is only touched on the failure path, and hints are cached per process. A hint never displaces the existing "Did you mean" suggestion, and never appears for a command that *is* registered — so Phar users see no change at all.

Companion PR that declares the actual metadata:

* https://github.com/wp-cli/wp-cli-bundle/pull/1111

## Result

```
Error: 'package' is not a registered wp command. See 'wp help' for available commands.
The 'package' command is bundled with the WP-CLI Phar, but is an optional dependency
of Composer-based installations. Run `composer require wp-cli/package-command` to add
it, or manage WP-CLI packages as regular Composer dependencies of your project instead.
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01G27BNpnRNerEeSGjvefzBf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helpful hints when users run unregistered WP-CLI commands or subcommands.
  * Hints appear after any “Did you mean…” suggestion and can be customized through the `unregistered_command_hint` filter.
  * Package-provided and root-level hints are supported, including projects with customized vendor locations.

* **Documentation**
  * Documented the `unregistered_command_hint` filter in the available WP-CLI hooks.

* **Tests**
  * Added coverage for command suggestions, package-provided hints, overrides, invalid configurations, and missing metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->