### PR TITLE
Report likely typos in parameters of catch-all commands

### DIFF
--- a/features/validation.feature
+++ b/features/validation.feature
@@ -42,3 +42,224 @@ Feature: Argument validation
       Error: Too many positional arguments: invalid
       """
     And STDOUT should be empty
+
+  Scenario: A catch-all command reports a parameter that looks like a typo
+    Given an empty directory
+    And a custom-cmd.php file:
+      """
+      <?php
+      /**
+       * Updates an entity.
+       *
+       * <entity_id>
+       * : The entity to update.
+       *
+       * [--entity_name=<entity_name>]
+       * : A documented parameter.
+       *
+       * [--create=<create>]
+       * : A documented parameter the built-in alias map points 'add' at.
+       *
+       * [--<field>=<value>]
+       * : One or more fields to update.
+       *
+       * @when before_wp_load
+       */
+      WP_CLI::add_command(
+      	'entity update',
+      	function ( $args, $assoc_args ) {
+      		ksort( $assoc_args );
+      		foreach ( $assoc_args as $key => $value ) {
+      			WP_CLI::log( "{$key}={$value}" );
+      		}
+      		WP_CLI::success( "Updated {$args[0]}." );
+      	}
+      );
+      """
+
+    # A documented parameter is untouched by any of this.
+    When I run `wp --require=custom-cmd.php entity update 1 --entity_name=beta`
+    Then STDOUT should contain:
+      """
+      entity_name=beta
+      """
+    And STDOUT should contain:
+      """
+      Success: Updated 1.
+      """
+
+    # One edit away from a documented parameter, so it is reported rather than
+    # silently ignored. This is what the command used to accept without a word.
+    When I try `wp --require=custom-cmd.php entity update 1 --entity_nme=beta`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      unknown --entity_nme parameter
+      """
+    And STDERR should contain:
+      """
+      Did you mean '--entity_name'?
+      """
+    And STDOUT should be empty
+
+    # Anything further away is what the catch-all exists for: it has to reach the
+    # command, not merely avoid an error.
+    When I run `wp --require=custom-cmd.php entity update 1 --custom_field=gamma`
+    Then STDOUT should contain:
+      """
+      custom_field=gamma
+      """
+    And STDOUT should contain:
+      """
+      Success: Updated 1.
+      """
+
+  Scenario: A catch-all command does not measure its parameters against the global ones
+    Given an empty directory
+    And a custom-cmd.php file:
+      """
+      <?php
+      /**
+       * Updates an entity.
+       *
+       * <entity_id>
+       * : The entity to update.
+       *
+       * [--entity_name=<entity_name>]
+       * : A documented parameter.
+       *
+       * [--create=<create>]
+       * : A documented parameter the built-in alias map points 'add' at.
+       *
+       * [--<field>=<value>]
+       * : One or more fields to update.
+       *
+       * @when before_wp_load
+       */
+      WP_CLI::add_command(
+      	'entity update',
+      	function ( $args, $assoc_args ) {
+      		ksort( $assoc_args );
+      		foreach ( $assoc_args as $key => $value ) {
+      			WP_CLI::log( "{$key}={$value}" );
+      		}
+      		WP_CLI::success( "Updated {$args[0]}." );
+      	}
+      );
+
+      /**
+       * Creates an entity.
+       *
+       * [--entity_name=<entity_name>]
+       * : A documented parameter.
+       *
+       * [--create=<create>]
+       * : A documented parameter the built-in alias map points 'add' at.
+       *
+       * @when before_wp_load
+       */
+      WP_CLI::add_command(
+      	'entity create',
+      	function ( $args, $assoc_args ) {
+      		WP_CLI::success( 'Created.' );
+      	}
+      );
+      """
+
+    # '--cat' is two edits from the global '--path', and a real query var on
+    # commands like this one. The global parameters share a namespace with the
+    # fields a catch-all command takes, so they are not candidates for it.
+    When I run `wp --require=custom-cmd.php entity update 1 --cat=5`
+    Then STDOUT should contain:
+      """
+      cat=5
+      """
+    And STDOUT should contain:
+      """
+      Success: Updated 1.
+      """
+
+    # The same parameter on a command with no catch-all is still reported, so
+    # the global parameters keep helping everywhere they did before.
+    When I try `wp --require=custom-cmd.php entity create --cat=5`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      unknown --cat parameter
+      """
+    And STDERR should contain:
+      """
+      Did you mean '--path'?
+      """
+
+  Scenario: A catch-all command does not consult the command alias map
+    Given an empty directory
+    And a custom-cmd.php file:
+      """
+      <?php
+      /**
+       * Updates an entity.
+       *
+       * <entity_id>
+       * : The entity to update.
+       *
+       * [--create=<create>]
+       * : A documented parameter the built-in alias map points 'add' at.
+       *
+       * [--<field>=<value>]
+       * : One or more fields to update.
+       *
+       * @when before_wp_load
+       */
+      WP_CLI::add_command(
+      	'entity update',
+      	function ( $args, $assoc_args ) {
+      		ksort( $assoc_args );
+      		foreach ( $assoc_args as $key => $value ) {
+      			WP_CLI::log( "{$key}={$value}" );
+      		}
+      		WP_CLI::success( "Updated {$args[0]}." );
+      	}
+      );
+
+      /**
+       * Creates an entity.
+       *
+       * [--create=<create>]
+       * : A documented parameter the built-in alias map points 'add' at.
+       *
+       * @when before_wp_load
+       */
+      WP_CLI::add_command(
+      	'entity create',
+      	function ( $args, $assoc_args ) {
+      		WP_CLI::success( 'Created.' );
+      	}
+      );
+      """
+
+    # The alias map is command vocabulary and ignores the threshold: 'add' is
+    # five edits from 'create'. On a catch-all command it would be the only
+    # reason to reject a field, so it is not consulted there.
+    When I run `wp --require=custom-cmd.php entity update 1 --add=beta`
+    Then STDOUT should contain:
+      """
+      add=beta
+      """
+    And STDOUT should contain:
+      """
+      Success: Updated 1.
+      """
+
+    # Where the suggestion only decorates an error raised on other grounds, the
+    # alias map still applies.
+    When I try `wp --require=custom-cmd.php entity create --add=beta`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      unknown --add parameter
+      """
+    And STDERR should contain:
+      """
+      Did you mean '--create'?
+      """

