### PR TITLE
Fix: Remove deprecated back-compat conversions

### DIFF
--- a/features/aliases.feature
+++ b/features/aliases.feature
@@ -157,17 +157,6 @@ Feature: Create shortcuts to specific WordPress installs
         path: {TEST_DIR}/foo
       """
 
-    When I try `wp cli aliases`
-    Then STDOUT should be YAML containing:
-      """
-      @all: Run command against every registered alias.
-      @foo:
-        path: {TEST_DIR}/foo
-      """
-    And STDERR should contain:
-      """
-      The 'wp cli aliases' syntax is deprecated and will be removed in WP-CLI 4.0. Use 'wp cli alias list' instead.
-      """
 
     When I run `wp cli alias list --format=json`
     Then STDOUT should be JSON containing:
@@ -175,15 +164,7 @@ Feature: Create shortcuts to specific WordPress installs
       {"@all":"Run command against every registered alias.","@foo":{"path":"{TEST_DIR}/foo"}}
       """
 
-    When I try `wp cli aliases --format=json`
-    Then STDOUT should be JSON containing:
-      """
-      {"@all":"Run command against every registered alias.","@foo":{"path":"{TEST_DIR}/foo"}}
-      """
-    And STDERR should contain:
-      """
-      The 'wp cli aliases' syntax is deprecated and will be removed in WP-CLI 4.0. Use 'wp cli alias list' instead.
-      """
+
 
   Scenario: Get alias information
     Given a WP installation in 'foo'

--- a/features/back-compat.feature
+++ b/features/back-compat.feature
@@ -5,32 +5,6 @@ Feature: Deprecated command and flag syntaxes still work but warn
   deprecation warning naming the modern form, and are scheduled for removal in
   4.0. The rewrite itself keeps working throughout the 3.x cycle.
 
-  Scenario: A deprecated top-level command alias warns
-    Given an empty directory
-
-    When I try `wp sql`
-    Then STDERR should contain:
-      """
-      The 'wp sql' syntax is deprecated and will be removed in WP-CLI 4.0. Use 'wp db' instead.
-      """
-
-  Scenario: A deprecated subcommand syntax warns
-    Given an empty directory
-
-    When I try `wp plugin update-all`
-    Then STDERR should contain:
-      """
-      The 'wp plugin update-all' syntax is deprecated and will be removed in WP-CLI 4.0. Use 'wp plugin update --all' instead.
-      """
-
-  Scenario: A deprecated flag warns
-    Given an empty directory
-
-    When I try `wp post list --ids`
-    Then STDERR should contain:
-      """
-      The '--ids' syntax is deprecated and will be removed in WP-CLI 4.0. Use '--format=ids' instead.
-      """
 
   Scenario: Retained shorthands are not treated as deprecated
     Given an empty directory

--- a/features/runcommand.feature
+++ b/features/runcommand.feature
@@ -328,25 +328,6 @@ Feature: Run a WP-CLI command
     And STDERR should be empty
     And the return code should be 0
 
-  Scenario Outline: Apply backwards compat conversions
-    Given a WP installation
-
-    When I try `wp <flag> run "term url category 1"`
-    Then STDOUT should be:
-      """
-      https://example.com/?cat=1
-      returned: NULL
-      """
-    And STDERR should contain:
-      """
-      The 'wp term url' syntax is deprecated and will be removed in WP-CLI 4.0. Use 'wp term list --field=url' instead.
-      """
-    And the return code should be 0
-
-    Examples:
-      | flag        |
-      | --no-launch |
-      | --launch    |
 
   @skip-windows
   Scenario Outline: Check that proc_open() and proc_close() aren't disabled for launch

--- a/php/WP_CLI/Runner.php
+++ b/php/WP_CLI/Runner.php
@@ -1426,99 +1426,6 @@ class Runner {
 			$args = $split_args;
 		}
 
