### PR TITLE
Synopsis: Support uppercase letters in arguments for completion

### DIFF
--- a/features/cli-bash-completion.feature
+++ b/features/cli-bash-completion.feature
@@ -478,3 +478,30 @@ Feature: `wp cli completions` tasks
     Then STDOUT should be empty
     And STDERR should be empty
     And the return code should be 0
+
+  Scenario: Bash Completion for a mixed-case parameter name
+    Given an empty directory
+    And a custom-cmd.php file:
+      """
+      <?php
+      class Mixed_Case_Command extends WP_CLI_Command {
+          /**
+           * Update a thing.
+           *
+           * ## OPTIONS
+           *
+           * [--comment_author_IP=<comment_author_IP>]
+           * : The IP address of the comment author.
+           *
+           * @when before_wp_load
+           */
+          public function update( $args, $assoc_args ) {}
+      }
+      WP_CLI::add_command( 'mixed', 'Mixed_Case_Command' );
+      """
+
+    When I run `wp --require=custom-cmd.php cli completions --line="wp mixed update --comment" --point=100`
+    Then STDOUT should contain:
+      """
+      --comment_author_IP=
+      """

--- a/php/WP_CLI/SynopsisParser.php
+++ b/php/WP_CLI/SynopsisParser.php
@@ -173,7 +173,12 @@ class SynopsisParser {
 
 		list( $aliases, $token ) = self::extract_aliases( $token );
 
-		$p_name  = '([a-z-_0-9]+)';
+		// Uppercase is allowed in parameter names because some WordPress core
+		// fields are mixed-case, e.g. `comment_post_ID` and `comment_author_IP`.
+		// A lowercase-only pattern silently truncated such names at the first
+		// uppercase character, so `--comment_author_IP=<comment_author_IP>`
+		// registered a parameter named `comment_author_`.
+		$p_name  = '([a-zA-Z-_0-9]+)';
 		$p_value = '([a-zA-Z-_|,0-9]+)';
 
 		if ( preg_match( "/^<($p_value)>$/", $token, $matches ) ) {

--- a/tests/SynopsisParserTest.php
+++ b/tests/SynopsisParserTest.php
@@ -90,6 +90,31 @@ class SynopsisParserTest extends TestCase {
 		$this->assertTrue( is_array( $param['value'] ) && ! empty( $param['value']['optional'] ) );
 	}
 
+	public function testMixedCaseAssoc(): void {
+		// Some WordPress core fields are mixed-case, e.g. `comment_post_ID`
+		// and `comment_author_IP`. The parameter name must not be silently
+		// truncated at the first uppercase character.
+		$r = SynopsisParser::parse( '[--comment_author_IP=<comment_author_IP>] [--comment_post_ID=<comment_post_ID>]' );
+
+		$this->assertCount( 2, $r );
+
+		$param = $r[0];
+		$this->assertEquals( 'assoc', $param['type'] );
+		$this->assertEquals( 'comment_author_IP', $param['name'] );
+
+		$param = $r[1];
+		$this->assertEquals( 'assoc', $param['type'] );
+		$this->assertEquals( 'comment_post_ID', $param['name'] );
+	}
+
+	public function testParseThenRenderMixedCase(): void {
+		$o = '--comment_post_ID=<comment_post_ID> --<field>=<value> [--flag]';
+		$a = SynopsisParser::parse( $o );
+		$this->assertSame( 'comment_post_ID', $a[0]['name'] );
+		$r = SynopsisParser::render( $a );
+		$this->assertSame( $o, $r );
+	}
+
 	public function testInvalidAssoc(): void {
 		$r = SynopsisParser::parse( '--bar[=<value>] --bar=[<value>] --count=100' );
 


### PR DESCRIPTION
Fixes the parser issue discussed in #5286.

Some WordPress core fields are mixed-case, for example `comment_post_ID` and `comment_author_IP`. The parameter name pattern in `SynopsisParser::classify_token()` only matched lowercase, so a docblock parameter with an uppercase letter was silently truncated at the first uppercase character. `[--comment_author_IP=<comment_author_IP>]` registered a parameter named `comment_author_`, the help output rendered the truncated name, and validation treated the real name as unknown.

The fix allows uppercase letters in the name pattern, matching what the value pattern already allows. Two tests are included: one for parsing mixed-case names, and one round-trip parse and render check.

This is independent of the typo detection discussion, as suggested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command parameter parsing so mixed-case parameter names are preserved correctly.
  * Prevented uppercase letters in parameter names from being truncated during parsing and rendering.
  * Ensured mixed-case parameters appear correctly in Bash completion suggestions.

* **Tests**
  * Added coverage for mixed-case associative parameter names, including round-trip parsing and rendering.
  * Added Bash completion coverage for mixed-case command parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->