--- a/features/validation.feature
+++ b/features/validation.feature
@@ -43,7 +43,7 @@ Feature: Argument validation
       """
     And STDOUT should be empty
 
-  Scenario: A catch-all command reports a parameter that looks like a typo
+  Scenario: A catch-all command warns about a parameter that looks like a typo
     Given an empty directory
     And a custom-cmd.php file:
       """
@@ -87,23 +87,29 @@ Feature: Argument validation
       """
       Success: Updated 1.
       """
+    And STDERR should be empty
 
     # One edit away from a documented parameter, so it is reported rather than
     # silently ignored. This is what the command used to accept without a word.
+    # The parameter still reaches the command and the exit code is unaffected:
+    # the synopsis says arbitrary keys are legitimate, so the command decides.
     When I try `wp --require=custom-cmd.php entity update 1 --entity_nme=beta`
-    Then the return code should be 1
+    Then the return code should be 0
     And STDERR should contain:
       """
-      unknown --entity_nme parameter
+      Warning: --entity_nme looks like a typo of --entity_name
       """
-    And STDERR should contain:
+    And STDOUT should contain:
       """
-      Did you mean '--entity_name'?
+      entity_nme=beta
       """
-    And STDOUT should be empty
+    And STDOUT should contain:
+      """
+      Success: Updated 1.
+      """
 
     # Anything further away is what the catch-all exists for: it has to reach the
-    # command, not merely avoid an error.
+    # command without a word.
     When I run `wp --require=custom-cmd.php entity update 1 --custom_field=gamma`
     Then STDOUT should contain:
       """
@@ -112,6 +118,56 @@ Feature: Argument validation
     And STDOUT should contain:
       """
       Success: Updated 1.