-		$top_level_aliases = [
-			'sql'  => 'db',
-			'blog' => 'site',
-		];
-		if ( count( $args ) > 0 ) {
-			foreach ( $top_level_aliases as $old => $new ) {
-				if ( $old === $args[0] ) {
-					self::deprecated_syntax( "wp {$old}", "wp {$new}" );
-					$args[0] = $new;
-					break;
-				}
-			}
-		}
-
-		// *-meta  ->  * meta
-		if ( ! empty( $args ) && preg_match( '/(post|comment|user|network)-meta/', (string) $args[0], $matches ) ) {
-			self::deprecated_syntax( "wp {$args[0]}", "wp {$matches[1]} meta" );
-			array_shift( $args );
-			array_unshift( $args, 'meta' );
-			array_unshift( $args, $matches[1] );
-		}
-
-		// cli aliases  ->  cli alias list
-		if ( [ 'cli', 'aliases' ] === array_slice( $args, 0, 2 ) ) {
-			self::deprecated_syntax( 'wp cli aliases', 'wp cli alias list' );
-			list( $args[0], $args[1], $args[2] ) = [ 'cli', 'alias', 'list' ];
-		}
-
-		// core (multsite-)install --admin_name=  ->  --admin_user=
-		if ( count( $args ) > 0 && 'core' === $args[0] && isset( $assoc_args['admin_name'] ) ) {
-			self::deprecated_syntax( '--admin_name', '--admin_user' );
-			$assoc_args['admin_user'] = $assoc_args['admin_name'];
-			unset( $assoc_args['admin_name'] );
-		}
-
-		// core config  ->  config create
-		if ( [ 'core', 'config' ] === array_slice( $args, 0, 2 ) ) {
-			self::deprecated_syntax( 'wp core config', 'wp config create' );
-			list( $args[0], $args[1] ) = [ 'config', 'create' ];
-		}
-		// core language  ->  language core
-		if ( [ 'core', 'language' ] === array_slice( $args, 0, 2 ) ) {
-			self::deprecated_syntax( 'wp core language', 'wp language core' );
-			list( $args[0], $args[1] ) = [ 'language', 'core' ];
-		}
-
-		// checksum core  ->  core verify-checksums
-		if ( [ 'checksum', 'core' ] === array_slice( $args, 0, 2 ) ) {
-			self::deprecated_syntax( 'wp checksum core', 'wp core verify-checksums' );
-			list( $args[0], $args[1] ) = [ 'core', 'verify-checksums' ];
-		}
-
-		// checksum plugin  ->  plugin verify-checksums
-		if ( [ 'checksum', 'plugin' ] === array_slice( $args, 0, 2 ) ) {
-			self::deprecated_syntax( 'wp checksum plugin', 'wp plugin verify-checksums' );
-			list( $args[0], $args[1] ) = [ 'plugin', 'verify-checksums' ];
-		}
-
-		// site create --site_id=  ->  site create --network_id=
-		if ( count( $args ) >= 2 && 'site' === $args[0] && 'create' === $args[1] && isset( $assoc_args['site_id'] ) ) {
-			self::deprecated_syntax( '--site_id', '--network_id' );
-			$assoc_args['network_id'] = $assoc_args['site_id'];
-			unset( $assoc_args['site_id'] );
-		}
-
-		// {plugin|theme} update-all  ->  {plugin|theme} update --all
-		if ( count( $args ) > 1 && in_array( $args[0], [ 'plugin', 'theme' ], true )
-			&& 'update-all' === $args[1]
-		) {
-			self::deprecated_syntax( "wp {$args[0]} update-all", "wp {$args[0]} update --all" );
-			$args[1]           = 'update';
-			$assoc_args['all'] = true;
-		}
-
-		// transient delete-expired  ->  transient delete --expired
-		if ( count( $args ) > 1 && 'transient' === $args[0] && 'delete-expired' === $args[1] ) {
-			self::deprecated_syntax( 'wp transient delete-expired', 'wp transient delete --expired' );
-			$args[1]               = 'delete';
-			$assoc_args['expired'] = true;
-		}
-
-		// transient delete-all  ->  transient delete --all
-		if ( count( $args ) > 1 && 'transient' === $args[0] && 'delete-all' === $args[1] ) {
-			self::deprecated_syntax( 'wp transient delete-all', 'wp transient delete --all' );
-			$args[1]           = 'delete';
-			$assoc_args['all'] = true;
-		}
-
-		// plugin scaffold  ->  scaffold plugin
-		if ( [ 'plugin', 'scaffold' ] === array_slice( $args, 0, 2 ) ) {
-			self::deprecated_syntax( 'wp plugin scaffold', 'wp scaffold plugin' );
-			list( $args[0], $args[1] ) = [ $args[1], $args[0] ];
-		}
 
 		// foo --help  ->  help foo
 		if ( isset( $assoc_args['help'] ) ) {
@@ -1526,15 +1433,6 @@ class Runner {
 			unset( $assoc_args['help'] );
 		}
 
-		// {post|user} list --ids  ->  {post|user} list --format=ids
-		if ( count( $args ) > 1 && in_array( $args[0], [ 'post', 'user' ], true )
-			&& 'list' === $args[1]
-			&& isset( $assoc_args['ids'] )
-		) {
-			self::deprecated_syntax( '--ids', '--format=ids' );
-			$assoc_args['format'] = 'ids';
-			unset( $assoc_args['ids'] );
-		}
 
 		// --json  ->  --format=json
 		if ( isset( $assoc_args['json'] ) ) {
@@ -1554,44 +1452,6 @@ class Runner {
 			}
 		}
 
-		// (post|comment|site|term) url  --> (post|comment|site|term) list --*__in --field=url
-		if ( count( $args ) >= 2 && in_array( $args[0], [ 'post', 'comment', 'site', 'term' ], true ) && 'url' === $args[1] ) {
-			self::deprecated_syntax( "wp {$args[0]} url", "wp {$args[0]} list --field=url" );
-			switch ( $args[0] ) {
-				case 'post':
-					$post_ids                = array_slice( $args, 2 );
-					$args                    = [ 'post', 'list' ];
-					$assoc_args['post__in']  = implode( ',', $post_ids );
-					$assoc_args['post_type'] = 'any';
-					$assoc_args['orderby']   = 'post__in';
-					$assoc_args['field']     = 'url';
-					break;
-				case 'comment':
-					$comment_ids               = array_slice( $args, 2 );
-					$args                      = [ 'comment', 'list' ];
-					$assoc_args['comment__in'] = implode( ',', $comment_ids );
-					$assoc_args['orderby']     = 'comment__in';
-					$assoc_args['field']       = 'url';
-					break;
-				case 'site':
-					$site_ids               = array_slice( $args, 2 );
-					$args                   = [ 'site', 'list' ];
-					$assoc_args['site__in'] = implode( ',', $site_ids );
-					$assoc_args['field']    = 'url';
-					break;
-				case 'term':
-					$taxonomy = '';
-					if ( isset( $args[2] ) ) {
-						$taxonomy = $args[2];
-					}
-					$term_ids              = array_slice( $args, 3 );
-					$args                  = [ 'term', 'list', $taxonomy ];
-					$assoc_args['include'] = implode( ',', $term_ids );
-					$assoc_args['orderby'] = 'include';
-					$assoc_args['field']   = 'url';
-					break;
-			}
-		}
 
 		// config get --[global|constant]=<global|constant> --> config get <name> --type=constant|variable
 		// config get --> config list
@@ -1629,33 +1489,6 @@ class Runner {
 		];
 	}
 
