### PR TITLE
Make Formatter self-register built-in formats on demand

### DIFF
--- a/php/WP_CLI/Bootstrap/InitializeFormatter.php
+++ b/php/WP_CLI/Bootstrap/InitializeFormatter.php
@@ -7,6 +7,9 @@ namespace WP_CLI\Bootstrap;
  *
  * Registers the built-in format handlers for the Formatter class.
  *
+ * The Formatter also registers them on demand, so this step only makes sure they
+ * are in place early on. Formatter::register_builtin_formats() is idempotent.
+ *
  * @package WP_CLI\Bootstrap
  */
 final class InitializeFormatter implements BootstrapStep {

--- a/php/WP_CLI/Formatter.php
+++ b/php/WP_CLI/Formatter.php
@@ -53,6 +53,13 @@ class Formatter {
 	private static $single_value_formatters = [];
 
 	/**
+	 * Whether the built-in format handlers have been registered yet.
+	 *
+	 * @var bool
+	 */
+	private static $builtin_formats_registered = false;
+
+	/**
 	 * How the items should be output.
 	 *
 	 * @var array{format: string, fields: string[], field: string|null, alignments: array<string, int>}
@@ -106,6 +113,8 @@ class Formatter {
 		/** @var array{format: string, fields: array<string>, field: string|null, alignments: array<string, int>} $format_args */
 		$this->args   = $format_args;
 		$this->prefix = $prefix;
+
+		self::register_builtin_formats();
 	}
 
 	/**
@@ -142,6 +151,11 @@ class Formatter {
 		if ( ! is_callable( $handler ) ) {
 			WP_CLI::error( 'Format handler must be callable.' );
 		}
+
+		// Make sure the built-ins are in place first, so that registering a
+		// handler for an existing format name always overrides the built-in one.
+		self::register_builtin_formats();
+
 		self::$custom_formatters[ $format_name ] = $handler;
 		self::$format_options[ $format_name ]    = $options;
 	}
@@ -174,6 +188,11 @@ class Formatter {
 		if ( ! is_callable( $handler ) ) {
 			WP_CLI::error( 'Single-value format handler must be callable.' );
 		}
+
+		// Make sure the built-ins are in place first, so that registering a
+		// handler for an existing format name always overrides the built-in one.
+		self::register_builtin_formats();
+
 		self::$single_value_formatters[ $format_name ] = $handler;
 	}
 
@@ -187,6 +206,8 @@ class Formatter {
 	 * @return string The formatted value (without trailing newline).
 	 */
 	public static function format_single_value( $value, $format ) {
+		self::register_builtin_formats();
+
 		if ( isset( self::$single_value_formatters[ $format ] ) ) {
 			return call_user_func( self::$single_value_formatters[ $format ], $value );
 		}
@@ -206,9 +227,25 @@ class Formatter {
 	 * This method registers the default format handlers (table, json, csv, yaml, count, ids)
 	 * using the add_format() API, allowing them to be overridden like custom formats.
 	 *
+	 * It is called during bootstrap, but is also self-triggered from every entry
+	 * point into the registry, so that the Formatter keeps working when it is used
+	 * without the WP-CLI bootstrap having run for this particular copy of the class
+	 * (as a Composer library, in unit tests, or when a second copy of WP-CLI on the
+	 * autoloader stack wins the class lookup).
+	 *
+	 * Repeat calls are a no-op, so registering built-ins never clobbers a handler
+	 * that an extension registered for the same format name.
+	 *
 	 * @return void
 	 */
 	public static function register_builtin_formats() {
+		if ( self::$builtin_formats_registered ) {
+			return;
+		}
+
+		// Set before registering, as add_format() calls back into this method.
+		self::$builtin_formats_registered = true;
+
 		// Register 'table' format
 		self::add_format(
 			'table',
@@ -354,6 +391,8 @@ class Formatter {
 	 * @return string[] Array of format names.
 	 */
 	public static function get_available_formats() {
+		self::register_builtin_formats();
+
 		$all_formats = array_keys( self::$custom_formatters );
 
 		/**

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -5,9 +5,28 @@ use WP_CLI\Tests\TestCase;
 
 class FormatterTest extends TestCase {
 
-	public static function set_up_before_class(): void {
-		// Ensure built-in formats are registered for tests
-		Formatter::register_builtin_formats();
+	/**
+	 * Wipe the format registry, as if this copy of the class had just been autoloaded
+	 * and the `InitializeFormatter` bootstrap step had never run for it.
+	 *
+	 * @return void
+	 */
+	private function reset_format_registry(): void {
+		foreach (
+			[
+				'custom_formatters'          => [],
+				'format_options'             => [],
+				'single_value_formatters'    => [],
+				'builtin_formats_registered' => false,
+			] as $property => $value
+		) {
+			$reflection = new \ReflectionProperty( Formatter::class, $property );
+			if ( PHP_VERSION_ID < 80100 ) {
+				// @phpstan-ignore method.deprecated
+				$reflection->setAccessible( true );
+			}
+			$reflection->setValue( null, $value );
+		}
 	}
 
 	public function test_add_format(): void {
@@ -461,5 +480,69 @@ class FormatterTest extends TestCase {
 		$output = ob_get_clean();
 
 		$this->assertSame( "---\n- 1\n- 2\n- 3", trim( (string) $output ) );
+	}
+
+	/**
+	 * Built-in formats have to work without `InitializeFormatter` having run, because
+	 * the class can be loaded from a Composer install whose bootstrap never executes.
+	 *
+	 * @see https://github.com/wp-cli/wp-cli/issues/4632
+	 */
+	public function test_builtin_formats_self_register_without_bootstrap(): void {
+		$this->reset_format_registry();
+
+		$items      = [ [ 'name' => 'Alice' ] ];
+		$assoc_args = [ 'format' => 'table' ];
+		$formatter  = new Formatter( $assoc_args, [ 'name' ] );
+
+		ob_start();
+		$formatter->display_items( $items );
+		$output = (string) ob_get_clean();
+
+		$this->assertStringContainsString( 'Alice', $output, 'Built-in table format should work without an explicit register_builtin_formats() call' );
+	}
+
+	/**
+	 * Without self-registration, `print_value()` silently fell through to var_export()
+	 * for `--format=json`, producing wrong output rather than an error.
+	 */
+	public function test_single_value_formats_self_register_without_bootstrap(): void {
+		$this->reset_format_registry();
+
+		$this->assertSame( '{"key":"value"}', Formatter::format_single_value( [ 'key' => 'value' ], 'json' ) );
+	}
+
+	public function test_get_available_formats_self_registers_without_bootstrap(): void {
+		$this->reset_format_registry();
+
+		$this->assertSame( [ 'table', 'json', 'csv', 'yaml', 'count', 'ids' ], Formatter::get_available_formats() );
+	}
+
+	/**
+	 * The built-in registration is idempotent, so a late `register_builtin_formats()`
+	 * call (e.g. from the bootstrap step) cannot clobber an extension's override.
+	 */
+	public function test_register_builtin_formats_does_not_clobber_overrides(): void {
+		$this->reset_format_registry();
+
+		Formatter::add_format(
+			'json',
+			static function () {
+				echo 'OVERRIDDEN';
+			}
+		);
+
+		Formatter::register_builtin_formats();
+
+		$assoc_args = [ 'format' => 'json' ];
+		$formatter  = new Formatter( $assoc_args, [ 'name' ] );
+
+		ob_start();
+		$formatter->display_items( [ [ 'name' => 'Alice' ] ] );
+		$output = ob_get_clean();
+
+		$this->assertSame( 'OVERRIDDEN', $output );
+
+		$this->reset_format_registry();
 	}
 }

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -5,6 +5,15 @@ use WP_CLI\Tests\TestCase;
 
 class FormatterTest extends TestCase {
 
+	public function tear_down(): void {
+		// Several tests register handlers that override the built-in formats. Wipe the
+		// registry so that they cannot leak into the next test; the built-ins are
+		// registered again on demand.
+		$this->reset_format_registry();
+
+		parent::tear_down();
+	}
+
 	/**
 	 * Wipe the format registry, as if this copy of the class had just been autoloaded
 	 * and the `InitializeFormatter` bootstrap step had never run for it.
@@ -338,8 +347,6 @@ class FormatterTest extends TestCase {
 	}
 
 	public function test_display_item_object_with_protected_properties(): void {
-		Formatter::register_builtin_formats();
-
 		$dummy = new class() {
 			/** @var string */
 			public $public_prop = 'public_val';
@@ -366,8 +373,6 @@ class FormatterTest extends TestCase {
 	}
 
 	public function test_display_item_object_inaccessible_protected_property_issues_warning(): void {
-		Formatter::register_builtin_formats();
-
 		$prev_logger = WP_CLI::get_logger();
 		$logger      = new WP_CLI\Loggers\Execution();
 		WP_CLI::set_logger( $logger );
@@ -396,8 +401,6 @@ class FormatterTest extends TestCase {
 	}
 
 	public function test_display_item_object_with_magic_getter(): void {
-		Formatter::register_builtin_formats();
-
 		$dummy = new class() {
 			/** @var string */
 			protected $protected_prop = 'protected_val';
@@ -433,8 +436,6 @@ class FormatterTest extends TestCase {
 	}
 
 	public function test_display_items_with_traversable(): void {
-		Formatter::register_builtin_formats();
-
 		$items = new \ArrayObject(
 			[
 				[
@@ -459,8 +460,6 @@ class FormatterTest extends TestCase {
 	}
 
 	public function test_display_items_scalar_items_in_json_and_yaml(): void {
-		Formatter::register_builtin_formats();
-
 		$items = [ 1, 2, 3 ];
 
 		$assoc_args = [ 'format' => 'json' ];
@@ -532,8 +531,6 @@ class FormatterTest extends TestCase {
 			}
 		);
 
-		Formatter::register_builtin_formats();
-
 		$assoc_args = [ 'format' => 'json' ];
 		$formatter  = new Formatter( $assoc_args, [ 'name' ] );
 
@@ -542,7 +539,5 @@ class FormatterTest extends TestCase {
 		$output = ob_get_clean();
 
 		$this->assertSame( 'OVERRIDDEN', $output );
-
-		$this->reset_format_registry();
 	}
 }

--- a/tests/WPCLITest.php
+++ b/tests/WPCLITest.php
@@ -1,15 +1,9 @@
 <?php
 
-use WP_CLI\Formatter;
 use WP_CLI\Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class WPCLITest extends TestCase {
-
-	public static function set_up_before_class(): void {
-		// Ensure built-in formats are registered for print_value tests
-		Formatter::register_builtin_formats();
-	}
 
 	public function test_get_php_binary(): void {
 		$this->assertSame( WP_CLI\Utils\get_php_binary(), WP_CLI::get_php_binary() );


### PR DESCRIPTION
## Summary
This change makes the `Formatter` class self-register its built-in format handlers on demand, rather than relying solely on the `InitializeFormatter` bootstrap step. This ensures the Formatter works correctly when used as a standalone Composer library, in unit tests, or when multiple copies of WP-CLI are loaded.

## Key Changes
- Added `$builtin_formats_registered` static property to track registration state
- Modified `register_builtin_formats()` to be idempotent (safe to call multiple times)
- Added automatic `register_builtin_formats()` calls to all public entry points:
  - `Formatter::__construct()` - ensures formats are available when creating instances
  - `Formatter::add_format()` - ensures built-ins are registered before custom overrides
  - `Formatter::add_single_value_format()` - ensures built-ins are registered before custom overrides
  - `Formatter::format_single_value()` - ensures formats are available when formatting values
  - `Formatter::get_available_formats()` - ensures formats are available when listing them
- Updated test infrastructure to remove explicit `register_builtin_formats()` calls from test setup
- Added comprehensive test coverage for self-registration behavior:
  - `test_builtin_formats_self_register_without_bootstrap()` - verifies table format works without bootstrap
  - `test_single_value_formats_self_register_without_bootstrap()` - verifies JSON formatting works without bootstrap
  - `test_get_available_formats_self_registers_without_bootstrap()` - verifies format listing works without bootstrap
  - `test_register_builtin_formats_does_not_clobber_overrides()` - verifies idempotency prevents clobbering custom handlers
- Added helper method `reset_format_registry()` in tests to simulate fresh class loading

## Implementation Details
- The idempotent guard (`if ( self::$builtin_formats_registered ) return;`) prevents redundant registration
- The flag is set before registering formats to prevent infinite recursion since `add_format()` calls back into `register_builtin_formats()`
- Custom format overrides are preserved because built-in registration only happens once and is skipped on subsequent calls
- The bootstrap step remains in place for early initialization but is no longer required for functionality

https://claude.ai/code/session_019pchNHzW3g3egMb1qDMAhb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Built-in output formats now register automatically when needed, without requiring prior initialization.
  - Single-value formatting and available-format discovery now work reliably after a reset.
  - Repeated registration is safely ignored.
  - Custom formatter overrides are preserved when built-in formats are registered later.

- **Documentation**
  - Clarified formatter registration timing and idempotent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->