+      """
+    And STDERR should be empty
+
+  Scenario: A catch-all command warns about a typo on a real command
+    Given a WP install
+
+    # The password is a documented field of `wp user update`, and the command has
+    # a `--<field>=<value>` catch-all, so `--user-pass` used to be accepted and
+    # then never applied. It is still passed through, but no longer in silence.
+    When I try `wp user update 1 --user-pass=secret`
+    Then the return code should be 0
+    And STDERR should contain:
+      """
+      Warning: --user-pass looks like a typo of --user_pass
+      """
+    And STDOUT should contain:
+      """
+      Success: Updated user 1.
+      """
+
+    # A key that is nothing like a documented field is what the catch-all is
+    # for, so nothing is said about it.
+    When I run `wp user update 1 --some_plugin_key=value`
+    Then STDOUT should contain:
+      """
+      Success: Updated user 1.
+      """
+    And STDERR should be empty
+
+    When I run `wp user update 1 --user_pass=secret`
+    Then STDOUT should contain:
+      """
+      Success: Updated user 1.
+      """
+    And STDERR should be empty
+
+  Scenario: A catch-all read command still accepts a real argument that resembles a documented one
+    Given a WP multisite install
+
+    # `site_id` is a real column of the sites table and a real WP_Site_Query
+    # argument, two edits from the documented `--site__in`. Whatever the check
+    # makes of it (newer entity-command releases document it as an alias of
+    # `--network`, older ones do not), the argument has to reach the command
+    # and the command has to succeed: the synopsis says arbitrary keys are
+    # legitimate, and this one is.
+    When I try `wp site list --site_id=1 --format=ids`
+    Then the return code should be 0
+    And STDOUT should be:
+      """
+      1
       """
 
   Scenario: A catch-all command does not measure its parameters against the global ones
@@ -178,6 +234,7 @@ Feature: Argument validation
       """
       Success: Updated 1.
       """
+    And STDERR should be empty
 
     # The same parameter on a command with no catch-all is still reported, so
     # the global parameters keep helping everywhere they did before.
@@ -190,6 +247,113 @@ Feature: Argument validation
     And STDERR should contain:
       """
       Did you mean '--path'?
+      """
+
+  Scenario: A catch-all command does not measure its parameters against positional ones
+    Given an empty directory
+    And a custom-cmd.php file:
+      """
+      <?php
+      /**
+       * Runs a query.
+       *
+       * <sql>
+       * : The query to run.
+       *
+       * [--format=<format>]
+       * : A documented parameter.
+       *
+       * [--<field>=<value>]
+       * : Options passed through to the client.
+       *
+       * @when before_wp_load
+       */
+      WP_CLI::add_command(
+      	'entity query',
+      	function ( $args, $assoc_args ) {
+      		ksort( $assoc_args );
+      		foreach ( $assoc_args as $key => $value ) {
+      			WP_CLI::log( "{$key}={$value}" );
+      		}
+      		WP_CLI::success( "Ran {$args[0]}." );
+      	}
+      );
+      """
+
+    # '--xml' is two edits from the positional '<sql>', and a real option of the
+    # client the command hands its parameters to. A positional argument cannot
+    # be spelled `--sql` in the first place, so it is not a candidate.
+    When I run `wp --require=custom-cmd.php entity query 'SELECT 1' --xml=1`
+    Then STDOUT should contain:
+      """
+      xml=1
+      """
+    And STDOUT should contain:
+      """
+      Success: Ran SELECT 1.
+      """
+    And STDERR should be empty
+
+    # The documented parameters of the command remain candidates.
+    When I try `wp --require=custom-cmd.php entity query 'SELECT 1' --fomat=json`
+    Then the return code should be 0
+    And STDERR should contain:
+      """
+      Warning: --fomat looks like a typo of --format
+      """
+
+  Scenario: A catch-all command does not treat a prefix of a documented parameter as a typo
+    Given an empty directory
+    And a custom-cmd.php file:
+      """
+      <?php
+      /**
+       * Lists entities.
+       *
+       * [--paged=<page>]
+       * : A documented parameter.
+       *
+       * [--tag_id=<id>]
+       * : A documented parameter.
+       *
+       * [--<field>=<value>]
+       * : One or more query arguments.
+       *
+       * @when before_wp_load
+       */
+      WP_CLI::add_command(
+      	'entity list',
+      	function ( $args, $assoc_args ) {
+      		ksort( $assoc_args );
+      		foreach ( $assoc_args as $key => $value ) {
+      			WP_CLI::log( "{$key}={$value}" );
+      		}
+      		WP_CLI::success( 'Listed.' );
+      	}
+      );
+      """
+
+    # Documented families nest: '--page' is one edit from '--paged' and '--tag'
+    # is a prefix of '--tag_id', and both are real query arguments. A typo is
+    # not usually a clean truncation, so a prefix of a documented parameter,
+    # or a parameter a documented one is a prefix of, is passed through quietly.
+    When I run `wp --require=custom-cmd.php entity list --page=2 --tag_id_x=3`
+    Then STDOUT should contain:
+      """
+      page=2
+      """
+    And STDOUT should contain:
+      """
+      tag_id_x=3
+      """
+    And STDERR should be empty
+
+    # A transposition is not a prefix, so it is still reported.
+    When I try `wp --require=custom-cmd.php entity list --pgaed=2`
+    Then the return code should be 0
+    And STDERR should contain:
+      """
+      Warning: --pgaed looks like a typo of --paged
       """
 
   Scenario: A catch-all command does not consult the command alias map
@@ -240,7 +404,7 @@ Feature: Argument validation
 
     # The alias map is command vocabulary and ignores the threshold: 'add' is
     # five edits from 'create'. On a catch-all command it would be the only
-    # reason to reject a field, so it is not consulted there.
+    # reason to doubt a field, so it is not consulted there.
     When I run `wp --require=custom-cmd.php entity update 1 --add=beta`
     Then STDOUT should contain:
       """
