### PR TITLE
Use spl_object_id() instead of spl_object_hash() for hook IDs

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -441,7 +441,7 @@ class WP_CLI {
 	 * @param int      $priority
 	 * @return string|false
 	 */
-	private static function wp_hook_build_unique_id( $tag, $function, $priority ) {
+	private static function wp_hook_build_unique_id( $tag, $function, $priority ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $priority retained to match core's _wp_filter_build_unique_id() signature.
 		if ( is_string( $function ) ) {
 			return $function;
 		}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -442,41 +442,24 @@ class WP_CLI {
 	 * @return string|false
 	 */
 	private static function wp_hook_build_unique_id( $tag, $function, $priority ) {
-		global $wp_filter;
-		static $filter_id_count = 0;
-
 		if ( is_string( $function ) ) {
 			return $function;
 		}
 
 		if ( is_object( $function ) ) {
 			// Closures are currently implemented as objects.
-			$function = [ $function, '' ];
-		} else {
-			$function = (array) $function;
+			return (string) spl_object_id( $function );
+		}
+
+		$function = (array) $function;
+
+		if ( ! isset( $function[1] ) || ! is_string( $function[1] ) ) {
+			return false;
 		}
 
 		if ( is_object( $function[0] ) ) {
 			// Object Class Calling.
-			if ( function_exists( 'spl_object_hash' ) ) {
-				return spl_object_hash( $function[0] ) . $function[1];
-			}
-
-			$obj_idx = get_class( $function[0] ) . $function[1];
-			if ( ! isset( $function[0]->wp_filter_id ) ) {
-				if ( false === $priority ) {
-					return false;
-				}
-				$obj_idx .= isset( $wp_filter[ $tag ][ $priority ] ) ? count( (array) $wp_filter[ $tag ][ $priority ] ) : $filter_id_count;
-
-				// @phpstan-ignore property.notFound
-				$function[0]->wp_filter_id = $filter_id_count;
-				++$filter_id_count;
-			} else {
-				$obj_idx .= $function[0]->wp_filter_id;
-			}
-
-			return $obj_idx;
+			return ( (string) spl_object_id( $function[0] ) ) . $function[1];
 		}
 
 		if ( is_string( $function[0] ) ) {


### PR DESCRIPTION
PHP 8.6 deprecates `spl_object_hash()` in favour of `spl_object_id()`, which would emit a deprecation notice whenever `WP_CLI::add_wp_hook()` registers an object or closure callback before WordPress is loaded.

`WP_CLI::wp_hook_build_unique_id()` now mirrors the current `_wp_filter_build_unique_id()` implementation in core: build the ID from `spl_object_id()`, and add core's `isset( $function[1] ) || ! is_string( $function[1] )` guard.

The `wp_filter_id` / `$filter_id_count` fallback is gone entirely. It only existed for PHP versions predating SPL, and `spl_object_id()` has been available since PHP 7.2, which is this package's floor — so the `function_exists()` check is dead too. That also removes the `global $wp_filter` and the `@phpstan-ignore property.notFound` annotation.

This is the same change as wp-cli/server-command#105, which has been merged.

### Why the ID format can change safely

The IDs this builds only key `$wp_filter` during the window before WordPress loads. `WP_Hook::build_preinitialized_hooks()` discards those keys and re-registers each callback through `$hook->add_filter()`, recomputing IDs with core's own implementation. So the format here never has to match any particular WordPress version, and `remove_filter()` on a pre-load hook is unaffected.

### On the retained `$priority` parameter

Dropping the fallback left `$priority` unused, which trips `Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed`. It's kept so the signature still matches core's `_wp_filter_build_unique_id()`, annotated the way the rest of the codebase handles this (`php/utils.php`, `php/fallback-functions.php`, `CompositeCommand.php`). Happy to just drop `$tag` and `$priority` instead if you'd prefer — the method is `private` with a single call site, so there's no BC surface.

### Testing

Verified that the new implementation returns identical IDs to the server-command copy across string, static, array-static, object-method, closure, and invokable-object callables, and that IDs are stable per object and distinct across instances of the same class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jAUxp4R7zvrd6hpgp6eW6

---
_Generated by [Claude Code](https://claude.ai/code/session_017jAUxp4R7zvrd6hpgp6eW6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of callback identifiers for closures and object-based callbacks.
  * Added validation for malformed callbacks to prevent errors and return a safe failure result.
  * Improved consistency when registering callbacks, including callbacks that use objects or arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->