### PR TITLE
Detect restrictive OS-level ulimit -v and warn in `wp cli info`

### DIFF
--- a/features/cli-info.feature
+++ b/features/cli-info.feature
@@ -43,6 +43,21 @@ Feature: Review CLI information
       "php_memory_limit":
       """
 
+  Scenario: Display OS virtual memory limit
+    Given an empty directory
+
+    When I run `wp cli info`
+    Then STDOUT should contain:
+      """
+      OS virtual memory limit (ulimit -v):
+      """
+
+    When I run `wp cli info --format=json`
+    Then STDOUT should contain:
+      """
+      "os_virtual_memory_limit":
+      """
+
   Scenario: Warn about low memory limit
     Given an empty directory
 

--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -160,7 +160,11 @@ class CLI_Command extends WP_CLI_Command {
 			$packages_dir = null;
 		}
 
-		$memory_limit = ini_get( 'memory_limit' );
+		$memory_limit              = ini_get( 'memory_limit' );
+		$os_virtual_memory         = $this->get_virtual_memory_ulimit();
+		$os_virtual_memory_display = is_int( $os_virtual_memory )
+			? $this->format_kilobytes( $os_virtual_memory )
+			: $os_virtual_memory;
 
 		if ( Utils\get_flag_value( $assoc_args, 'format' ) === 'json' ) {
 			$info = [
@@ -169,6 +173,7 @@ class CLI_Command extends WP_CLI_Command {
 				'php_binary_path'          => $php_bin,
 				'php_version'              => PHP_VERSION,
 				'php_memory_limit'         => $memory_limit,
+				'os_virtual_memory_limit'  => $os_virtual_memory_display,
 				'php_ini_used'             => get_cfg_var( 'cfg_file_path' ),
 				'mysql_binary_path'        => Utils\get_mysql_binary_path(),
 				'mysql_version'            => Utils\get_mysql_version(),
@@ -194,6 +199,7 @@ class CLI_Command extends WP_CLI_Command {
 			WP_CLI::line( "PHP binary:\t" . $php_bin );
 			WP_CLI::line( "PHP version:\t" . PHP_VERSION );
 			WP_CLI::line( "PHP memory limit:\t" . $memory_limit );
+			WP_CLI::line( "OS virtual memory limit (ulimit -v):\t" . $os_virtual_memory_display );
 			WP_CLI::line( "php.ini used:\t" . $cfg_file_path );
 			WP_CLI::line( "MySQL binary:\t" . Utils\get_mysql_binary_path() );
 			WP_CLI::line( "MySQL version:\t" . Utils\get_mysql_version() );
@@ -209,27 +215,28 @@ class CLI_Command extends WP_CLI_Command {
 		}
 
 		// Emit a warning if the memory limit is set to a low value.
-		$this->check_memory_limit( $memory_limit );
+		$this->check_memory_limit( $memory_limit, $os_virtual_memory );
 	}
 
 	/**
 	 * Checks if the PHP memory limit is too low and emits a warning if needed.
 	 *
-	 * @param string $memory_limit The current memory limit value from ini_get().
+	 * Also checks for a restrictive OS-level virtual memory limit (`ulimit -v`),
+	 * which is a separate constraint from PHP's `memory_limit` and a common
+	 * cause of "mmap() failed: Cannot allocate memory" errors on shared hosting
+	 * even when `memory_limit` itself looks sufficient.
+	 *
+	 * @param string     $memory_limit         The current memory limit value from ini_get().
+	 * @param int|string $os_virtual_memory_kb The `ulimit -v` value in kilobytes, or 'unlimited'/'n/a'.
 	 * @return void
 	 */
-	private function check_memory_limit( $memory_limit ) {
-		// If memory limit is -1 (unlimited), no warning needed.
-		if ( '-1' === $memory_limit ) {
-			return;
-		}
-
-		// Convert memory limit string (e.g., "256M", "1G") to bytes.
-		$limit_bytes = $this->convert_to_bytes( $memory_limit );
+	private function check_memory_limit( $memory_limit, $os_virtual_memory_kb = 'n/a' ) {
+		// Convert memory limit string (e.g., "256M", "1G") to bytes. Returns -1 if unlimited.
+		$php_limit_bytes = ( '-1' === $memory_limit ) ? -1 : $this->convert_to_bytes( $memory_limit );
 
 		// Warn if limit is below 512M.
 		// This is a reasonable threshold for CLI operations.
-		if ( $limit_bytes > 0 && $limit_bytes < self::MEMORY_LIMIT_WARNING_THRESHOLD ) {
+		if ( $php_limit_bytes > 0 && $php_limit_bytes < self::MEMORY_LIMIT_WARNING_THRESHOLD ) {
 			WP_CLI::warning(
 				sprintf(
 					'PHP memory limit is set to %s. This may be too low for some WP-CLI operations. Consider increasing it to at least 512M or setting it to -1 (unlimited) for CLI usage.',
@@ -237,6 +244,87 @@ class CLI_Command extends WP_CLI_Command {
 				)
 			);
 		}
+
+		if ( ! is_int( $os_virtual_memory_kb ) ) {
+			return;
+		}
+
+		// When PHP's own memory_limit is unlimited, fall back to the same
+		// threshold used above as a reasonable reference point.
+		$reference_bytes = ( -1 === $php_limit_bytes ) ? self::MEMORY_LIMIT_WARNING_THRESHOLD : $php_limit_bytes;
+		$os_limit_bytes  = $os_virtual_memory_kb * 1024;
+
+		if ( $reference_bytes > 0 && $os_limit_bytes < $reference_bytes ) {
+			$php_limit_description = ( -1 === $php_limit_bytes )
+				? 'unlimited'
+				: $memory_limit;
+
+			WP_CLI::warning(
+				sprintf(
+					"This shell's OS-level virtual memory limit (`ulimit -v`) is set to %s, which is lower than PHP's memory limit (%s). This is a common cause of \"mmap() failed: Cannot allocate memory\" errors even though memory_limit itself looks sufficient. Increasing memory_limit will not help; ask your hosting provider to raise the OS-level limit instead.",
+					$this->format_kilobytes( $os_virtual_memory_kb ),
+					$php_limit_description
+				)
+			);
+		}
+	}
+
+	/**
+	 * Gets the OS-level virtual memory limit (`ulimit -v`) currently in effect for this process, in kilobytes.
+	 *
+	 * `ulimit -v` maps to the POSIX `RLIMIT_AS` resource limit, which caps the
+	 * total virtual address space a process may map. It is inherited by child
+	 * processes, so shelling out to a fresh `sh` reports the limit already in
+	 * effect for the running PHP process. This is distinct from PHP's own
+	 * `memory_limit` setting, and some hosting environments (e.g. restrictive
+	 * SSH jails) constrain it independently, and often more tightly.
+	 *
+	 * @return int|string The limit in kilobytes, 'unlimited', or 'n/a' if it could not be determined.
+	 */
+	private function get_virtual_memory_ulimit() {
+		if ( Utils\is_windows() || ! function_exists( 'shell_exec' ) ) {
+			return 'n/a';
+		}
+
+		$output = @shell_exec( 'ulimit -v 2>/dev/null' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+
+		if ( ! is_string( $output ) || '' === trim( $output ) ) {
+			return 'n/a';
+		}
+
+		$output = trim( $output );
+
+		if ( ! is_numeric( $output ) ) {
+			return 'unlimited';
+		}
+
+		return (int) $output;
+	}
+
+	/**
+	 * Formats a kilobyte value as a human-readable string (e.g. "512M").
+	 *
+	 * @param int $kilobytes The value in kilobytes.
+	 * @return string
+	 */
+	private function format_kilobytes( $kilobytes ) {
+		$units      = [ 'K', 'M', 'G', 'T' ];
+		$last_index = count( $units ) - 1;
+		$value      = (float) $kilobytes;
+		$index      = 0;
+
+		while ( $value >= 1024 && $index < $last_index ) {
+			$value /= 1024;
+			++$index;
+		}
+
+		$value = floor( $value * 100 ) / 100;
+
+		if ( floor( $value ) === $value ) {
+			$value = (int) $value;
+		}
+
+		return $value . $units[ $index ];
 	}
 
 	/**

--- a/tests/CLICommandTest.php
+++ b/tests/CLICommandTest.php
@@ -60,6 +60,40 @@ class CLICommandTest extends TestCase {
 	}
 
 	/**
+	 * @param string     $memory_limit
+	 * @param int|string $os_virtual_memory_kb
+	 * @return void
+	 */
+	private function call_check_memory_limit( $memory_limit, $os_virtual_memory_kb = 'n/a' ) {
+		$cli_command = new CLI_Command();
+		$method      = new \ReflectionMethod( $cli_command, 'check_memory_limit' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			// @phpstan-ignore method.deprecated
+			$method->setAccessible( true );
+		}
+		$method->invoke( $cli_command, $memory_limit, $os_virtual_memory_kb );
+	}
+
+	/**
+	 * @param int $kilobytes
+	 * @return string
+	 */
+	private function call_format_kilobytes( $kilobytes ) {
+		$cli_command = new CLI_Command();
+		$method      = new \ReflectionMethod( $cli_command, 'format_kilobytes' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			// @phpstan-ignore method.deprecated
+			$method->setAccessible( true );
+		}
+		/**
+		 * @var string $result
+		 */
+		$result = $method->invoke( $cli_command, $kilobytes );
+
+		return $result;
+	}
+
+	/**
 	 * @param string $temp
 	 * @param string $current_phar
 	 * @return void
@@ -308,5 +342,68 @@ class CLICommandTest extends TestCase {
 
 			@unlink( $current_phar );
 		}
+	}
+
+	public function testFormatKilobytesFormatsWholeUnitsWithoutDecimals(): void {
+		$this->assertSame( '512K', $this->call_format_kilobytes( 512 ) );
+		$this->assertSame( '1M', $this->call_format_kilobytes( 1024 ) );
+		$this->assertSame( '768M', $this->call_format_kilobytes( 786432 ) );
+		$this->assertSame( '2G', $this->call_format_kilobytes( 2097152 ) );
+	}
+
+	public function testFormatKilobytesFormatsFractionalUnits(): void {
+		$this->assertSame( '1.5M', $this->call_format_kilobytes( 1536 ) );
+	}
+
+	public function testCheckMemoryLimitWarnsOnLowPhpMemoryLimitOnly(): void {
+		$this->call_check_memory_limit( '256M', 'n/a' );
+
+		$this->assertStringContainsString( 'PHP memory limit is set to 256M', $this->logger->stderr );
+		$this->assertStringNotContainsString( 'ulimit', $this->logger->stderr );
+	}
+
+	public function testCheckMemoryLimitDoesNotWarnWhenPhpMemoryLimitIsSufficient(): void {
+		$this->call_check_memory_limit( '1G', 'n/a' );
+
+		$this->assertSame( '', $this->logger->stderr );
+	}
+
+	public function testCheckMemoryLimitDoesNotWarnWhenOsUlimitIsUnknownOrUnlimited(): void {
+		$this->call_check_memory_limit( '748M', 'n/a' );
+		$this->assertSame( '', $this->logger->stderr );
+
+		$this->call_check_memory_limit( '748M', 'unlimited' );
+		$this->assertSame( '', $this->logger->stderr );
+	}
+
+	/**
+	 * Reproduces the scenario from https://github.com/wp-cli/wp-cli/issues/6326:
+	 * a generous PHP memory_limit, but a tighter OS-level `ulimit -v` that
+	 * causes "mmap() failed: Cannot allocate memory" regardless of memory_limit.
+	 */
+	public function testCheckMemoryLimitWarnsWhenOsUlimitIsMoreRestrictiveThanMemoryLimit(): void {
+		$this->call_check_memory_limit( '748M', 262144 ); // 262144 KB == 256M.
+
+		$this->assertStringContainsString( 'OS-level virtual memory limit (`ulimit -v`) is set to 256M', $this->logger->stderr );
+		$this->assertStringContainsString( "lower than PHP's memory limit (748M)", $this->logger->stderr );
+		$this->assertStringNotContainsString( 'PHP memory limit is set to 748M', $this->logger->stderr );
+	}
+
+	public function testCheckMemoryLimitDoesNotWarnWhenOsUlimitIsHigherThanMemoryLimit(): void {
+		$this->call_check_memory_limit( '512M', 1048576 ); // 1048576 KB == 1G.
+
+		$this->assertSame( '', $this->logger->stderr );
+	}
+
+	public function testCheckMemoryLimitWarnsWhenUnlimitedPhpMemoryLimitStillHitsRestrictiveOsUlimit(): void {
+		$this->call_check_memory_limit( '-1', 262144 ); // 262144 KB == 256M.
+
+		$this->assertStringContainsString( "lower than PHP's memory limit (unlimited)", $this->logger->stderr );
+	}
+
+	public function testCheckMemoryLimitDoesNotWarnWhenPhpMemoryLimitIsUnlimitedAndOsUlimitIsUnlimited(): void {
+		$this->call_check_memory_limit( '-1', 'unlimited' );
+
+		$this->assertSame( '', $this->logger->stderr );
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #6326.

Reports on that issue trace back to `mmap() failed: [12] Cannot allocate memory` errors happening on shared/cPanel hosting even though PHP's `memory_limit` is generous (e.g. 748M) and the site itself runs fine. As one commenter on the issue put it: "I think it is ulimit limiting it. No graceful fallback if ulimit memory limit kills the process?"

That diagnosis is correct. On these hosts, the shell/SSH jail enforces an OS-level `ulimit -v` (`RLIMIT_AS`, total virtual address space) that is independent of and often much lower than PHP's `memory_limit`. When PHP's Zend memory manager tries to `mmap()` a new memory chunk, the OS refuses well before `memory_limit` is ever reached, and the process aborts with the cryptic `mmap() failed` message. Raising `memory_limit` does nothing in this situation, which is exactly the dead end users hit in the issue thread.

This PR does not attempt to work around the OS constraint itself (that's not something a userland PHP process can safely do), but it makes the real cause visible instead of leaving users guessing:

- `wp cli info` (and its `--format=json` output) now also reports the shell's `ulimit -v` value, alongside the existing `memory_limit` line.
- The existing low-memory-limit check in `wp cli info` is extended to also warn when the detected `ulimit -v` is more restrictive than PHP's `memory_limit`, explicitly calling out that increasing `memory_limit` won't help and that the OS-level limit needs to be raised instead.
- Detection is a plain `ulimit -v` shell query (rlimits are inherited by child processes, so it reflects the limit already in effect for the running PHP process); it degrades to `n/a`/no-op on Windows or if `shell_exec` is unavailable, so there's no behavior change for environments without this constraint.

### Reproducing the original issue

Using Docker to simulate the reporter's environment (`memory_limit=748M`, restrictive `ulimit -v`):

```
$ docker run --rm php:8.2-cli sh -c "ulimit -v 65536; php -d memory_limit=748M -r '\$a = str_repeat(\"x\", 200*1024*1024);'"
Fatal error: Out of memory (allocated 2097152 bytes) (tried to allocate 209715232 bytes) in Command line code on line 1
mmap() failed: [12] Cannot allocate memory
mmap() failed: [12] Cannot allocate memory
```

Running the patched `wp cli info` in the same shell now surfaces the actual cause up front:

```
PHP memory limit:	748M
OS virtual memory limit (ulimit -v):	64M
...
Warning: This shell's OS-level virtual memory limit (`ulimit -v`) is set to 64M, which is lower than PHP's memory limit (748M). This is a common cause of "mmap() failed: Cannot allocate memory" errors even though memory_limit itself looks sufficient. Increasing memory_limit will not help; ask your hosting provider to raise the OS-level limit instead.
```

## Test plan

- [x] Added unit tests in `tests/CLICommandTest.php` covering `format_kilobytes()` and the new/extended `check_memory_limit()` branches (low memory_limit only, sufficient memory_limit, unknown/unlimited ulimit, restrictive ulimit vs. finite memory_limit, restrictive ulimit vs. unlimited memory_limit, ulimit higher than memory_limit).
- [x] Added a Behat scenario in `features/cli-info.feature` asserting the new `OS virtual memory limit` line/field appears in both text and JSON output of `wp cli info`.
- [x] `composer phpunit` — full suite passes (532 tests).
- [x] `composer phpcs` — clean.
- [x] `vendor/bin/phpstan analyse ... --memory-limit=1G` — no new errors (pre-existing, unrelated `method.deprecated` baseline mismatches on this PHP version are present identically on `main`).
- [x] Manually reproduced the original `mmap() failed` error via Docker with a restrictive `ulimit -v` and confirmed the new warning correctly identifies the root cause (see above).
- [x] Ran `wp cli info` / `wp cli info --format=json` locally via `bin/wp` to confirm normal (unrestricted) output is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `wp cli info` now displays the operating system’s virtual memory limit in human-readable and JSON output.
  * Memory diagnostics now identify when operating system or PHP limits may restrict available memory.
* **Bug Fixes**
  * Improved memory-limit warnings for low, restrictive, unlimited, or unavailable limits.
  * Memory values are formatted more clearly for display.
  * Warnings now indicate when the operating system’s virtual memory limit is lower than PHP’s configured memory limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->