### PR TITLE
Skip the SQLite table re-filter on the MySQL-on-SQLite driver

### DIFF
--- a/php/utils-wp.php
+++ b/php/utils-wp.php
@@ -542,9 +542,14 @@ function wp_get_table_names( $args, $assoc_args = [] ) {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- uses esc_sql_ident() and $wpdb->_escape().
 		$tables = $wpdb->get_col( sprintf( "SHOW TABLES WHERE %s IN ('%s')", esc_sql_ident( 'Tables_in_' . $wpdb->dbname ), implode( "', '", $wpdb->_escape( $wp_tables ) ) ) );
 
-		// Filter tables after the query for improved SQLite compatibility.
+		// Filter tables after the query for improved SQLite compatibility: drop-ins
+		// older than the MySQL-on-SQLite driver ignore the `WHERE` clause above and
+		// return every table in the database.
 		// See https://github.com/WordPress/sqlite-database-integration/issues/319.
-		if ( 'sqlite' === get_db_type() ) {
+		$is_legacy_sqlite_dropin = 'sqlite' === get_db_type()
+			&& ( ! defined( 'SQLITE_DRIVER_VERSION' ) || version_compare( SQLITE_DRIVER_VERSION, '3.0.0', '<' ) );
+
+		if ( $is_legacy_sqlite_dropin ) {
 			$tables = array_values( array_intersect( $tables, $wp_tables ) );
 		}
 


### PR DESCRIPTION
`wp_get_table_names()` re-filters the `SHOW TABLES` result in PHP on SQLite. This gates that on the drop-in generation, since it is only needed for older drop-ins, and notes in passing what the workaround is actually for.

### What the workaround is for

The legacy `WP_SQLite_Translator` drop-in does not expose the result column as `Tables_in_<database>`, so the `WHERE` clause in the `SHOW TABLES` query above is ignored and the query returns every table in the database, including tables that do not belong to WordPress. That is [sqlite-database-integration#319](https://github.com/WordPress/sqlite-database-integration/issues/319), which the existing comment already links to.

The MySQL-on-SQLite driver that superseded it applies the clause, and also sorts by table name. I verified this by running the exact query this function builds against the 3.0 driver: `SHOW TABLES WHERE \`Tables_in_<db>\` IN (...)` returns only the requested tables, in sorted order, so the `array_intersect()` is a no-op there.

### Why `SQLITE_DRIVER_VERSION` and not the drop-in version

`SQLITE_DB_DROPIN_VERSION` cannot be used for this. It versions the `db.php` shim rather than the driver behind it, and is frozen at `1.8.0` — the same value in v2.1.13, v2.2.23 and v3.0.0. (It is still the right signal for detecting SQLite at all, which is what `get_db_type()` uses it for.)

`SQLITE_DRIVER_VERSION` does track the plugin: `2.2.23`, `3.0.0`, and absent before 2.2.x. It is defined by `db.php` before `wpdb` is constructed, so it is always available by the time this runs.

The check is deliberately conservative. sqlite-database-integration 2.2.x shipped *both* implementations and only used the newer one when the `WP_SQLITE_AST_DRIVER` constant was set, so a `2.2.23` install may be on either driver. Those installs keep filtering, which is harmless — the filter can only ever remove tables that should not be listed. Only 3.0+, where the MySQL-on-SQLite driver is the sole code path, skips it.

### Context

This came out of adapting `wp-cli/db-command` to sqlite-database-integration 3.0 ([db-command#344](https://github.com/wp-cli/db-command/pull/344)), where the 3.0 upgrade changed `wp db tables` output from creation order to sorted order — the same driver switch that makes this filter redundant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite compatibility when retrieving table names.
  * Legacy SQLite integrations continue to receive correct table listings, while modern integrations avoid unnecessary filtering.
  * Existing table-filtering behavior remains unchanged for affected legacy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->