### PR TITLE
Fix PHPStan errors with WordPress 7.1 stubs

### DIFF
--- a/php/utils.php
+++ b/php/utils.php
@@ -856,6 +856,7 @@ function make_progress_bar( $message, $count, $interval = 100 ) {
  *               case of PHP_URL_PORT - integer when it does. See parse_url()'s
  *               return values.
  *
+ * @phpstan-param int<-1, 7> $component
  * @phpstan-return ($component is non-negative-int ? string|null|int|false : array{scheme?: string, host?: string, port?: int, user?: string, pass?: string, query?: string, path?: string, fragment?: string})
  */
 function parse_url( $url, $component = - 1, $auto_add_scheme = true ) {

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -996,7 +996,7 @@ class UtilsTest extends TestCase {
 	/**
 	 * @dataProvider dataParseUrl
 	 * @param string $url
-	 * @param int $component
+	 * @param int<-1, 7> $component
 	 * @param bool $auto_add_scheme
 	 * @param array<string, mixed>|string|false $expected
 	 */


### PR DESCRIPTION
`php-stubs/wordpress-stubs` v7.1.0 tightened WP core types, which broke the PHPStan job on `main` (see [this run](https://github.com/wp-cli/wp-cli/actions/runs/33229093041)).

`wp_parse_url()` now declares `@phpstan-param int<-1, 7> $component`, so passing our own loosely typed `int` through was reported as `argument.type`.

- `php/utils.php`: annotate `Utils\parse_url()`'s `$component` with the same `int<-1, 7>` range, matching what `parse_url()` actually accepts (`-1` plus the `PHP_URL_*` constants).
- `tests/UtilsTest.php`: narrow `testParseUrl()`'s `@param` accordingly. The data provider only uses `-1` and `PHP_URL_HOST`.

Docblocks only, no runtime change.

---
_Generated by [Claude Code](https://claude.ai/code/session_018PGksEeKBJuBAjUKEV3B9j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that URL component values must be within the supported range of -1 through 7.
  * Updated related test documentation to reflect the valid parameter range.

* **Tests**
  * Aligned test annotations with the documented URL component constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->