@@ -250,6 +414,7 @@ Feature: Argument validation
       """
       Success: Updated 1.
       """
+    And STDERR should be empty
 
     # Where the suggestion only decorates an error raised on other grounds, the
     # alias map still applies.

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -598,12 +598,32 @@ class Subcommand extends CompositeCommand {
 		}
 
 		if ( 'help' !== $this->name ) {
-			foreach ( $validator->unknown_assoc( $assoc_args ) as $key ) {
-				$suggestion    = Utils\get_suggestion(
+			// A `--<field>=<value>` token means the command accepts keys that cannot be
+			// enumerated up front, so an unrecognized parameter is reported only when it
+			// looks like a typo of a documented one. Anything further away is passed
+			// through untouched, which keeps custom fields and query filters working.
+			$has_generic = $validator->has_generic();
+
+			// Global parameters are left out of the candidate set for those commands. They
+			// are harmless as a hint on an error raised anyway, but a catch-all command's
+			// own arguments share their namespace: `wp post list --cat=5` and `--s=hello`
+			// are real query vars two edits away from `--path` and `--ssh`.
+			$parameters = $this->get_parameters( $synopsis_spec, ! $has_generic );
+
+			foreach ( $validator->unknown_assoc( $assoc_args, $has_generic ) as $key ) {
+				// The alias map in get_suggestion() is command vocabulary and ignores the
+				// threshold. That is fine when a suggestion merely decorates an error we
+				// already decided to raise, but here it would be the thing raising it.
+				$suggestion = Utils\get_suggestion(
 					$key,
-					$this->get_parameters( $synopsis_spec ),
-					$threshold = 2
+					$parameters,
+					2,
+					! $has_generic
 				);
+
+				if ( $has_generic && '' === $suggestion ) {
+					continue;
+				}
 
 				$errors['fatal'][] = sprintf(
 					'unknown --%s parameter%s',
@@ -889,13 +909,19 @@ class Subcommand extends CompositeCommand {
 	 * Get an array of parameter names, by merging the command-specific and the
 	 * global parameters.
 	 *
-	 * @param array<int, array<string, mixed>> $spec Optional. Specification of the current command.
+	 * @param array<int, array<string, mixed>> $spec           Optional. Specification of the current command.
+	 * @param bool                             $include_global Optional. Whether to include the global parameters.
 	 *
 	 * @return array<int, string> Array of parameter names
 	 */
-	private function get_parameters( $spec = [] ) {
+	private function get_parameters( $spec = [], $include_global = true ) {
 		/** @var list<string> $local_parameters */
 		$local_parameters = array_values( array_filter( array_column( $spec, 'name' ), 'is_string' ) );
+
+		if ( ! $include_global ) {
+			return array_values( array_unique( $local_parameters ) );
+		}
+
 		/** @var list<string> $global_parameters */
 		$global_parameters = array_values(
 			array_filter(

--- a/php/WP_CLI/Dispatcher/Subcommand.php
+++ b/php/WP_CLI/Dispatcher/Subcommand.php
@@ -599,16 +599,20 @@ class Subcommand extends CompositeCommand {
 
 		if ( 'help' !== $this->name ) {
 			// A `--<field>=<value>` token means the command accepts keys that cannot be
-			// enumerated up front, so an unrecognized parameter is reported only when it
-			// looks like a typo of a documented one. Anything further away is passed
-			// through untouched, which keeps custom fields and query filters working.
+			// enumerated up front, so an unrecognized parameter is not an error there. It
+			// is still worth a word when it looks like a typo of a documented one, because
+			// the command would otherwise accept it and silently do nothing with it.
 			$has_generic = $validator->has_generic();
 
-			// Global parameters are left out of the candidate set for those commands. They
-			// are harmless as a hint on an error raised anyway, but a catch-all command's
-			// own arguments share their namespace: `wp post list --cat=5` and `--s=hello`
-			// are real query vars two edits away from `--path` and `--ssh`.
-			$parameters = $this->get_parameters( $synopsis_spec, ! $has_generic );
+			// The candidate set for those commands is their own `--<name>` parameters.
+			// Global parameters are harmless as a hint on an error raised anyway, but a
+			// catch-all command's arguments share their namespace: `wp post list --cat=5`
+			// and `--s=hello` are real query vars two edits away from `--path` and `--ssh`.
+			// Positional names are left out for the same reason: `wp db query --xml` is a
+			// real mysql option two edits away from `<sql>`.
+			$parameters = $has_generic
+				? $this->get_parameters( $synopsis_spec, false, [ 'assoc', 'flag' ] )
+				: $this->get_parameters( $synopsis_spec );
 
 			foreach ( $validator->unknown_assoc( $assoc_args, $has_generic ) as $key ) {
 				// The alias map in get_suggestion() is command vocabulary and ignores the
@@ -621,7 +625,18 @@ class Subcommand extends CompositeCommand {
 					! $has_generic
 				);
 
-				if ( $has_generic && '' === $suggestion ) {
+				if ( $has_generic ) {
+					if ( '' === $suggestion || self::is_prefix_of_other( $key, $suggestion ) ) {
+						continue;
+					}
+
+					// The parameter is passed through untouched; the command decides what it
+					// means. So this is a warning, not an error, and the exit code is unaffected.
+					$errors['warning'][] = sprintf(
+						'--%s looks like a typo of --%s',
+						$key,
+						$suggestion
+					);
 					continue;
 				}
 
@@ -906,15 +921,47 @@ class Subcommand extends CompositeCommand {
 	}
 
 	/**
+	 * Check whether one of two parameter names is a strict prefix of the other.
+	 *
+	 * A documented family of parameters often nests this way (`page` and `paged`,
+	 * `tag` and `tag_id`), and one of the pair being undocumented is no reason to
+	 * doubt it. A typo, on the other hand, is not usually a clean truncation.
+	 *
+	 * @param string $a First parameter name.
+	 * @param string $b Second parameter name.
+	 *
+	 * @return bool
+	 */
+	private static function is_prefix_of_other( $a, $b ) {
+		if ( $a === $b ) {
+			return false;
+		}
+
+		return 0 === strpos( $a, $b ) || 0 === strpos( $b, $a );
+	}
+
+	/**
 	 * Get an array of parameter names, by merging the command-specific and the
 	 * global parameters.
 	 *
 	 * @param array<int, array<string, mixed>> $spec           Optional. Specification of the current command.
 	 * @param bool                             $include_global Optional. Whether to include the global parameters.
+	 * @param array<int, string>               $types          Optional. Restrict the command-specific parameters to
+	 *                                                         these synopsis types ('positional', 'assoc', 'flag').
+	 *                                                         Empty means no restriction.
 	 *
 	 * @return array<int, string> Array of parameter names
 	 */
-	private function get_parameters( $spec = [], $include_global = true ) {
+	private function get_parameters( $spec = [], $include_global = true, $types = [] ) {
+		if ( ! empty( $types ) ) {
+			$spec = array_filter(
+				$spec,
+				static function ( $param ) use ( $types ) {
+					return isset( $param['type'] ) && in_array( $param['type'], $types, true );
+				}
+			);
+		}
+
 		/** @var list<string> $local_parameters */
 		$local_parameters = array_values( array_filter( array_column( $spec, 'name' ), 'is_string' ) );
 

--- a/php/WP_CLI/SynopsisValidator.php
+++ b/php/WP_CLI/SynopsisValidator.php
@@ -129,19 +129,37 @@ class SynopsisValidator {
 	}
 
 	/**
+	 * Check whether the synopsis accepts arbitrary parameters.
+	 *
+	 * A `--<field>=<value>` token means the command takes keys that cannot be
+	 * enumerated up front, so an unrecognized parameter is not automatically
+	 * an error.
+	 *
+	 * @return bool
+	 */
+	public function has_generic() {
+		return (bool) count(
+			$this->query_spec(
+				[
+					'type' => 'generic',
+				]
+			)
+		);
+	}
+
+	/**
 	 * Check whether there are unknown parameters supplied.
 	 *
-	 * @param array<string, mixed> $assoc_args Parameters passed to command.
+	 * @param array<string, mixed> $assoc_args     Parameters passed to command.
+	 * @param bool                 $ignore_generic Whether to report unknown parameters even
+	 *                                             when the synopsis has a generic token.
+	 *                                             Callers that pass true are responsible for
+	 *                                             deciding which of the returned parameters
+	 *                                             are actually errors.
 	 * @return array<int, string>
 	 */
-	public function unknown_assoc( $assoc_args ) {
-		$generic = $this->query_spec(
-			[
-				'type' => 'generic',
-			]
-		);
-
-		if ( count( $generic ) ) {
+	public function unknown_assoc( $assoc_args, $ignore_generic = false ) {
+		if ( ! $ignore_generic && $this->has_generic() ) {
 			return [];
 		}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -1672,12 +1672,18 @@ function glob_brace( $pattern, $dummy_flags = null ) { // phpcs:ignore Generic.C
  * If the "distance" to the closest term is higher than the threshold, an empty
  * string is returned.
  *
- * @param string        $target    Target term to get a suggestion for.
- * @param array<string> $options   Array with possible options.
- * @param int           $threshold Threshold above which to return an empty string.
+ * The built-in alias map below is command vocabulary ('add' => 'create' and
+ * friends) and is applied before, and independently of, the threshold. Callers
+ * matching something other than command names - parameter names, for instance -
+ * should pass false for $use_aliases so that only the distance decides.
+ *
+ * @param string        $target      Target term to get a suggestion for.
+ * @param array<string> $options     Array with possible options.
+ * @param int           $threshold   Threshold above which to return an empty string.
+ * @param bool          $use_aliases Whether to consult the built-in command alias map.
  * @return string
  */
-function get_suggestion( $target, array $options, $threshold = 2 ) {
+function get_suggestion( $target, array $options, $threshold = 2, $use_aliases = true ) {
 
 	$suggestion_map = [
 		'add'        => 'create',
@@ -1702,7 +1708,10 @@ function get_suggestion( $target, array $options, $threshold = 2 ) {
 		'v'          => 'version',
 	];
 
-	if ( array_key_exists( $target, $suggestion_map ) && in_array( $suggestion_map[ $target ], $options, true ) ) {
+	if ( $use_aliases
+		&& array_key_exists( $target, $suggestion_map )
+		&& in_array( $suggestion_map[ $target ], $options, true )
+	) {
 		return $suggestion_map[ $target ];
 	}
 

--- a/tests/SynopsisValidatorTest.php
+++ b/tests/SynopsisValidatorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use WP_CLI\SynopsisValidator;
+use WP_CLI\Tests\TestCase;
+
+class SynopsisValidatorTest extends TestCase {
+
+	public function testHasGenericIsFalseWithoutGenericToken(): void {
+		$validator = new SynopsisValidator( '<id> [--format=<format>] [--porcelain]' );
+
+		$this->assertFalse( $validator->has_generic() );
+	}
+
+	public function testHasGenericIsTrueWithGenericToken(): void {
+		$validator = new SynopsisValidator( '<id> [--format=<format>] --<field>=<value>' );
+
+		$this->assertTrue( $validator->has_generic() );
+	}
+
+	public function testUnknownAssocWithoutGenericToken(): void {
+		$validator = new SynopsisValidator( '<id> [--user_pass=<password>] [--skip-email]' );
+
+		$this->assertSame(
+			[ 'user-pass' ],
+			$validator->unknown_assoc(
+				[
+					'user_pass' => 'a',
+					'user-pass' => 'b',
+				]
+			)
+		);
+	}
+
+	/**
+	 * A generic token means arbitrary keys are legitimate, so nothing is
+	 * reported unless the caller opts in.
+	 */
+	public function testUnknownAssocIsEmptyWithGenericToken(): void {
+		$validator = new SynopsisValidator( '<id> [--user_pass=<password>] --<field>=<value>' );
+
+		$this->assertSame(
+			[],
+			$validator->unknown_assoc( [ 'user-pass' => 'b' ] )
+		);
+	}
+
+	/**
+	 * With $ignore_generic, the caller gets the full set and decides which of
+	 * them are actually errors.
+	 */
+	public function testUnknownAssocReportsWithIgnoreGeneric(): void {
+		$validator = new SynopsisValidator( '<id> [--user_pass=<password>] --<field>=<value>' );
+
+		$this->assertSame(
+			[ 'user-pass', 'acme_crm_id' ],
+			$validator->unknown_assoc(
+				[
+					'user_pass'   => 'a',
+					'user-pass'   => 'b',
+					'acme_crm_id' => 'c',
+				],
+				true
+			)
+		);
+	}
+
+	public function testUnknownAssocIgnoreGenericStillExcludesFlags(): void {
+		$validator = new SynopsisValidator( '<id> [--skip-email] --<field>=<value>' );
+
+		$this->assertSame(
+			[],
+			$validator->unknown_assoc( [ 'skip-email' => true ], true )
+		);
+	}
+}

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -1259,6 +1259,32 @@ class UtilsTest extends TestCase {
 		$this->assertSame( 'true', $process->stdout );
 	}
 
+	public function testGetSuggestionUsesDistance(): void {
+		$options = [ 'user_pass', 'user_email', 'first_name' ];
+
+		$this->assertSame( 'user_pass', Utils\get_suggestion( 'user-pass', $options ) );
+		$this->assertSame( '', Utils\get_suggestion( 'acme_crm_id', $options ) );
+	}
+
+	/**
+	 * The alias map is command vocabulary and is applied regardless of the
+	 * threshold, so callers matching parameter names can opt out of it.
+	 */
+	public function testGetSuggestionAliasMapCanBeDisabled(): void {
+		$options = [ 'locale', 'user_pass', 'role' ];
+
+		// 'language' is 6 edits from 'locale', but the alias map matches it.
+		$this->assertSame( 'locale', Utils\get_suggestion( 'language', $options ) );
+		$this->assertSame( 'locale', Utils\get_suggestion( 'language', $options, 2, true ) );
+		$this->assertSame( '', Utils\get_suggestion( 'language', $options, 2, false ) );
+	}
+
+	public function testGetSuggestionAliasMapDisabledKeepsCloseMatches(): void {
+		$options = [ 'locale', 'user_pass', 'role' ];
+
+		$this->assertSame( 'locale', Utils\get_suggestion( 'locail', $options, 2, false ) );
+	}
+
 	private function buildHasStdinCommand(): string {
 		$php      = Utils\get_php_binary();
 		$root     = WP_CLI_ROOT;


### PR DESCRIPTION
Draft, opened alongside wp-cli/entity-command#636 to make the framework side of #5286 concrete. **Not mergeable as-is** — it introduces one regression, described below, which I think is the most useful thing in this PR.

## The mechanic

`SynopsisValidator::unknown_assoc()` returns early whenever the synopsis contains a `--<field>=<value>` token, so unknown-parameter checking is skipped for the whole command — including the parameters that *are* documented. That is why `wp user update 1 --user-pass=secret` reports success and leaves the password alone, while `wp term update` catches the same mistake.

## What this does

Default-on, no opt-in tag, near-miss only, as settled on the issue. Verified against a real WordPress install with entity-command#636:

```
$ wp user update 1 --user-pass=secret
Error: Parameter errors:
 unknown --user-pass parameter
Did you mean '--user_pass'?

$ wp user update 1 --some_plugin_key=value    → Success
$ wp user update 1 --telegram=@handle         → Success
$ wp user update 1 --language=de_DE           → Success
$ wp post list --cat=1 --format=count         → 1
```

## The regression, and why it matters more than the feature

Running entity-command's full Behat suite against this branch versus stock `3.0.0-alpha`:

| | scenarios | passed | failed |
|---|---|---|---|
| stock | 474 | 448 | 25 |
| this branch | 474 | **447** | **26** |

Diffing the JUnit output, exactly one scenario regresses: **`site.feature` → "Create a subdomain site"**, on this step:

```
$ wp site list --site_id=2 --format=ids
Error: Parameter errors:
 unknown --site_id parameter
Did you mean '--site__in'?
```

`levenshtein( 'site__in', 'site_id' ) === 2`. A real argument, in this project's own test suite, now hard-errors.

**The important part is that my false-positive sweep did not catch this.** The sweep runs each query class's `query_var_defaults` through the checker, and `site_id` is not among `WP_Site_Query`'s defaults — so `site list` measures as 0 flagged even after I added it:

```
user list         30 WP_User_Query vars         0 flagged
site list         37 WP_Site_Query vars         0 flagged   <-- misses the real case
term list         31 WP_Term_Query vars         0 flagged
post list         36 WP_Query vars              1 flagged
      !! --feed (=> --field)
comment list      45 WP_Comment_Query vars      0 flagged
user update       34 core fields + plugin keys  0 flagged
post update       37 core fields + plugin keys  0 flagged
comment update    27 core fields + plugin keys  0 flagged
comment create    27 core fields + plugin keys  0 flagged
post create       37 core fields + plugin keys  0 flagged
------------------------------------------------------------
1/341 legitimate arguments would newly error (0.3%)
```

So treat that 0.3% as a **floor, not an estimate**. Arguments people actually pass to list commands are a superset of any enumerable corpus: query vars registered by plugins, columns not in `query_var_defaults`, and `WP_Query`/`WP_Site_Query` keys handled downstream. There is no list to validate against, which is the whole reason these commands carry a catch-all.

## What I think this says about scope

The risk concentrates entirely on the **read/list** commands, and so does the weak benefit — on those, near-miss only ever catches typos of `--format`, `--fields`, `--field`, since that is all they document. Every genuine win in this PR (`--user-pass`, `--post-title`, `--comment-content`) is on a **write** command, where the field set really is enumerable and where a dropped value silently corrupts data instead of just returning odd rows.

Restricting the check to write commands would remove this regression and keep every case #5286 is actually about. I have not made that change, because you explicitly asked for read commands to be covered — so the evidence is here rather than a decision I took on your behalf. Happy to push it either way.

If read commands stay in scope, the escape hatch stops being a nicety: `wp site list --site_id=2` would need an override permanently.

## Two things that fell out of building it

**The alias map in `get_suggestion()` had to be made optional.** It maps command vocabulary — `'add' => 'create'`, `'language' => 'locale'` — and returns a match *before* any distance calculation, ignoring the threshold:

```
--language    aliases ON => --locale       aliases OFF => (none)
```

Six edits away. Once entity-command documents `--locale` on `user update` (#636 does), `wp user update 1 --language=de_DE` would hard-fail. Added `$use_aliases`, default `true`, off only on this path.

**Global parameters had to leave the candidate set** for catch-all commands, or `wp post list --cat=5` matches `--path` and `--s=hello` matches `--ssh`. That change alone took the measured rate from 12/402 to 1/341.

## The open question

The escape hatch is not in this PR — it deserves a decision rather than a follow-up. One constraint: it should not be a `WP_CLI::confirm()`, since `--yes` is already scattered across CI and would silently disarm the check where a silent typo does the most damage. A dedicated flag plus per-command `wp-cli.yml` config looks right; note the unknown check is passed `$assoc_args` only, while `validate_assoc()` above it gets `array_merge( $config, $extra_args, $assoc_args )`, so a config-declared override would parse fine and then be ignored.

## Tests

Added `tests/SynopsisValidatorTest.php` (6 cases) and three `get_suggestion()` cases in `UtilsTest.php`.

PHPUnit could not be installed here (`wp-cli-tests` resolution hits an unrelated `composer/composer` stability conflict, so `WP_CLI\Tests\TestCase` is unavailable). Every assertion in both files was executed directly against the real implementations (12/12 passing). The Behat numbers above are real runs, on SQLite, against WordPress trunk.

## Depends on

wp-cli/entity-command#636 for the field lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SSZzqMJRDTiLiDxQEPYcL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catch-all commands now accept arbitrary named parameters while continuing to validate documented options.
  * Near-typo parameters produce warnings and still reach the command instead of being rejected.
  * Improved unknown-parameter suggestions, including relevant handling for generic and standard commands.
  * Command alias suggestions are applied selectively where appropriate.

* **Bug Fixes**
  * Prevented global options and aliases from appearing as misleading suggestions for catch-all commands.

* **Tests**
  * Added coverage for generic parameters, validation behavior, suggestions, aliases, and close-match handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->