### PR TITLE
Correct the value type of parse_shell_arrays()'s $assoc_args

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -1977,9 +1977,14 @@ function is_json( $argument, $ignore_scalars = true ) {
 /**
  * Parse known shell arrays included in the $assoc_args array.
  *
- * @param array<string, string> $assoc_args      Associative array of arguments.
- * @param array<string>         $array_arguments Array of argument keys that should receive an
- *                                               array through the shell.
+ * Values are not necessarily strings: a flag arrives as boolean true, and a
+ * key that was already parsed arrives as an array. Only the keys named in
+ * $array_arguments are considered, and only when they hold a JSON string -
+ * is_json() rejects everything else - so other values are returned untouched.
+ *
+ * @param array<string, mixed> $assoc_args      Associative array of arguments.
+ * @param array<string>        $array_arguments Array of argument keys that should receive an
+ *                                              array through the shell.
  * @return array<string, mixed>
  */
 function parse_shell_arrays( $assoc_args, $array_arguments ) {

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -919,7 +919,7 @@ class UtilsTest extends TestCase {
 
 	/**
 	 * @dataProvider dataParseShellArray
-	 * @param array<string, string> $assoc_args
+	 * @param array<string, mixed> $assoc_args
 	 * @param array<int, string> $array_arguments
 	 * @param array<string, mixed> $expected
 	 */
@@ -933,6 +933,21 @@ class UtilsTest extends TestCase {
 			[ [ 'alpha' => '{"key":"value"}' ], [], [ 'alpha' => '{"key":"value"}' ] ],
 			[ [ 'alpha' => '{"key":"value"}' ], [ 'alpha' ], [ 'alpha' => [ 'key' => 'value' ] ] ],
 			[ [ 'alpha' => '{"key":"value"}' ], [ 'beta' ], [ 'alpha' => '{"key":"value"}' ] ],
+			// Values are not necessarily strings, and anything is_json() rejects is left alone.
+			[ [ 'alpha' => true ], [ 'alpha' ], [ 'alpha' => true ] ],
+			[ [ 'alpha' => [ 'key' => 'value' ] ], [ 'alpha' ], [ 'alpha' => [ 'key' => 'value' ] ] ],
+			[ [ 'alpha' => 'not json' ], [ 'alpha' ], [ 'alpha' => 'not json' ] ],
+			[
+				[
+					'alpha' => '{"key":"value"}',
+					'beta'  => true,
+				],
+				[ 'alpha', 'beta' ],
+				[
+					'alpha' => [ 'key' => 'value' ],
+					'beta'  => true,
+				],
+			],
 		];
 	}
 


### PR DESCRIPTION
`Utils\parse_shell_arrays()` is annotated `@param array<string, string> $assoc_args`, but associative arguments are not all strings — a flag arrives as boolean `true`, and a key that has already been parsed arrives as an array.

The function has never required strings. It looks only at the keys named in `$array_arguments`, and acts only when `is_json()` returns true — which begins by rejecting anything that is not a string. Every other value is returned exactly as it came in.

## Why it is worth fixing rather than working around

The narrow annotation is contagious, and it penalises the callers doing the right thing.

A command that documents its arguments accurately as `array<string, mixed>` cannot call this function without PHPStan reporting `argument.type` at level 9. A command whose `$assoc_args` parameter carries no type at all passes silently, because implicit `mixed` is not checked at that level and `missingType.parameter` is generally ignored.

That is exactly what happens in `entity-command` today: `Post_Command` and `User_Command` call it without complaint from untyped parameters, while `Comment_Command` — the one file that annotates its arguments correctly — fails. The available fixes there are to weaken an accurate annotation or to wrap the call, and neither is a good trade for a docblock that is simply wrong.

## Safety

Widening a parameter type cannot break existing callers: everything that satisfied `array<string, string>` still satisfies `array<string, mixed>`. The return type is already `array<string, mixed>`.

The one thing worth checking was whether the `@phpstan-ignore cast.useless` inside the function would become an unmatched ignore once the value type is no longer known to be a string. It does not — `is_json()` carries `@phpstan-assert-if-true =non-empty-string`, so the value is still narrowed to a string inside the branch where the cast happens.

## Testing

Four cases added to the existing `dataParseShellArray` provider, covering what the annotation had been hiding: a boolean flag, an already-decoded array, a non-JSON string, and a mixed set where one key decodes and another passes through.

```
$ phpunit --filter testParseShellArray tests/UtilsTest.php
OK (7 tests, 7 assertions)
```

PHPStan over the full analysed paths is unchanged at 1552 errors before and after in my environment (that absolute number is inflated — this environment cannot install the PHPStan extensions CI uses — but the before/after comparison is like-for-like, and the only differences are messages that embed line numbers, shifted by the five lines added to the docblock). PHPCS is clean on both changed files.

I also verified the effect downstream: with this branch in place, `Comment_Command`'s plain `Utils\parse_shell_arrays( $assoc_args, [ 'comment_meta' ] )` call reports no PHPStan errors, so wp-cli/entity-command#636 can drop its local workaround once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SSZzqMJRDTiLiDxQEPYcL

---
_Generated by [Claude Code](https://claude.ai/code/session_014SSZzqMJRDTiLiDxQEPYcL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how mixed-value associative arguments are handled when parsing shell arrays.

* **Bug Fixes**
  * Ensured only configured values containing valid JSON strings are converted to arrays.
  * Preserved booleans, existing arrays, invalid JSON, and other non-string values unchanged.

* **Tests**
  * Added coverage for mixed-value inputs and combinations of valid and non-JSON values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->