### PR TITLE
Fix trailing-newline SSH scenario left failing on main by #6249

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -493,7 +493,7 @@ Feature: Global flags
     When I try `newline_arg="$(printf 'foo\nx')"; wp --debug --ssh=wordpress option get "${newline_arg%x}"`
     Then STDERR should contain:
       """
-      Running SSH command: ssh -T -vvv 'wordpress' 'wp --debug option get '\''foo
+      Running SSH command: ssh -T -vvv 'wordpress' 'WP_CLI_SSH_RUN=1 wp --debug option get '\''foo
       '\'''
       """
 


### PR DESCRIPTION
Tests only — no functional changes. This fixes the one Behat scenario that has been failing on `main` since #6249 was merged.

## Summary

`WP_CLI_SSH_RUN` was already introduced in #6249; this PR does **not** add it or change any behaviour. It only updates a stale test expectation that #6249 missed, in a single line of `features/flags.feature`.

## Root cause

A merge race between two PRs that were each green on their own branch:

- #6384 (merged Aug 6) added the scenario `SSH arguments with a trailing newline should be escaped`, expecting `... 'wordpress' 'wp --debug option get ...'`.
- #6249 (merged Aug 11) started prefixing the remote command with `WP_CLI_SSH_RUN=1` in `Runner::generate_ssh_command()`, so WP-CLI can detect that it is already running inside an SSH/container session and avoid recursing.

#6249 updated every other `Running SSH command` expectation in `features/flags.feature` and `features/aliases.feature`, but its branch was created before #6384 landed, so it never saw that new scenario. The two merged without a git conflict (different lines), leaving `main` red.

## The change

```diff
-      Running SSH command: ssh -T -vvv 'wordpress' 'wp --debug option get '\''foo
+      Running SSH command: ssh -T -vvv 'wordpress' 'WP_CLI_SSH_RUN=1 wp --debug option get '\''foo
```

This was the only remaining stale expectation; every other `Running SSH command` assertion in `features/` already carries the prefix. That matches CI, which reported `434 scenarios (433 passed, 1 failed)`.

## Verification

The scenario and its `STDERR should contain` assertion were reproduced against real output, taking the expected block from the feature file rather than retyping it:

- Old expectation: **FAIL** (reproduces the CI failure)
- New expectation: **PASS**

The assertion still covers the property #6384 added it for: an argument with a trailing newline must reach the remote shell single-quoted (`'\''foo⏎'\''`) rather than bare. Only the environment-variable prefix changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)