-	/**
-	 * Emits a deprecation warning for a legacy command or flag syntax that is
-	 * still rewritten by back_compat_conversions().
-	 *
-	 * The rewrite keeps working throughout the 3.x cycle. These syntaxes were
-	 * never warned about before, so 3.0 is the first release to signal that they
-	 * are on their way out; they are scheduled for removal in WP-CLI 4.0. See
-	 * https://github.com/wp-cli/wp-cli/issues/6353.
-	 *
-	 * The conversion runs during the `ConfigureRunner` bootstrap step, before the
-	 * logger is initialized, so this writes to STDERR directly, matching the
-	 * existing `--blog`-style deprecation notice in Configurator.
-	 *
-	 * @param string $old_syntax The deprecated syntax that was used.
-	 * @param string $new_syntax The modern replacement to use instead.
-	 * @return void
-	 */
-	private static function deprecated_syntax( $old_syntax, $new_syntax ) {
-		fwrite(
-			STDERR,
-			sprintf(
-				"WP-CLI: The '%s' syntax is deprecated and will be removed in WP-CLI 4.0. Use '%s' instead.\n",
-				$old_syntax,
-				$new_syntax
-			)
-		);
-	}
 
 	/**
 	 * Whether or not the output should be rendered in color


### PR DESCRIPTION
## Summary

- Remove deprecated back-compat command and flag conversions scheduled for WP-CLI 4.0.
- Remove the associated deprecation warning helper.
- Remove Behat scenarios that covered the deprecated syntax.

Fixes #6361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed support for several deprecated command aliases, legacy command names, options, and URL shortcuts.
  * Removed deprecation warnings and compatibility handling for outdated syntax, including `wp cli aliases`, `wp sql`, `wp plugin update-all`, and related forms.
  * Existing `--help`, `--json`, version, information, and configuration commands continue to support their compatibility behavior.
* **Tests**
  * Updated command coverage to reflect the removal of deprecated syntax while retaining JSON alias-listing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->