### PR TITLE
Fix wp --info / wp --version being dropped under WP_CLI_STRICT_ARGS_MODE

### DIFF
--- a/features/flags.feature
+++ b/features/flags.feature
@@ -379,6 +379,80 @@ Feature: Global flags
       local: foo.dev
       """
 
+  Scenario: `WP_CLI_STRICT_ARGS_MODE` preserves unknown global flags like `--info` and `--version`
+    Given an empty directory
+
+    When I run `WP_CLI_STRICT_ARGS_MODE=1 wp --info`
+    Then STDOUT should contain:
+      """
+      WP-CLI version:
+      """
+    And STDOUT should not contain:
+      """
+      wp <command>
+      """
+
+    When I run `WP_CLI_STRICT_ARGS_MODE=1 wp --version`
+    Then STDOUT should contain:
+      """
+      WP-CLI
+      """
+    And STDOUT should not contain:
+      """
+      wp <command>
+      """
+
+  Scenario: Unknown global flags are forwarded in `WP_CLI_STRICT_ARGS_MODE`
+    Given an empty directory
+    And a cmd.php file:
+      """
+      <?php
+      /**
+       * @when before_wp_load
+       */
+      $cmd_test = function ( $args, $assoc_args ) {
+          if ( ! isset( $assoc_args['custom'] ) ) {
+              WP_CLI::log( 'custom:not-set' );
+          } elseif ( is_array( $assoc_args['custom'] ) ) {
+              WP_CLI::log( 'custom:' . implode( ',', $assoc_args['custom'] ) );
+          } elseif ( is_bool( $assoc_args['custom'] ) ) {
+              WP_CLI::log( 'custom:' . ( $assoc_args['custom'] ? 'true' : 'false' ) );
+          } else {
+              WP_CLI::log( 'custom:' . $assoc_args['custom'] );
+          }
+      };
+      WP_CLI::add_command( 'cmd-test', $cmd_test );
+      """
+    And a wp-cli.yml file:
+      """
+      require:
+        - cmd.php
+      """
+
+    When I run `WP_CLI_STRICT_ARGS_MODE=1 wp --custom=val cmd-test`
+    Then STDOUT should be:
+      """
+      custom:val
+      """
+
+    When I run `WP_CLI_STRICT_ARGS_MODE=1 wp --custom=one --custom=two cmd-test`
+    Then STDOUT should be:
+      """
+      custom:one,two
+      """
+
+    When I run `WP_CLI_STRICT_ARGS_MODE=1 wp --custom cmd-test`
+    Then STDOUT should be:
+      """
+      custom:true
+      """
+
+    When I run `WP_CLI_STRICT_ARGS_MODE=1 wp --custom --no-custom cmd-test`
+    Then STDOUT should be:
+      """
+      custom:false
+      """
+
   Scenario: Using --http=<url> requires wp-cli/restful
     Given an empty directory
 

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -364,11 +364,22 @@ class Configurator {
 		if ( getenv( 'WP_CLI_STRICT_ARGS_MODE' ) ) {
 			foreach ( $global_assoc as $tmp ) {
 				[ $key, $value ] = $tmp;
+				// Not a known runtime config key (e.g. `--info`, `--version`); keep it as an assoc arg
+				// instead of silently dropping it, matching non-strict mode's behavior.
 				if ( isset( $this->spec[ $key ] ) && false !== $this->spec[ $key ]['runtime'] ) {
 					$this->assoc_arg_to_runtime_config( $key, $value, $runtime_config );
+				} elseif ( isset( $assoc_args[ $key ] ) ) {
+					// Collect multiple values for the same key into an array, except for boolean flags
+					// Boolean flags (--flag or --no-flag) use last-wins behavior
+					if ( is_bool( $value ) ) {
+						$assoc_args[ $key ] = $value;
+					} else {
+						if ( ! is_array( $assoc_args[ $key ] ) ) {
+							$assoc_args[ $key ] = [ $assoc_args[ $key ] ];
+						}
+						$assoc_args[ $key ][] = $value;
+					}
 				} else {
-					// Not a known runtime config key (e.g. `--info`, `--version`); keep it as an assoc arg
-					// instead of silently dropping it, matching non-strict mode's behavior.
 					$assoc_args[ $key ] = $value;
 				}
 			}

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -366,6 +366,10 @@ class Configurator {
 				[ $key, $value ] = $tmp;
 				if ( isset( $this->spec[ $key ] ) && false !== $this->spec[ $key ]['runtime'] ) {
 					$this->assoc_arg_to_runtime_config( $key, $value, $runtime_config );
+				} else {
+					// Not a known runtime config key (e.g. `--info`, `--version`); keep it as an assoc arg
+					// instead of silently dropping it, matching non-strict mode's behavior.
+					$assoc_args[ $key ] = $value;
 				}
 			}
 			foreach ( $local_assoc as $tmp ) {

--- a/php/WP_CLI/Configurator.php
+++ b/php/WP_CLI/Configurator.php
@@ -368,37 +368,13 @@ class Configurator {
 				// instead of silently dropping it, matching non-strict mode's behavior.
 				if ( isset( $this->spec[ $key ] ) && false !== $this->spec[ $key ]['runtime'] ) {
 					$this->assoc_arg_to_runtime_config( $key, $value, $runtime_config );
-				} elseif ( isset( $assoc_args[ $key ] ) ) {
-					// Collect multiple values for the same key into an array, except for boolean flags
-					// Boolean flags (--flag or --no-flag) use last-wins behavior
-					if ( is_bool( $value ) ) {
-						$assoc_args[ $key ] = $value;
-					} else {
-						if ( ! is_array( $assoc_args[ $key ] ) ) {
-							$assoc_args[ $key ] = [ $assoc_args[ $key ] ];
-						}
-						$assoc_args[ $key ][] = $value;
-					}
 				} else {
-					$assoc_args[ $key ] = $value;
+					$this->add_assoc_arg( $assoc_args, $key, $value );
 				}
 			}
 			foreach ( $local_assoc as $tmp ) {
 				[ $key, $value ] = $tmp;
-				// Collect multiple values for the same key into an array, except for boolean flags
-				if ( isset( $assoc_args[ $key ] ) ) {
-					// Boolean flags (--flag or --no-flag) use last-wins behavior
-					if ( is_bool( $value ) ) {
-						$assoc_args[ $key ] = $value;
-					} else {
-						if ( ! is_array( $assoc_args[ $key ] ) ) {
-							$assoc_args[ $key ] = [ $assoc_args[ $key ] ];
-						}
-						$assoc_args[ $key ][] = $value;
-					}
-				} else {
-					$assoc_args[ $key ] = $value;
-				}
+				$this->add_assoc_arg( $assoc_args, $key, $value );
 			}
 		} else {
 			foreach ( $mixed_args as $tmp ) {
@@ -406,24 +382,37 @@ class Configurator {
 
 				if ( isset( $this->spec[ $key ] ) && false !== $this->spec[ $key ]['runtime'] ) {
 					$this->assoc_arg_to_runtime_config( $key, $value, $runtime_config );
-				} elseif ( isset( $assoc_args[ $key ] ) ) {
-					// Collect multiple values for the same key into an array, except for boolean flags
-					// Boolean flags (--flag or --no-flag) use last-wins behavior
-					if ( is_bool( $value ) ) {
-						$assoc_args[ $key ] = $value;
-					} else {
-						if ( ! is_array( $assoc_args[ $key ] ) ) {
-							$assoc_args[ $key ] = [ $assoc_args[ $key ] ];
-						}
-						$assoc_args[ $key ][] = $value;
-					}
 				} else {
-					$assoc_args[ $key ] = $value;
+					$this->add_assoc_arg( $assoc_args, $key, $value );
 				}
 			}
 		}
 
 		return [ $assoc_args, $runtime_config ];
+	}
+
+	/**
+	 * Add an associative argument, aggregating multiple values into an array (except for booleans).
+	 *
+	 * @param array<string, mixed> $assoc_args Associative arguments array passed by reference.
+	 * @param string               $key        Argument key.
+	 * @param mixed                $value      Argument value.
+	 * @return void
+	 */
+	private function add_assoc_arg( &$assoc_args, $key, $value ) {
+		if ( isset( $assoc_args[ $key ] ) ) {
+			// Boolean flags (--flag or --no-flag) use last-wins behavior
+			if ( is_bool( $value ) ) {
+				$assoc_args[ $key ] = $value;
+			} else {
+				if ( ! is_array( $assoc_args[ $key ] ) ) {
+					$assoc_args[ $key ] = [ $assoc_args[ $key ] ];
+				}
+				$assoc_args[ $key ][] = $value;
+			}
+		} else {
+			$assoc_args[ $key ] = $value;
+		}
 	}
 
 	/**

--- a/tests/ConfiguratorTest.php
+++ b/tests/ConfiguratorTest.php
@@ -197,6 +197,33 @@ class ConfiguratorTest extends TestCase {
 		$this->assertFalse( $assoc_args2['verbose'] );
 	}
 
+	public function testParseArgsStrictModeKeepsUnknownGlobalFlags(): void {
+		$original_value = getenv( 'WP_CLI_STRICT_ARGS_MODE' );
+		putenv( 'WP_CLI_STRICT_ARGS_MODE=1' );
+
+		try {
+			$configurator = new Configurator( __DIR__ . '/../php/config-spec.php' );
+
+			// `--info` and `--version` aren't part of the runtime config spec, but since
+			// there's no positional command argument, they're classified as "global" flags.
+			// They must still surface in $assoc_args so `Runner::back_compat_conversions()`
+			// can turn them into `cli info` / `cli version`, instead of being silently dropped.
+			$parsed = $configurator->parse_args( [ '--info' ] );
+			$this->assertSame( [], $parsed[0] );
+			$this->assertArrayHasKey( 'info', $parsed[1] );
+			$this->assertTrue( $parsed[1]['info'] );
+
+			// A known runtime config key (e.g. `--url`) should still be routed to
+			// runtime_config, not $assoc_args, preserving strict mode's original behavior.
+			$parsed_url = $configurator->parse_args( [ '--url=foo.dev', 'command' ] );
+			$this->assertArrayNotHasKey( 'url', $parsed_url[1] );
+			$this->assertArrayHasKey( 'url', $parsed_url[2] );
+			$this->assertSame( 'foo.dev', $parsed_url[2]['url'] );
+		} finally {
+			putenv( false === $original_value ? 'WP_CLI_STRICT_ARGS_MODE' : "WP_CLI_STRICT_ARGS_MODE={$original_value}" );
+		}
+	}
+
 	public function testMergeYmlSelfInheritRecursionGuard(): void {
 		$temp_dir = sys_get_temp_dir();
 		$file     = tempnam( $temp_dir, 'wp-cli-test-self-' );

--- a/tests/ConfiguratorTest.php
+++ b/tests/ConfiguratorTest.php
@@ -225,6 +225,11 @@ class ConfiguratorTest extends TestCase {
 			$parsed_repeated = $configurator->parse_args( [ '--foo=1', '--foo=2' ] );
 			$this->assertArrayHasKey( 'foo', $parsed_repeated[1] );
 			$this->assertSame( [ '1', '2' ], $parsed_repeated[1]['foo'] );
+
+			// Repeated boolean global flags should use last-wins behavior.
+			$parsed_bool = $configurator->parse_args( [ '--bar', '--no-bar' ] );
+			$this->assertArrayHasKey( 'bar', $parsed_bool[1] );
+			$this->assertFalse( $parsed_bool[1]['bar'] );
 		} finally {
 			putenv( false === $original_value ? 'WP_CLI_STRICT_ARGS_MODE' : "WP_CLI_STRICT_ARGS_MODE={$original_value}" );
 		}

--- a/tests/ConfiguratorTest.php
+++ b/tests/ConfiguratorTest.php
@@ -219,6 +219,12 @@ class ConfiguratorTest extends TestCase {
 			$this->assertArrayNotHasKey( 'url', $parsed_url[1] );
 			$this->assertArrayHasKey( 'url', $parsed_url[2] );
 			$this->assertSame( 'foo.dev', $parsed_url[2]['url'] );
+
+			// Repeated unknown global flags should aggregate into an array, same as
+			// repeated local flags, instead of the last value silently overwriting the rest.
+			$parsed_repeated = $configurator->parse_args( [ '--foo=1', '--foo=2' ] );
+			$this->assertArrayHasKey( 'foo', $parsed_repeated[1] );
+			$this->assertSame( [ '1', '2' ], $parsed_repeated[1]['foo'] );
 		} finally {
 			putenv( false === $original_value ? 'WP_CLI_STRICT_ARGS_MODE' : "WP_CLI_STRICT_ARGS_MODE={$original_value}" );
 		}


### PR DESCRIPTION
## Summary

- `wp --info` (and `wp --version`) silently fell through to showing general help when `WP_CLI_STRICT_ARGS_MODE=1` was set, instead of printing the CLI info/version screen.
- Root cause: `Configurator::unmix_assoc_args()` only forwards "global" flags (those appearing before any positional/command argument) into the parsed args when they're part of the known runtime config spec. `--info` and `--version` aren't spec entries — they're special-cased later in `Runner::back_compat_conversions()` via `$assoc_args['info']` / `$assoc_args['version']` — so under strict mode they were dropped entirely before ever reaching that check.
- Fix: unknown global flags (not part of the spec) now fall through to `$assoc_args`, matching non-strict mode's existing behavior. Known spec keys (e.g. `--url`) are unaffected and still route to `$runtime_config` only, preserving strict mode's original global/local disambiguation behavior.

## Test plan

- [x] `WP_CLI_STRICT_ARGS_MODE=1 php php/boot-fs.php --info` now prints the info screen (previously showed general help)
- [x] `WP_CLI_STRICT_ARGS_MODE=1 php php/boot-fs.php --version` works
- [x] Non-strict mode `--info` / `--version` unaffected (regression check)
- [x] `WP_CLI_STRICT_ARGS_MODE=1 php php/boot-fs.php --url=example.com cli info` confirms known spec keys (`--url`) still route to runtime config as before
- [x] Added `testParseArgsStrictModeKeepsUnknownGlobalFlags` to `tests/ConfiguratorTest.php`
- [x] Full PHPUnit suite passes (524 tests)
- [x] PHPCS clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Unknown global flags, including valueless flags such as `--info`, are now preserved when strict argument mode is enabled.
  - Repeated unknown flags with values are correctly collected instead of being overwritten.
  - Repeated boolean and negated flags continue to follow last-value behavior.
  - Recognized runtime configuration options, such as `--url`, continue to be routed correctly in strict mode.
  - Built-in `--info` and `--version` flags continue to execute as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->